### PR TITLE
feat: scan after server initialization

### DIFF
--- a/application/server/lsp/message_types.go
+++ b/application/server/lsp/message_types.go
@@ -161,6 +161,8 @@ type InitializeParams struct {
 	WorkspaceFolders []WorkspaceFolder `json:"workspaceFolders,omitempty"`
 }
 
+type InitializedParams struct{}
+
 type ServerCapabilities struct {
 	TextDocumentSync                 *sglsp.TextDocumentSyncOptionsOrKind   `json:"textDocumentSync,omitempty"`
 	HoverProvider                    bool                                   `json:"hoverProvider,omitempty"`

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -78,6 +78,7 @@ func Start() {
 
 func initHandlers(srv *jrpc2.Server, handlers *handler.Map) {
 	(*handlers)["initialize"] = InitializeHandler(srv)
+	(*handlers)["initialized"] = InitializedHandler(srv)
 	(*handlers)["textDocument/didOpen"] = TextDocumentDidOpenHandler()
 	(*handlers)["textDocument/didChange"] = NoOpHandler()
 	(*handlers)["textDocument/didClose"] = NoOpHandler()
@@ -200,7 +201,7 @@ func InitializeHandler(srv *jrpc2.Server) handler.Func {
 				w.AddFolder(workspace.NewFolder(params.RootPath, params.ClientInfo.Name, di.Scanner(), di.HoverService()))
 			}
 		}
-		w.ScanWorkspace(context.Background())
+
 		return lsp.InitializeResult{
 			ServerInfo: lsp.ServerInfo{
 				Name:    "snyk-ls",
@@ -235,6 +236,12 @@ func InitializeHandler(srv *jrpc2.Server) handler.Func {
 				},
 			},
 		}, nil
+	})
+}
+func InitializedHandler(srv *jrpc2.Server) handler.Func {
+	return handler.New(func(ctx context.Context, params lsp.InitializedParams) (interface{}, error) {
+		workspace.Get().ScanWorkspace(context.Background())
+		return nil, nil
 	})
 }
 


### PR DESCRIPTION
### Description

At the moment when server is responding to initialization request, it runs workspace scan. This results in notifications (e.g. `SnykIsAvailableCli`) to be sent during initialization.

Unfortunately, VS Code language client `v8.0.0-next.2` is not ready to react to notifications during initialization process, since it doesn't see server in the readiness state (see [here](https://github.com/microsoft/vscode-languageserver-node/blob/cdf4d6fdaefe329ce417621cf0f8b14e0b9bb39d/client/src/common/client.ts#L3307) when server is ready to accept notifications).

The sibling PR for VS Code, fixing the readiness state is https://github.com/snyk/vscode-extension/pull/298

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced