### PR TITLE
feat: schedule oss re-runs after 24h [ROAD-1220]

### DIFF
--- a/infrastructure/cli/cli_fake.go
+++ b/infrastructure/cli/cli_fake.go
@@ -30,7 +30,7 @@ type TestExecutor struct {
 	wasExecuted     bool
 	ExecuteDuration time.Duration
 	finishedScans   int
-	counterLock     sync.Mutex
+	counterLock     sync.RWMutex
 }
 
 func NewTestExecutor() *TestExecutor {
@@ -45,7 +45,12 @@ func NewTestExecutorWithResponse(executeResponsePath string) *TestExecutor {
 	return &TestExecutor{ExecuteResponse: fileContent}
 }
 
-func (t *TestExecutor) GetFinishedScans() int { return t.finishedScans }
+func (t *TestExecutor) GetFinishedScans() int {
+	t.counterLock.RLock()
+	scanCount := t.finishedScans
+	t.counterLock.RUnlock()
+	return scanCount
+}
 
 func (t *TestExecutor) Execute(ctx context.Context, _ []string, _ string) (resp []byte, err error) {
 	err = ctx.Err()

--- a/infrastructure/iac/iac_test.go
+++ b/infrastructure/iac/iac_test.go
@@ -67,7 +67,7 @@ func Test_ErroredWorkspaceScan_TracksAnalytics(t *testing.T) {
 	executor := cli.NewTestExecutor()
 	scanner := New(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, executor)
 
-	executor.ExecuteResponse = "invalid JSON"
+	executor.ExecuteResponse = []byte("invalid JSON")
 	scanner.Scan(context.Background(), "fake.yml", "")
 
 	assert.Len(t, analytics.GetAnalytics(), 1)

--- a/infrastructure/oss/oss.go
+++ b/infrastructure/oss/oss.go
@@ -100,6 +100,7 @@ type Scanner struct {
 	mutex                 *sync.Mutex
 	runningScans          map[string]*scans.ScanProgress
 	scheduledScanDuration time.Duration
+	scheduledScan         *time.Timer
 	scanCount             int
 }
 
@@ -415,7 +416,12 @@ func (oss *Scanner) trackResult(success bool) {
 
 // Schedules new scan after 24h once existing OSS results might be stale
 func (oss *Scanner) scheduleNewScan(path string) {
-	time.AfterFunc(oss.scheduledScanDuration, func() {
+	if oss.scheduledScan != nil {
+		// Cancel previously scheduled scan
+		oss.scheduledScan.Stop()
+	}
+
+	oss.scheduledScan = time.AfterFunc(oss.scheduledScanDuration, func() {
 		if !oss.IsEnabled() {
 			return
 		}

--- a/infrastructure/oss/oss.go
+++ b/infrastructure/oss/oss.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/pkg/errors"
@@ -91,26 +92,27 @@ var supportedFiles = map[string]bool{
 	"mix.lock":                true,
 }
 
-// a counter for scans, used for logging
-var scanCount = 1
-
 type Scanner struct {
-	instrumentor  performance.Instrumentor
-	errorReporter error_reporting.ErrorReporter
-	analytics     ux2.Analytics
-	cli           cli.Executor
-	mutex         *sync.Mutex
-	runningScans  map[string]*scans.ScanProgress
+	instrumentor          performance.Instrumentor
+	errorReporter         error_reporting.ErrorReporter
+	analytics             ux2.Analytics
+	cli                   cli.Executor
+	mutex                 *sync.Mutex
+	runningScans          map[string]*scans.ScanProgress
+	scheduledScanDuration time.Duration
+	scanCount             int
 }
 
 func New(instrumentor performance.Instrumentor, errorReporter error_reporting.ErrorReporter, analytics ux2.Analytics, cli cli.Executor) *Scanner {
 	return &Scanner{
-		instrumentor:  instrumentor,
-		errorReporter: errorReporter,
-		analytics:     analytics,
-		cli:           cli,
-		mutex:         &sync.Mutex{},
-		runningScans:  map[string]*scans.ScanProgress{},
+		instrumentor:          instrumentor,
+		errorReporter:         errorReporter,
+		analytics:             analytics,
+		cli:                   cli,
+		mutex:                 &sync.Mutex{},
+		runningScans:          map[string]*scans.ScanProgress{},
+		scheduledScanDuration: 24 * time.Hour,
+		scanCount:             1,
 	}
 }
 
@@ -162,14 +164,14 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	}
 
 	oss.mutex.Lock()
-	i := scanCount
+	i := oss.scanCount
 	previousScan, wasFound := oss.runningScans[workDir]
 	if wasFound && !previousScan.IsDone() { // If there's already a scan for the current workdir, we want to cancel it and restart it
 		previousScan.CancelScan()
 	}
 	newScan := scans.NewScanProgress()
 	go newScan.Listen(cancel, i)
-	scanCount++
+	oss.scanCount++
 	oss.runningScans[workDir] = newScan
 	oss.mutex.Unlock()
 
@@ -187,11 +189,16 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	}
 
 	issues = oss.unmarshallAndRetrieveAnalysis(ctx, res, uri.PathToUri(workDir))
+	oss.trackResult(true)
 
 	oss.mutex.Lock()
 	log.Debug().Msgf("Scan %v is done", i)
 	newScan.SetDone()
 	oss.mutex.Unlock()
+
+	if issues != nil {
+		oss.scheduleNewScan(path)
+	}
 
 	return issues
 }
@@ -238,7 +245,6 @@ func (oss *Scanner) unmarshallAndRetrieveAnalysis(ctx context.Context, res []byt
 		issues = append(issues, oss.retrieveIssues(scanResult, targetFileUri, fileContent)...)
 	}
 
-	oss.trackResult(true)
 	return issues
 }
 
@@ -404,5 +410,26 @@ func (oss *Scanner) trackResult(success bool) {
 	oss.analytics.AnalysisIsReady(ux2.AnalysisIsReadyProperties{
 		AnalysisType: ux2.OpenSource,
 		Result:       result,
+	})
+}
+
+// Schedules new scan after 24h once existing OSS results might be stale
+func (oss *Scanner) scheduleNewScan(path string) {
+	time.AfterFunc(oss.scheduledScanDuration, func() {
+		if !oss.IsEnabled() {
+			return
+		}
+
+		oss.analytics.AnalysisIsTriggered(
+			ux2.AnalysisIsTriggeredProperties{
+				AnalysisType:    []ux2.AnalysisType{ux2.OpenSource},
+				TriggeredByUser: false,
+			},
+		)
+
+		span := oss.instrumentor.NewTransaction(context.WithValue(context.Background(), oss.Product(), oss), string(oss.Product()), "oss.scheduleNewScanIn")
+		defer oss.instrumentor.Finish(span)
+
+		oss.Scan(span.Context(), path, "")
 	})
 }

--- a/infrastructure/oss/oss_integration_test.go
+++ b/infrastructure/oss/oss_integration_test.go
@@ -37,6 +37,7 @@ func Test_Scan(t *testing.T) {
 	ctx := context.Background()
 	di.TestInit(t)
 	_ = di.Initializer().Init()
+	testutil.CreateDummyProgressListener(t)
 
 	workingDir, _ := os.Getwd()
 	path, _ := filepath.Abs(workingDir + "/testdata/package.json")


### PR DESCRIPTION
### Description

Triggers new OSS scan after 24h without a scan to provide fresh OSS results to the user.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
