### PR TITLE
fix: 🐛 re-add release information to binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,7 @@ builds:
       - goarch: arm64
         goos: windows
     ldflags:
-      - -s -w -X github.com/snyk/snyk-ls/config.Version={{.Version}}
+      - -s -w -X github.com/snyk/snyk-ls/application/config.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"
 
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DEV_GOOS := $(shell go env GOOS)
 GOPATH := $(shell go env GOPATH)
 VERSION := $(shell git show -s --format=%cd --date=format:%Y%m%d.%H%M%S)
 COMMIT := $(shell git show -s --oneline)
-LDFLAGS_DEV := "-X 'github.com/snyk/snyk-ls/config.Development=true' -X 'github.com/snyk/snyk-ls/config.Version=v$(VERSION)-SNAPSHOT-$(COMMIT)'"
+LDFLAGS_DEV := "-X 'github.com/snyk/snyk-ls/application/config.Development=true' -X 'github.com/snyk/snyk-ls/application/config.Version=v$(VERSION)-SNAPSHOT-$(COMMIT)'"
 
 PARALLEL := "-p=1"
 NOCACHE := "-count=1"


### PR DESCRIPTION
Due to the refactoring, the release version was not injected anymore into the binary, as Makefile and goreleaser searched to inject in `config.Version` instead of `application/config.Version`.