### PR TITLE
test: add -failfast flag to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,20 +51,20 @@ lint: tools
 test:
 	@echo "==> Running unit tests..."
 	@mkdir -p $(BUILD_DIR)
-	@go test $(PARALLEL) $(NOCACHE) $(TIMEOUT) $(VERBOSE) -cover -coverprofile=$(BUILD_DIR)/coverage.out ./...
+	@go test $(PARALLEL) $(NOCACHE) $(TIMEOUT) $(VERBOSE) -failfast -cover -coverprofile=$(BUILD_DIR)/coverage.out ./...
 
 .PHONY: race-test
 race-test:
 	@echo "==> Running integration tests with race-detector..."
 	@mkdir -p $(BUILD_DIR)
 	@export INTEG_TESTS=true
-	@go test $(PARALLEL) $(NOCACHE) $(TIMEOUT) $(VERBOSE) -race ./...
+	@go test $(PARALLEL) $(NOCACHE) $(TIMEOUT) $(VERBOSE) -race -failfast ./...
 
 .PHONY: proxy-test
 proxy-test:
 	@echo "==> Running integration tests with proxy"
 	@docker build -t "snyk-ls:$(VERSION)" -f .github/docker-based-tests/Dockerfile .
-	@docker run --rm --cap-add=NET_ADMIN --name "snyk-ls" --env "SNYK_TOKEN=$(SNYK_TOKEN)" snyk-ls:$(VERSION) go test $(PARALLEL) $(NOCACHE) $(TIMEOUT) $(VERBOSE) ./...
+	@docker run --rm --cap-add=NET_ADMIN --name "snyk-ls" --env "SNYK_TOKEN=$(SNYK_TOKEN)" snyk-ls:$(VERSION) go test -failfast $(PARALLEL) $(NOCACHE) $(TIMEOUT) $(VERBOSE) ./...
 
 
 ## build: Build binary for default local system's OS and architecture.


### PR DESCRIPTION
Add -failfast flag to tests in order to save time and exit quickly when tests fail