### PR TITLE
fix: 🐛 switch to writable working dir before calling CLI

### DIFF
--- a/iac/iac_test.go
+++ b/iac/iac_test.go
@@ -51,14 +51,13 @@ func Test_ScanFile(t *testing.T) {
 	config.CurrentConfig.SetFormat(config.FormatHtml)
 	preconditions.EnsureReadyForAnalysisAndWait()
 
-	path, _ := filepath.Abs("testdata/RBAC.yaml")
-	content, _ := os.ReadFile(path)
+	workingDir, _ := os.Getwd()
+	path, _ := filepath.Abs(workingDir + "/testdata/RBAC.yaml")
 
 	doc := lsp.TextDocumentItem{
 		URI:        lsp.DocumentURI(path),
 		LanguageID: "yaml",
 		Version:    0,
-		Text:       string(content),
 	}
 
 	dChan := make(chan lsp2.DiagnosticResult, 1)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,6 +23,10 @@ func (c SnykCli) Execute(cmd []string) (resp []byte, err error) {
 	Mutex.Lock()
 	defer Mutex.Unlock()
 	log.Info().Str("method", "SnykCli.Execute").Interface("cmd", cmd).Msg("calling Snyk CLI")
+	cwd, _ := os.Getwd()
+	defer func(dir string) {
+		_ = os.Chdir(dir)
+	}(cwd)
 	err = c.changeToExecutionDir()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See https://snyk.slack.com/archives/CRV0PMFDH/p1653045602435899

IaC needs a writable directory to function.