### PR TITLE
fix: 🐛 correct hover / position overlap calculation [HEAD-53]

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -421,7 +421,7 @@ func textDocumentHover() jrpc2.Handler {
 	return handler.New(func(_ context.Context, params hover.Params) (hover.Result, error) {
 		log.Info().Str("method", "TextDocumentHover").Interface("params", params).Msg("RECEIVING")
 
-		hoverResult := di.HoverService().GetHover(params.TextDocument.URI, params.Position)
+		hoverResult := di.HoverService().GetHover(params.TextDocument.URI, converter.FromPosition(params.Position))
 		return hoverResult, nil
 	})
 }

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/application/server/lsp"
+	"github.com/snyk/snyk-ls/domain/ide/converter"
 	"github.com/snyk/snyk-ls/domain/ide/hover"
 	"github.com/snyk/snyk-ls/domain/ide/workspace"
 	"github.com/snyk/snyk-ls/domain/observability/performance"
@@ -935,7 +936,7 @@ func Test_IntegrationHoverResults(t *testing.T) {
 		t.Fatal(err, "Hover retrieval failed")
 	}
 
-	assert.Equal(t, hoverResult.Contents.Value, di.HoverService().GetHover(uri.PathToUri(testPath), testPosition).Contents.Value)
+	assert.Equal(t, hoverResult.Contents.Value, di.HoverService().GetHover(uri.PathToUri(testPath), converter.FromPosition(testPosition)).Contents.Value)
 	assert.Equal(t, hoverResult.Contents.Kind, "markdown")
 }
 func Test_SmokeSnykCodeFileScan(t *testing.T) {

--- a/domain/ide/converter/converter.go
+++ b/domain/ide/converter/converter.go
@@ -174,7 +174,7 @@ func ToHovers(issues []snyk.Issue) (hovers []hover.Hover[hover.Context]) {
 
 		hovers = append(hovers, hover.Hover[hover.Context]{
 			Id:      i.ID,
-			Range:   ToRange(i.Range),
+			Range:   i.Range,
 			Message: message,
 			Context: i,
 		})

--- a/domain/ide/hover/fake_service.go
+++ b/domain/ide/hover/fake_service.go
@@ -20,6 +20,7 @@ import (
 	sglsp "github.com/sourcegraph/go-lsp"
 
 	ux2 "github.com/snyk/snyk-ls/domain/observability/ux"
+	"github.com/snyk/snyk-ls/domain/snyk"
 )
 
 type FakeHoverService struct {
@@ -50,7 +51,7 @@ func (t *FakeHoverService) ClearAllHovers() {
 	}
 }
 
-func (t *FakeHoverService) GetHover(_ sglsp.DocumentURI, pos sglsp.Position) Result {
+func (t *FakeHoverService) GetHover(_ sglsp.DocumentURI, pos snyk.Position) Result {
 	//TODO implement me
 	panic("implement me")
 }

--- a/domain/ide/hover/model.go
+++ b/domain/ide/hover/model.go
@@ -18,15 +18,17 @@ package hover
 
 import (
 	sglsp "github.com/sourcegraph/go-lsp"
+
+	"github.com/snyk/snyk-ls/domain/snyk"
 )
 
 type Context any
 
 type Hover[T Context] struct {
 	Id      string
-	Range   sglsp.Range
+	Range   snyk.Range
 	Message string
-	Context T
+	Context T // this normally contains snyk.Issue
 }
 
 type DocumentHovers struct {

--- a/domain/ide/hover/service.go
+++ b/domain/ide/hover/service.go
@@ -34,7 +34,7 @@ type Service interface {
 	DeleteHover(documentUri sglsp.DocumentURI)
 	Channel() chan DocumentHovers
 	ClearAllHovers()
-	GetHover(fileUri sglsp.DocumentURI, pos sglsp.Position) Result
+	GetHover(fileUri sglsp.DocumentURI, pos snyk.Position) Result
 	SetAnalytics(analytics ux2.Analytics)
 }
 
@@ -59,11 +59,12 @@ func NewDefaultService(analytics ux2.Analytics) Service {
 	return s
 }
 
-func (s *DefaultHoverService) isHoverForPosition(hover Hover[Context], pos sglsp.Position) bool {
-	return hover.Range.Start.Line < pos.Line && hover.Range.End.Line > pos.Line ||
-		(hover.Range.Start.Line == pos.Line &&
-			hover.Range.Start.Character <= pos.Character &&
-			hover.Range.End.Character >= pos.Character)
+func (s *DefaultHoverService) isHoverForPosition(hover Hover[Context], pos snyk.Position) bool {
+	hoverRange := hover.Range
+	posRange := snyk.Range{Start: pos, End: pos}
+	overlaps := hoverRange.Overlaps(posRange)
+	log.Debug().Str("method", "isHoverForPosition").Msgf("hover: %v, pos: %v, overlaps: %v", hoverRange, pos, overlaps)
+	return overlaps
 }
 
 func (s *DefaultHoverService) registerHovers(result DocumentHovers) {
@@ -75,6 +76,11 @@ func (s *DefaultHoverService) registerHovers(result DocumentHovers) {
 		hoverIndex := uri.PathFromUri(key) + fmt.Sprintf("%v%v", newHover.Range, newHover.Id)
 
 		if !s.hoverIndexes[hoverIndex] {
+			log.Debug().
+				Str("method", "registerHovers").
+				Str("hoverIndex", hoverIndex).
+				Msg("registering hover")
+
 			s.hovers[key] = append(s.hovers[key], newHover)
 			s.hoverIndexes[hoverIndex] = true
 		}
@@ -89,6 +95,12 @@ func (s *DefaultHoverService) DeleteHover(documentUri sglsp.DocumentURI) {
 	for key := range s.hoverIndexes {
 		document := uri.PathFromUri(documentUri)
 		if strings.Contains(key, document) {
+			log.Debug().
+				Str("method", "DeleteHover").
+				Str("key", key).
+				Str("document", document).
+				Msg("deleting hover")
+
 			delete(s.hoverIndexes, key)
 		}
 	}
@@ -106,7 +118,7 @@ func (s *DefaultHoverService) ClearAllHovers() {
 	s.hoverIndexes = map[string]bool{}
 }
 
-func (s *DefaultHoverService) GetHover(fileUri sglsp.DocumentURI, pos sglsp.Position) Result {
+func (s *DefaultHoverService) GetHover(fileUri sglsp.DocumentURI, pos snyk.Position) Result {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/domain/ide/hover/service_test.go
+++ b/domain/ide/hover/service_test.go
@@ -31,9 +31,9 @@ import (
 func setupFakeHover() sglsp.DocumentURI {
 	target := NewDefaultService(ux2.NewTestAnalytics()).(*DefaultHoverService)
 	fakeHover := []Hover[Context]{
-		{Range: sglsp.Range{
-			Start: sglsp.Position{Line: 3, Character: 56},
-			End:   sglsp.Position{Line: 5, Character: 80},
+		{Range: snyk.Range{
+			Start: snyk.Position{Line: 3, Character: 56},
+			End:   snyk.Position{Line: 5, Character: 80},
 		},
 		},
 	}
@@ -53,12 +53,12 @@ func Test_registerHovers(t *testing.T) {
 		Hover: []Hover[Context]{
 			{
 				Id: "test-id",
-				Range: sglsp.Range{
-					Start: sglsp.Position{
+				Range: snyk.Range{
+					Start: snyk.Position{
 						Line:      10,
 						Character: 14,
 					},
-					End: sglsp.Position{
+					End: snyk.Position{
 						Line:      56,
 						Character: 87,
 					},
@@ -99,65 +99,65 @@ func Test_GetHoverMultiline(t *testing.T) {
 
 	tests := []struct {
 		hoverDetails []Hover[Context]
-		query        sglsp.Position
+		query        snyk.Position
 		expected     Result
 	}{
 		// multiline range
 		{
-			hoverDetails: []Hover[Context]{{Range: sglsp.Range{
-				Start: sglsp.Position{Line: 3, Character: 56},
-				End:   sglsp.Position{Line: 5, Character: 80},
+			hoverDetails: []Hover[Context]{{Range: snyk.Range{
+				Start: snyk.Position{Line: 3, Character: 56},
+				End:   snyk.Position{Line: 5, Character: 80},
 			},
 				Message: "## Vulnerabilities found"}},
-			query: sglsp.Position{Line: 4, Character: 66},
+			query: snyk.Position{Line: 4, Character: 66},
 			expected: Result{Contents: MarkupContent{
 				Kind: "markdown", Value: "## Vulnerabilities found"},
 			},
 		},
 		// exact line but within character range
 		{
-			hoverDetails: []Hover[Context]{{Range: sglsp.Range{
-				Start: sglsp.Position{Line: 4, Character: 56},
-				End:   sglsp.Position{Line: 4, Character: 80},
+			hoverDetails: []Hover[Context]{{Range: snyk.Range{
+				Start: snyk.Position{Line: 4, Character: 56},
+				End:   snyk.Position{Line: 4, Character: 80},
 			},
 				Message: "## Vulnerabilities found"}},
-			query: sglsp.Position{Line: 4, Character: 66},
+			query: snyk.Position{Line: 4, Character: 66},
 			expected: Result{Contents: MarkupContent{
 				Kind: "markdown", Value: "## Vulnerabilities found"},
 			},
 		},
 		// exact line and exact character
 		{
-			hoverDetails: []Hover[Context]{{Range: sglsp.Range{
-				Start: sglsp.Position{Line: 4, Character: 56},
-				End:   sglsp.Position{Line: 4, Character: 56},
+			hoverDetails: []Hover[Context]{{Range: snyk.Range{
+				Start: snyk.Position{Line: 4, Character: 56},
+				End:   snyk.Position{Line: 4, Character: 56},
 			},
 				Message: "## Vulnerabilities found"}},
-			query: sglsp.Position{Line: 4, Character: 56},
+			query: snyk.Position{Line: 4, Character: 56},
 			expected: Result{Contents: MarkupContent{
 				Kind: "markdown", Value: "## Vulnerabilities found"},
 			},
 		},
 		// hover left of the character position on exact line
 		{
-			hoverDetails: []Hover[Context]{{Range: sglsp.Range{
-				Start: sglsp.Position{Line: 4, Character: 56},
-				End:   sglsp.Position{Line: 4, Character: 86},
+			hoverDetails: []Hover[Context]{{Range: snyk.Range{
+				Start: snyk.Position{Line: 4, Character: 56},
+				End:   snyk.Position{Line: 4, Character: 86},
 			},
 				Message: "## Vulnerabilities found"}},
-			query: sglsp.Position{Line: 4, Character: 45},
+			query: snyk.Position{Line: 4, Character: 45},
 			expected: Result{Contents: MarkupContent{
 				Kind: "markdown", Value: ""},
 			},
 		},
 		// hover right of the character position on exact line
 		{
-			hoverDetails: []Hover[Context]{{Range: sglsp.Range{
-				Start: sglsp.Position{Line: 4, Character: 56},
-				End:   sglsp.Position{Line: 4, Character: 86},
+			hoverDetails: []Hover[Context]{{Range: snyk.Range{
+				Start: snyk.Position{Line: 4, Character: 56},
+				End:   snyk.Position{Line: 4, Character: 86},
 			},
 				Message: "## Vulnerabilities found"}},
-			query: sglsp.Position{Line: 4, Character: 105},
+			query: snyk.Position{Line: 4, Character: 105},
 			expected: Result{Contents: MarkupContent{
 				Kind: "markdown", Value: ""},
 			},
@@ -191,14 +191,14 @@ func Test_TracksAnalytics(t *testing.T) {
 				IssueType:        snyk.ContainerVulnerability,
 				AffectedFilePath: path,
 			},
-			Range: sglsp.Range{
-				Start: sglsp.Position{Line: 3, Character: 56},
-				End:   sglsp.Position{Line: 5, Character: 80},
+			Range: snyk.Range{
+				Start: snyk.Position{Line: 3, Character: 56},
+				End:   snyk.Position{Line: 5, Character: 80},
 			},
 			Message: "## Vulnerabilities found"},
 	}
 
-	target.GetHover(documentURI, sglsp.Position{Line: 4, Character: 66})
+	target.GetHover(documentURI, snyk.Position{Line: 4, Character: 66})
 	assert.Len(t, analytics.GetAnalytics(), 1)
 	assert.Equal(t, ux2.IssueHoverIsDisplayedProperties{
 		IssueId:   "issue",


### PR DESCRIPTION
### Description

Previously, hovers were not correctly calculated, when 

- the hover was multi-line and 
- the last char position on the last line was < cursor position

The change switches usage from sourcegraph ranges to our Snyk domain ranges, as that type already has working helper functions to test for overlap. Also, it removes duplication of range/overlap logic.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

![image](https://user-images.githubusercontent.com/20150761/215045899-b908c6ff-780d-4779-af2e-ad784ad98e80.png)

![image](https://user-images.githubusercontent.com/20150761/215043787-0ab68917-75b7-494e-b88b-9e3dc1a0fb0e.png)
