### PR TITLE
fix: empty integration reported to CLI in auth provider [ROAD-1049]

### DIFF
--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -186,15 +186,7 @@ func (a *CliAuthenticationProvider) buildCLICmd(ctx context.Context, args ...str
 		args = append(args, "--insecure")
 	}
 	cmd := exec.CommandContext(ctx, config.CurrentConfig().CliSettings().Path(), args...)
-	cmd.Env = os.Environ()
-
-	endpoint := config.CurrentConfig().SnykApi()
-	if endpoint != "" {
-		cmd.Env = append(cmd.Env, cli.ApiEnvVar+"="+endpoint)
-	}
-	if !config.CurrentConfig().IsTelemetryEnabled() {
-		cmd.Env = append(cmd.Env, cli.DisableAnalyticsEnvVar+"=1")
-	}
+	cmd.Env = cli.AppendCliEnvironmentVariables(os.Environ())
 
 	log.Info().Str("command", cmd.String()).Interface("env", cmd.Env).Msg("running Snyk CLI command")
 	return cmd

--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -186,7 +186,7 @@ func (a *CliAuthenticationProvider) buildCLICmd(ctx context.Context, args ...str
 		args = append(args, "--insecure")
 	}
 	cmd := exec.CommandContext(ctx, config.CurrentConfig().CliSettings().Path(), args...)
-	cmd.Env = cli.AppendCliEnvironmentVariables(os.Environ())
+	cmd.Env = cli.AppendCliEnvironmentVariables(os.Environ(), false)
 
 	log.Info().Str("command", cmd.String()).Interface("env", cmd.Env).Msg("running Snyk CLI command")
 	return cmd

