### PR TITLE
feat: report Code markers in "snyk/scan" message [HEAD-9]

### DIFF
--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -90,6 +90,26 @@ func (n *scanNotifier) sendSuccess(pr product.Product, folderPath string, issues
 				Lines:     lines,
 			})
 		}
+
+		markers := make([]lsp.Marker, 0, len(additionalData.Markers))
+		for _, marker := range additionalData.Markers {
+			positions := make([]lsp.MarkerPosition, 0)
+			for _, pos := range marker.Pos {
+				positions = append(positions, lsp.MarkerPosition{
+					Position: lsp.Position{
+						Rows: pos.Rows,
+						Cols: pos.Cols,
+					},
+					File: pos.File,
+				})
+			}
+
+			markers = append(markers, lsp.Marker{
+				Msg: marker.Msg,
+				Pos: positions,
+			})
+		}
+
 		scanIssues = append(scanIssues, lsp.ScanIssue{
 			Id:       issue.ID,
 			Title:    "Title",
@@ -106,8 +126,7 @@ func (n *scanNotifier) sendSuccess(pr product.Product, folderPath string, issues
 				Cols:               additionalData.Cols,
 				Rows:               additionalData.Rows,
 
-				// TODO - fill these with real data
-				Markers: nil,
+				Markers: markers,
 				LeadURL: "",
 			},
 		})

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -278,9 +278,9 @@ func (s *SarifResponse) toIssues() (issues []snyk.Issue) {
 			// convert the documentURI to a path according to our conversion
 			path := loc.PhysicalLocation.ArtifactLocation.URI
 
-			startLine := loc.PhysicalLocation.Region.StartLine - 1
-			endLine := loc.PhysicalLocation.Region.EndLine - 1
-			startCol := loc.PhysicalLocation.Region.StartColumn - 1
+			startLine := loc.PhysicalLocation.Region.StartLine
+			endLine := loc.PhysicalLocation.Region.EndLine
+			startCol := loc.PhysicalLocation.Region.StartColumn
 			endCol := loc.PhysicalLocation.Region.EndColumn
 
 			myRange := snyk.Range{
@@ -384,9 +384,9 @@ func (r *result) getMarkers() []snyk.Marker {
 			index, _ := strconv.Atoi(i)
 			loc := r.CodeFlows[0].ThreadFlows[0].Locations[index]
 
-			startLine := loc.Location.PhysicalLocation.Region.StartLine - 1 // todo: move to an extract func
-			endLine := loc.Location.PhysicalLocation.Region.EndLine - 1
-			startCol := loc.Location.PhysicalLocation.Region.StartColumn - 1
+			startLine := loc.Location.PhysicalLocation.Region.StartLine // todo: move to an extract func
+			endLine := loc.Location.PhysicalLocation.Region.EndLine
+			startCol := loc.Location.PhysicalLocation.Region.StartColumn
 			endCol := loc.Location.PhysicalLocation.Region.EndColumn
 
 			positions = append(positions, snyk.MarkerPosition{

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -407,7 +407,7 @@ func (r *result) getMarkers() []snyk.Marker {
 		// compute index to insert markers
 		indexTemplate := fmt.Sprintf("{%d}", i)
 		msgStartIndex := strings.LastIndex(markdownStr, indexTemplate)
-		msgEndIndex := msgStartIndex + len(substituteStr)
+		msgEndIndex := msgStartIndex + len(substituteStr) - 1
 
 		markdownStr = strings.Replace(markdownStr, indexTemplate, substituteStr, 1)
 

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -323,6 +323,8 @@ func (s *SarifResponse) toIssues() (issues []snyk.Issue) {
 				isSecurityType = false
 			}
 
+			markers := result.getMarkers()
+
 			additionalData := snyk.CodeIssueData{
 				Message:            result.Message.Text,
 				Rule:               rule.Name,
@@ -330,7 +332,7 @@ func (s *SarifResponse) toIssues() (issues []snyk.Issue) {
 				ExampleCommitFixes: exampleFixes,
 				CWE:                rule.Properties.Cwe,
 				Text:               rule.Help.Markdown,
-				Markers:            []snyk.Marker{}, // TODO: Clarify how to pull markers from the new API with Code Team
+				Markers:            markers,
 				Cols:               [2]int{startCol, endCol},
 				Rows:               [2]int{startLine, endLine},
 				IsSecurityType:     isSecurityType,
@@ -365,6 +367,54 @@ func getIssueId(ruleId string, path string, startLine int, endLine int, startCol
 	// deepcode ignore InsecureHash: The hash isn't used for security purposes.
 	id := md5.Sum([]byte(ruleId + path + strconv.Itoa(startLine) + strconv.Itoa(endLine) + strconv.Itoa(startCol) + strconv.Itoa(endCol)))
 	return hex.EncodeToString(id[:])
+}
+
+func (r *result) getMarkers() []snyk.Marker {
+	markers := make([]snyk.Marker, 0)
+
+	markdownStr := r.Message.Markdown
+	for i, arg := range r.Message.Arguments {
+		// Compute markers
+		indecesRegex := regexp.MustCompile(`(\d)`)
+		indices := indecesRegex.FindAllString(arg, -1) // extract the indices from the brackets
+
+		positions := make([]snyk.MarkerPosition, 0)
+		for _, i := range indices {
+			// get the location of the index
+			index, _ := strconv.Atoi(i)
+			loc := r.CodeFlows[0].ThreadFlows[0].Locations[index]
+
+			startLine := loc.Location.PhysicalLocation.Region.StartLine - 1 // todo: move to an extract func
+			endLine := loc.Location.PhysicalLocation.Region.EndLine - 1
+			startCol := loc.Location.PhysicalLocation.Region.StartColumn - 1
+			endCol := loc.Location.PhysicalLocation.Region.EndColumn
+
+			positions = append(positions, snyk.MarkerPosition{
+				Rows: [2]int{startLine, endLine},
+				Cols: [2]int{startCol, endCol},
+				File: loc.Location.PhysicalLocation.ArtifactLocation.URI,
+			})
+		}
+
+		// Extract the text between the brackets
+		strRegex := regexp.MustCompile(`\[(.*?)\]`)
+		substituteStr := strRegex.FindStringSubmatch(arg)[1] // extract the text between the brackets
+
+		// compute index to insert markers
+		indexTemplate := fmt.Sprintf("{%d}", i)
+		msgStartIndex := strings.LastIndex(markdownStr, indexTemplate)
+		msgEndIndex := msgStartIndex + len(substituteStr)
+
+		markdownStr = strings.Replace(markdownStr, indexTemplate, substituteStr, 1)
+
+		// write marker
+		markers = append(markers, snyk.Marker{
+			Msg: [2]int{msgStartIndex, msgEndIndex},
+			Pos: positions,
+		})
+	}
+
+	return markers
 }
 
 func (s *SarifResponse) reportDiagnostic(d snyk.Issue) bool {

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -404,11 +404,12 @@ func getSarifResponseJson(filePath string) string {
             "level": "note",
             "message": {
               "text": "Printing the stack trace of java.lang.InterruptedException. Production code should not use printStackTrace.",
-              "markdown": "Printing the stack trace of {0}. Production code should not use {1}.",
-              "arguments": [
-                "[java.lang.InterruptedException](0)",
-                "[printStackTrace](1)"
-              ]
+							"markdown": "Printing the stack trace of {0}. Production code should not use {1}. {2}",
+							"arguments": [
+								"[java.lang.InterruptedException](0)",
+								"[printStackTrace](1)(2)",
+								"[This is a test argument](3)"
+							]
             },
             "locations": [
               {
@@ -468,7 +469,41 @@ func getSarifResponseJson(filePath string) string {
                             }
                           }
                         }
-                      }
+                      },
+											{
+												"location": {
+                          "id": 2,
+                          "physicalLocation": {
+                            "artifactLocation": {
+																"uri": "%s",
+                              "uriBaseId": "dummy"
+                            },
+                            "region": {
+                              "startLine": 10,
+                              "endLine": 10,
+                              "startColumn": 10,
+                              "endColumn": 10
+                            }
+                          }
+                        }
+											},
+											{
+												"location": {
+                          "id": 3,
+                          "physicalLocation": {
+                            "artifactLocation": {
+																"uri": "%s",
+                              "uriBaseId": "dummy"
+                            },
+                            "region": {
+                              "startLine": 20,
+                              "endLine": 20,
+                              "startColumn": 20,
+                              "endColumn": 20
+                            }
+                          }
+                        }
+											}
                     ]
                   }
                 ]
@@ -583,7 +618,7 @@ func getSarifResponseJson(filePath string) string {
     ]
   }
 }
-`, filePath, filePath, filePath, filePath, filePath)
+`, filePath, filePath, filePath, filePath, filePath, filePath, filePath)
 }
 
 func TestSnykCodeBackendService_convert_shouldConvertIssues(t *testing.T) {
@@ -639,6 +674,21 @@ func markersForSampleSarifResponse(path string) []snyk.Marker {
 				{
 					Rows: [2]int{6, 6},
 					Cols: [2]int{9, 23},
+					File: path,
+				},
+				{
+					Rows: [2]int{10, 10},
+					Cols: [2]int{10, 10},
+					File: path,
+				},
+			},
+		},
+		{
+			Msg: [2]int{108, 131},
+			Pos: []snyk.MarkerPosition{
+				{
+					Rows: [2]int{20, 20},
+					Cols: [2]int{20, 20},
 					File: path,
 				},
 			},

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -604,6 +604,7 @@ func TestSnykCodeBackendService_convert_shouldConvertIssues(t *testing.T) {
 	assert.Equal(t, references, issue.References)
 	assert.Contains(t, issue.FormattedMessage, "Example Commit Fixes")
 	assert.NotEmpty(t, issue.Commands, "should have getCommands filled from codeflow")
+	assert.Equal(t, markersForSampleSarifResponse(path), issue.AdditionalData.(snyk.CodeIssueData).Markers)
 }
 
 func referencesForSampleSarifResponse() []snyk.Reference {
@@ -620,6 +621,32 @@ func referencesForSampleSarifResponse() []snyk.Reference {
 	return references
 }
 
+func markersForSampleSarifResponse(path string) []snyk.Marker {
+	references := []snyk.Marker{
+		{
+			Msg: [2]int{28, 58},
+			Pos: []snyk.MarkerPosition{
+				{
+					Rows: [2]int{4, 4},
+					Cols: [2]int{13, 33},
+					File: path,
+				},
+			},
+		},
+		{
+			Msg: [2]int{91, 106},
+			Pos: []snyk.MarkerPosition{
+				{
+					Rows: [2]int{5, 5},
+					Cols: [2]int{8, 23},
+					File: path,
+				},
+			},
+		},
+	}
+
+	return references
+}
 func Test_getFormattedMessage(t *testing.T) {
 	testutil.UnitTest(t)
 	_, _, sarifResponse := setupConversionTests(t, true, true)

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -697,6 +697,7 @@ func markersForSampleSarifResponse(path string) []snyk.Marker {
 
 	return references
 }
+
 func Test_getFormattedMessage(t *testing.T) {
 	testutil.UnitTest(t)
 	_, _, sarifResponse := setupConversionTests(t, true, true)

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -627,8 +627,8 @@ func markersForSampleSarifResponse(path string) []snyk.Marker {
 			Msg: [2]int{28, 58},
 			Pos: []snyk.MarkerPosition{
 				{
-					Rows: [2]int{4, 4},
-					Cols: [2]int{13, 33},
+					Rows: [2]int{5, 5},
+					Cols: [2]int{14, 33},
 					File: path,
 				},
 			},
@@ -637,8 +637,8 @@ func markersForSampleSarifResponse(path string) []snyk.Marker {
 			Msg: [2]int{91, 106},
 			Pos: []snyk.MarkerPosition{
 				{
-					Rows: [2]int{5, 5},
-					Cols: [2]int{8, 23},
+					Rows: [2]int{6, 6},
+					Cols: [2]int{9, 23},
 					File: path,
 				},
 			},

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -659,7 +659,7 @@ func referencesForSampleSarifResponse() []snyk.Reference {
 func markersForSampleSarifResponse(path string) []snyk.Marker {
 	references := []snyk.Marker{
 		{
-			Msg: [2]int{28, 58},
+			Msg: [2]int{28, 57},
 			Pos: []snyk.MarkerPosition{
 				{
 					Rows: [2]int{5, 5},
@@ -669,7 +669,7 @@ func markersForSampleSarifResponse(path string) []snyk.Marker {
 			},
 		},
 		{
-			Msg: [2]int{91, 106},
+			Msg: [2]int{91, 105},
 			Pos: []snyk.MarkerPosition{
 				{
 					Rows: [2]int{6, 6},
@@ -684,7 +684,7 @@ func markersForSampleSarifResponse(path string) []snyk.Marker {
 			},
 		},
 		{
-			Msg: [2]int{108, 131},
+			Msg: [2]int{108, 130},
 			Pos: []snyk.MarkerPosition{
 				{
 					Rows: [2]int{20, 20},


### PR DESCRIPTION
### Description

- Reports Snyk Code markers in the `snyk/scan` message to VS Code extension.
- Corrects issue line and column indices.
 
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
