### PR TITLE
feat: One scan per folder [ROAD-1126]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -246,14 +246,14 @@ func (c *Config) Token() string {
 	return c.token
 }
 
-// TokenWithChangesChannel returns the current token with a channel that will be written into once the token has changed.
+// TokenChangesChannel returns a channel that will be written into once the token has changed.
 // This allows aborting operations when the token is changed.
-func (c *Config) TokenWithChangesChannel() (string, <-chan string) {
+func (c *Config) TokenChangesChannel() <-chan string {
 	c.m.Lock()
 	defer c.m.Unlock()
 	channel := make(chan string, 1)
 	c.tokenChangeChannels = append(c.tokenChangeChannels, channel)
-	return c.token, channel
+	return channel
 }
 
 func (c *Config) SetCliSettings(settings *CliSettings) {

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -34,7 +34,7 @@ func TestConfigDefaults(t *testing.T) {
 func Test_TokenChanged_ChannelsInformed(t *testing.T) {
 	// Arrange
 	c := New()
-	_, tokenChangedChannel := c.TokenWithChangesChannel()
+	tokenChangedChannel := c.TokenChangesChannel()
 
 	// Act
 	// There's a 1 in 5 undecillion (5 * 10^36) chance for a collision here so let's hold our fingers
@@ -49,7 +49,8 @@ func Test_TokenChanged_ChannelsInformed(t *testing.T) {
 func Test_TokenChangedToSameToken_ChannelsNotInformed(t *testing.T) {
 	// Arrange
 	c := New()
-	token, tokenChangedChannel := c.TokenWithChangesChannel()
+	tokenChangedChannel := c.TokenChangesChannel()
+	token := c.Token()
 
 	// Act
 	c.SetToken(token)

--- a/domain/snyk/scanner.go
+++ b/domain/snyk/scanner.go
@@ -3,6 +3,7 @@ package snyk
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -102,6 +103,7 @@ func (sc *DelegatingConcurrentScanner) Scan(
 				foundIssues := s.Scan(span.Context(), path, folderPath)
 				processResults(foundIssues)
 				log.Debug().Msgf("Scanning %s with %T: COMPLETE found %v issues", path, s, len(foundIssues))
+				ctx, _ = context.WithDeadline(ctx, time.Now()+time.Minute*5)
 			}(scanner)
 		} else {
 			log.Debug().Msgf("Skipping scan with %T because it is not enabled", scanner)

--- a/domain/snyk/scanner.go
+++ b/domain/snyk/scanner.go
@@ -54,7 +54,7 @@ func (sc *DelegatingConcurrentScanner) Scan(
 	defer close(done)
 
 	sc.initializer.Init()
-	_, tokenChangeChannel := config.CurrentConfig().TokenWithChangesChannel()
+	tokenChangeChannel := config.CurrentConfig().TokenChangesChannel()
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 

--- a/domain/snyk/scanner.go
+++ b/domain/snyk/scanner.go
@@ -3,7 +3,6 @@ package snyk
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -103,7 +102,6 @@ func (sc *DelegatingConcurrentScanner) Scan(
 				foundIssues := s.Scan(span.Context(), path, folderPath)
 				processResults(foundIssues)
 				log.Debug().Msgf("Scanning %s with %T: COMPLETE found %v issues", path, s, len(foundIssues))
-				ctx, _ = context.WithDeadline(ctx, time.Now()+time.Minute*5)
 			}(scanner)
 		} else {
 			log.Debug().Msgf("Skipping scan with %T because it is not enabled", scanner)

--- a/domain/snyk/scanner.go
+++ b/domain/snyk/scanner.go
@@ -56,6 +56,8 @@ func (sc *DelegatingConcurrentScanner) Scan(
 	sc.initializer.Init()
 	_, tokenChangeChannel := config.CurrentConfig().TokenWithChangesChannel()
 	ctx, cancelFunc := context.WithCancel(ctx)
+	defer cancelFunc()
+
 	go func() { // This goroutine will listen to token changes and cancel the scans using a context
 		select {
 		case <-tokenChangeChannel:

--- a/infrastructure/cli/cli.go
+++ b/infrastructure/cli/cli.go
@@ -149,34 +149,3 @@ func (c SnykCli) HandleErrors(ctx context.Context, output string) (fail bool) {
 	}
 	return false
 }
-
-type TestExecutor struct {
-	ExecuteResponse string
-	wasExecuted     bool
-}
-
-func NewTestExecutor() *TestExecutor {
-	return &TestExecutor{ExecuteResponse: "{}"}
-}
-
-func (t *TestExecutor) Execute(ctx context.Context, cmd []string, workingDir string) (resp []byte, err error) {
-	err = ctx.Err()
-	if err != nil { // When the operation is cancelled via the context, return empty results and don't set "wasExecuted"
-		return make([]byte, 0), err
-	}
-
-	t.wasExecuted = true
-	return []byte(t.ExecuteResponse), err
-}
-
-func (t *TestExecutor) ExpandParametersFromConfig(base []string) []string {
-	return nil
-}
-
-func (t *TestExecutor) HandleErrors(ctx context.Context, output string) (fail bool) {
-	return false
-}
-
-func (t *TestExecutor) WasExecuted() bool {
-	return t.wasExecuted
-}

--- a/infrastructure/cli/cli_fake.go
+++ b/infrastructure/cli/cli_fake.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 type TestExecutor struct {
@@ -28,6 +30,7 @@ func (t *TestExecutor) Execute(ctx context.Context, cmd []string, workingDir str
 
 	select {
 	case <-time.After(t.ExecuteDuration):
+		log.Debug().Msg("Dummy CLI Execution time finished")
 		// Indicate that the scan has finished and return the ExecuteResponse
 		t.wasExecuted = true
 		t.counterLock.Lock()
@@ -35,6 +38,7 @@ func (t *TestExecutor) Execute(ctx context.Context, cmd []string, workingDir str
 		t.counterLock.Unlock()
 		return []byte(t.ExecuteResponse), err
 	case <-ctx.Done():
+		log.Debug().Msg("Dummy CLI Execution cancelled")
 		return resp, ctx.Err()
 	}
 }

--- a/infrastructure/cli/cli_fake.go
+++ b/infrastructure/cli/cli_fake.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type TestExecutor struct {
+	ExecuteResponse string
+	wasExecuted     bool
+	ExecuteDuration time.Duration
+	runningScans    int
+	maxRunningScans int
+	counterLock     sync.Mutex
+}
+
+func NewTestExecutor() *TestExecutor {
+	return &TestExecutor{ExecuteResponse: "{}"}
+}
+
+func (t *TestExecutor) GetRunningScans() int    { return t.runningScans }
+func (t *TestExecutor) GetMaxRunningScans() int { return t.maxRunningScans }
+
+func (t *TestExecutor) Execute(ctx context.Context, cmd []string, workingDir string) (resp []byte, err error) {
+	err = ctx.Err()
+	if err != nil { // When the operation is cancelled via the context, return empty results and don't set "wasExecuted"
+		return resp, err
+	}
+
+	t.counterLock.Lock()
+	t.runningScans++
+	if t.runningScans > t.maxRunningScans {
+		t.maxRunningScans = t.runningScans
+	}
+	t.counterLock.Unlock()
+
+	if t.ExecuteDuration > 0 {
+		time.Sleep(t.ExecuteDuration)
+	}
+
+	t.wasExecuted = true
+	return []byte(t.ExecuteResponse), err
+}
+
+func (t *TestExecutor) ExpandParametersFromConfig(base []string) []string {
+	return nil
+}
+
+func (t *TestExecutor) HandleErrors(ctx context.Context, output string) (fail bool) {
+	return false
+}
+
+func (t *TestExecutor) WasExecuted() bool {
+	return t.wasExecuted
+}

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -34,7 +34,7 @@ type ScanMetrics struct {
 
 type ScanStatus struct {
 	// finished channel is closed once the scan has finished
-	finished chan struct{}
+	finished chan bool
 
 	// isRunning is true when the scan is either running or waiting to run, and changed to false when it's done
 	isRunning bool
@@ -45,7 +45,7 @@ type ScanStatus struct {
 
 func NewScanStatus() *ScanStatus {
 	return &ScanStatus{
-		finished:  make(chan struct{}),
+		finished:  make(chan bool),
 		isRunning: false,
 		isPending: false,
 	}

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -96,6 +96,7 @@ func (sc *Scanner) Scan(ctx context.Context, _ string, folderPath string) []snyk
 	previousScanStatus, wasFound := sc.runningScans[folderPath]
 	if wasFound && previousScanStatus.isRunning {
 		if previousScanStatus.isPending {
+			sc.scanStatusMutex.Unlock()
 			return []snyk.Issue{}
 		}
 

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -32,13 +32,34 @@ type ScanMetrics struct {
 	lastScanFileCount         int
 }
 
+type ScanStatus struct {
+	// finished channel is closed once the scan has finished
+	finished chan struct{}
+
+	// isRunning is true when the scan is either running or waiting to run, and changed to false when it's done
+	isRunning bool
+
+	// isPending is true when the scan is currently waiting for a previous scan to finish
+	isPending bool
+}
+
+func NewScanStatus() *ScanStatus {
+	return &ScanStatus{
+		finished:  make(chan struct{}),
+		isRunning: false,
+		isPending: false,
+	}
+}
+
 type Scanner struct {
-	BundleUploader *BundleUploader
-	SnykApiClient  snyk_api.SnykApiClient
-	errorReporter  error_reporting.ErrorReporter
-	analytics      ux2.Analytics
-	ignorePatterns []string
-	mutex          sync.Mutex
+	BundleUploader  *BundleUploader
+	SnykApiClient   snyk_api.SnykApiClient
+	errorReporter   error_reporting.ErrorReporter
+	analytics       ux2.Analytics
+	ignorePatterns  []string
+	mutex           sync.Mutex
+	scanStatusMutex sync.Mutex
+	runningScans    map[string]*ScanStatus
 }
 
 func New(bundleUploader *BundleUploader, apiClient snyk_api.SnykApiClient, reporter error_reporting.ErrorReporter, analytics ux2.Analytics) *Scanner {
@@ -64,6 +85,41 @@ func (sc *Scanner) SupportedCommands() []snyk.CommandName {
 }
 
 func (sc *Scanner) Scan(ctx context.Context, _ string, folderPath string) []snyk.Issue {
+	// When starting a scan for a folderPath that's already scanned, the new scan will wait for the previous scan
+	// to finish before starting.
+	// When there's already a scan waiting, the function returns immediately with empty results.
+	waitForPreviousScan := false
+	scanStatus := NewScanStatus()
+	scanStatus.isRunning = true
+	sc.scanStatusMutex.Lock()
+	previousScanStatus, wasFound := sc.runningScans[folderPath]
+	if wasFound && previousScanStatus.isRunning {
+		if previousScanStatus.isPending {
+			return []snyk.Issue{}
+		}
+
+		waitForPreviousScan = true
+		scanStatus.isPending = true
+	}
+
+	sc.runningScans[folderPath] = scanStatus
+	sc.scanStatusMutex.Unlock()
+	if waitForPreviousScan {
+		<-previousScanStatus.finished // Block here until previous scan is finished
+
+		// Setting isPending = false allows for future scans to wait for the current
+		// scan to finish, instead of returning immediately
+		sc.scanStatusMutex.Lock()
+		scanStatus.isPending = false
+		sc.scanStatusMutex.Unlock()
+	}
+	defer func() {
+		sc.scanStatusMutex.Lock()
+		scanStatus.isRunning = false
+		close(scanStatus.finished)
+		sc.scanStatusMutex.Unlock()
+	}()
+
 	startTime := time.Now()
 	span := sc.BundleUploader.instrumentor.StartSpan(ctx, "code.ScanWorkspace")
 	defer sc.BundleUploader.instrumentor.Finish(span)
@@ -78,7 +134,8 @@ func (sc *Scanner) Scan(ctx context.Context, _ string, folderPath string) []snyk
 	}
 
 	metrics := sc.newMetrics(len(files), startTime)
-	return sc.UploadAndAnalyze(span.Context(), files, folderPath, metrics)
+	results := sc.UploadAndAnalyze(span.Context(), files, folderPath, metrics)
+	return results
 }
 
 func (sc *Scanner) files(folderPath string) (filePaths []string, err error) {

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -68,6 +68,7 @@ func New(bundleUploader *BundleUploader, apiClient snyk_api.SnykApiClient, repor
 		SnykApiClient:  apiClient,
 		errorReporter:  reporter,
 		analytics:      analytics,
+		runningScans:   map[string]*ScanStatus{},
 	}
 	return sc
 }

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -49,7 +49,7 @@ type Scanner struct {
 	analytics     ux2.Analytics
 	cli           cli.Executor
 	mutex         sync.Mutex
-	runningScans  map[sglsp.DocumentURI]*scans.RunningScan
+	runningScans  map[sglsp.DocumentURI]*scans.ScanProgress
 }
 
 func New(instrumentor performance.Instrumentor, errorReporter error_reporting.ErrorReporter, analytics ux2.Analytics, cli cli.Executor) *Scanner {
@@ -102,7 +102,7 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	if wasFound && !previousScan.IsDone() { // If there's already a scan for the current workdir, we want to cancel it and restart it
 		previousScan.CancelScan()
 	}
-	newScan := scans.NewRunningScan()
+	newScan := scans.NewScanProgress()
 	go newScan.Listen(cancel, i)
 	scanCount++
 	iac.runningScans[documentURI] = newScan

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -78,7 +78,7 @@ func (iac *Scanner) SupportedCommands() []snyk.CommandName {
 func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []snyk.Issue) {
 	if ctx.Err() != nil {
 		log.Info().Msg("Cancelling IAC scan - IAC scanner received cancellation signal")
-		return []snyk.Issue{}
+		return
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -115,6 +115,8 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 		noCancellation := ctx.Err() == nil
 		if noCancellation { // Only reports errors that are not intentional cancellations
 			iac.errorReporter.CaptureError(err)
+		} else { // If the scan was cancelled, return empty results
+			return
 		}
 	}
 

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -127,17 +127,13 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 		}
 	}
 
-	issues = iac.retrieveIssues(ctx, scanResults, issues, workspacePath, err)
+	issues = iac.retrieveIssues(scanResults, issues, workspacePath, err)
 	return issues
 }
 
-func (iac *Scanner) retrieveIssues(ctx context.Context, scanResults []iacScanResult, issues []snyk.Issue, workspacePath string, err error) []snyk.Issue {
+func (iac *Scanner) retrieveIssues(scanResults []iacScanResult, issues []snyk.Issue, workspacePath string, err error) []snyk.Issue {
 	if len(scanResults) > 0 {
 		for _, s := range scanResults {
-			if ctx.Err() != nil {
-				return nil
-			}
-
 			issues = append(issues, iac.retrieveAnalysis(s, workspacePath)...)
 		}
 	}

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -131,9 +131,6 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	iac.mutex.Lock()
 	log.Debug().Msgf("Scan %v is done", i)
 	newScan.SetDone()
-	if iac.runningScans[documentURI] == newScan {
-		delete(iac.runningScans, documentURI)
-	}
 	iac.mutex.Unlock()
 	p.End("Snyk Iac Scan completed.")
 	return issues

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -59,6 +59,7 @@ func New(instrumentor performance.Instrumentor, errorReporter error_reporting.Er
 		analytics:     analytics,
 		cli:           cli,
 		mutex:         sync.Mutex{},
+		runningScans:  map[sglsp.DocumentURI]*scans.ScanProgress{},
 	}
 }
 

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -129,7 +129,7 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 func (iac *Scanner) retrieveIssues(ctx context.Context, scanResults []iacScanResult, issues []snyk.Issue, workspacePath string, err error) []snyk.Issue {
 	if len(scanResults) > 0 {
 		for _, s := range scanResults {
-			if ctx.Err != nil {
+			if ctx.Err() != nil {
 				return nil
 			}
 

--- a/infrastructure/oss/scanner.go
+++ b/infrastructure/oss/scanner.go
@@ -181,11 +181,6 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	oss.mutex.Lock()
 	log.Debug().Msgf("Scan %v is done", i)
 	newScan.SetDone()
-
-	// Because the creation of a new scan writes over the dictionary entry for workdir, the current value is being checked
-	if oss.runningScans[workDir] == newScan {
-		delete(oss.runningScans, workDir)
-	}
 	oss.mutex.Unlock()
 
 	return issues

--- a/infrastructure/oss/scanner.go
+++ b/infrastructure/oss/scanner.go
@@ -151,18 +151,7 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 		previousScan.CancelScan()
 	}
 	newScan := scans.NewRunningScan()
-	go func(i int) {
-		log.Debug().Msgf("Starting goroutine for scan %v", i)
-		select {
-		case <-newScan.GetCancelChannel():
-			log.Debug().Msgf("Cancelling scan %v", i)
-			cancel()
-			return
-		case <-newScan.GetDoneChannel():
-			log.Debug().Msgf("Scan %v is done", i)
-			return
-		}
-	}(i)
+	go newScan.Listen(cancel, i)
 	scanCount++
 	oss.runningScans[workDir] = newScan
 	oss.mutex.Unlock()

--- a/infrastructure/oss/scanner.go
+++ b/infrastructure/oss/scanner.go
@@ -83,7 +83,7 @@ type Scanner struct {
 	analytics     ux2.Analytics
 	cli           cli.Executor
 	mutex         *sync.Mutex
-	runningScans  map[string]*scans.RunningScan
+	runningScans  map[string]*scans.ScanProgress
 }
 
 func New(instrumentor performance.Instrumentor, errorReporter error_reporting.ErrorReporter, analytics ux2.Analytics, cli cli.Executor) *Scanner {
@@ -93,7 +93,7 @@ func New(instrumentor performance.Instrumentor, errorReporter error_reporting.Er
 		analytics:     analytics,
 		cli:           cli,
 		mutex:         &sync.Mutex{},
-		runningScans:  map[string]*scans.RunningScan{},
+		runningScans:  map[string]*scans.ScanProgress{},
 	}
 }
 
@@ -150,7 +150,7 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	if wasFound && !previousScan.IsDone() { // If there's already a scan for the current workdir, we want to cancel it and restart it
 		previousScan.CancelScan()
 	}
-	newScan := scans.NewRunningScan()
+	newScan := scans.NewScanProgress()
 	go newScan.Listen(cancel, i)
 	scanCount++
 	oss.runningScans[workDir] = newScan

--- a/infrastructure/oss/scanner.go
+++ b/infrastructure/oss/scanner.go
@@ -169,7 +169,8 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 
 	cmd := oss.cli.ExpandParametersFromConfig([]string{config.CurrentConfig().CliSettings().Path(), "test", workDir, "--json"})
 	res, err := oss.cli.Execute(ctx, cmd, workDir)
-	if err != nil {
+	noCancellation := ctx.Err() == nil
+	if err != nil && noCancellation {
 		if oss.handleError(err, res, cmd) {
 			return
 		}

--- a/infrastructure/oss/scanner.go
+++ b/infrastructure/oss/scanner.go
@@ -195,10 +195,6 @@ func (oss *Scanner) unmarshallAndRetrieveAnalysis(ctx context.Context, res []byt
 	}
 
 	for _, scanResult := range scanResults {
-		if ctx.Err() != nil {
-			return nil
-		}
-
 		targetFile := oss.determineTargetFile(scanResult.DisplayTargetFile)
 		targetFilePath := filepath.Join(uri.PathFromUri(documentURI), targetFile)
 		targetFileUri := uri.PathToUri(targetFilePath)

--- a/infrastructure/oss/scanner.go
+++ b/infrastructure/oss/scanner.go
@@ -159,8 +159,12 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	cmd := oss.cli.ExpandParametersFromConfig([]string{config.CurrentConfig().CliSettings().Path(), "test", workDir, "--json"})
 	res, err := oss.cli.Execute(ctx, cmd, workDir)
 	noCancellation := ctx.Err() == nil
-	if err != nil && noCancellation {
-		if oss.handleError(err, res, cmd) {
+	if err != nil {
+		if noCancellation {
+			if oss.handleError(err, res, cmd) {
+				return
+			}
+		} else { // If scan was cancelled, return empty results
 			return
 		}
 	}

--- a/infrastructure/oss/scanner_test.go
+++ b/infrastructure/oss/scanner_test.go
@@ -207,6 +207,9 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 
 	// Act
 	for i := 0; i < concurrentScanRequests; i++ {
+		// Adding a short delay so the cancel listener will start before a new scan is sending the cancel signal
+		time.Sleep(100 * time.Millisecond)
+
 		wg.Add(1)
 		go func() {
 			scanner.Scan(context.Background(), path, folderPath)

--- a/infrastructure/oss/scanner_test.go
+++ b/infrastructure/oss/scanner_test.go
@@ -127,9 +127,8 @@ func TestUnmarshalOssJsonSingle(t *testing.T) {
 	if err != nil {
 		t.Fatal(t, "couldn't read test result file")
 	}
-	scanResults, done, err := scanner.unmarshallOssJson(fileContent)
+	scanResults, err := scanner.unmarshallOssJson(fileContent)
 	assert.NoError(t, err)
-	assert.False(t, done)
 	assert.Len(t, scanResults, 1)
 }
 
@@ -145,9 +144,8 @@ func TestUnmarshalOssJsonArray(t *testing.T) {
 	if err != nil {
 		t.Fatal(t, "couldn't read test result file")
 	}
-	scanResults, done, err := scanner.unmarshallOssJson(fileContent)
+	scanResults, err := scanner.unmarshallOssJson(fileContent)
 	assert.NoError(t, err)
-	assert.False(t, done)
 	assert.Len(t, scanResults, 3)
 }
 
@@ -163,9 +161,8 @@ func TestUnmarshalOssErroneousJson(t *testing.T) {
 	if err != nil {
 		t.Fatal(t, "couldn't read test result file")
 	}
-	scanResults, done, err := scanner.unmarshallOssJson(fileContent)
+	scanResults, err := scanner.unmarshallOssJson(fileContent)
 	assert.Error(t, err)
-	assert.True(t, done)
 	assert.Nil(t, scanResults)
 }
 

--- a/internal/scans/running_scan.go
+++ b/internal/scans/running_scan.go
@@ -22,5 +22,8 @@ func (rs *RunningScan) IsDone() bool                      { return rs.isDone }
 func (rs *RunningScan) CancelScan()                       { rs.cancel <- struct{}{} }
 func (rs *RunningScan) SetDone() {
 	rs.isDone = true
-	rs.done <- struct{}{}
+	select {
+	case rs.done <- struct{}{}: // If possible, send a done message
+	default: // If there are no listeners, do nothing
+	}
 }

--- a/internal/scans/running_scan.go
+++ b/internal/scans/running_scan.go
@@ -1,5 +1,11 @@
 package scans
 
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+)
+
 // RunningScan is a type that's used for tracking current running scans, listen to their progress events
 // and invoke cancellations or "done" signals. This allows throttling or cancelling previous scans instead of
 // having many scans running at once for the same files.
@@ -19,11 +25,30 @@ func NewRunningScan() *RunningScan {
 func (rs *RunningScan) GetDoneChannel() <-chan struct{}   { return rs.done }
 func (rs *RunningScan) GetCancelChannel() <-chan struct{} { return rs.cancel }
 func (rs *RunningScan) IsDone() bool                      { return rs.isDone }
-func (rs *RunningScan) CancelScan()                       { rs.cancel <- struct{}{} }
+func (rs *RunningScan) CancelScan() {
+	// Using select to send the signal without blocking when there are no listeners
+	select {
+	case rs.cancel <- struct{}{}:
+	default: // If no one listening, do nothing
+	}
+}
 func (rs *RunningScan) SetDone() {
 	rs.isDone = true
 	select {
 	case rs.done <- struct{}{}: // If possible, send a done message
 	default: // If there are no listeners, do nothing
+	}
+}
+
+func (rs *RunningScan) Listen(cancel context.CancelFunc, i int) {
+	log.Debug().Msgf("Starting goroutine for scan %v", i)
+	select {
+	case <-rs.GetCancelChannel():
+		log.Debug().Msgf("Cancelling scan %v", i)
+		cancel()
+		return
+	case <-rs.GetDoneChannel():
+		log.Debug().Msgf("Scan %v is done", i)
+		return
 	}
 }

--- a/internal/scans/running_scan.go
+++ b/internal/scans/running_scan.go
@@ -1,0 +1,26 @@
+package scans
+
+// RunningScan is a type that's used for tracking current running scans, listen to their progress events
+// and invoke cancellations or "done" signals. This allows throttling or cancelling previous scans instead of
+// having many scans running at once for the same files.
+type RunningScan struct {
+	isDone bool
+	done   chan struct{}
+	cancel chan struct{}
+}
+
+func NewRunningScan() *RunningScan {
+	return &RunningScan{
+		cancel: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+}
+
+func (rs *RunningScan) GetDoneChannel() <-chan struct{}   { return rs.done }
+func (rs *RunningScan) GetCancelChannel() <-chan struct{} { return rs.cancel }
+func (rs *RunningScan) IsDone() bool                      { return rs.isDone }
+func (rs *RunningScan) CancelScan()                       { rs.cancel <- struct{}{} }
+func (rs *RunningScan) SetDone() {
+	rs.isDone = true
+	rs.done <- struct{}{}
+}

--- a/internal/scans/scan_progress.go
+++ b/internal/scans/scan_progress.go
@@ -6,33 +6,33 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// RunningScan is a type that's used for tracking current running scans, listen to their progress events
+// ScanProgress is a type that's used for tracking current running scans, listen to their progress events
 // and invoke cancellations or "done" signals. This allows throttling or cancelling previous scans instead of
 // having many scans running at once for the same files.
-type RunningScan struct {
+type ScanProgress struct {
 	isDone bool
 	done   chan struct{}
 	cancel chan struct{}
 }
 
-func NewRunningScan() *RunningScan {
-	return &RunningScan{
+func NewScanProgress() *ScanProgress {
+	return &ScanProgress{
 		cancel: make(chan struct{}),
 		done:   make(chan struct{}),
 	}
 }
 
-func (rs *RunningScan) GetDoneChannel() <-chan struct{}   { return rs.done }
-func (rs *RunningScan) GetCancelChannel() <-chan struct{} { return rs.cancel }
-func (rs *RunningScan) IsDone() bool                      { return rs.isDone }
-func (rs *RunningScan) CancelScan() {
+func (rs *ScanProgress) GetDoneChannel() <-chan struct{}   { return rs.done }
+func (rs *ScanProgress) GetCancelChannel() <-chan struct{} { return rs.cancel }
+func (rs *ScanProgress) IsDone() bool                      { return rs.isDone }
+func (rs *ScanProgress) CancelScan() {
 	// Using select to send the signal without blocking when there are no listeners
 	select {
 	case rs.cancel <- struct{}{}:
 	default: // If no one listening, do nothing
 	}
 }
-func (rs *RunningScan) SetDone() {
+func (rs *ScanProgress) SetDone() {
 	rs.isDone = true
 	select {
 	case rs.done <- struct{}{}: // If possible, send a done message
@@ -40,7 +40,7 @@ func (rs *RunningScan) SetDone() {
 	}
 }
 
-func (rs *RunningScan) Listen(cancel context.CancelFunc, i int) {
+func (rs *ScanProgress) Listen(cancel context.CancelFunc, i int) {
 	log.Debug().Msgf("Starting goroutine for scan %v", i)
 	select {
 	case <-rs.GetCancelChannel():

--- a/internal/scans/scan_progress.go
+++ b/internal/scans/scan_progress.go
@@ -2,6 +2,7 @@ package scans
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -12,10 +13,15 @@ const timeout = 5 * time.Second
 // ScanProgress is a type that's used for tracking current running scans, listen to their progress events
 // and invoke cancellations or "done" signals. This allows throttling or cancelling previous scans instead of
 // having many scans running at once for the same files.
+//
+// The correct usage would be to create a NewScanProgress and call "go Listen()" to
+// listen for cancel/done signals in the background.
+// ScanProgress operations should be done in locked sections.
 type ScanProgress struct {
 	isDone bool
 	done   chan struct{}
 	cancel chan struct{}
+	mutex  sync.Mutex
 }
 
 func NewScanProgress() *ScanProgress {
@@ -25,32 +31,59 @@ func NewScanProgress() *ScanProgress {
 	}
 }
 
-func (rs *ScanProgress) GetDoneChannel() <-chan struct{}   { return rs.done }
+func (rs *ScanProgress) GetDoneChannel() <-chan struct{} { return rs.done }
+
 func (rs *ScanProgress) GetCancelChannel() <-chan struct{} { return rs.cancel }
-func (rs *ScanProgress) IsDone() bool                      { return rs.isDone }
+
+// IsDone is true if the scan finished whether by cancellation or by a SetDone call
+func (rs *ScanProgress) IsDone() bool {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+	return rs.isDone
+}
+
 func (rs *ScanProgress) CancelScan() {
 	log.Debug().Msg("Cancelling scan")
 	select {
 	case <-time.After(timeout):
-		log.Debug().Msg("No listeners for scan cancellation")
+		// This should not happen if ScanProgress is used correctly and is here for safety.
+		// Seeing this message in a log is a sign that something is wrong.
+		// There should always be a goroutine that listens for this channel
+		log.Warn().Str("method", "CancelScan").Msg("No listeners for cancel message - timing out")
 		return
 	case rs.cancel <- struct{}{}:
 		log.Debug().Msg("Cancel signal sent")
+		rs.mutex.Lock()
+		defer rs.mutex.Unlock()
+		rs.isDone = true
 	}
 }
 
+// SetDone will mark the ScanProgress as done and send a message to the "done" channel.
+// It is safe to call SetDone repeatedly, or after CancelScan was called, so it's ok to
+// defer a function that calls SetDone in a locked section.
 func (rs *ScanProgress) SetDone() {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+	if rs.isDone {
+		log.Debug().Msg("Scan progress is already done - returning without further action")
+		return
+	}
 	rs.isDone = true
 	select {
 	case <-time.After(timeout):
-		log.Debug().Msg("No listeners for Done message")
+		// This should not happen if ScanProgress is used correctly and is here for safety.
+		// Seeing this message in a log is a sign that something is wrong.
+		// There should always be a goroutine that listens for this channel
+		log.Warn().Str("method", "SetDone").Msg("No listeners for Done message - timing out")
 	case rs.done <- struct{}{}:
 		log.Debug().Msg("Done signal sent")
 	}
 }
 
 // Listen waits for cancel or done signals until one of them is received.
-// If the cancel signal is received, the cancel function will be called
+// If the cancel signal is received, the cancel function will be called.
+// Listen stops after the first signal is processed.
 func (rs *ScanProgress) Listen(cancel context.CancelFunc, scanNumber int) {
 	log.Debug().Msgf("Starting goroutine for scan %v", scanNumber)
 	cancelChannel := rs.GetCancelChannel()


### PR DESCRIPTION
### Description

Product scanners avoid running several scans at once for the same paths. For OSS & IAC the previous scans are cancelled and restarted, and for Code the new scan will wait for the previous scan to finish