### PR TITLE
fix: disable executable compression

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,9 +37,9 @@ builds:
     ldflags:
       - -s -w -X github.com/snyk/snyk-ls/config.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"
-    hooks:
-      post:
-        - upx -9fv --lzma "{{ .Path }}"
+#    hooks:
+#      post:
+#       - upx -9fv --lzma "{{ .Path }}"
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"


### PR DESCRIPTION
Executable compression may trigger virus scanners. On our machines, the snyk-ls binary is insta-killed, potentially because of the Antivirus kicking in.