### PR TITLE
feat: add cli concurrency limit [ROAD-1155]

### DIFF
--- a/infrastructure/cli/cli.go
+++ b/infrastructure/cli/cli.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"

--- a/infrastructure/cli/cli.go
+++ b/infrastructure/cli/cli.go
@@ -64,7 +64,7 @@ func NewExecutor(authenticator snyk.AuthenticationService, errorReporter error_r
 		errorReporter,
 		analytics,
 		make(chan int, concurrencyLimit),
-		90 * time.Minute, // TODO: add preference to make this configurable
+		90 * time.Minute, // TODO: add preference to make this configurable [ROAD-1184]
 	}
 }
 


### PR DESCRIPTION
### Description

_This PR should limit the concurrent CLI processes by using a semaphore. It also sets a 15 mins deadline on running CLI processes to guard against the CLI hanging._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
