### PR TITLE
fix: Use API /user/me to check if user is authenticated [ROAD-1236]

### DIFF
--- a/infrastructure/cli/auth/initializer.go
+++ b/infrastructure/cli/auth/initializer.go
@@ -53,11 +53,14 @@ func (i *Initializer) Init() error {
 
 	authenticator := i.authenticator
 	currentConfig := config.CurrentConfig()
-	isAuthenticated, _ := authenticator.IsAuthenticated()
-	if currentConfig.NonEmptyToken() && isAuthenticated {
-		log.Info().Msg("Skipping authentication - user is already authenticated")
-		return nil
+	if currentConfig.NonEmptyToken() {
+		isValidToken, _ := authenticator.IsAuthenticated()
+		if isValidToken {
+			log.Info().Msg("Skipping authentication - user is already authenticated")
+			return nil
+		}
 	}
+
 	if !currentConfig.AutomaticAuthentication() {
 		if currentConfig.NonEmptyToken() { // Only send notification when the token is invalid
 			err := &AuthenticationFailedError{manualAuthentication: true}
@@ -85,7 +88,7 @@ func (i *Initializer) Init() error {
 	}
 
 	authenticator.UpdateToken(token, true)
-	isAuthenticated, err = authenticator.IsAuthenticated()
+	isAuthenticated, err := authenticator.IsAuthenticated()
 
 	if !isAuthenticated {
 		err = errors.Wrap(err, errorMessage)

--- a/infrastructure/cli/auth/initializer_test.go
+++ b/infrastructure/cli/auth/initializer_test.go
@@ -25,6 +25,7 @@ import (
 	errorreporting "github.com/snyk/snyk-ls/domain/observability/error_reporting"
 	ux2 "github.com/snyk/snyk-ls/domain/observability/ux"
 	"github.com/snyk/snyk-ls/infrastructure/services"
+	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 )
 
 func Test_autoAuthenticationDisabled_doesNotAuthenticate(t *testing.T) {
@@ -39,7 +40,7 @@ func getAutoAuthenticationTest(autoAuthentication bool, expectError bool) func(t
 		config.CurrentConfig().SetAutomaticAuthentication(autoAuthentication)
 		analytics := ux2.NewTestAnalytics()
 		provider := NewFakeCliAuthenticationProvider().(*FakeAuthenticationProvider)
-		authenticator := services.NewAuthenticationService(provider, analytics, errorreporting.NewTestErrorReporter())
+		authenticator := services.NewAuthenticationService(&snyk_api.FakeApiClient{}, provider, analytics, errorreporting.NewTestErrorReporter())
 		initializer := NewInitializer(authenticator, errorreporting.NewTestErrorReporter(), analytics)
 
 		// Act

--- a/infrastructure/services/auth_service.go
+++ b/infrastructure/services/auth_service.go
@@ -87,8 +87,14 @@ func (a AuthenticationService) Logout(ctx context.Context) {
 func (a AuthenticationService) IsAuthenticated() (bool, error) {
 	_, err := a.apiClient.GetActiveUser()
 	isAuthenticated := err == nil
-	if err.StatusCode() == 401 {
-		return false, errors.New("Authentication failed. Please update your token.")
+
+	if !isAuthenticated {
+		switch err.StatusCode() {
+		case 401:
+			return false, errors.New("Authentication failed. Please update your token.")
+		default:
+			return false, errors.New(err.Error())
+		}
 	}
 
 	return isAuthenticated, err

--- a/infrastructure/services/auth_service.go
+++ b/infrastructure/services/auth_service.go
@@ -85,17 +85,17 @@ func (a AuthenticationService) Logout(ctx context.Context) {
 }
 
 func (a AuthenticationService) IsAuthenticated() (bool, error) {
-	_, err := a.apiClient.GetActiveUser()
-	isAuthenticated := err == nil
+	_, getActiveUserErr := a.apiClient.GetActiveUser()
+	isAuthenticated := getActiveUserErr == nil
 
 	if !isAuthenticated {
-		switch err.StatusCode() {
+		switch getActiveUserErr.StatusCode() {
 		case 401:
 			return false, errors.New("Authentication failed. Please update your token.")
 		default:
-			return false, errors.New(err.Error())
+			return false, errors.New("Error checking authentication.")
 		}
 	}
 
-	return isAuthenticated, err
+	return isAuthenticated, nil
 }

--- a/infrastructure/services/auth_service.go
+++ b/infrastructure/services/auth_service.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"context"
+	"errors"
 
 	"github.com/rs/zerolog/log"
 
@@ -27,17 +28,19 @@ import (
 	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
 	"github.com/snyk/snyk-ls/domain/observability/ux"
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 	"github.com/snyk/snyk-ls/internal/notification"
 )
 
 type AuthenticationService struct {
+	apiClient     snyk_api.SnykApiClient
 	authenticator snyk.AuthenticationProvider
 	analytics     ux.Analytics
 	errorReporter error_reporting.ErrorReporter
 }
 
-func NewAuthenticationService(authenticator snyk.AuthenticationProvider, analytics ux.Analytics, errorReporter error_reporting.ErrorReporter) *AuthenticationService {
-	return &AuthenticationService{authenticator, analytics, errorReporter}
+func NewAuthenticationService(apiProvider snyk_api.SnykApiClient, authenticator snyk.AuthenticationProvider, analytics ux.Analytics, errorReporter error_reporting.ErrorReporter) *AuthenticationService {
+	return &AuthenticationService{apiProvider, authenticator, analytics, errorReporter}
 }
 
 func (a AuthenticationService) Provider() snyk.AuthenticationProvider {
@@ -82,9 +85,11 @@ func (a AuthenticationService) Logout(ctx context.Context) {
 }
 
 func (a AuthenticationService) IsAuthenticated() (bool, error) {
-	token := config.CurrentConfig().Token()
-	err := a.authenticator.AuthenticateToken(token)
+	_, err := a.apiClient.GetActiveUser()
 	isAuthenticated := err == nil
+	if err.StatusCode() == 401 {
+		return false, errors.New("Authentication failed. Please update your token.")
+	}
 
 	return isAuthenticated, err
 }

--- a/infrastructure/services/auth_service.go
+++ b/infrastructure/services/auth_service.go
@@ -93,7 +93,7 @@ func (a AuthenticationService) IsAuthenticated() (bool, error) {
 		case 401:
 			return false, errors.New("Authentication failed. Please update your token.")
 		default:
-			return false, errors.New("Error checking authentication.")
+			return false, getActiveUserErr
 		}
 	}
 

--- a/infrastructure/services/auth_service_test.go
+++ b/infrastructure/services/auth_service_test.go
@@ -97,7 +97,7 @@ func Test_IsAuthenticated(t *testing.T) {
 		isAuthenticated, err := service.IsAuthenticated()
 
 		assert.False(t, isAuthenticated)
-		assert.Equal(t, err.Error(), "Error checking authentication.")
+		assert.Equal(t, err.Error(), snykApiError.Error())
 	})
 }
 

--- a/infrastructure/services/auth_service_test.go
+++ b/infrastructure/services/auth_service_test.go
@@ -31,13 +31,14 @@ import (
 	"github.com/snyk/snyk-ls/domain/observability/ux"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/cli/auth"
+	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
 func Test_UpdateToken(t *testing.T) {
 	testutil.UnitTest(t)
 	analytics := ux.NewTestAnalytics()
-	service := NewAuthenticationService(&auth.CliAuthenticationProvider{}, analytics, error_reporting.NewTestErrorReporter())
+	service := NewAuthenticationService(&snyk_api.FakeApiClient{}, &auth.CliAuthenticationProvider{}, analytics, error_reporting.NewTestErrorReporter())
 
 	service.UpdateToken("new-token", false)
 
@@ -52,7 +53,7 @@ func Test_Logout(t *testing.T) {
 	// set up workspace
 	analytics := ux.NewTestAnalytics()
 	authProvider := auth.FakeAuthenticationProvider{}
-	service := NewAuthenticationService(&authProvider, analytics, error_reporting.NewTestErrorReporter())
+	service := NewAuthenticationService(&snyk_api.FakeApiClient{}, &authProvider, analytics, error_reporting.NewTestErrorReporter())
 	hoverService := hover.NewFakeHoverService()
 	scanner := snyk.NewTestScanner()
 	w := workspace.New(performance.NewTestInstrumentor(), scanner, hoverService)

--- a/infrastructure/snyk_api/fake_api_client.go
+++ b/infrastructure/snyk_api/fake_api_client.go
@@ -79,7 +79,7 @@ func (f *FakeApiClient) SastEnabled() (sastEnabled bool, localCodeEngineEnabled 
 	return f.CodeEnabled, false, false, nil
 }
 
-func (f *FakeApiClient) GetActiveUser() (user ActiveUser, err error) {
+func (f *FakeApiClient) GetActiveUser() (user ActiveUser, err *SnykApiError) {
 	f.addCall([]any{}, ActiveUserOperation)
 	return ActiveUser{Id: "FakeUser"}, nil
 }

--- a/infrastructure/snyk_api/fake_api_client.go
+++ b/infrastructure/snyk_api/fake_api_client.go
@@ -26,6 +26,7 @@ const (
 type FakeApiClient struct {
 	Calls       map[string][][]any
 	CodeEnabled bool
+	ApiError    *SnykApiError
 }
 
 var (
@@ -81,5 +82,10 @@ func (f *FakeApiClient) SastEnabled() (sastEnabled bool, localCodeEngineEnabled 
 
 func (f *FakeApiClient) GetActiveUser() (user ActiveUser, err *SnykApiError) {
 	f.addCall([]any{}, ActiveUserOperation)
+
+	if f.ApiError != nil {
+		return ActiveUser{}, f.ApiError
+	}
+
 	return ActiveUser{Id: "FakeUser"}, nil
 }

--- a/infrastructure/snyk_api/fake_api_client.go
+++ b/infrastructure/snyk_api/fake_api_client.go
@@ -74,7 +74,7 @@ func (f *FakeApiClient) GetAllCalls(op string) [][]any {
 	return calls
 }
 
-func (f *FakeApiClient) SastEnabled() (sastEnabled bool, localCodeEngineEnabled bool, reportFalsePositivesEnabled bool, err error) {
+func (f *FakeApiClient) SastEnabled() (sastEnabled bool, localCodeEngineEnabled bool, reportFalsePositivesEnabled bool, err *SnykApiError) {
 	f.addCall([]any{}, SastEnabledOperation)
 	return f.CodeEnabled, false, false, nil
 }

--- a/infrastructure/snyk_api/snyk_api.go
+++ b/infrastructure/snyk_api/snyk_api.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,7 +59,24 @@ type ActiveUser struct {
 
 type SnykApiClient interface {
 	SastEnabled() (sastEnabled bool, localCodeEngineEnabled bool, reportFalsePositivesEnabled bool, err error)
-	GetActiveUser() (user ActiveUser, err error)
+	GetActiveUser() (user ActiveUser, err *SnykApiError)
+}
+
+type SnykApiError struct {
+	msg        string
+	statusCode int
+}
+
+func NewSnykApiError(msg string, statusCode int) *SnykApiError {
+	return &SnykApiError{msg, statusCode}
+}
+
+func (e *SnykApiError) Error() string {
+	return e.msg
+}
+
+func (e *SnykApiError) StatusCode() int {
+	return e.statusCode
 }
 
 func NewSnykApiClient() SnykApiClient {
@@ -95,33 +111,33 @@ func (s *SnykApiClientImpl) SastEnabled() (sastEnabled bool, localCodeEngineEnab
 	return response.SastEnabled, response.LocalCodeEngine.Enabled, response.ReportFalsePositivesEnabled, nil
 }
 
-func (s *SnykApiClientImpl) GetActiveUser() (activeUser ActiveUser, err error) {
+func (s *SnykApiClientImpl) GetActiveUser() (activeUser ActiveUser, err *SnykApiError) {
 	log.Debug().Str("method", "GetActiveUser").Msg("API: Getting ActiveUser")
 	path := "/user/me"
 	responseBody, err := s.doCall("GET", path, nil)
 	if err != nil {
-		err = fmt.Errorf("%v: %v", err, responseBody)
-		log.Err(err).Str("method", "GetActiveUser").Msg("error when calling SnykApi.GetActiveUser endpoint")
+		fmtErr := fmt.Errorf("%v: %v", err, responseBody)
+		log.Err(fmtErr).Str("method", "GetActiveUser").Msg("error when calling SnykApi.GetActiveUser endpoint")
 		return ActiveUser{}, err
 	}
 
 	var response activeUserResponse
-	err = json.Unmarshal(responseBody, &response)
+	unmarshalErr := json.Unmarshal(responseBody, &response)
 	if err != nil {
-		err = fmt.Errorf("%v: %v", err, responseBody)
-		log.Err(err).Str("method", "GetActiveUser").Msg("couldn't unmarshal GetActiveUser")
-		return ActiveUser{}, err
+		fmtErr := fmt.Errorf("%v: %v", unmarshalErr, responseBody)
+		log.Err(fmtErr).Str("method", "GetActiveUser").Msg("couldn't unmarshal GetActiveUser")
+		return ActiveUser{}, NewSnykApiError(fmtErr.Error(), 0)
 	}
 	log.Debug().Str("method", "GetActiveUser").Msgf("Retrieved user %v", response)
 	return ActiveUser(response), nil
 }
 
-func (s *SnykApiClientImpl) doCall(method string, path string, requestBody []byte) (responseBody []byte, err error) {
+func (s *SnykApiClientImpl) doCall(method string, path string, requestBody []byte) (responseBody []byte, err *SnykApiError) {
 	host := config.CurrentConfig().SnykApi()
 	b := bytes.NewBuffer(requestBody)
-	req, err := http.NewRequest(method, host+path, b)
-	if err != nil {
-		return nil, err
+	req, requestErr := http.NewRequest(method, host+path, b)
+	if requestErr != nil {
+		return nil, NewSnykApiError(requestErr.Error(), 0)
 	}
 	req.Header.Set("Authorization", "token "+config.CurrentConfig().Token())
 	req.Header.Set("Content-Type", "application/json")
@@ -130,9 +146,9 @@ func (s *SnykApiClientImpl) doCall(method string, path string, requestBody []byt
 	req.Header.Set("x-snyk-ide", "snyk-ls-"+clientID)
 
 	log.Trace().Str("requestBody", string(requestBody)).Msg("SEND TO REMOTE")
-	response, err := s.client.Do(req)
-	if err != nil {
-		return nil, err
+	response, requestErr := s.client.Do(req)
+	if requestErr != nil {
+		return nil, NewSnykApiError(requestErr.Error(), response.StatusCode) // todo: check if status code is returned here
 	}
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
@@ -140,10 +156,10 @@ func (s *SnykApiClientImpl) doCall(method string, path string, requestBody []byt
 			log.Err(err).Msg("Couldn't close response body in call to Snyk API")
 		}
 	}(response.Body)
-	responseBody, err = io.ReadAll(response.Body)
+	responseBody, readErr := io.ReadAll(response.Body)
 	log.Trace().Str("response.Status", response.Status).Str("responseBody", string(responseBody)).Msg("RECEIVED FROM REMOTE")
-	if err != nil {
-		return nil, err
+	if readErr != nil {
+		return nil, NewSnykApiError(err.Error(), 0)
 	}
 
 	err = checkResponseCode(response)
@@ -154,10 +170,10 @@ func (s *SnykApiClientImpl) doCall(method string, path string, requestBody []byt
 	return responseBody, err
 }
 
-func checkResponseCode(r *http.Response) error {
+func checkResponseCode(r *http.Response) *SnykApiError {
 	if r.StatusCode >= 200 && r.StatusCode <= 299 {
 		return nil
 	}
 
-	return errors.New("Unexpected response code: " + r.Status)
+	return NewSnykApiError("Unexpected response code: "+r.Status, r.StatusCode)
 }


### PR DESCRIPTION
### Description

_This PR should change how we check a user is authenticated by using an API endpoint instead of CLI auth. This should stop auth checks from writing to the config store.._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

