### PR TITLE
feat: add trust management mechanism

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,4 +60,4 @@ dist: build
 env:
   - GO111MODULE=on
   - CGO_ENABLED=0
-  - LS_PROTOCOL_VERSION=3
+  - LS_PROTOCOL_VERSION=4

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ tools:
 	@echo "==> Installing go-licenses"
 	@go install github.com/google/go-licenses@latest
 ifeq (,$(wildcard ./.bin/golangci-lint*))
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.48.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.50.0
 else
 	@echo "==> golangci-lint is already installed"
 endif

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Right now the language server supports the following actions:
   }
   ```
 
+- Trust Notification
+  - method: `$/snyk.addTrustedFolders`
+  - payload:
+  ```json
+  {
+    "trustedFolders": ["/a/path/to/trust"]
+  }
+  ```
+
 ## Installation
 
 ### Download
@@ -132,11 +141,36 @@ within `initializationOptions?: LSPAny;` we support the following settings:
   "organization": "a string", // The name of your organization, e.g. the output of: curl -H "Authorization: token $(snyk config get api)"  https://snyk.io/api/cli-config/settings/sast | jq .org
   "enableTelemetry":  "true", // Whether or not user analytics can be tracked
   "manageBinariesAutomatically": "true", // Whether or not CLI/LS binaries will be downloaded & updated automatically
-  "cliPath":  "/a/patch/snyk-cli" // The path where the CLI can be found, or where it should be downloaded to
-  "token":  "secret-token" // The Snyk token, e.g.: snyk config get api
-  "automaticAuthentication": "true" // Whether or not LS will automatically authenticate on scan start (default: true)
+  "cliPath":  "/a/patch/snyk-cli", // The path where the CLI can be found, or where it should be downloaded to
+  "token":  "secret-token", // The Snyk token, e.g.: snyk config get api
+  "automaticAuthentication": "true", // Whether or not LS will automatically authenticate on scan start (default: true)
+  "enableTrustedFoldersFeature": "true", // Whether or not LS will prompt to trust a folder (default: true)
+  "trustedFolders": ["/a/trusted/path", "/another/trusted/path"], // An array of folder that should be trusted
 }
 ```
