### PR TITLE
refactor: remove redundant notifications (ROAD-1049)

### DIFF
--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -20,13 +20,10 @@ import (
 	"context"
 	"sync"
 
-	sglsp "github.com/sourcegraph/go-lsp"
-
 	"github.com/snyk/snyk-ls/application/server/lsp"
 	"github.com/snyk/snyk-ls/domain/ide/hover"
 	"github.com/snyk/snyk-ls/domain/observability/performance"
 	"github.com/snyk/snyk-ls/domain/snyk"
-	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/uri"
 )
 
@@ -90,10 +87,6 @@ func (w *Workspace) GetFolderContaining(path string) (folder *Folder) {
 }
 
 func (w *Workspace) ScanWorkspace(ctx context.Context) {
-	if len(w.folders) > 0 {
-		notification.Send(sglsp.ShowMessageParams{Type: sglsp.Info, Message: "Workspace scan started."})
-	}
-
 	for _, folder := range w.folders {
 		go folder.ScanFolder(ctx)
 	}

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -99,12 +99,16 @@ func (i *Initializer) installCli() {
 
 	// Check if the file is actually in the cliPath
 	if !currentConfig.CliSettings().Installed() {
+		notification.Send(sglsp.ShowMessageParams{Type: sglsp.Info, Message: "Snyk CLI will be downloaded to run security scans."})
 		cliPath, err = i.installer.Install(context.Background())
 		notification.Send(lsp.SnykIsAvailableCli{CliPath: cliPath})
 		if err != nil {
 			log.Err(err).Str("method", "installCli").Msg("could not download Snyk CLI binary")
 			i.handleInstallerError(err)
+			notification.Send(sglsp.ShowMessageParams{Type: sglsp.Warning, Message: "Failed to download Snyk CLI."})
 			cliPath, _ = i.installer.Find()
+		} else {
+			notification.Send(sglsp.ShowMessageParams{Type: sglsp.Info, Message: "Snyk CLI has been downloaded."})
 		}
 	}
 

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -99,8 +99,6 @@ func (i *Initializer) installCli() {
 
 	// Check if the file is actually in the cliPath
 	if !currentConfig.CliSettings().Installed() {
-		notification.Send(sglsp.ShowMessageParams{Type: sglsp.Info, Message: "Snyk CLI needs to be installed."})
-
 		cliPath, err = i.installer.Install(context.Background())
 		notification.Send(lsp.SnykIsAvailableCli{CliPath: cliPath})
 		if err != nil {


### PR DESCRIPTION
### Description

- Avoid "workspace scan" notification, as this is communicated via IDE progress elements.
- Clarify Snyk CLI notification
- Add successful and unsuccessful messaging to Snyk CLI downloads

Context:
https://snyk.slack.com/archives/G01QAALCGH4/p1666007565172169

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs
**Old**
![image](https://user-images.githubusercontent.com/2239563/196172546-be16de9b-d63e-46e9-8367-bd0ecf3e8066.png)
**New**
<img width="563" alt="Screenshot 2022-10-18 at 09 34 24" src="https://user-images.githubusercontent.com/2239563/196366038-8a8d5ecf-06e9-4c57-913e-a859175d40e5.png">
