### PR TITLE
fix: don't report authentication timeouts [ROAD-1213]

### DIFF
--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -47,7 +47,10 @@ func (a *CliAuthenticationProvider) Authenticate(ctx context.Context) (string, e
 	err := a.authenticate(ctx)
 	if err != nil {
 		log.Err(err).Str("method", "Authenticate").Msg("error while authenticating")
-		a.errorReporter.CaptureError(err)
+		const timedOutExitCode = 2
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != timedOutExitCode {
+			a.errorReporter.CaptureError(err)
+		}
 	}
 	token, err := a.getToken(ctx)
 	log.Debug().Str("method", "Authenticate").Int("token length", len(token)).Msg("got token")

--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -50,7 +50,8 @@ func (a *CliAuthenticationProvider) Authenticate(ctx context.Context) (string, e
 
 		// No need to report the error when it's due to the user not authenticating
 		const timedOutExitCode = 2
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != timedOutExitCode {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok || exitErr.ExitCode() != timedOutExitCode {
 			a.errorReporter.CaptureError(err)
 		}
 	}

--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -54,6 +54,8 @@ func (a *CliAuthenticationProvider) Authenticate(ctx context.Context) (string, e
 		if !ok || exitErr.ExitCode() != timedOutExitCode {
 			a.errorReporter.CaptureError(err)
 		}
+
+		return "", err
 	}
 	token, err := a.getToken(ctx)
 	log.Debug().Str("method", "Authenticate").Int("token length", len(token)).Msg("got token")

--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -47,6 +47,8 @@ func (a *CliAuthenticationProvider) Authenticate(ctx context.Context) (string, e
 	err := a.authenticate(ctx)
 	if err != nil {
 		log.Err(err).Str("method", "Authenticate").Msg("error while authenticating")
+
+		// No need to report the error when it's due to the user not authenticating
 		const timedOutExitCode = 2
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != timedOutExitCode {
 			a.errorReporter.CaptureError(err)


### PR DESCRIPTION
### Description

Stops reporting authentication timeouts to Sentry