+
+#### Workspace Trust
+
+As part of examining the codebase for vulnerabilities, Snyk may automatically execute code on your computer to obtain
+additional data for analysis. For example, this includes invoking the package manager (e.g., pip, gradle, maven, yarn,
+npm, etc.)
+to get dependency information for Snyk Open Source. Invoking these programs on untrusted code that has malicious
+configurations may expose your system to malicious code execution and exploits.
+
+To safeguard from using the language server on untrusted folders, our language server will ask for folder trust
+before running scans against these folders. When in doubt, do not grant trust.
+
+The trust feature is enabled by default. When a folder is trusted, all sub-folders are also trusted. After a folder
+is trusted, Snyk Language Server notifies the Language Server Client with the custom `$/snyk.addTrustedFolders`
+notification,
+which contains a list of currently trusted folder paths. Based on this, a client can then implement logic to intercept
+this notification and persist the decision and trust in the IDE or Editor storage mechanism.
+
+Trust dialogs can be disabled by setting `enableTrustedFoldersFeature` to `false` in the initialization options. This
+will disable all trust prompts and checks.
+
+An initial set of trusted folders can be provided by setting `trustedFolders` to an array of paths in the
+`initializationOptions`. These folders will be trusted on startup and will not prompt the user to trust them.
 
 #### Environment variables
 

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -119,33 +119,35 @@ func (c *CliSettings) DefaultBinaryInstallPath() string {
 }
 
 type Config struct {
-	configLoaded                concurrency.AtomicBool
-	cliSettings                 *CliSettings
-	configFile                  string
-	format                      string
-	isErrorReportingEnabled     concurrency.AtomicBool
-	isSnykCodeEnabled           concurrency.AtomicBool
-	isSnykOssEnabled            concurrency.AtomicBool
-	isSnykIacEnabled            concurrency.AtomicBool
-	isSnykContainerEnabled      concurrency.AtomicBool
-	isSnykAdvisorEnabled        concurrency.AtomicBool
-	isTelemetryEnabled          concurrency.AtomicBool
-	manageBinariesAutomatically concurrency.AtomicBool
-	logPath                     string
-	organization                string
-	snykCodeAnalysisTimeout     time.Duration
-	snykApiUrl                  string
-	snykCodeApiUrl              string
-	token                       string
-	deviceId                    string
-	clientCapabilities          lsp.ClientCapabilities
-	m                           sync.Mutex
-	path                        string
-	defaultDirs                 []string
-	integrationName             string
-	integrationVersion          string
-	automaticAuthentication     bool
-	tokenChangeChannels         []chan string
+	configLoaded                 concurrency.AtomicBool
+	cliSettings                  *CliSettings
+	configFile                   string
+	format                       string
+	isErrorReportingEnabled      concurrency.AtomicBool
+	isSnykCodeEnabled            concurrency.AtomicBool
+	isSnykOssEnabled             concurrency.AtomicBool
+	isSnykIacEnabled             concurrency.AtomicBool
+	isSnykContainerEnabled       concurrency.AtomicBool
+	isSnykAdvisorEnabled         concurrency.AtomicBool
+	isTelemetryEnabled           concurrency.AtomicBool
+	manageBinariesAutomatically  concurrency.AtomicBool
+	logPath                      string
+	organization                 string
+	snykCodeAnalysisTimeout      time.Duration
+	snykApiUrl                   string
+	snykCodeApiUrl               string
+	token                        string
+	deviceId                     string
+	clientCapabilities           lsp.ClientCapabilities
+	m                            sync.Mutex
+	path                         string
+	defaultDirs                  []string
+	integrationName              string
+	integrationVersion           string
+	automaticAuthentication      bool
+	tokenChangeChannels          []chan string
+	trustedFolders               []string
+	trustedFoldersFeatureEnabled bool
 }
 
 func CurrentConfig() *Config {
@@ -185,6 +187,7 @@ func New() *Config {
 	c.snykCodeApiUrl = defaultDeeproxyApiUrl
 	c.snykCodeAnalysisTimeout = snykCodeAnalysisTimeoutFromEnv()
 	c.token = ""
+	c.trustedFoldersFeatureEnabled = true
 	c.clientSettingsFromEnv()
 	c.deviceId = c.determineDeviceId()
 	c.addDefaults()
@@ -209,6 +212,16 @@ func (c *Config) determineDeviceId() string {
 	} else {
 		return id
 	}
+}
+
+func (c *Config) IsTrustedFolderFeatureEnabled() bool {
+	return c.trustedFoldersFeatureEnabled
+}
+
+func (c *Config) SetTrustedFolderFeatureEnabled(enabled bool) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.trustedFoldersFeatureEnabled = enabled
 }
 
 func (c *Config) Load() {
@@ -537,4 +550,16 @@ func (c *Config) SetIntegrationName(integrationName string) {
 
 func (c *Config) SetIntegrationVersion(integrationVersion string) {
 	c.integrationVersion = integrationVersion
+}
+
+func (c *Config) TrustedFolders() []string {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.trustedFolders
+}
+
+func (c *Config) SetTrustedFolders(folderPaths []string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.trustedFolders = folderPaths
 }

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -45,6 +45,7 @@ func TestConfigDefaults(t *testing.T) {
 	assert.True(t, c.IsSnykIacEnabled(), "Snyk IaC should be enabled by default")
 	assert.Equal(t, "", c.LogPath(), "Logpath should be empty by default")
 	assert.Equal(t, "md", c.Format(), "Output format should be md by default")
+	assert.Empty(t, c.trustedFolders)
 }
 
 func Test_TokenChanged_ChannelsInformed(t *testing.T) {

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -37,7 +38,7 @@ func WorkspaceDidChangeConfiguration(srv *jrpc2.Server) jrpc2.Handler {
 		defer log.Info().Str("method", "WorkspaceDidChangeConfiguration").Interface("params", params).Msg("DONE")
 
 		emptySettings := lsp.Settings{}
-		if params.Settings != emptySettings {
+		if !reflect.DeepEqual(params.Settings, emptySettings) {
 			// client used settings push
 			UpdateSettings(ctx, params.Settings)
 			return true, nil
@@ -65,7 +66,7 @@ func WorkspaceDidChangeConfiguration(srv *jrpc2.Server) jrpc2.Handler {
 			return false, err
 		}
 
-		if fetchedSettings[0] != emptySettings {
+		if !reflect.DeepEqual(fetchedSettings[0], emptySettings) {
 			UpdateSettings(ctx, fetchedSettings[0])
 			return true, nil
 		}
@@ -86,7 +87,7 @@ func UpdateSettings(ctx context.Context, settings lsp.Settings) {
 
 func writeSettings(ctx context.Context, settings lsp.Settings, initialize bool) {
 	emptySettings := lsp.Settings{}
-	if settings == emptySettings {
+	if reflect.DeepEqual(settings, emptySettings) {
 		return
 	}
 	updateToken(settings.Token)
@@ -98,6 +99,20 @@ func writeSettings(ctx context.Context, settings lsp.Settings, initialize bool) 
 	updateTelemetry(settings)
 	updateOrganization(settings)
 	manageBinariesAutomatically(settings)
+	updateTrustedFolders(settings)
+}
+
+func updateTrustedFolders(settings lsp.Settings) {
+	trustedFoldersFeatureEnabled, err := strconv.ParseBool(settings.EnableTrustedFoldersFeature)
+	if err == nil {
+		config.CurrentConfig().SetTrustedFolderFeatureEnabled(trustedFoldersFeatureEnabled)
+	} else {
+		config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	}
+
+	if settings.TrustedFolders != nil {
+		config.CurrentConfig().SetTrustedFolders(settings.TrustedFolders)
+	}
 }
 
 func updateAutoAuthentication(settings lsp.Settings) {

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -71,7 +71,7 @@ func Test_WorkspaceDidChangeConfiguration_Push(t *testing.T) {
 	assert.Equal(t, "token", config.CurrentConfig().Token())
 }
 
-func callBackMock(ctx context.Context, request *jrpc2.Request) (interface{}, error) {
+func callBackMock(_ context.Context, request *jrpc2.Request) (interface{}, error) {
 	jsonRPCRecorder.Record(*request)
 	if request.Method() == "workspace/configuration" {
 		return []lsp.Settings{sampleSettings}, nil
@@ -151,6 +151,7 @@ func Test_UpdateSettings(t *testing.T) {
 			ManageBinariesAutomatically: "false",
 			CliPath:                     "C:\\Users\\CliPath\\snyk-ls.exe",
 			Token:                       "a fancy token",
+			TrustedFolders:              []string{"trustedPath1", "trustedPath2"},
 		}
 
 		UpdateSettings(context.Background(), settings)
@@ -171,6 +172,8 @@ func Test_UpdateSettings(t *testing.T) {
 		assert.False(t, c.ManageBinariesAutomatically())
 		assert.Equal(t, "C:\\Users\\CliPath\\snyk-ls.exe", c.CliSettings().Path())
 		assert.Equal(t, "a fancy token", c.Token())
+		assert.Contains(t, c.TrustedFolders(), "trustedPath1")
+		assert.Contains(t, c.TrustedFolders(), "trustedPath2")
 	})
 
 	t.Run("blank organisation is ignored", func(t *testing.T) {
@@ -208,6 +211,15 @@ func Test_UpdateSettings(t *testing.T) {
 		assert.Empty(t, os.Getenv("a"))
 		assert.Empty(t, os.Getenv("b"))
 		assert.Empty(t, os.Getenv(";"))
+	})
+	t.Run("trusted folders", func(t *testing.T) {
+		config.SetCurrentConfig(config.New())
+
+		UpdateSettings(context.Background(), lsp.Settings{TrustedFolders: []string{"/a/b", "/b/c"}})
+
+		c := config.CurrentConfig()
+		assert.Contains(t, c.TrustedFolders(), "/a/b")
+		assert.Contains(t, c.TrustedFolders(), "/b/c")
 	})
 
 	t.Run("manage binaries automatically", func(t *testing.T) {

--- a/application/server/execute_command.go
+++ b/application/server/execute_command.go
@@ -25,7 +25,9 @@ import (
 	"github.com/rs/zerolog/log"
 	sglsp "github.com/sourcegraph/go-lsp"
 
+	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
+	"github.com/snyk/snyk-ls/application/server/lsp"
 	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/ide/workspace"
 	"github.com/snyk/snyk-ls/domain/snyk"
@@ -49,10 +51,18 @@ func ExecuteCommandHandler(srv *jrpc2.Server) jrpc2.Handler {
 			}
 			navigateToLocation(srv, args)
 		case snyk.WorkspaceScanCommand:
-			workspace.Get().ClearIssues(bgCtx)
-			workspace.Get().ScanWorkspace(bgCtx)
+			w := workspace.Get()
+			w.ClearIssues(bgCtx)
+			w.ScanWorkspace(bgCtx)
+			handleUntrustedFolders(bgCtx, srv)
 		case snyk.OpenBrowserCommand:
 			command.OpenBrowser(params.Arguments[0].(string))
+		case snyk.TrustWorkspaceFoldersCommand:
+			err := TrustWorkspaceFolders()
+			if err != nil {
+				log.Err(err).Msgf("Error on %s command", snyk.TrustWorkspaceFoldersCommand)
+				notification.SendError(err)
+			}
 		case snyk.LoginCommand:
 			authenticator := di.Authenticator()
 			_, err := authenticator.Authenticate(context.Background())
@@ -74,4 +84,20 @@ func ExecuteCommandHandler(srv *jrpc2.Server) jrpc2.Handler {
 		}
 		return nil, nil
 	})
+}
+
+func TrustWorkspaceFolders() error {
+	if !config.CurrentConfig().IsTrustedFolderFeatureEnabled() {
+		return nil
+	}
+
+	trustedFolderPaths := config.CurrentConfig().TrustedFolders()
+	_, untrusted := workspace.Get().GetFolderTrust()
+	for _, folder := range untrusted {
+		trustedFolderPaths = append(trustedFolderPaths, folder.Path())
+	}
+
+	config.CurrentConfig().SetTrustedFolders(trustedFolderPaths)
+	notification.Send(lsp.SnykTrustedFoldersParams{TrustedFolders: trustedFolderPaths})
+	return nil
 }

--- a/application/server/lsp/message_types.go
+++ b/application/server/lsp/message_types.go
@@ -233,24 +233,26 @@ type WorkspaceFoldersChangeEvent struct {
 
 // Settings is the struct that is parsed from the InitializationParams.InitializationOptions field
 type Settings struct {
-	ActivateSnykOpenSource      string `json:"activateSnykOpenSource,omitempty"`
-	ActivateSnykCode            string `json:"activateSnykCode,omitempty"`
-	ActivateSnykIac             string `json:"activateSnykIac,omitempty"`
-	Insecure                    string `json:"insecure,omitempty"`
-	Endpoint                    string `json:"endpoint,omitempty"`
-	AdditionalParams            string `json:"additionalParams,omitempty"`
-	AdditionalEnv               string `json:"additionalEnv,omitempty"`
-	Path                        string `json:"path,omitempty"`
-	SendErrorReports            string `json:"sendErrorReports,omitempty"`
-	Organization                string `json:"organization,omitempty"`
-	EnableTelemetry             string `json:"enableTelemetry,omitempty"`
-	ManageBinariesAutomatically string `json:"manageBinariesAutomatically,omitempty"`
-	CliPath                     string `json:"cliPath,omitempty"`
-	Token                       string `json:"token,omitempty"`
-	IntegrationName             string `json:"integrationName,omitempty"`
-	IntegrationVersion          string `json:"integrationVersion,omitempty"`
-	AutomaticAuthentication     string `json:"automaticAuthentication,omitempty"`
-	DeviceId                    string `json:"deviceId,omitempty"`
+	ActivateSnykOpenSource      string   `json:"activateSnykOpenSource,omitempty"`
+	ActivateSnykCode            string   `json:"activateSnykCode,omitempty"`
+	ActivateSnykIac             string   `json:"activateSnykIac,omitempty"`
+	Insecure                    string   `json:"insecure,omitempty"`
+	Endpoint                    string   `json:"endpoint,omitempty"`
+	AdditionalParams            string   `json:"additionalParams,omitempty"`
+	AdditionalEnv               string   `json:"additionalEnv,omitempty"`
+	Path                        string   `json:"path,omitempty"`
+	SendErrorReports            string   `json:"sendErrorReports,omitempty"`
+	Organization                string   `json:"organization,omitempty"`
+	EnableTelemetry             string   `json:"enableTelemetry,omitempty"`
+	ManageBinariesAutomatically string   `json:"manageBinariesAutomatically,omitempty"`
+	CliPath                     string   `json:"cliPath,omitempty"`
+	Token                       string   `json:"token,omitempty"`
+	IntegrationName             string   `json:"integrationName,omitempty"`
+	IntegrationVersion          string   `json:"integrationVersion,omitempty"`
+	AutomaticAuthentication     string   `json:"automaticAuthentication,omitempty"`
+	DeviceId                    string   `json:"deviceId,omitempty"`
+	EnableTrustedFoldersFeature string   `json:"enableTrustedFoldersFeature,omitempty"`
+	TrustedFolders              []string `json:"trustedFolders,omitempty"`
 }
 
 type DidChangeConfigurationParams struct {
@@ -606,4 +608,25 @@ type ShowDocumentParams struct {
 	 * file.
 	 */
 	Selection sglsp.Range `json:"selection"`
+}
+
+type MessageActionItem struct {
+	Title string `json:"title"`
+}
+
+type ShowMessageRequestParams struct {
+	Type    MessageType         `json:"type"`
+	Message string              `json:"message"`
+	Actions []MessageActionItem `json:"actions"`
+}
+
+type MessageType int
+
+const Error MessageType = 1
+const Warning MessageType = 2
+const Info MessageType = 3
+const Log MessageType = 4
+
+type SnykTrustedFoldersParams struct {
+	TrustedFolders []string `json:"trustedFolders"`
 }

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -186,13 +186,6 @@ func InitializeHandler(srv *jrpc2.Server) handler.Func {
 
 		addWorkspaceFolders(params, w)
 
-		newContext := context.Background()
-		w.ScanWorkspace(newContext)
-
-		if config.CurrentConfig().AutomaticAuthentication() || config.CurrentConfig().NonEmptyToken() {
-			go handleUntrustedFolders(newContext, srv)
-		}
-
 		return lsp.InitializeResult{
 			ServerInfo: lsp.ServerInfo{
 				Name:    "snyk-ls",
@@ -233,6 +226,9 @@ func InitializeHandler(srv *jrpc2.Server) handler.Func {
 func InitializedHandler(srv *jrpc2.Server) handler.Func {
 	return handler.New(func(ctx context.Context, params lsp.InitializedParams) (interface{}, error) {
 		workspace.Get().ScanWorkspace(context.Background())
+		if config.CurrentConfig().AutomaticAuthentication() || config.CurrentConfig().NonEmptyToken() {
+			go handleUntrustedFolders(context.Background(), srv)
+		}
 		return nil, nil
 	})
 }

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -90,7 +90,7 @@ func initHandlers(srv *jrpc2.Server, handlers *handler.Map) {
 	(*handlers)["textDocument/willSaveWaitUntil"] = NoOpHandler()
 	(*handlers)["shutdown"] = Shutdown()
 	(*handlers)["exit"] = Exit(srv)
-	(*handlers)["workspace/didChangeWorkspaceFolders"] = WorkspaceDidChangeWorkspaceFoldersHandler()
+	(*handlers)["workspace/didChangeWorkspaceFolders"] = WorkspaceDidChangeWorkspaceFoldersHandler(srv)
 	(*handlers)["workspace/didChangeConfiguration"] = WorkspaceDidChangeConfiguration(srv)
 	(*handlers)["window/workDoneProgress/cancel"] = WindowWorkDoneProgressCancelHandler()
 	(*handlers)["workspace/executeCommand"] = ExecuteCommandHandler(srv)
@@ -145,7 +145,7 @@ func CodeActionHandler() jrpc2.Handler {
 	})
 }
 
-func WorkspaceDidChangeWorkspaceFoldersHandler() jrpc2.Handler {
+func WorkspaceDidChangeWorkspaceFoldersHandler(srv *jrpc2.Server) jrpc2.Handler {
 	return handler.New(func(ctx context.Context, params lsp.DidChangeWorkspaceFoldersParams) (interface{}, error) {
 		// The context provided by the JSON-RPC server is cancelled once a new message is being processed,
 		// so we don't want to propagate it to functions that start background operations
@@ -153,7 +153,8 @@ func WorkspaceDidChangeWorkspaceFoldersHandler() jrpc2.Handler {
 
 		log.Info().Str("method", "WorkspaceDidChangeWorkspaceFoldersHandler").Msg("RECEIVING")
 		defer log.Info().Str("method", "WorkspaceDidChangeWorkspaceFoldersHandler").Msg("SENDING")
-		workspace.Get().ProcessFolderChange(bgCtx, params)
+		workspace.Get().AddAndRemoveFoldersAndTriggerScan(bgCtx, params)
+		handleUntrustedFolders(bgCtx, srv)
 		return nil, nil
 	})
 }
@@ -183,23 +184,13 @@ func InitializeHandler(srv *jrpc2.Server) handler.Func {
 			os.Exit(0)
 		}()
 
-		if len(params.WorkspaceFolders) > 0 {
-			for _, workspaceFolder := range params.WorkspaceFolders {
-				log.Info().Str("method", method).Msgf("Adding workspaceFolder %v", workspaceFolder)
-				f := workspace.NewFolder(
-					uri.PathFromUri(workspaceFolder.Uri),
-					workspaceFolder.Name,
-					di.Scanner(),
-					di.HoverService(),
-				)
-				w.AddFolder(f)
-			}
-		} else {
-			if params.RootURI != "" {
-				w.AddFolder(workspace.NewFolder(uri.PathFromUri(params.RootURI), params.ClientInfo.Name, di.Scanner(), di.HoverService()))
-			} else if params.RootPath != "" {
-				w.AddFolder(workspace.NewFolder(params.RootPath, params.ClientInfo.Name, di.Scanner(), di.HoverService()))
-			}
+		addWorkspaceFolders(params, w)
+
+		newContext := context.Background()
+		w.ScanWorkspace(newContext)
+
+		if config.CurrentConfig().AutomaticAuthentication() || config.CurrentConfig().NonEmptyToken() {
+			go handleUntrustedFolders(newContext, srv)
 		}
 
 		return lsp.InitializeResult{
@@ -232,6 +223,7 @@ func InitializeHandler(srv *jrpc2.Server) handler.Func {
 						snyk.LoginCommand,
 						snyk.CopyAuthLinkCommand,
 						snyk.LogoutCommand,
+						snyk.TrustWorkspaceFoldersCommand,
 					},
 				},
 			},
@@ -243,6 +235,30 @@ func InitializedHandler(srv *jrpc2.Server) handler.Func {
 		workspace.Get().ScanWorkspace(context.Background())
 		return nil, nil
 	})
+}
+
+func addWorkspaceFolders(params lsp.InitializeParams, w *workspace.Workspace) {
+	const method = "addWorkspaceFolders"
+	if len(params.WorkspaceFolders) > 0 {
+		for _, workspaceFolder := range params.WorkspaceFolders {
+			log.Info().Str("method", method).Msgf("Adding workspaceFolder %v", workspaceFolder)
+			f := workspace.NewFolder(
+				uri.PathFromUri(workspaceFolder.Uri),
+				workspaceFolder.Name,
+				di.Scanner(),
+				di.HoverService(),
+			)
+			w.AddFolder(f)
+		}
+	} else {
+		if params.RootURI != "" {
+			f := workspace.NewFolder(uri.PathFromUri(params.RootURI), params.ClientInfo.Name, di.Scanner(), di.HoverService())
+			w.AddFolder(f)
+		} else if params.RootPath != "" {
+			f := workspace.NewFolder(params.RootPath, params.ClientInfo.Name, di.Scanner(), di.HoverService())
+			w.AddFolder(f)
+		}
+	}
 }
 
 func setClientInformation(initParams lsp.InitializeParams) {
@@ -400,6 +416,12 @@ func registerNotifier(srv *jrpc2.Server) {
 				Interface("source", source).
 				Interface("diagnosticCount", len(params.Diagnostics)).
 				Msg("publishing diagnostics")
+		case lsp.SnykTrustedFoldersParams:
+			notifier(srv, "$/snyk.addTrustedFolders", params)
+			log.Info().
+				Str("method", "registerNotifier").
+				Interface("trustedPaths", params.TrustedFolders).
+				Msg("sending trusted Folders to client")
 		default:
 			log.Warn().
 				Str("method", "registerNotifier").

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -477,6 +477,9 @@ func Test_initialize_handlesUntrustedFoldersWhenAutomaticAuthentication(t *testi
 		InitializationOptions: initializationOptions,
 		WorkspaceFolders:      []lsp.WorkspaceFolder{{Uri: uri.PathToUri("/untrusted/dummy"), Name: "dummy"}}}
 	_, err := loc.Client.Call(ctx, "initialize", params)
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
 
 	_, err = loc.Client.Call(ctx, "initialized", nil)
 	if err != nil {
@@ -497,6 +500,9 @@ func Test_initialize_handlesUntrustedFoldersWhenAuthenticated(t *testing.T) {
 		InitializationOptions: initializationOptions,
 		WorkspaceFolders:      []lsp.WorkspaceFolder{{Uri: uri.PathToUri("/untrusted/dummy"), Name: "dummy"}}}
 	_, err := loc.Client.Call(ctx, "initialize", params)
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
 
 	_, err = loc.Client.Call(ctx, "initialized", nil)
 	if err != nil {
@@ -516,7 +522,9 @@ func Test_initialize_doesnotHandleUntrustedFolders(t *testing.T) {
 		InitializationOptions: initializationOptions,
 		WorkspaceFolders:      []lsp.WorkspaceFolder{{Uri: uri.PathToUri("/untrusted/dummy"), Name: "dummy"}}}
 	_, err := loc.Client.Call(ctx, "initialize", params)
-
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
 	_, err = loc.Client.Call(ctx, "initialized", nil)
 	if err != nil {
 		t.Fatal(err, "couldn't send initialized")

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -240,8 +240,8 @@ func Test_TextDocumentCodeLenses_shouldReturnCodeLenses(t *testing.T) {
 			ActivateSnykIac:             "false",
 			Organization:                "fancy org",
 			Token:                       "xxx",
-			ManageBinariesAutomatically: "false",
-			CliPath:                     "dummy",
+			ManageBinariesAutomatically: "true",
+			CliPath:                     "",
 			EnableTrustedFoldersFeature: "false",
 		},
 	}
@@ -478,6 +478,11 @@ func Test_initialize_handlesUntrustedFoldersWhenAutomaticAuthentication(t *testi
 		WorkspaceFolders:      []lsp.WorkspaceFolder{{Uri: uri.PathToUri("/untrusted/dummy"), Name: "dummy"}}}
 	_, err := loc.Client.Call(ctx, "initialize", params)
 
+	_, err = loc.Client.Call(ctx, "initialized", nil)
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
+
 	assert.Nil(t, err)
 	assert.Eventually(t, func() bool { return checkTrustMessageRequest() }, time.Second, time.Millisecond)
 }
@@ -493,6 +498,11 @@ func Test_initialize_handlesUntrustedFoldersWhenAuthenticated(t *testing.T) {
 		WorkspaceFolders:      []lsp.WorkspaceFolder{{Uri: uri.PathToUri("/untrusted/dummy"), Name: "dummy"}}}
 	_, err := loc.Client.Call(ctx, "initialize", params)
 
+	_, err = loc.Client.Call(ctx, "initialized", nil)
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
+
 	assert.Nil(t, err)
 	assert.Eventually(t, func() bool { return checkTrustMessageRequest() }, time.Second, time.Millisecond)
 }
@@ -506,6 +516,11 @@ func Test_initialize_doesnotHandleUntrustedFolders(t *testing.T) {
 		InitializationOptions: initializationOptions,
 		WorkspaceFolders:      []lsp.WorkspaceFolder{{Uri: uri.PathToUri("/untrusted/dummy"), Name: "dummy"}}}
 	_, err := loc.Client.Call(ctx, "initialize", params)
+
+	_, err = loc.Client.Call(ctx, "initialized", nil)
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
 
 	assert.Nil(t, err)
 	assert.Eventually(t, func() bool { return checkTrustMessageRequest() }, time.Second, time.Millisecond)
@@ -524,13 +539,18 @@ func Test_textDocumentDidOpenHandler_shouldAcceptDocumentItemAndPublishDiagnosti
 			Organization:                "fancy org",
 			Token:                       "xxx",
 			ManageBinariesAutomatically: "false",
-			CliPath:                     "dummy",
+			CliPath:                     "",
 			EnableTrustedFoldersFeature: "false",
 		},
 	}
 	_, err := loc.Client.Call(ctx, "initialize", clientParams)
 	if err != nil {
 		t.Fatal(err, "couldn't initialize")
+	}
+
+	_, err = loc.Client.Call(ctx, "initialized", nil)
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
 	}
 
 	_, err = loc.Client.Call(ctx, "textDocument/didOpen", didOpenParams)
@@ -732,8 +752,9 @@ func runSmokeTest(repo string, commit string, file1 string, file2 string, t *tes
 	clientParams := lsp.InitializeParams{
 		WorkspaceFolders: []lsp.WorkspaceFolder{folder},
 		InitializationOptions: lsp.Settings{
-			Endpoint: os.Getenv("SNYK_API"),
-			Token:    os.Getenv("SNYK_TOKEN"),
+			Endpoint:                    os.Getenv("SNYK_API"),
+			Token:                       os.Getenv("SNYK_TOKEN"),
+			EnableTrustedFoldersFeature: "false",
 		},
 	}
 

--- a/application/server/trust.go
+++ b/application/server/trust.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+
+	"github.com/snyk/snyk-ls/application/server/lsp"
+	"github.com/snyk/snyk-ls/domain/ide/workspace"
+)
+
+const doTrust = "Trust folders and continue"
+const dontTrust = "Don't trust folders"
+
+func handleUntrustedFolders(ctx context.Context, srv *jrpc2.Server) {
+	w := workspace.Get()
+	// debounce requests from overzealous clients (Eclipse, I'm looking at you)
+	if w.IsTrustRequestOngoing() {
+		return
+	}
+	w.StartRequestTrustCommunication()
+	defer w.EndRequestTrustCommunication()
+
+	_, untrusted := w.GetFolderTrust()
+	if len(untrusted) > 0 {
+
+		decision, err := showTrustDialog(srv, untrusted, doTrust, dontTrust)
+		if err != nil {
+			return
+		}
+
+		if decision.Title == doTrust {
+			w.TrustFoldersAndScan(ctx, untrusted)
+		}
+	}
+}
+
+func showTrustDialog(srv *jrpc2.Server, untrusted []*workspace.Folder, dontTrust string, doTrust string) (lsp.MessageActionItem, error) {
+	method := "showTrustDialog"
+	result, err := srv.Callback(context.Background(), "window/showMessageRequest", lsp.ShowMessageRequestParams{
+		Type:    lsp.Warning,
+		Message: getTrustMessage(untrusted),
+		Actions: []lsp.MessageActionItem{{Title: dontTrust}, {Title: doTrust}},
+	})
+	if err != nil {
+		log.Err(errors.Wrap(err, "couldn't show trust message")).Str("method", method).Send()
+		return lsp.MessageActionItem{Title: dontTrust}, err
+	}
+
+	var trust lsp.MessageActionItem
+	if result != nil {
+		err = result.UnmarshalResult(&trust)
+		if err != nil {
+			log.Err(errors.Wrap(err, "couldn't unmarshal trust message")).Str("method", method).Send()
+			return lsp.MessageActionItem{Title: dontTrust}, err
+		}
+	}
+	return trust, err
+}
+
+func getTrustMessage(untrusted []*workspace.Folder) string {
+	var untrustedFolderString string
+	for _, folder := range untrusted {
+		untrustedFolderString += folder.Path() + "\n"
+	}
+	return fmt.Sprintf("When scanning for vulnerabilities, Snyk may automatically execute code such as invoking "+
+		"the package manager to get dependency information. You should only scan folders you trust."+
+		"\n\nUntrusted Folders: \n%s\n\n", untrustedFolderString)
+}

--- a/application/server/trust_test.go
+++ b/application/server/trust_test.go
@@ -104,6 +104,11 @@ func Test_initializeHandler_shouldCallHandleUntrustedFolders(t *testing.T) {
 		RootURI: uri.PathToUri("/untrusted/dummy"),
 	})
 
+	_, err = loc.Client.Call(ctx, "initialized", nil)
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
+
 	assert.NoError(t, err)
 	assert.Eventually(t, func() bool { return checkTrustMessageRequest() }, time.Second, time.Millisecond)
 }

--- a/application/server/trust_test.go
+++ b/application/server/trust_test.go
@@ -103,6 +103,9 @@ func Test_initializeHandler_shouldCallHandleUntrustedFolders(t *testing.T) {
 	_, err := loc.Client.Call(context.Background(), "initialize", lsp.InitializeParams{
 		RootURI: uri.PathToUri("/untrusted/dummy"),
 	})
+	if err != nil {
+		t.Fatal(err, "couldn't send initialized")
+	}
 
 	_, err = loc.Client.Call(ctx, "initialized", nil)
 	if err != nil {

--- a/application/server/trust_test.go
+++ b/application/server/trust_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/application/di"
+	"github.com/snyk/snyk-ls/application/server/lsp"
+	"github.com/snyk/snyk-ls/domain/ide/workspace"
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/internal/uri"
+)
+
+func Test_handleUntrustedFolders_shouldTriggerTrustRequestAndNotScan(t *testing.T) {
+	loc := setupServer(t)
+	w := workspace.Get()
+	scanner := &snyk.TestScanner{}
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	w.AddFolder(workspace.NewFolder("dummy", "dummy", scanner, di.HoverService()))
+	handleUntrustedFolders(context.Background(), loc.Server)
+
+	assert.True(t, checkTrustMessageRequest())
+	assert.Equal(t, scanner.Calls(), 0)
+}
+
+func Test_handleUntrustedFolders_shouldNotTriggerTrustRequestWhenAlreadyRequesting(t *testing.T) {
+	loc := setupServer(t)
+	w := workspace.Get()
+	scanner := &snyk.TestScanner{}
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	w.AddFolder(workspace.NewFolder("dummy", "dummy", scanner, di.HoverService()))
+	w.StartRequestTrustCommunication()
+
+	handleUntrustedFolders(context.Background(), loc.Server)
+
+	assert.Len(t, jsonRPCRecorder.FindCallbacksByMethod("window/showMessageRequest"), 0)
+	assert.Equal(t, scanner.Calls(), 0)
+}
+
+func Test_handleUntrustedFolders_shouldTriggerTrustRequestAndScanAfterConfirmation(t *testing.T) {
+	loc := setupCustomServer(t, func(_ context.Context, _ *jrpc2.Request) (interface{}, error) {
+		return lsp.MessageActionItem{
+			Title: doTrust,
+		}, nil
+	})
+	registerNotifier(loc.Server)
+
+	w := workspace.Get()
+	scanner := &snyk.TestScanner{}
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	w.AddFolder(workspace.NewFolder("/trusted/dummy", "dummy", scanner, di.HoverService()))
+
+	handleUntrustedFolders(context.Background(), loc.Server)
+
+	assert.Eventually(t, func() bool {
+		addTrustedSent := len(jsonRPCRecorder.FindNotificationsByMethod("$/snyk.addTrustedFolders")) == 1
+		return scanner.Calls() == 1 && addTrustedSent
+	}, time.Second, time.Millisecond)
+}
+
+func Test_handleUntrustedFolders_shouldTriggerTrustRequestAndNotScanAfterNegativeConfirmation(t *testing.T) {
+	loc := setupCustomServer(t, func(_ context.Context, _ *jrpc2.Request) (interface{}, error) {
+		return lsp.MessageActionItem{
+			Title: dontTrust,
+		}, nil
+	})
+	registerNotifier(loc.Server)
+	w := workspace.Get()
+	scanner := &snyk.TestScanner{}
+	w.AddFolder(workspace.NewFolder("/trusted/dummy", "dummy", scanner, di.HoverService()))
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+
+	handleUntrustedFolders(context.Background(), loc.Server)
+
+	assert.Equal(t, scanner.Calls(), 0)
+}
+
+func Test_initializeHandler_shouldCallHandleUntrustedFolders(t *testing.T) {
+	loc := setupServer(t)
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+
+	_, err := loc.Client.Call(context.Background(), "initialize", lsp.InitializeParams{
+		RootURI: uri.PathToUri("/untrusted/dummy"),
+	})
+
+	assert.NoError(t, err)
+	assert.Eventually(t, func() bool { return checkTrustMessageRequest() }, time.Second, time.Millisecond)
+}
+
+func Test_DidWorkspaceFolderChange_shouldCallHandleUntrustedFolders(t *testing.T) {
+	loc := setupServer(t)
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+
+	_, err := loc.Client.Call(context.Background(), "workspace/didChangeWorkspaceFolders", lsp.DidChangeWorkspaceFoldersParams{
+		Event: lsp.WorkspaceFoldersChangeEvent{
+			Added: []lsp.WorkspaceFolder{
+				{Uri: uri.PathToUri("/untrusted/dummy"), Name: "dummy"},
+			},
+			Removed: []lsp.WorkspaceFolder{},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Eventually(t, func() bool { return checkTrustMessageRequest() }, time.Second, time.Millisecond)
+}
+
+func checkTrustMessageRequest() bool {
+	callbacks := jsonRPCRecorder.FindCallbacksByMethod("window/showMessageRequest")
+	if len(callbacks) == 0 {
+		return false
+	}
+	var params lsp.ShowMessageRequestParams
+	_ = callbacks[0].UnmarshalParams(&params)
+	_, untrusted := workspace.Get().GetFolderTrust()
+	return params.Type == lsp.Warning && params.Message == getTrustMessage(untrusted)
+}

--- a/domain/ide/workspace/folder_test.go
+++ b/domain/ide/workspace/folder_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/server/lsp"
 	"github.com/snyk/snyk-ls/domain/ide/hover"
 	"github.com/snyk/snyk-ls/domain/snyk"
@@ -71,7 +72,7 @@ func Test_Scan_WhenCachedResultsButNoIssues_shouldNotReScan(t *testing.T) {
 	assert.Equal(t, 1, scannerRecorder.Calls())
 }
 
-func TestProcessResults_SendsDiagnosticsAndHovers(t *testing.T) {
+func Test_ProcessResults_SendsDiagnosticsAndHovers(t *testing.T) {
 	t.Skipf("test this once we have uniform abstractions for hover & diagnostics")
 	testutil.UnitTest(t)
 	hoverService := hover.NewFakeHoverService()
@@ -86,7 +87,7 @@ func TestProcessResults_SendsDiagnosticsAndHovers(t *testing.T) {
 	// assert.hoverService.GetAll()
 }
 
-func TestProcessResults_whenDifferentPaths_AddsToCache(t *testing.T) {
+func Test_ProcessResults_whenDifferentPaths_AddsToCache(t *testing.T) {
 	testutil.UnitTest(t)
 	f := NewFolder("dummy", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
 
@@ -102,7 +103,7 @@ func TestProcessResults_whenDifferentPaths_AddsToCache(t *testing.T) {
 	assert.Len(t, f.documentDiagnosticCache.Get("path2"), 1)
 }
 
-func TestProcessResults_whenSamePaths_AddsToCache(t *testing.T) {
+func Test_ProcessResults_whenSamePaths_AddsToCache(t *testing.T) {
 	testutil.UnitTest(t)
 	f := NewFolder("dummy", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
 
@@ -116,7 +117,7 @@ func TestProcessResults_whenSamePaths_AddsToCache(t *testing.T) {
 	assert.Len(t, f.documentDiagnosticCache.Get("path1"), 2)
 }
 
-func TestProcessResults_whenDifferentPaths_AccumulatesIssues(t *testing.T) {
+func Test_ProcessResults_whenDifferentPaths_AccumulatesIssues(t *testing.T) {
 	testutil.UnitTest(t)
 	f := NewFolder("dummy", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
 
@@ -132,7 +133,7 @@ func TestProcessResults_whenDifferentPaths_AccumulatesIssues(t *testing.T) {
 	assert.NotNil(t, f.documentDiagnosticCache.Get("path3"))
 }
 
-func TestProcessResults_whenSamePaths_AccumulatesIssues(t *testing.T) {
+func Test_ProcessResults_whenSamePaths_AccumulatesIssues(t *testing.T) {
 	testutil.UnitTest(t)
 	f := NewFolder("dummy", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
 
@@ -147,7 +148,7 @@ func TestProcessResults_whenSamePaths_AccumulatesIssues(t *testing.T) {
 	assert.Len(t, f.documentDiagnosticCache.Get("path1"), 3)
 }
 
-func TestProcessResults_whenSamePathsAndDuplicateIssues_DeDuplicates(t *testing.T) {
+func Test_ProcessResults_whenSamePathsAndDuplicateIssues_DeDuplicates(t *testing.T) {
 	testutil.UnitTest(t)
 	f := NewFolder("dummy", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
 
@@ -199,4 +200,51 @@ func Test_ClearDiagnostics(t *testing.T) {
 		1*time.Second,
 		10*time.Millisecond,
 	)
+}
+
+func Test_IsTrusted_shouldReturnFalseByDefault(t *testing.T) {
+	testutil.UnitTest(t)
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	f := NewFolder("dummy", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
+	assert.False(t, f.IsTrusted())
+}
+
+func Test_IsTrusted_shouldReturnTrueForPathContainedInTrustedFolders(t *testing.T) {
+	testutil.UnitTest(t)
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	config.CurrentConfig().SetTrustedFolders([]string{"dummy"})
+	f := NewFolder("dummy", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
+	assert.True(t, f.IsTrusted())
+}
+
+func Test_IsTrusted_shouldReturnTrueForSubfolderOfTrustedFolders_Linux(t *testing.T) {
+	testutil.IntegTest(t)
+	testutil.NotOnWindows(t, "Unix/macOS file paths are incompatible with Windows")
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	config.CurrentConfig().SetTrustedFolders([]string{"/dummy"})
+	f := NewFolder("/dummy/dummyF", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
+	assert.True(t, f.IsTrusted())
+}
+
+func Test_IsTrusted_shouldReturnFalseForDifferentFolder(t *testing.T) {
+	testutil.UnitTest(t)
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	config.CurrentConfig().SetTrustedFolders([]string{"/dummy"})
+	f := NewFolder("/UntrustedPath", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
+	assert.False(t, f.IsTrusted())
+}
+
+func Test_IsTrusted_shouldReturnTrueForSubfolderOfTrustedFolders(t *testing.T) {
+	testutil.IntegTest(t)
+	testutil.OnlyOnWindows(t, "Windows specific test")
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	config.CurrentConfig().SetTrustedFolders([]string{"c:\\dummy"})
+	f := NewFolder("c:\\dummy\\dummyF", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
+	assert.True(t, f.IsTrusted())
+}
+
+func Test_IsTrusted_shouldReturnTrueIfTrustFeatureDisabled(t *testing.T) {
+	testutil.UnitTest(t) // disables trust feature
+	f := NewFolder("c:\\dummy\\dummyF", "dummy", snyk.NewTestScanner(), hover.NewFakeHoverService())
+	assert.True(t, f.IsTrusted())
 }

--- a/domain/ide/workspace/workspace_test.go
+++ b/domain/ide/workspace/workspace_test.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workspace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/application/server/lsp"
+	"github.com/snyk/snyk-ls/domain/observability/performance"
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/uri"
+)
+
+func Test_GetFolderTrust_shouldReturnTrustedAndUntrustedFolders(t *testing.T) {
+	testutil.UnitTest(t)
+	const trustedDummy = "trustedDummy"
+	const untrustedDummy = "untrustedDummy"
+	scanner := &snyk.TestScanner{}
+	w := New(performance.NewTestInstrumentor(), scanner, nil)
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	config.CurrentConfig().SetTrustedFolders([]string{trustedDummy})
+	w.AddFolder(NewFolder(trustedDummy, trustedDummy, scanner, nil))
+	w.AddFolder(NewFolder(untrustedDummy, untrustedDummy, scanner, nil))
+
+	trusted, untrusted := w.GetFolderTrust()
+
+	assert.Equal(t, trustedDummy, trusted[0].path)
+	assert.Equal(t, untrustedDummy, untrusted[0].path)
+}
+
+func Test_TrustFoldersAndScan_shouldAddFoldersToTrustedFoldersAndTriggerScan(t *testing.T) {
+	testutil.UnitTest(t)
+	const trustedDummy = "trustedDummy"
+	const untrustedDummy = "untrustedDummy"
+	scanner := &snyk.TestScanner{}
+	w := New(performance.NewTestInstrumentor(), scanner, nil)
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	trustedFolder := NewFolder(trustedDummy, trustedDummy, scanner, nil)
+	w.AddFolder(trustedFolder)
+	untrustedFolder := NewFolder(untrustedDummy, untrustedDummy, scanner, nil)
+	w.AddFolder(untrustedFolder)
+
+	w.TrustFoldersAndScan(context.Background(), []*Folder{trustedFolder})
+
+	assert.Contains(t, config.CurrentConfig().TrustedFolders(), trustedFolder.path)
+	assert.NotContains(t, config.CurrentConfig().TrustedFolders(), untrustedFolder.path)
+	assert.Eventually(t, func() bool {
+		return scanner.Calls() == 1
+	}, time.Second, time.Millisecond, "scanner should be called after trust is granted")
+}
+
+func Test_AddAndRemoveFoldersAndTriggerScan(t *testing.T) {
+	testutil.UnitTest(t)
+	const trustedDummy = "trustedDummy"
+	const untrustedDummy = "untrustedDummy"
+	const toBeRemoved = "toBeRemoved"
+	trustedPathAfterConversions := uri.PathFromUri(uri.PathToUri(trustedDummy))
+	toBeRemovedAbsolutePathAfterConversions := uri.PathFromUri(uri.PathToUri(toBeRemoved))
+
+	scanner := &snyk.TestScanner{}
+	w := New(performance.NewTestInstrumentor(), scanner, nil)
+	toBeRemovedFolder := NewFolder(toBeRemovedAbsolutePathAfterConversions, toBeRemoved, scanner, nil)
+	w.AddFolder(toBeRemovedFolder)
+
+	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	config.CurrentConfig().SetTrustedFolders([]string{trustedPathAfterConversions})
+
+	params := lsp.DidChangeWorkspaceFoldersParams{Event: lsp.WorkspaceFoldersChangeEvent{
+		Added: []lsp.WorkspaceFolder{
+			{Name: trustedDummy, Uri: uri.PathToUri(trustedDummy)},
+			{Name: untrustedDummy, Uri: uri.PathToUri(untrustedDummy)},
+		},
+		Removed: []lsp.WorkspaceFolder{
+			{Name: toBeRemoved, Uri: uri.PathToUri(toBeRemoved)},
+		},
+	}}
+
+	w.AddAndRemoveFoldersAndTriggerScan(context.Background(), params)
+
+	assert.Nil(t, w.GetFolderContaining(toBeRemoved))
+
+	// one call for one trusted folder
+	assert.Eventually(t, func() bool {
+		return scanner.Calls() == 1
+	}, time.Second, time.Millisecond, "scanner should be called after trust is granted")
+}
+
+func Test_Get(t *testing.T) {
+	New(nil, nil, nil)
+	assert.Equal(t, instance, Get())
+}
+
+func Test_Set(t *testing.T) {
+	w := New(nil, nil, nil)
+	Set(w)
+	assert.Equal(t, w, instance)
+}

--- a/domain/ide/workspace/workspace_trust.go
+++ b/domain/ide/workspace/workspace_trust.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workspace
+
+func (w *Workspace) StartRequestTrustCommunication() {
+	w.trustMutex.Lock()
+	w.trustRequestOngoing = true
+	w.trustMutex.Unlock()
+}
+
+func (w *Workspace) EndRequestTrustCommunication() {
+	w.trustMutex.Lock()
+	w.trustRequestOngoing = false
+	w.trustMutex.Unlock()
+}
+
+func (w *Workspace) IsTrustRequestOngoing() bool {
+	w.trustMutex.Lock()
+	defer w.trustMutex.Unlock()
+	return w.trustRequestOngoing
+}

--- a/domain/ide/workspace/workspace_trust_test.go
+++ b/domain/ide/workspace/workspace_trust_test.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Snyk Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+)
+
+func TestWorkspace_TrustRequests(t *testing.T) {
+	testutil.UnitTest(t)
+	w := New(nil, nil, nil)
+	w.StartRequestTrustCommunication()
+	w.IsTrustRequestOngoing()
+	assert.True(t, w.IsTrustRequestOngoing())
+	w.EndRequestTrustCommunication()
+	assert.False(t, w.IsTrustRequestOngoing())
+}

--- a/domain/snyk/command.go
+++ b/domain/snyk/command.go
@@ -17,12 +17,13 @@
 package snyk
 
 const (
-	NavigateToRangeCommand = "snyk.navigateToRange"
-	WorkspaceScanCommand   = "snyk.workspace.scan"
-	OpenBrowserCommand     = "snyk.openBrowser"
-	LoginCommand           = "snyk.login"
-	CopyAuthLinkCommand    = "snyk.copyAuthLink"
-	LogoutCommand          = "snyk.logout"
+	NavigateToRangeCommand       = "snyk.navigateToRange"
+	WorkspaceScanCommand         = "snyk.workspace.scan"
+	OpenBrowserCommand           = "snyk.openBrowser"
+	LoginCommand                 = "snyk.login"
+	CopyAuthLinkCommand          = "snyk.copyAuthLink"
+	LogoutCommand                = "snyk.logout"
+	TrustWorkspaceFoldersCommand = "snyk.trustWorkspaceFolders"
 )
 
 type Command struct {

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -45,6 +45,7 @@ func UnitTest(t *testing.T) {
 	c := config.New()
 	c.SetManageBinariesAutomatically(false)
 	c.SetToken("00000000-0000-0000-0000-000000000001")
+	c.SetTrustedFolderFeatureEnabled(false)
 	config.SetCurrentConfig(c)
 	CLIDownloadLockFileCleanUp(t)
 }
@@ -123,6 +124,7 @@ func prepareTestHelper(t *testing.T, envVar string) {
 	c.SetToken(GetEnvironmentToken())
 	c.SetErrorReportingEnabled(false)
 	c.SetTelemetryEnabled(false)
+	c.SetTrustedFolderFeatureEnabled(false)
 	config.SetCurrentConfig(c)
 
 	CLIDownloadLockFileCleanUp(t)


### PR DESCRIPTION
### Description

Snyk Language Server by default has a workspace trust feature enabled. If a client asks for an untrusted folder to
be scanned, Snyk Language Server will prompt the user to trust the folder. The user can then choose to trust the folder
or decline it, which will result in either scanning the folder when choosing the former, or no activities from Snyk on that folder if choosing the latter. When a folder is trusted all sub-folders are also trusted. After a folder is trusted, Snyk Language Server notifies the Language Server Client with the custom `$/snyk.addTrustedFolders` notification, which contains the list of trusted folders.
A client can then implement logic to intercept this notification and persist the decision and trust in the IDE or Editor storage mechanism.

Trust dialogs can be disabled by setting `enableTrustedFoldersFeature` to `false` in the initialization options. This
will disable all trust prompts and checks.

An initial set of trusted folders can be provided by setting `trustedFolders` to an array of paths in the
`initializationOptions`. These folders will be trusted on startup and will not prompt the user to trust them.


### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced