### PR TITLE
feat: allow setting device Id by clients [ROAD-1049]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -496,6 +496,10 @@ func (c *Config) DeviceID() string {
 	return c.deviceId
 }
 
+func (c *Config) SetDeviceID(deviceId string) {
+	c.deviceId = deviceId
+}
+
 func (c *Config) ClientCapabilities() lsp.ClientCapabilities {
 	return c.clientCapabilities
 }

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -77,6 +77,7 @@ func WorkspaceDidChangeConfiguration(srv *jrpc2.Server) jrpc2.Handler {
 func InitializeSettings(ctx context.Context, settings lsp.Settings) {
 	writeSettings(ctx, settings, true)
 	updateAutoAuthentication(settings)
+	updateDeviceInformation(settings)
 }
 
 func UpdateSettings(ctx context.Context, settings lsp.Settings) {
@@ -107,6 +108,13 @@ func updateAutoAuthentication(settings lsp.Settings) {
 	} else {
 		// When the field is omitted, set to true by default
 		config.CurrentConfig().SetAutomaticAuthentication(true)
+	}
+}
+
+func updateDeviceInformation(settings lsp.Settings) {
+	deviceId := strings.TrimSpace(settings.DeviceId)
+	if deviceId != "" {
+		config.CurrentConfig().SetDeviceID(deviceId)
 	}
 }
 

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -238,3 +238,28 @@ func Test_UpdateSettings(t *testing.T) {
 		})
 	})
 }
+
+func Test_InitializeSettings(t *testing.T) {
+	testutil.UnitTest(t)
+	di.TestInit(t)
+
+	t.Run("device ID is passed", func(t *testing.T) {
+		config.SetCurrentConfig(config.New())
+		deviceId := "test-device-id"
+
+		InitializeSettings(context.Background(), lsp.Settings{DeviceId: deviceId})
+
+		c := config.CurrentConfig()
+		assert.Equal(t, deviceId, c.DeviceID())
+	})
+
+	t.Run("device ID is not passed", func(t *testing.T) {
+		config.SetCurrentConfig(config.New())
+		curentDeviceId := config.CurrentConfig().DeviceID()
+
+		InitializeSettings(context.Background(), lsp.Settings{})
+
+		c := config.CurrentConfig()
+		assert.Equal(t, curentDeviceId, c.DeviceID())
+	})
+}

--- a/application/server/lsp/message_types.go
+++ b/application/server/lsp/message_types.go
@@ -248,6 +248,7 @@ type Settings struct {
 	IntegrationName             string `json:"integrationName,omitempty"`
 	IntegrationVersion          string `json:"integrationVersion,omitempty"`
 	AutomaticAuthentication     string `json:"automaticAuthentication,omitempty"`
+	DeviceId                    string `json:"deviceId,omitempty"`
 }
 
 type DidChangeConfigurationParams struct {

--- a/infrastructure/segment/client.go
+++ b/infrastructure/segment/client.go
@@ -33,7 +33,6 @@ import (
 
 type Client struct {
 	authenticatedUserId string
-	anonymousUserId     string
 	segment             segment.Client
 	snykApiClient       snyk_api.SnykApiClient
 	errorReporter       error_reporting.ErrorReporter
@@ -134,7 +133,7 @@ func (s *Client) Identify() {
 	}
 
 	err = s.segment.Enqueue(analytics.Identify{
-		AnonymousId: s.anonymousUserId,
+		AnonymousId: config.CurrentConfig().DeviceID(),
 		UserId:      s.authenticatedUserId,
 	})
 	if err != nil {

--- a/infrastructure/segment/client.go
+++ b/infrastructure/segment/client.go
@@ -45,10 +45,9 @@ func NewSegmentClient(snykApiClient snyk_api.SnykApiClient, errorReporter error_
 		log.Error().Str("method", "NewSegmentClient").Err(err).Msg("Error creating segment client")
 	}
 	segmentClient := &Client{
-		segment:         client,
-		snykApiClient:   snykApiClient,
-		errorReporter:   errorReporter,
-		anonymousUserId: config.CurrentConfig().DeviceID(),
+		segment:       client,
+		snykApiClient: snykApiClient,
+		errorReporter: errorReporter,
 	}
 
 	return segmentClient
@@ -103,7 +102,7 @@ func (s *Client) enqueueEvent(properties interface{}, event string) {
 			UserId:      s.authenticatedUserId,
 			Event:       event,
 			Properties:  s.getSerialisedProperties(properties),
-			AnonymousId: s.anonymousUserId,
+			AnonymousId: config.CurrentConfig().DeviceID(),
 		})
 		if err != nil {
 			log.Warn().Err(err).Msg("Couldn't enqueue analytics")

--- a/infrastructure/segment/client_test.go
+++ b/infrastructure/segment/client_test.go
@@ -41,7 +41,7 @@ func TestClient_IdentifyAuthenticatedUser(t *testing.T) {
 	assert.Equal(t, 1, len(fakeSegmentClient.trackedEvents))
 	assert.Equal(t, fakeSegmentClient.trackedEvents[0], analytics.Identify{
 		UserId:      s.authenticatedUserId,
-		AnonymousId: s.anonymousUserId,
+		AnonymousId: config.CurrentConfig().DeviceID(),
 	})
 }
 

--- a/infrastructure/segment/install_event_test.go
+++ b/infrastructure/segment/install_event_test.go
@@ -50,7 +50,7 @@ func Test_NewInstallationSendsInstallEvent(t *testing.T) {
 	assert.Equal(t, segment.Track{
 		UserId:      "",
 		Event:       "Plugin Is Installed",
-		AnonymousId: s.anonymousUserId,
+		AnonymousId: config.CurrentConfig().DeviceID(),
 		Properties: segment.Properties{}.
 			Set("ide", ux2.IDE("Visual Studio Code")).
 			Set("itly", true),


### PR DESCRIPTION
### Description

Language Server clients may generate Device ID themselves for telemetry. We want to respect it in order to map it onto authenticated ID for analytical purposes.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

