### PR TITLE
fix: copyAuthURL breaking Snyk in Sublime [ROAD-1166]

### DIFF
--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -79,6 +79,8 @@ func (a *CliAuthenticationProvider) authenticate(ctx context.Context) error {
 
 	reader, writer := io.Pipe()
 	go func() {
+		defer writer.Close()
+
 		out := &strings.Builder{}
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {

--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -77,7 +77,6 @@ func (a *CliAuthenticationProvider) authenticate(ctx context.Context) error {
 		return err
 	}
 
-	// by assigning the writer to stdout, we pipe the cmd output to the go routine that parses it
 	reader, writer := io.Pipe()
 	go func() {
 		out := &strings.Builder{}


### PR DESCRIPTION
### Description

_This PR should fix scans not working in sublime due to an errant `break` in the `copyAuthURL` logic._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
