### PR TITLE
feat: pass limitToFiles to Code engine [HEAD-122]

### DIFF
--- a/infrastructure/code/backend_service_pact_test.go
+++ b/infrastructure/code/backend_service_pact_test.go
@@ -192,7 +192,7 @@ func TestSnykCodeBackendServicePact(t *testing.T) { // nolint:gocognit // this i
 			analysisOptions := AnalysisOptions{
 				bundleHash:   bundleHash,
 				shardKey:     "shardKey",
-				limitToFiles: []string{},
+				limitToFiles: []string{"path/to/file1.go"},
 				severity:     0,
 			}
 

--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -40,6 +40,7 @@ type Bundle struct {
 	errorReporter error_reporting.ErrorReporter
 	requestId     string
 	missingFiles  []string
+	limitToFiles  []string
 	rootPath      string
 	scanNotifier  snyk.ScanNotifier
 }
@@ -93,7 +94,7 @@ func (b *Bundle) retrieveAnalysis(ctx context.Context) ([]snyk.Issue, error) {
 	analysisOptions := AnalysisOptions{
 		bundleHash:   b.BundleHash,
 		shardKey:     b.getShardKey(b.rootPath, config.CurrentConfig().Token()),
-		limitToFiles: []string{},
+		limitToFiles: b.limitToFiles,
 		severity:     0,
 	}
 

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -144,7 +144,7 @@ func (sc *Scanner) Scan(ctx context.Context, path string, folderPath string) (is
 
 	metrics := sc.newMetrics(len(folderFiles), startTime)
 	results, err := sc.UploadAndAnalyze(span.Context(), folderFiles, folderPath, metrics)
-	if err != nil {
+	if err == nil {
 		sc.changedFiles.ClearAll()
 	}
 	return results, err

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -96,6 +96,7 @@ func New(bundleUploader *BundleUploader,
 		errorReporter:  reporter,
 		analytics:      analytics,
 		runningScans:   map[string]*ScanStatus{},
+		changedPaths:   map[string]bool{},
 	}
 	return sc
 }

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -121,7 +121,7 @@ func (sc *Scanner) Scan(ctx context.Context, path string, folderPath string) (is
 		return issues, errors.New("SAST is not enabled")
 	}
 
-	sc.changedFilesMutex.Lock() // todo: see if we can reuse another mutex
+	sc.changedFilesMutex.Lock()
 	sc.changedPaths[path] = true
 	sc.changedFilesMutex.Unlock()
 

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -122,7 +122,7 @@ func (sc *Scanner) Scan(ctx context.Context, path string, folderPath string) (is
 	}
 
 	sc.changedFilesMutex.Lock()
-	didUpdateChangedFiles := sc.UpdateChangedFiles(path)
+	sc.UpdateChangedFiles(path)
 	sc.changedFilesMutex.Unlock()
 
 	// When starting a scan for a folderPath that's already scanned, the new scan will wait for the previous scan
@@ -145,11 +145,6 @@ func (sc *Scanner) Scan(ctx context.Context, path string, folderPath string) (is
 	}()
 
 	sc.changedFilesMutex.Lock()
-	if didUpdateChangedFiles && !sc.changedFiles.Contains(path) {
-		log.Debug().Msg("file " + path + " is not in changed files, skipping scan")
-		sc.changedFilesMutex.Unlock()
-		return []snyk.Issue{}, nil
-	}
 	changedFiles := make([]string, 0, sc.changedFiles.Length())
 	sc.changedFiles.Range(func(key, value interface{}) bool {
 		changedFiles = append(changedFiles, key.(string))

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -312,7 +312,7 @@ func Test_Scan(t *testing.T) {
 	t.Run("Should update changed files", func(t *testing.T) {
 		testutil.UnitTest(t)
 		// Arrange
-		snykCodeMock := &FakeSnykCodeClient{} // fail on create bundle to avoid clearing changed files
+		snykCodeMock := &FakeSnykCodeClient{}
 		scanner := New(
 			NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
 			&snyk_api.FakeApiClient{CodeEnabled: true},
@@ -320,12 +320,13 @@ func Test_Scan(t *testing.T) {
 			ux2.NewTestAnalytics(),
 		)
 		wg := sync.WaitGroup{}
+		_, tempDir, _, _, _ := setupIgnoreWorkspace(t)
 
 		// Act
 		for i := 0; i < 5; i++ {
 			wg.Add(1)
 			go func(i int) {
-				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", "")
+				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", tempDir)
 				wg.Done()
 			}(i)
 		}
@@ -359,12 +360,13 @@ func Test_Scan(t *testing.T) {
 			ux2.NewTestAnalytics(),
 		)
 		wg := sync.WaitGroup{}
+		tempDir := t.TempDir()
 
 		// Act
 		for i := 0; i < 5; i++ {
 			wg.Add(1)
 			go func(i int) {
-				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", "")
+				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", tempDir)
 				wg.Done()
 			}(i)
 		}

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -368,7 +368,7 @@ func Test_Scan(t *testing.T) {
 		wg.Wait()
 
 		// Assert
-		assert.Equal(t, 0, scanner.changedPaths.Length())
+		assert.Equal(t, 0, len(scanner.changedPaths))
 	})
 
 	t.Run("Should not mark folders as changed files", func(t *testing.T) {

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 	"github.com/snyk/snyk-ls/internal/data_structure"
 	"github.com/snyk/snyk-ls/internal/notification"
-	"github.com/snyk/snyk-ls/internal/progress"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/uri"
 	"github.com/snyk/snyk-ls/internal/util"

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -312,7 +312,7 @@ func Test_Scan(t *testing.T) {
 	t.Run("Should update changed files", func(t *testing.T) {
 		testutil.UnitTest(t)
 		// Arrange
-		snykCodeMock := &FakeSnykCodeClient{FailOnCreateBundle: true} // fail on create bundle to avoid clearing changed files
+		snykCodeMock := &FakeSnykCodeClient{} // fail on create bundle to avoid clearing changed files
 		scanner := New(
 			NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
 			&snyk_api.FakeApiClient{CodeEnabled: true},
@@ -340,14 +340,11 @@ func Test_Scan(t *testing.T) {
 			"file4.go",
 		}
 
-		actualChangedFiles := make([]string, 0, scanner.changedFiles.Length())
-		scanner.changedFiles.Range(func(key any, _ any) bool {
-			actualChangedFiles = append(actualChangedFiles, key.(string))
-			return true
-		})
-
+		params := snykCodeMock.GetCallParams(0, RunAnalysisOperation)
+		assert.NotNil(t, params)
+		assert.Equal(t, 5, len(params[1].([]string)))
 		for _, file := range expectedChangedFiles {
-			assert.Contains(t, actualChangedFiles, file)
+			assert.Contains(t, params[1], file)
 		}
 	})
 

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -322,7 +322,6 @@ func Test_Scan(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", tempDir)
-				progress.CleanupChannels()
 				wg.Done()
 			}(i)
 		}
@@ -362,7 +361,6 @@ func Test_Scan(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", tempDir)
-				progress.CleanupChannels()
 				wg.Done()
 			}(i)
 		}
@@ -401,7 +399,6 @@ func Test_Scan(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				_, _ = scanner.Scan(context.Background(), "", tempDir)
-				progress.CleanupChannels()
 				wg.Done()
 			}()
 		}

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -357,6 +357,7 @@ func Test_Scan(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", tempDir)
+				progress.CleanupChannels()
 				wg.Done()
 			}(i)
 		}
@@ -395,6 +396,7 @@ func Test_Scan(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				_, _ = scanner.Scan(context.Background(), "", tempDir)
+				progress.CleanupChannels()
 				wg.Done()
 			}()
 		}

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -337,11 +337,16 @@ func Test_Scan(t *testing.T) {
 			"file4.go",
 		}
 
-		params := snykCodeMock.GetCallParams(0, RunAnalysisOperation)
-		assert.NotNil(t, params)
-		assert.Equal(t, 5, len(params[1].([]string)))
+		allCalls := snykCodeMock.GetAllCalls(RunAnalysisOperation)
+		communicatedChangedFiles := make([]string, 0)
+		for _, call := range allCalls {
+			params := call[1].([]string)
+			communicatedChangedFiles = append(communicatedChangedFiles, params...)
+		}
+
+		assert.Equal(t, 5, len(communicatedChangedFiles))
 		for _, file := range expectedChangedFiles {
-			assert.Contains(t, params[1], file)
+			assert.Contains(t, communicatedChangedFiles, file)
 		}
 	})
 

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -368,7 +368,7 @@ func Test_Scan(t *testing.T) {
 		wg.Wait()
 
 		// Assert
-		assert.Equal(t, 0, scanner.changedFiles.Length())
+		assert.Equal(t, 0, scanner.changedPaths.Length())
 	})
 
 	t.Run("Should not mark folders as changed files", func(t *testing.T) {

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -410,7 +410,7 @@ func Test_Scan(t *testing.T) {
 		wg.Wait()
 
 		// Assert
-		assert.Equal(t, 0, len(scanner.changedPaths))
+		assert.Equal(t, 0, len(scanner.changedPaths[tempDir]))
 	})
 
 	t.Run("Should not mark folders as changed files", func(t *testing.T) {

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -335,16 +335,11 @@ func Test_Scan(t *testing.T) {
 			"file4.go",
 		}
 
-		allCalls := snykCodeMock.GetAllCalls(RunAnalysisOperation)
-		communicatedChangedFiles := make([]string, 0)
-		for _, call := range allCalls {
-			params := call[1].([]string)
-			communicatedChangedFiles = append(communicatedChangedFiles, params...)
-		}
-
-		assert.Equal(t, 5, len(communicatedChangedFiles))
+		params := snykCodeMock.GetCallParams(0, RunAnalysisOperation)
+		assert.NotNil(t, params)
+		assert.Equal(t, 5, len(params[1].([]string)))
 		for _, file := range expectedChangedFiles {
-			assert.Contains(t, communicatedChangedFiles, file)
+			assert.Contains(t, params[1], file)
 		}
 	})
 

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 	"github.com/snyk/snyk-ls/internal/data_structure"
 	"github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/progress"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/uri"
 	"github.com/snyk/snyk-ls/internal/util"
@@ -321,6 +322,7 @@ func Test_Scan(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				_, _ = scanner.Scan(context.Background(), "file"+strconv.Itoa(i)+".go", tempDir)
+				progress.CleanupChannels()
 				wg.Done()
 			}(i)
 		}

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -110,7 +110,7 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	defer p.End("Snyk Iac Scan completed.")
 
 	var workspacePath string
-	if uri.IsDirectory(documentURI) {
+	if uri.IsUriDirectory(documentURI) {
 		workspacePath = uri.PathFromUri(documentURI)
 	} else {
 		workspacePath = filepath.Dir(uri.PathFromUri(documentURI))
@@ -163,7 +163,7 @@ func (iac *Scanner) retrieveIssues(scanResults []iacScanResult, issues []snyk.Is
 
 func (iac *Scanner) isSupported(documentURI sglsp.DocumentURI) bool {
 	ext := filepath.Ext(uri.PathFromUri(documentURI))
-	return uri.IsDirectory(documentURI) || extensions[ext]
+	return uri.IsUriDirectory(documentURI) || extensions[ext]
 }
 
 func (iac *Scanner) doScan(ctx context.Context, documentURI sglsp.DocumentURI, workspacePath string) (scanResults []iacScanResult, err error) {

--- a/infrastructure/oss/oss.go
+++ b/infrastructure/oss/oss.go
@@ -158,7 +158,7 @@ func (oss *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 	}
 
 	var workDir string
-	if uri.IsDirectory(documentURI) {
+	if uri.IsUriDirectory(documentURI) {
 		workDir = path
 	} else {
 		workDir = filepath.Dir(path)
@@ -217,7 +217,7 @@ func (oss *Scanner) prepareScanCommand(workDir string) []string {
 }
 
 func (oss *Scanner) isSupported(documentURI sglsp.DocumentURI) bool {
-	return uri.IsDirectory(documentURI) || supportedFiles[filepath.Base(uri.PathFromUri(documentURI))]
+	return uri.IsUriDirectory(documentURI) || supportedFiles[filepath.Base(uri.PathFromUri(documentURI))]
 }
 
 func (oss *Scanner) unmarshallAndRetrieveAnalysis(ctx context.Context, res []byte, documentURI sglsp.DocumentURI) (issues []snyk.Issue) {

--- a/internal/concurrency/atomic_map.go
+++ b/internal/concurrency/atomic_map.go
@@ -74,5 +74,7 @@ func (m *AtomicMap) Delete(key any) {
 }
 
 func (m *AtomicMap) Range(f func(key any, value any) bool) {
+	m.mut.Lock()
 	m.m.Range(f)
+	m.mut.Unlock()
 }

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -25,8 +25,8 @@ import (
 	"github.com/snyk/snyk-ls/application/server/lsp"
 )
 
-var Channel = make(chan lsp.ProgressParams, 100)
-var CancelProgressChannel = make(chan lsp.ProgressToken, 100)
+var Channel = make(chan lsp.ProgressParams, 10000)
+var CancelProgressChannel = make(chan lsp.ProgressToken, 10000)
 
 type Tracker struct {
 	channel              chan lsp.ProgressParams

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -25,8 +25,8 @@ import (
 	"github.com/snyk/snyk-ls/application/server/lsp"
 )
 
-var Channel = make(chan lsp.ProgressParams, 10000)
-var CancelProgressChannel = make(chan lsp.ProgressToken, 10000)
+var Channel = make(chan lsp.ProgressParams, 100)
+var CancelProgressChannel = make(chan lsp.ProgressToken, 100)
 
 type Tracker struct {
 	channel              chan lsp.ProgressParams
@@ -155,4 +155,13 @@ func (t *Tracker) send(progress lsp.ProgressParams) {
 		log.Error().Str("method", "EndProgress").Msg("progress token must be set")
 	}
 	t.channel <- progress
+}
+
+func CleanupChannels() {
+	for len(Channel) > 0 {
+		<-Channel
+	}
+	for len(CancelProgressChannel) > 0 {
+		<-CancelProgressChannel
+	}
 }

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -52,6 +52,7 @@ func UnitTest(t *testing.T) {
 	t.Cleanup(func() {
 		notification.DisposeListener()
 		cleanupFakeCliFile(c)
+		progress.CleanupChannels()
 	})
 }
 

--- a/internal/uri/uri_util.go
+++ b/internal/uri/uri_util.go
@@ -61,12 +61,12 @@ func PathToUri(path string) sglsp.DocumentURI {
 	return sglsp.DocumentURI(uri.File(path))
 }
 
-func IsDirectory(documentURI sglsp.DocumentURI) bool {
+func IsUriDirectory(documentURI sglsp.DocumentURI) bool {
 	workspaceUri := PathFromUri(documentURI)
-	return isDirectory(workspaceUri)
+	return IsDirectory(workspaceUri)
 }
 
-func isDirectory(path string) bool {
+func IsDirectory(path string) bool {
 	stat, err := os.Stat(path)
 	if err != nil {
 		log.Err(err).Err(err).Msg("Error while checking file")

--- a/internal/uri/uri_util.go
+++ b/internal/uri/uri_util.go
@@ -69,7 +69,6 @@ func IsUriDirectory(documentURI sglsp.DocumentURI) bool {
 func IsDirectory(path string) bool {
 	stat, err := os.Stat(path)
 	if err != nil {
-		log.Err(err).Err(err).Msg("Error while checking file")
 		return false
 	}
 	return stat.IsDir()


### PR DESCRIPTION
### Description

When `limitToFiles` is omitted from request payload to `/analysis`, Snyk Code assumes that all workspace folders have been changed. This results in higher load on the engine.

This PR passes `limitToFiles` to the backend.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
