### PR TITLE
feat: filter issues by severity during runtime [ROAD-1143]

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ within `initializationOptions?: LSPAny;` we support the following settings:
   "automaticAuthentication": "true", // Whether or not LS will automatically authenticate on scan start (default: true)
   "enableTrustedFoldersFeature": "true", // Whether or not LS will prompt to trust a folder (default: true)
   "trustedFolders": ["/a/trusted/path", "/another/trusted/path"], // An array of folder that should be trusted
+  "filterSeverity": { // Filters to be applied for the determined issues
+    "critical": true,
+    "high": true,
+    "medium": true,
+    "low": true,
+  }
 }
 ```
 

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -351,14 +351,16 @@ func (c *Config) SetSnykContainerEnabled(enabled bool) { c.isSnykContainerEnable
 
 func (c *Config) SetSnykAdvisorEnabled(enabled bool) { c.isSnykAdvisorEnabled.Set(enabled) }
 
-func (c *Config) SetSeverityFilter(severityFilter lsp.SeverityFilter) {
+func (c *Config) SetSeverityFilter(severityFilter lsp.SeverityFilter) bool {
 	emptySeverityFilter := lsp.SeverityFilter{}
 	if severityFilter == emptySeverityFilter {
-		return
+		return false
 	}
 
+	filterModified := c.filterSeverity != severityFilter
 	log.Debug().Str("method", "SetSeverityFilter").Msgf("Setting severity filter: %v", severityFilter)
 	c.filterSeverity = severityFilter
+	return filterModified
 }
 
 func (c *Config) SetToken(token string) {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -194,7 +194,7 @@ func New() *Config {
 	c.clientSettingsFromEnv()
 	c.deviceId = c.determineDeviceId()
 	c.addDefaults()
-	c.setDefaultSeverityFilter()
+	c.filterSeverity = lsp.DefaultSeverityFilter()
 	return c
 }
 
@@ -560,15 +560,6 @@ func (c *Config) addDefaults() {
 	}
 	c.determineJavaHome()
 	c.determineMavenHome()
-}
-
-func (c *Config) setDefaultSeverityFilter() {
-	c.filterSeverity = lsp.SeverityFilter{
-		Critical: true,
-		High:     true,
-		Medium:   true,
-		Low:      true,
-	}
 }
 
 func (c *Config) SetIntegrationName(integrationName string) {

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -47,7 +47,7 @@ func TestConfigDefaults(t *testing.T) {
 	assert.True(t, c.IsSnykIacEnabled(), "Snyk IaC should be enabled by default")
 	assert.Equal(t, "", c.LogPath(), "Logpath should be empty by default")
 	assert.Equal(t, "md", c.Format(), "Output format should be md by default")
-	assert.Equal(t, lsp.SeverityFilter{Critical: true, High: true, Medium: true, Low: true}, c.FilterSeverity(), "All severities should be enabled by default")
+	assert.Equal(t, lsp.DefaultSeverityFilter(), c.FilterSeverity(), "All severities should be enabled by default")
 	assert.Empty(t, c.trustedFolders)
 }
 
@@ -167,5 +167,24 @@ func TestSnykCodeApi(t *testing.T) {
 		t.Setenv("DEEPROXY_API_URL", customDeeproxyUrl)
 		codeApiEndpoint, _ := getCodeApiUrlFromCustomEndpoint("")
 		assert.Equal(t, customDeeproxyUrl, codeApiEndpoint)
+	})
+}
+
+func Test_SetSeverityFilter(t *testing.T) {
+	t.Run("Saves filter", func(t *testing.T) {
+		c := New()
+		c.SetSeverityFilter(lsp.NewSeverityFilter(true, true, false, false))
+		assert.Equal(t, lsp.NewSeverityFilter(true, true, false, false), c.FilterSeverity())
+	})
+
+	t.Run("Returns correctly", func(t *testing.T) {
+		c := New()
+		lowExcludedFilter := lsp.NewSeverityFilter(true, true, false, false)
+
+		modified := c.SetSeverityFilter(lowExcludedFilter)
+		assert.True(t, modified)
+
+		modified = c.SetSeverityFilter(lowExcludedFilter)
+		assert.False(t, modified)
 	})
 }

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -256,5 +256,16 @@ func updateProductEnablement(settings lsp.Settings) {
 
 func updateSeverityFilter(s lsp.SeverityFilter) {
 	log.Debug().Str("method", "updateSeverityFilter").Msgf("Updating severity filter: %v", s)
-	config.CurrentConfig().SetSeverityFilter(s)
+	modified := config.CurrentConfig().SetSeverityFilter(s)
+
+	if modified {
+		ws := workspace.Get()
+		if ws == nil {
+			return
+		}
+
+		for _, folder := range ws.Folders() {
+			folder.FilterCachedDiagnostics()
+		}
+	}
 }

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -85,11 +85,15 @@ func InitializeSettings(settings lsp.Settings) {
 func UpdateSettings(settings lsp.Settings) {
 	currentConfig := config.CurrentConfig()
 	previouslySupportedProducts := currentConfig.GetSupportedProducts()
-	ws := workspace.Get()
 
 	writeSettings(settings, false)
 
 	// If a product was removed, clear all issues for this product
+	ws := workspace.Get()
+	if ws == nil {
+		return
+	}
+
 	newSupportedProducts := currentConfig.GetSupportedProducts()
 	for product, wasSupported := range previouslySupportedProducts {
 		if wasSupported && !newSupportedProducts[product] {
@@ -265,7 +269,7 @@ func updateSeverityFilter(s lsp.SeverityFilter) {
 		}
 
 		for _, folder := range ws.Folders() {
-			folder.FilterCachedDiagnostics()
+			folder.FilterAndPublishCachedDiagnostics()
 		}
 	}
 }

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -151,7 +151,7 @@ func Test_UpdateSettings(t *testing.T) {
 			ManageBinariesAutomatically: "false",
 			CliPath:                     "C:\\Users\\CliPath\\snyk-ls.exe",
 			Token:                       "a fancy token",
-			FilterSeverity:              lsp.SeverityFilter{Low: true, Medium: true, High: true, Critical: true},
+			FilterSeverity:              lsp.DefaultSeverityFilter(),
 			TrustedFolders:              []string{"trustedPath1", "trustedPath2"},
 		}
 
@@ -173,7 +173,7 @@ func Test_UpdateSettings(t *testing.T) {
 		assert.False(t, c.ManageBinariesAutomatically())
 		assert.Equal(t, "C:\\Users\\CliPath\\snyk-ls.exe", c.CliSettings().Path())
 		assert.Equal(t, "a fancy token", c.Token())
-		assert.Equal(t, lsp.SeverityFilter{Low: true, Medium: true, High: true, Critical: true}, c.FilterSeverity())
+		assert.Equal(t, lsp.DefaultSeverityFilter(), c.FilterSeverity())
 		assert.Contains(t, c.TrustedFolders(), "trustedPath1")
 		assert.Contains(t, c.TrustedFolders(), "trustedPath2")
 	})
@@ -256,7 +256,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("severity filter", func(t *testing.T) {
 		config.SetCurrentConfig(config.New())
 		t.Run("filtering gets passed", func(t *testing.T) {
-			mixedSeverityFilter := lsp.SeverityFilter{Low: true, Medium: false, High: true, Critical: false}
+			mixedSeverityFilter := lsp.NewSeverityFilter(true, false, true, false)
 			UpdateSettings(lsp.Settings{FilterSeverity: mixedSeverityFilter})
 
 			c := config.CurrentConfig()

--- a/application/server/lsp/severity_filter.go
+++ b/application/server/lsp/severity_filter.go
@@ -1,0 +1,21 @@
+package lsp
+
+// TODO: this belongs to Snyk domain but has to live here until there's no dependency on lsp from the domain layer.
+
+func NewSeverityFilter(critical bool, high bool, medium bool, low bool) SeverityFilter {
+	return SeverityFilter{
+		Critical: critical,
+		High:     high,
+		Medium:   medium,
+		Low:      low,
+	}
+}
+
+func DefaultSeverityFilter() SeverityFilter {
+	return SeverityFilter{
+		Critical: true,
+		High:     true,
+		Medium:   true,
+		Low:      true,
+	}
+}

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -242,7 +242,7 @@ func Test_TextDocumentCodeLenses_shouldReturnCodeLenses(t *testing.T) {
 			Token:                       "xxx",
 			ManageBinariesAutomatically: "true",
 			CliPath:                     "",
-			FilterSeverity:              lsp.SeverityFilter{Critical: true, High: true, Medium: true, Low: true},
+			FilterSeverity:              lsp.DefaultSeverityFilter(),
 			EnableTrustedFoldersFeature: "false",
 		},
 	}
@@ -289,7 +289,7 @@ func Test_initialize_updatesSettings(t *testing.T) {
 		InitializationOptions: lsp.Settings{
 			Organization:   "fancy org",
 			Token:          "xxx",
-			FilterSeverity: lsp.SeverityFilter{Critical: true, High: true, Medium: true, Low: true},
+			FilterSeverity: lsp.DefaultSeverityFilter(),
 		},
 	}
 
@@ -553,7 +553,7 @@ func Test_textDocumentDidOpenHandler_shouldAcceptDocumentItemAndPublishDiagnosti
 			Token:                       "xxx",
 			ManageBinariesAutomatically: "false",
 			CliPath:                     "",
-			FilterSeverity:              lsp.SeverityFilter{Critical: true, High: true, Medium: true, Low: true},
+			FilterSeverity:              lsp.DefaultSeverityFilter(),
 			EnableTrustedFoldersFeature: "false",
 		},
 	}
@@ -770,7 +770,7 @@ func runSmokeTest(repo string, commit string, file1 string, file2 string, t *tes
 			Endpoint:                    os.Getenv("SNYK_API"),
 			Token:                       os.Getenv("SNYK_TOKEN"),
 			EnableTrustedFoldersFeature: "false",
-			FilterSeverity:              lsp.SeverityFilter{Critical: true, High: true, Medium: true, Low: true},
+			FilterSeverity:              lsp.DefaultSeverityFilter(),
 		},
 	}
 

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -145,16 +145,12 @@ func (f *Folder) DocumentDiagnosticsFromCache(file string) []snyk.Issue {
 }
 
 func (f *Folder) processResults(issues []snyk.Issue) {
-	logger := log.With().Str("method", "processResults").Logger()
-
-	var issuesByFile = map[string][]snyk.Issue{}
 	dedupMap := f.createDedupMap()
 
 	// TODO: perform issue diffing (current <-> newly reported)
 	// Update diagnostic cache
-	cachedIssues := []snyk.Issue{}
 	for _, issue := range issues {
-		cachedIssues, _ = f.documentDiagnosticCache.Load(issue.AffectedFilePath)
+		cachedIssues, _ := f.documentDiagnosticCache.Load(issue.AffectedFilePath)
 		if cachedIssues == nil {
 			cachedIssues = []snyk.Issue{}
 		}
@@ -166,33 +162,49 @@ func (f *Folder) processResults(issues []snyk.Issue) {
 		f.documentDiagnosticCache.Store(issue.AffectedFilePath, cachedIssues)
 	}
 
-	// update issues by file
-	filteredIssues := []snyk.Issue{}
-	severityFilters := config.CurrentConfig().FilterSeverity()
+	// Filter and publish cached diagnostics
+	f.FilterCachedDiagnostics()
+}
 
-	logger.Debug().Msgf("Filtering issues by severity: %v", severityFilters)
-	for _, cachedIssue := range cachedIssues {
-		if severityFilters.Critical && cachedIssue.Severity == snyk.Critical {
-			logger.Trace().Msgf("Including critical severity issue: %v", cachedIssue)
-			filteredIssues = append(filteredIssues, cachedIssue)
-		}
-		if severityFilters.High && cachedIssue.Severity == snyk.High {
-			logger.Trace().Msgf("Including high severity issue: %v", cachedIssue)
-			filteredIssues = append(filteredIssues, cachedIssue)
-		}
-		if severityFilters.Medium && cachedIssue.Severity == snyk.Medium {
-			logger.Trace().Msgf("Including medium severity issue: %v", cachedIssue)
-			filteredIssues = append(filteredIssues, cachedIssue)
-		}
-		if severityFilters.Low && cachedIssue.Severity == snyk.Low {
-			logger.Trace().Msgf("Including low severity issue: %v", cachedIssue)
-			filteredIssues = append(filteredIssues, cachedIssue)
-		}
-
-		issuesByFile[cachedIssue.AffectedFilePath] = filteredIssues
+func (f *Folder) FilterCachedDiagnostics() {
+	if f.documentDiagnosticCache.Size() == 0 {
+		// Cache is empty -> scan didn't run, thus nothing to filter
+		return
 	}
 
+	logger := log.With().Str("method", "processResults").Logger()
+	logger.Debug().Msgf("Filtering issues by severity: %v", config.CurrentConfig().FilterSeverity())
+	var issuesByFile = map[string][]snyk.Issue{}
+
+	f.documentDiagnosticCache.Range(func(filePath string, issues []snyk.Issue) bool {
+		filteredIssues := []snyk.Issue{}
+
+		for _, issue := range issues {
+			if isVisibleSeverity(issue) {
+				logger.Trace().Msgf("Including visible severity issue: %v", issue)
+				filteredIssues = append(filteredIssues, issue)
+			}
+		}
+
+		issuesByFile[filePath] = filteredIssues
+		return true
+	})
+
 	f.publishDiagnostics(issuesByFile)
+}
+
+func isVisibleSeverity(issue snyk.Issue) bool {
+	switch issue.Severity {
+	case snyk.Critical:
+		return config.CurrentConfig().FilterSeverity().Critical
+	case snyk.High:
+		return config.CurrentConfig().FilterSeverity().High
+	case snyk.Medium:
+		return config.CurrentConfig().FilterSeverity().Medium
+	case snyk.Low:
+		return config.CurrentConfig().FilterSeverity().Low
+	}
+	return false
 }
 
 func (f *Folder) publishDiagnostics(issuesByFile map[string][]snyk.Issue) {

--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -108,7 +108,7 @@ func (w *Workspace) GetFolderContaining(path string) (folder *Folder) {
 }
 
 func (w *Workspace) Folders() (folder []*Folder) {
-	folders := make([]*Folder, len(w.folders))
+	folders := make([]*Folder, 0, len(w.folders))
 	for _, folder := range w.folders {
 		folders = append(folders, folder)
 	}

--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -108,7 +108,7 @@ func (w *Workspace) GetFolderContaining(path string) (folder *Folder) {
 }
 
 func (w *Workspace) Folders() (folder []*Folder) {
-	folders := make([]*Folder, 0, len(w.folders))
+	folders := make([]*Folder, len(w.folders))
 	for _, folder := range w.folders {
 		folders = append(folders, folder)
 	}

--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -107,6 +107,15 @@ func (w *Workspace) GetFolderContaining(path string) (folder *Folder) {
 	return nil
 }
 
+func (w *Workspace) Folders() (folder []*Folder) {
+	folders := make([]*Folder, 0)
+	for _, folder := range w.folders {
+		folders = append(folders, folder)
+	}
+
+	return folders
+}
+
 func (w *Workspace) ScanWorkspace(ctx context.Context) {
 	trusted, _ := w.GetFolderTrust()
 

--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -108,7 +108,7 @@ func (w *Workspace) GetFolderContaining(path string) (folder *Folder) {
 }
 
 func (w *Workspace) Folders() (folder []*Folder) {
-	folders := make([]*Folder, 0)
+	folders := make([]*Folder, 0, len(w.folders))
 	for _, folder := range w.folders {
 		folders = append(folders, folder)
 	}

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pact-foundation/pact-go/dsl"
 
 	"github.com/snyk/snyk-ls/application/config"
-	"github.com/snyk/snyk-ls/application/server/lsp"
 	"github.com/snyk/snyk-ls/internal/progress"
 )
 
@@ -126,7 +125,6 @@ func prepareTestHelper(t *testing.T, envVar string) {
 	c.SetErrorReportingEnabled(false)
 	c.SetTelemetryEnabled(false)
 	c.SetTrustedFolderFeatureEnabled(false)
-	c.SetSeverityFilter(lsp.SeverityFilter{Critical: true, High: true, Medium: true, Low: true})
 	config.SetCurrentConfig(c)
 
 	CLIDownloadLockFileCleanUp(t)


### PR DESCRIPTION
### Description

- Enables client to filter issues by severity during runtime.
- Centralises filter instantiation to simplify future refactors, if needed.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs
![screen](https://user-images.githubusercontent.com/2239563/205861851-60eec83b-85c0-4474-9afe-dd675df7258a.gif)