--- a/infrastructure/cli/cli.go
+++ b/infrastructure/cli/cli.go
@@ -114,40 +114,10 @@ func (c SnykCli) doExecute(ctx context.Context, cmd []string, workingDir string,
 func (c SnykCli) getCommand(cmd []string, workingDir string, ctx context.Context) *exec.Cmd {
 	command := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
 	command.Dir = workingDir
-	cliEnv := appendCliEnvironmentVariables(os.Environ())
+	cliEnv := AppendCliEnvironmentVariables(os.Environ())
 	command.Env = cliEnv
 	log.Debug().Str("method", "getCommand").Interface("command", command).Send()
 	return command
-}
-
-// Returns the input array with additional variables used in the CLI run in the form of "key=value".
-// Since we append, our values are overwriting existing env variables (because exec.Cmd.Env chooses the last value
-// in case of key duplications).
-func appendCliEnvironmentVariables(currentEnv []string) (updatedEnv []string) {
-	updatedEnv = currentEnv
-
-	currentConfig := config.CurrentConfig()
-	organization := currentConfig.GetOrganization()
-	if organization != "" {
-		updatedEnv = append(updatedEnv, OrganizationEnvVar+"="+organization)
-	}
-
-	updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
-	if currentConfig.SnykApi() != "" {
-		updatedEnv = append(updatedEnv, ApiEnvVar+"="+currentConfig.SnykApi())
-	}
-	if !currentConfig.IsTelemetryEnabled() {
-		updatedEnv = append(updatedEnv, DisableAnalyticsEnvVar+"=1")
-	}
-
-	if currentConfig.IntegrationName() != "" {
-		updatedEnv = append(updatedEnv, IntegrationNameEnvVarKey+"="+currentConfig.IntegrationName())
-		updatedEnv = append(updatedEnv, IntegrationVersionEnvVarKey+"="+currentConfig.IntegrationVersion())
-	}
-	updatedEnv = append(updatedEnv, IntegrationEnvironmentEnvVarKey+"="+IntegrationEnvironmentEnvVarValue)
-	updatedEnv = append(updatedEnv, IntegrationEnvironmentVersionEnvVar+"="+config.Version)
-
-	return
 }
 
 // todo no need to export that, we could have a simpler interface that looks more like an actual CLI

--- a/infrastructure/cli/cli.go
+++ b/infrastructure/cli/cli.go
@@ -34,18 +34,6 @@ import (
 	"github.com/snyk/snyk-ls/internal/notification"
 )
 
-const (
-	OrganizationEnvVar                  = "SNYK_CFG_ORG"
-	ApiEnvVar                           = "SNYK_API"
-	TokenEnvVar                         = "SNYK_TOKEN"
-	DisableAnalyticsEnvVar              = "SNYK_CFG_DISABLE_ANALYTICS"
-	IntegrationNameEnvVarKey            = "SNYK_INTEGRATION_NAME"
-	IntegrationVersionEnvVarKey         = "SNYK_INTEGRATION_VERSION"
-	IntegrationEnvironmentEnvVarKey     = "SNYK_INTEGRATION_ENVIRONMENT"
-	IntegrationEnvironmentVersionEnvVar = "SNYK_INTEGRATION_ENVIRONMENT_VERSION"
-	IntegrationEnvironmentEnvVarValue   = "language-server"
-)
-
 type SnykCli struct {
 	authenticator snyk.AuthenticationService
 	errorReporter error_reporting.ErrorReporter
@@ -114,7 +102,7 @@ func (c SnykCli) doExecute(ctx context.Context, cmd []string, workingDir string,
 func (c SnykCli) getCommand(cmd []string, workingDir string, ctx context.Context) *exec.Cmd {
 	command := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
 	command.Dir = workingDir
-	cliEnv := AppendCliEnvironmentVariables(os.Environ())
+	cliEnv := AppendCliEnvironmentVariables(os.Environ(), true)
 	command.Env = cliEnv
 	log.Debug().Str("method", "getCommand").Interface("command", command).Send()
 	return command

--- a/infrastructure/cli/cli_test.go
+++ b/infrastructure/cli/cli_test.go
@@ -68,7 +68,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		config.CurrentConfig().SetIntegrationName(expectedIntegrationName)
 		config.CurrentConfig().SetIntegrationVersion(expectedIntegrationVersion)
 
-		updatedEnv := appendCliEnvironmentVariables([]string{})
+		updatedEnv := AppendCliEnvironmentVariables([]string{})
 
 		assert.Contains(t, updatedEnv, "SNYK_CFG_ORG="+config.CurrentConfig().GetOrganization())
 		assert.Contains(t, updatedEnv, "SNYK_API=https://app.snyk.io/api")
@@ -84,7 +84,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		testutil.UnitTest(t)
 		config.CurrentConfig().SetTelemetryEnabled(false)
 
-		updatedEnv := appendCliEnvironmentVariables([]string{})
+		updatedEnv := AppendCliEnvironmentVariables([]string{})
 
 		assert.Contains(t, updatedEnv, "SNYK_CFG_DISABLE_ANALYTICS=1")
 	})

--- a/infrastructure/cli/cli_test.go
+++ b/infrastructure/cli/cli_test.go
@@ -57,39 +57,6 @@ func Test_ExpandParametersFromConfigNoAllProjectsForIac(t *testing.T) {
 	assert.Contains(t, cmd, "-d")
 }
 
-func TestAddConfigValuesToEnv(t *testing.T) {
-	t.Run("Adds values to env", func(t *testing.T) {
-		const expectedIntegrationName = "ECLIPSE"
-		const expectedIntegrationVersion = "0.0.1rc1"
-
-		testutil.UnitTest(t)
-		config.CurrentConfig().SetOrganization("testOrg")
-		config.CurrentConfig().UpdateApiEndpoints("https://app.snyk.io/api")
-		config.CurrentConfig().SetIntegrationName(expectedIntegrationName)
-		config.CurrentConfig().SetIntegrationVersion(expectedIntegrationVersion)
-
-		updatedEnv := AppendCliEnvironmentVariables([]string{})
-
-		assert.Contains(t, updatedEnv, "SNYK_CFG_ORG="+config.CurrentConfig().GetOrganization())
-		assert.Contains(t, updatedEnv, "SNYK_API=https://app.snyk.io/api")
-		assert.Contains(t, updatedEnv, "SNYK_TOKEN="+config.CurrentConfig().Token())
-		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_NAME="+expectedIntegrationName)
-		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_VERSION="+expectedIntegrationVersion)
-		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_ENVIRONMENT="+IntegrationEnvironmentEnvVarValue)
-		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_ENVIRONMENT_VERSION="+config.Version)
-		assert.NotContains(t, updatedEnv, "SNYK_CFG_DISABLE_ANALYTICS=1")
-	})
-
-	t.Run("Disables analytics, if telemetry disabled", func(t *testing.T) {
-		testutil.UnitTest(t)
-		config.CurrentConfig().SetTelemetryEnabled(false)
-
-		updatedEnv := AppendCliEnvironmentVariables([]string{})
-
-		assert.Contains(t, updatedEnv, "SNYK_CFG_DISABLE_ANALYTICS=1")
-	})
-}
-
 func TestGetCommand_AddsToEnvironmentAndSetsDir(t *testing.T) {
 	testutil.UnitTest(t)
 	config.CurrentConfig().SetOrganization("TestGetCommand_AddsToEnvironmentAndSetsDirOrg")

--- a/infrastructure/cli/environment.go
+++ b/infrastructure/cli/environment.go
@@ -2,10 +2,23 @@ package cli
 
 import "github.com/snyk/snyk-ls/application/config"
 
+const (
+	OrganizationEnvVar                  = "SNYK_CFG_ORG"
+	ApiEnvVar                           = "SNYK_API"
+	TokenEnvVar                         = "SNYK_TOKEN"
+	DisableAnalyticsEnvVar              = "SNYK_CFG_DISABLE_ANALYTICS"
+	IntegrationNameEnvVarKey            = "SNYK_INTEGRATION_NAME"
+	IntegrationVersionEnvVarKey         = "SNYK_INTEGRATION_VERSION"
+	IntegrationEnvironmentEnvVarKey     = "SNYK_INTEGRATION_ENVIRONMENT"
+	IntegrationEnvironmentVersionEnvVar = "SNYK_INTEGRATION_ENVIRONMENT_VERSION"
+	IntegrationEnvironmentEnvVarValue   = "language-server"
+)
+
 // Returns the input array with additional variables used in the CLI run in the form of "key=value".
 // Since we append, our values are overwriting existing env variables (because exec.Cmd.Env chooses the last value
 // in case of key duplications).
-func AppendCliEnvironmentVariables(currentEnv []string) (updatedEnv []string) {
+// appendToken indicates whether we should append the token or not. No token should be appended in cases such as authentication.
+func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updatedEnv []string) {
 	updatedEnv = currentEnv
 
 	currentConfig := config.CurrentConfig()
@@ -14,7 +27,9 @@ func AppendCliEnvironmentVariables(currentEnv []string) (updatedEnv []string) {
 		updatedEnv = append(updatedEnv, OrganizationEnvVar+"="+organization)
 	}
 
-	updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
+	if appendToken {
+		updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
+	}
 	if currentConfig.SnykApi() != "" {
 		updatedEnv = append(updatedEnv, ApiEnvVar+"="+currentConfig.SnykApi())
 	}

--- a/infrastructure/cli/environment.go
+++ b/infrastructure/cli/environment.go
@@ -1,0 +1,33 @@
+package cli
+
+import "github.com/snyk/snyk-ls/application/config"
+
+// Returns the input array with additional variables used in the CLI run in the form of "key=value".
+// Since we append, our values are overwriting existing env variables (because exec.Cmd.Env chooses the last value
+// in case of key duplications).
+func AppendCliEnvironmentVariables(currentEnv []string) (updatedEnv []string) {
+	updatedEnv = currentEnv
+
+	currentConfig := config.CurrentConfig()
+	organization := currentConfig.GetOrganization()
+	if organization != "" {
+		updatedEnv = append(updatedEnv, OrganizationEnvVar+"="+organization)
+	}
+
+	updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
+	if currentConfig.SnykApi() != "" {
+		updatedEnv = append(updatedEnv, ApiEnvVar+"="+currentConfig.SnykApi())
+	}
+	if !currentConfig.IsTelemetryEnabled() {
+		updatedEnv = append(updatedEnv, DisableAnalyticsEnvVar+"=1")
+	}
+
+	if currentConfig.IntegrationName() != "" {
+		updatedEnv = append(updatedEnv, IntegrationNameEnvVarKey+"="+currentConfig.IntegrationName())
+		updatedEnv = append(updatedEnv, IntegrationVersionEnvVarKey+"="+currentConfig.IntegrationVersion())
+	}
+	updatedEnv = append(updatedEnv, IntegrationEnvironmentEnvVarKey+"="+IntegrationEnvironmentEnvVarValue)
+	updatedEnv = append(updatedEnv, IntegrationEnvironmentVersionEnvVar+"="+config.Version)
+
+	return
+}

--- a/infrastructure/cli/environment.go
+++ b/infrastructure/cli/environment.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cli
 
 import "github.com/snyk/snyk-ls/application/config"

--- a/infrastructure/cli/environment_test.go
+++ b/infrastructure/cli/environment_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/internal/testutil"
+)
+
+func TestAddConfigValuesToEnv(t *testing.T) {
+	t.Run("Adds values to env", func(t *testing.T) {
+		const expectedIntegrationName = "ECLIPSE"
+		const expectedIntegrationVersion = "0.0.1rc1"
+
+		testutil.UnitTest(t)
+		config.CurrentConfig().SetOrganization("testOrg")
+		config.CurrentConfig().UpdateApiEndpoints("https://app.snyk.io/api")
+		config.CurrentConfig().SetIntegrationName(expectedIntegrationName)
+		config.CurrentConfig().SetIntegrationVersion(expectedIntegrationVersion)
+
+		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
+
+		assert.Contains(t, updatedEnv, "SNYK_CFG_ORG="+config.CurrentConfig().GetOrganization())
+		assert.Contains(t, updatedEnv, "SNYK_API=https://app.snyk.io/api")
+		assert.Contains(t, updatedEnv, "SNYK_TOKEN="+config.CurrentConfig().Token())
+		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_NAME="+expectedIntegrationName)
+		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_VERSION="+expectedIntegrationVersion)
+		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_ENVIRONMENT="+IntegrationEnvironmentEnvVarValue)
+		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_ENVIRONMENT_VERSION="+config.Version)
+		assert.NotContains(t, updatedEnv, "SNYK_CFG_DISABLE_ANALYTICS=1")
+	})
+
+	t.Run("Disables analytics, if telemetry disabled", func(t *testing.T) {
+		testutil.UnitTest(t)
+		config.CurrentConfig().SetTelemetryEnabled(false)
+
+		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
+
+		assert.Contains(t, updatedEnv, "SNYK_CFG_DISABLE_ANALYTICS=1")
+	})
+}


### PR DESCRIPTION
### Description

CLI crafts authentication url with wrong UTM parameters when LS is launched via VS Code (see `CLI_V1_PLUGIN`):
`https://app.snyk.io/login/cli?token=4bc3ddde-1209-4fef-b0e3-4a64fedc325c&utm_medium=cli&utm_source=cli&utm_campaign=CLI_V1_PLUGIN&utm_campaign_content=1.1032.0&os=darwin&docker=false`
vs. Eclipse:
`https://app.snyk.io/login/cli?token=4e29b656-90cb-42e5-90af-ce3512c19d59&utm_medium=cli&utm_source=cli&utm_campaign=ECLIPSE&utm_campaign_content=2.0.0.202209271622&os=darwin&docker=false`

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
