### PR TITLE
fix: publish diagnostics from cache when file is opened

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -251,7 +251,6 @@ jobs:
           push: true
   test-release:
     name: test-release
-    needs: [ integration-tests, unit-tests, race-test, proxy-test ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -265,7 +264,23 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: create-license-report
+        run: |
+          go install github.com/google/go-licenses@latest
+          LICENSES=$(go-licenses report . --ignore github.com/snyk/snyk-ls)
+          echo 'LICENSES<<EOF' >> $GITHUB_OUTPUT
+          echo $LICENSES >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo $LICENSES
+
       - name: Do test release with goreleaser
         uses: goreleaser/goreleaser-action@v3
+        env:
+          LICENSES: ${{ steps.create-report.outputs.LICENSES }}
         with:
           args: build --rm-dist --single-target --snapshot
+
+      - name: Output compiled licenses
+        run: |
+          chmod +x build/snyk-ls_linux_amd64_v1/snyk-ls
+          build/snyk-ls_linux_amd64_v1/snyk-ls -licenses

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -264,7 +264,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: create-license-report
+      - name: Create License Report
+        id: create_license_report
         run: |
           go install github.com/google/go-licenses@latest
           LICENSES=$(go-licenses report . --ignore github.com/snyk/snyk-ls)
@@ -276,7 +277,7 @@ jobs:
       - name: Do test release with goreleaser
         uses: goreleaser/goreleaser-action@v3
         env:
-          LICENSES: ${{ steps.create-report.outputs.LICENSES }}
+          LICENSES: ${{ steps.create_license_report.outputs.LICENSES }}
         with:
           args: build --rm-dist --single-target --snapshot
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,12 +116,13 @@ jobs:
             --role-arn "arn:aws:iam::198361731867:role/Snyk-Assets-WriteOnly" \
             --region "${{ secrets.AWS_REGION }}" \
 
-      - name: Create release tag
+      - name: Create Release Tag
         run: |
           git tag "v$(git show -s --format=%cd --date=format:%Y%m%d.%H%M%S)"
           git push --tags
 
-      - name: create-license-report
+      - name: Create License Report
+        id: create_license_report
         run: |
           go install github.com/google/go-licenses@latest
           LICENSES=$(go-licenses report . --ignore github.com/snyk/snyk-ls)
@@ -136,7 +137,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
-          LICENSES: ${{ steps.create-license-report.outputs.LICENSES }}
+          LICENSES: ${{ steps.create_license_report.outputs.LICENSES }}
         with:
           version: 1.12.3
           args: release --rm-dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,6 +127,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          LICENSES: {{ go-licenses report . --ignore github.com/snyk/snyk-ls }}
         with:
           version: 1.12.3
           args: release --rm-dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,13 +121,27 @@ jobs:
           git tag "v$(git show -s --format=%cd --date=format:%Y%m%d.%H%M%S)"
           git push --tags
 
+      - name: create-license-report
+        run: |
+          go install github.com/google/go-licenses@latest
+          LICENSES=$(go-licenses report . --ignore github.com/snyk/snyk-ls)
+          echo 'LICENSES<<EOF' >> $GITHUB_OUTPUT
+          echo $LICENSES >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo $LICENSES
+
       - name: Release binaries with GoReleaser
         uses: goreleaser/goreleaser-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
-          LICENSES: {{ go-licenses report . --ignore github.com/snyk/snyk-ls }}
+          LICENSES: ${{ steps.create-license-report.outputs.LICENSES }}
         with:
           version: 1.12.3
           args: release --rm-dist
+
+      - name: Output compiled licenses
+        run: |
+          chmod +x build/snyk-ls_linux_amd64_v1/snyk-ls
+          build/snyk-ls_linux_amd64_v1/snyk-ls -licenses

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,7 @@ builds:
       - goarch: arm64
         goos: windows
     ldflags:
-      - -s -w -X github.com/snyk/snyk-ls/application/config.Version={{.Version}} -X github.com/snyk/snyk-ls/application/config.LsProtocolVersion={{.Env.LS_PROTOCOL_VERSION}} -X 'github.com/snyk/snyk-ls/application/config.Development=false'
+      - -s -w -X github.com/snyk/snyk-ls/application/config.Version={{.Version}} -X github.com/snyk/snyk-ls/application/config.LsProtocolVersion={{.Env.LS_PROTOCOL_VERSION}} -X 'github.com/snyk/snyk-ls/application/config.Development=false' -X 'github.com/snyk/snyk-ls/application/config.LicenseInformation={{.Env.LICENSES}}'
     mod_timestamp: "{{ .CommitTimestamp }}"
 
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,8 @@ DEV_GOARCH := $(shell go env GOARCH)
 DEV_GOOS := $(shell go env GOOS)
 GOPATH := $(shell go env GOPATH)
 VERSION := $(shell git show -s --format=%cd --date=format:%Y%m%d.%H%M%S)
-LICENSES := $(shell go-licenses report . --ignore github.com/snyk/snyk-ls)
 COMMIT := $(shell git show -s --format=%h)
-LDFLAGS_DEV := "-X 'github.com/snyk/snyk-ls/application/config.Development=true' -X 'github.com/snyk/snyk-ls/application/config.LicenseInformation=$(LICENSES)' -X 'github.com/snyk/snyk-ls/application/config.Version=v$(VERSION)-SNAPSHOT-$(COMMIT)'"
+LDFLAGS_DEV := "-X 'github.com/snyk/snyk-ls/application/config.Development=true' -X 'github.com/snyk/snyk-ls/application/config.Version=v$(VERSION)-SNAPSHOT-$(COMMIT)'"
 
 PARALLEL := "-p=1"
 NOCACHE := "-count=1"

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -380,9 +380,10 @@ func textDocumentDidOpenHandler() jrpc2.Handler {
 		logger.Info().Msg("Receiving")
 		folder := workspace.Get().GetFolderContaining(filePath)
 		issues := folder.DocumentDiagnosticsFromCache(filePath)
-		if len(issues) > 0 {
+		filteredIssues := workspace.FilterIssues(issues, config.CurrentConfig().GetDisplayableIssueTypes())
+
+		if len(filteredIssues) > 0 {
 			logger.Info().Msg("Sending cached issues")
-			filteredIssues := workspace.FilterIssues(issues, config.CurrentConfig().GetDisplayableIssueTypes())
 			diagnosticParams := lsp.PublishDiagnosticsParams{
 				URI:         params.TextDocument.URI,
 				Diagnostics: converter.ToDiagnostics(filteredIssues),

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -382,9 +382,10 @@ func textDocumentDidOpenHandler() jrpc2.Handler {
 		issues := folder.DocumentDiagnosticsFromCache(filePath)
 		if len(issues) > 0 {
 			logger.Info().Msg("Sending cached issues")
+			filteredIssues := workspace.FilterIssues(issues, config.CurrentConfig().GetDisplayableIssueTypes())
 			diagnosticParams := lsp.PublishDiagnosticsParams{
 				URI:         params.TextDocument.URI,
-				Diagnostics: converter.ToDiagnostics(issues),
+				Diagnostics: converter.ToDiagnostics(filteredIssues),
 			}
 			notification.Send(diagnosticParams)
 		}

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -197,7 +197,7 @@ func (f *Folder) filterCachedDiagnostics() (fileIssues map[string][]snyk.Issue) 
 	supportedIssueTypes := config.CurrentConfig().GetDisplayableIssueTypes()
 	f.documentDiagnosticCache.Range(func(filePath string, issues []snyk.Issue) bool {
 		// Consider doing the loop body in parallel for performance (and use a thread-safe map)
-		filteredIssues := filterIssues(issues, supportedIssueTypes)
+		filteredIssues := FilterIssues(issues, supportedIssueTypes)
 		issuesByFile[filePath] = filteredIssues
 		return true
 	})
@@ -205,8 +205,8 @@ func (f *Folder) filterCachedDiagnostics() (fileIssues map[string][]snyk.Issue) 
 	return issuesByFile
 }
 
-func filterIssues(issues []snyk.Issue, supportedIssueTypes map[product.FilterableIssueType]bool) []snyk.Issue {
-	logger := log.With().Str("method", "filterIssues").Logger()
+func FilterIssues(issues []snyk.Issue, supportedIssueTypes map[product.FilterableIssueType]bool) []snyk.Issue {
+	logger := log.With().Str("method", "FilterIssues").Logger()
 	filteredIssues := make([]snyk.Issue, 0)
 
 	for _, issue := range issues {


### PR DESCRIPTION
### Description

fix: report diagnostics from cache on "textDocument/didOpen"

Fixes switching between files in sublime, as sublime expects diagnostics to be reported anew when a file is opened.

Issue filed under: https://github.com/sublimelsp/LSP/issues/2200

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
