### PR TITLE
fix: CLI path reset during initial download [ROAD-1183]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -68,6 +68,12 @@ type CliSettings struct {
 	cliPathAccessMutex   sync.Mutex
 }
 
+func NewCliSettings() *CliSettings {
+	settings := &CliSettings{}
+	settings.SetPath("")
+	return settings
+}
+
 func (c *CliSettings) Installed() bool {
 	c.cliPathAccessMutex.Lock()
 	defer c.cliPathAccessMutex.Unlock()
@@ -100,6 +106,16 @@ func (c *CliSettings) SetPath(path string) {
 		path = filepath.Join(c.DefaultBinaryInstallPath(), filename.ExecutableName)
 	}
 	c.cliPath = path
+}
+
+func (c *CliSettings) DefaultBinaryInstallPath() string {
+	lsPath := filepath.Join(xdg.DataHome, "snyk-ls")
+	err := os.MkdirAll(lsPath, 0755)
+	if err != nil {
+		log.Err(err).Str("method", "lsPath").Msgf("couldn't create %s", lsPath)
+		return ""
+	}
+	return lsPath
 }
 
 type Config struct {
@@ -155,8 +171,7 @@ func IsDevelopment() bool {
 // New creates a configuration object with default values
 func New() *Config {
 	c := &Config{}
-	c.cliSettings = &CliSettings{}
-	c.cliSettings.SetPath("")
+	c.cliSettings = NewCliSettings()
 	c.automaticAuthentication = true
 	c.configFile = ""
 	c.format = "md"
@@ -450,16 +465,6 @@ func (c *Config) GetOrganization() string {
 
 func (c *Config) SetOrganization(organization string) {
 	c.organization = organization
-}
-
-func (c *CliSettings) DefaultBinaryInstallPath() string {
-	lsPath := filepath.Join(xdg.DataHome, "snyk-ls")
-	err := os.MkdirAll(lsPath, 0755)
-	if err != nil {
-		log.Err(err).Str("method", "lsPath").Msgf("couldn't create %s", lsPath)
-		return ""
-	}
-	return lsPath
 }
 
 func (c *Config) ManageBinariesAutomatically() bool {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -96,6 +96,9 @@ func (c *CliSettings) Path() string {
 func (c *CliSettings) SetPath(path string) {
 	c.cliPathAccessMutex.Lock()
 	defer c.cliPathAccessMutex.Unlock()
+	if path == "" {
+		path = filepath.Join(c.DefaultBinaryInstallPath(), filename.ExecutableName)
+	}
 	c.cliPath = path
 }
 
@@ -152,9 +155,8 @@ func IsDevelopment() bool {
 // New creates a configuration object with default values
 func New() *Config {
 	c := &Config{}
-	c.cliSettings = &CliSettings{
-		cliPath: filepath.Join(c.DefaultBinaryInstallPath(), filename.ExecutableName),
-	}
+	c.cliSettings = &CliSettings{}
+	c.cliSettings.SetPath("")
 	c.automaticAuthentication = true
 	c.configFile = ""
 	c.format = "md"
@@ -242,7 +244,7 @@ func (c *Config) CliSettings() *CliSettings {
 
 func (c *Config) Format() string { return c.format }
 func (c *Config) CLIDownloadLockFileName() string {
-	return filepath.Join(c.DefaultBinaryInstallPath(), "snyk-cli-download.lock")
+	return filepath.Join(c.cliSettings.DefaultBinaryInstallPath(), "snyk-cli-download.lock")
 }
 func (c *Config) IsErrorReportingEnabled() bool          { return c.isErrorReportingEnabled.Get() }
 func (c *Config) IsSnykOssEnabled() bool                 { return c.isSnykOssEnabled.Get() }
@@ -450,7 +452,7 @@ func (c *Config) SetOrganization(organization string) {
 	c.organization = organization
 }
 
-func (c *Config) DefaultBinaryInstallPath() string {
+func (c *CliSettings) DefaultBinaryInstallPath() string {
 	lsPath := filepath.Join(xdg.DataHome, "snyk-ls")
 	err := os.MkdirAll(lsPath, 0755)
 	if err != nil {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -387,7 +387,7 @@ func (c *Config) ConfigureLogging(level string) {
 		log.Info().Msgf("Logging to file %s", c.logPath)
 		log.Logger = log.Output(file)
 	} else {
-		log.Info().Msgf("Logging to console")
+		log.Info().Msgf("Logging to console") // TODO: log using LSP's 'window/logMessage'
 	}
 }
 

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"strings"
 	"time"
 
@@ -137,6 +138,7 @@ func (i *Initializer) updateCli() {
 
 	if updated {
 		log.Info().Str("method", "updateCli").Msg("CLI updated.")
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 	} else {
 		log.Info().Str("method", "updateCli").Msg("CLI is latest.")
 	}

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime/pprof"
 	"strings"
 	"time"
 
@@ -138,7 +137,6 @@ func (i *Initializer) updateCli() {
 
 	if updated {
 		log.Info().Str("method", "updateCli").Msg("CLI updated.")
-		_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 	} else {
 		log.Info().Str("method", "updateCli").Msg("CLI is latest.")
 	}

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -90,7 +90,7 @@ func (i *Initializer) installCli() {
 		if err != nil {
 			log.Info().Str("method", "installCli").Msg("could not find Snyk CLI in user directories and PATH.")
 			cliFileName := (&install.Discovery{}).ExecutableName(false)
-			cliPath = filepath.Join(currentConfig.DefaultBinaryInstallPath(), cliFileName)
+			cliPath = filepath.Join(currentConfig.CliSettings().DefaultBinaryInstallPath(), cliFileName)
 		} else {
 			log.Info().Str("method", "installCli").Msgf("found CLI at %s", cliPath)
 		}

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -58,6 +58,7 @@ func Test_EnsureCLIShouldRespectCliPathInEnv(t *testing.T) {
 }
 
 func TestInitializer_whenNoCli_Installs(t *testing.T) {
+	testutil.UnitTest(t)
 	config.CurrentConfig().SetManageBinariesAutomatically(true)
 	settings := &config.CliSettings{}
 	testCliPath := filepath.Join(t.TempDir(), "dummy.cli")
@@ -117,6 +118,7 @@ func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
 }
 
 func TestInitializer_whenBinaryUpdatesNotAllowed_DoesNotInstall(t *testing.T) {
+	testutil.UnitTest(t)
 	config.CurrentConfig().SetManageBinariesAutomatically(false)
 
 	installer := install.NewTestInstaller()
@@ -146,6 +148,7 @@ func TestInitializer_whenOutdated_Updates(t *testing.T) {
 }
 
 func TestInitializer_whenUpToDate_DoesNotUpdates(t *testing.T) {
+	testutil.UnitTest(t)
 	config.CurrentConfig().SetManageBinariesAutomatically(true)
 	threeDaysAgo := time.Now().Add(time.Hour * 24 * 3) // exactly 4 days is considered as not outdated.
 	createDummyCliBinaryWithCreatedDate(t, threeDaysAgo)

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -75,7 +75,7 @@ func TestInitializer_whenNoCli_Installs(t *testing.T) {
 }
 
 func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
-	testutil.IntegTest(t)
+	testutil.SmokeTest(t)
 
 	// arrange
 	config.CurrentConfig().SetManageBinariesAutomatically(true)
@@ -88,10 +88,16 @@ func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
 
 	// assert
 	lockFileName := config.CurrentConfig().CLIDownloadLockFileName()
+	expectedCliPath := filepath.Join(config.CurrentConfig().CliSettings().DefaultBinaryInstallPath(), filename.ExecutableName)
+
 	defer func() { // defer clean up
 		_, err := os.Stat(lockFileName)
 		if err == nil {
 			_ = os.RemoveAll(lockFileName)
+		}
+		_, err = os.Stat(expectedCliPath)
+		if err == nil {
+			_ = os.RemoveAll(expectedCliPath)
 		}
 	}()
 
@@ -107,8 +113,7 @@ func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
 		return err == nil
 	}, time.Second*120, time.Millisecond)
 
-	expectedPath := filepath.Join(config.CurrentConfig().CliSettings().DefaultBinaryInstallPath(), filename.ExecutableName)
-	assert.Equal(t, expectedPath, config.CurrentConfig().CliSettings().Path())
+	assert.Equal(t, expectedCliPath, config.CurrentConfig().CliSettings().Path())
 }
 
 func TestInitializer_whenBinaryUpdatesNotAllowed_DoesNotInstall(t *testing.T) {

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -84,6 +84,13 @@ func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
 	installer := install.NewInstaller(error_reporting.NewTestErrorReporter())
 	initializer := NewInitializer(error_reporting.NewTestErrorReporter(), installer)
 
+	// ensure CLI is not installed on the system
+	existingCliPath, _ := installer.Find()
+	for existingCliPath != "" {
+		_ = os.RemoveAll(existingCliPath)
+		existingCliPath, _ = installer.Find()
+	}
+
 	// act
 	go initializer.Init()
 

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -97,14 +97,14 @@ func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		_, err := os.Stat(lockFileName)
-		return err == nil
+		return err != nil
 	}, time.Second*10, time.Millisecond)
 
 	config.CurrentConfig().CliSettings().SetPath("") // reset CLI path during download for foolproofing
 
 	assert.Eventually(t, func() bool {
 		_, err := installer.Find()
-		return err != nil
+		return err == nil
 	}, time.Second*120, time.Millisecond)
 
 	expectedPath := filepath.Join(config.CurrentConfig().CliSettings().DefaultBinaryInstallPath(), filename.ExecutableName)

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -87,8 +87,16 @@ func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
 	go initializer.Init()
 
 	// assert
+	lockFileName := config.CurrentConfig().CLIDownloadLockFileName()
+	defer func() { // defer clean up
+		_, err := os.Stat(lockFileName)
+		if err == nil {
+			_ = os.RemoveAll(lockFileName)
+		}
+	}()
+
 	assert.Eventually(t, func() bool {
-		_, err := os.Stat(config.CurrentConfig().CLIDownloadLockFileName())
+		_, err := os.Stat(lockFileName)
 		return err == nil
 	}, time.Second*10, time.Millisecond)
 

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -131,6 +131,7 @@ func TestInitializer_whenBinaryUpdatesNotAllowed_DoesNotInstall(t *testing.T) {
 }
 
 func TestInitializer_whenOutdated_Updates(t *testing.T) {
+	testutil.UnitTest(t)
 	config.CurrentConfig().SetManageBinariesAutomatically(true)
 	createDummyCliBinaryWithCreatedDate(t, fiveDaysAgo)
 

--- a/infrastructure/cli/install/installer.go
+++ b/infrastructure/cli/install/installer.go
@@ -230,19 +230,19 @@ func cleanupLockFile(lockFileName string) {
 type TestInstaller struct {
 	updates  int
 	installs int
-	mutex    sync.RWMutex
+	mutex    sync.Mutex
 }
 
 func (t *TestInstaller) Updates() int {
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
 
 	return t.updates
 }
 
 func (t *TestInstaller) Installs() int {
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
 
 	return t.installs
 }
@@ -269,6 +269,6 @@ func (t *TestInstaller) Update(ctx context.Context) (bool, error) {
 
 func NewTestInstaller() *TestInstaller {
 	return &TestInstaller{
-		mutex: sync.RWMutex{},
+		mutex: sync.Mutex{},
 	}
 }

--- a/infrastructure/segment/install_event.go
+++ b/infrastructure/segment/install_event.go
@@ -31,7 +31,7 @@ const (
 )
 
 func (s *Client) captureInstalledEvent() {
-	installFile := filepath.Join(config.CurrentConfig().DefaultBinaryInstallPath(), installFilename)
+	installFile := filepath.Join(config.CurrentConfig().CliSettings().DefaultBinaryInstallPath(), installFilename)
 	_, err := os.Stat(installFile)
 	if err == nil {
 		return

--- a/infrastructure/segment/install_event_test.go
+++ b/infrastructure/segment/install_event_test.go
@@ -28,7 +28,7 @@ import (
 	ux2 "github.com/snyk/snyk-ls/domain/observability/ux"
 )
 
-var installEventFile = filepath.Join(config.CurrentConfig().DefaultBinaryInstallPath(), ".installed_event_sent")
+var installEventFile = filepath.Join(config.CurrentConfig().CliSettings().DefaultBinaryInstallPath(), ".installed_event_sent")
 
 func Test_NewInstallationCreatesStateFile(t *testing.T) {
 	s, _, _ := setupUnitTest(t)


### PR DESCRIPTION
### Description

If server is started first time and CLI is not found, IDE can issue `WorkspaceDidChangeConfiguration` notification. At this point CLI path won't be set, resulting in [UpdateSettings](https://github.com/snyk/snyk-ls/blob/692b48a2a0c941df409e3ca8a2cea524e84eede6/application/server/configuration.go#L69) reseting CLI path in `CurrentConfig` during download.

When download finishes Installer would report empty path to the initializer, resulting in `Could not find, nor install Snyk CLI` error.

To solve this, we'll assume CLI path is default, whenever client (IDE) reports us an empty string for cliPath in `WorkspaceDidChangeConfiguration`.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs
![image](https://user-images.githubusercontent.com/2239563/195383553-499383e3-7cd1-4b78-929c-5a12dbd3f19c.png)
