### PR TITLE
[ROAD-1227] fix: CLI path not provided error

### DIFF
--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -241,8 +241,8 @@ func Test_TextDocumentCodeLenses_shouldReturnCodeLenses(t *testing.T) {
 			ActivateSnykIac:             "false",
 			Organization:                "fancy org",
 			Token:                       "xxx",
-			ManageBinariesAutomatically: "false",
-			CliPath:                     "dummy",
+			ManageBinariesAutomatically: "true",
+			CliPath:                     "",
 		},
 	}
 	_, err := loc.Client.Call(ctx, "initialize", clientParams)
@@ -261,7 +261,7 @@ func Test_TextDocumentCodeLenses_shouldReturnCodeLenses(t *testing.T) {
 			path := uri.PathFromUri(didOpenParams.TextDocument.URI)
 			return workspace.Get().GetFolderContaining(path).DocumentDiagnosticsFromCache(path) != nil
 		},
-		5*time.Second,
+		50*time.Second,
 		time.Millisecond,
 		"Couldn't get diagnostics from cache",
 	)

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -480,8 +480,8 @@ func Test_textDocumentDidOpenHandler_shouldAcceptDocumentItemAndPublishDiagnosti
 			ActivateSnykIac:             "false",
 			Organization:                "fancy org",
 			Token:                       "xxx",
-			ManageBinariesAutomatically: "false",
-			CliPath:                     "dummy",
+			ManageBinariesAutomatically: "true",
+			CliPath:                     "",
 		},
 	}
 	_, err := loc.Client.Call(ctx, "initialize", clientParams)

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -47,7 +47,6 @@ func NewInitializer(errorReporter error_reporting.ErrorReporter, installer insta
 }
 
 func (i *Initializer) Init() error {
-	const errorMessage = "could not download CLI" // Returning an error notifies that the scan cannot continue
 	Mutex.Lock()
 	defer Mutex.Unlock()
 
@@ -55,7 +54,7 @@ func (i *Initializer) Init() error {
 	if !config.CurrentConfig().ManageBinariesAutomatically() {
 		if !cliInstalled {
 			notification.SendShowMessage(sglsp.Warning, "Automatic CLI downloads are disabled and no CLI path is configured. Enable automatic downloads or set a valid CLI path.")
-			return errors.New(errorMessage)
+			return errors.New("automatic management of binaries is disabled, and CLI is not found")
 		}
 		return nil
 	}
@@ -75,7 +74,7 @@ func (i *Initializer) Init() error {
 			config.CurrentConfig().SetSnykOssEnabled(false)
 			log.Warn().Str("method", "cli.Init").Msg("Disabling Snyk OSS and Snyk Iac as no CLI found after 3 tries")
 
-			return errors.New(errorMessage)
+			return errors.New("could not find or download CLI")
 		}
 		i.installCli()
 		if !config.CurrentConfig().CliSettings().Installed() {

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -103,7 +103,6 @@ func (i *Initializer) installCli() {
 	if !currentConfig.CliSettings().Installed() {
 		notification.SendShowMessage(sglsp.Info, "Snyk CLI will be downloaded to run security scans.")
 		cliPath, err = i.installer.Install(context.Background())
-		notification.Send(lsp.SnykIsAvailableCli{CliPath: cliPath})
 		if err != nil {
 			log.Err(err).Str("method", "installCli").Msg("could not download Snyk CLI binary")
 			i.handleInstallerError(err)


### PR DESCRIPTION
### Description

Fixed an error where the `$/snyk.isAvailableCli` message is sent with an empty CLI path.

_(Note that the message is sent on line 117, so no further changes needed)_