### PR TITLE
POC: Breadcrumbs in Sentry events

### DIFF
--- a/application/di/init.go
+++ b/application/di/init.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
+	"github.com/rs/zerolog"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/ide/hover"
@@ -57,6 +58,7 @@ var analytics ux2.Analytics
 var snykCli cli2.Executor
 var hoverService hover.Service
 var scanner snyk.Scanner
+var logger zerolog.Logger
 
 var initMutex = &sync.Mutex{}
 
@@ -108,6 +110,8 @@ func initInfrastructure() {
 		cli2.NewInitializer(errorReporter, install.NewInstaller(errorReporter)),
 		auth2.NewInitializer(authenticator, errorReporter, analytics),
 	)
+	logger = logger.Hook(&sentry2.BreadcrumbLogger{})
+	logger.Info().Msg("Hello")
 }
 
 // TODO this is becoming a hot mess we need to unify integ. test strategies
@@ -203,4 +207,10 @@ func Installer() install.Installer {
 	initMutex.Lock()
 	defer initMutex.Unlock()
 	return installer
+}
+
+func Logger() zerolog.Logger {
+	initMutex.Lock()
+	defer initMutex.Unlock()
+	return logger
 }

--- a/infrastructure/sentry/breadcrumb_logger.go
+++ b/infrastructure/sentry/breadcrumb_logger.go
@@ -1,0 +1,39 @@
+package sentry
+
+import (
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/rs/zerolog"
+)
+
+type BreadcrumbLogger struct{}
+
+func (l *BreadcrumbLogger) Run(_ *zerolog.Event, level zerolog.Level, message string) {
+	breadcrumb := sentry.Breadcrumb{
+		Type:      level.String(),
+		Message:   message,
+		Level:     toSentryLevel(level),
+		Timestamp: time.Now(),
+	}
+	sentry.AddBreadcrumb(&breadcrumb)
+}
+
+func toSentryLevel(l zerolog.Level) sentry.Level {
+	switch l {
+	case zerolog.FatalLevel:
+	case zerolog.PanicLevel:
+		return sentry.LevelFatal
+	case zerolog.ErrorLevel:
+		return sentry.LevelError
+	case zerolog.WarnLevel:
+		return sentry.LevelWarning
+	case zerolog.TraceLevel:
+	case zerolog.DebugLevel:
+		return sentry.LevelDebug
+	case zerolog.InfoLevel:
+		return sentry.LevelInfo
+	}
+
+	return sentry.LevelInfo
+}


### PR DESCRIPTION
### Description

Demonstrating how to include breadcrumbs in Sentry events. 
Implementing all over the codebase would mean replacing all the `log.x` statements with a logger from the DI module.