### PR TITLE
fix: set correct IAC warning ranges [ROAD-977]

### DIFF
--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -170,7 +170,9 @@ func (iac *Scanner) retrieveAnalysis(scanResult iacScanResult, workspacePath str
 	rawFileContent, err := os.ReadFile(targetFile)
 	fileContentString := ""
 	if err != nil {
-		log.Err(err).Msgf("Could not read file content from %s", targetFile)
+		errorMessage := "Could not read file content from " + targetFile
+		log.Err(err).Msg(errorMessage)
+		iac.errorReporter.CaptureError(errors.Wrap(err, errorMessage))
 	} else {
 		fileContentString = string(rawFileContent)
 	}


### PR DESCRIPTION
Set the correct ranges for IAC warnings.

Before:
![image](https://user-images.githubusercontent.com/35231408/183671380-663f88cd-a515-4295-ae6f-5100cb7dbc78.png)

After:
![image](https://user-images.githubusercontent.com/35231408/183671211-91360f5d-e054-4cfe-960a-a93f65700184.png)