### PR TITLE
fix: remove code actions when document has unsaved changes [HEAD-161]

### DIFF
--- a/application/codeaction/codeaction_test.go
+++ b/application/codeaction/codeaction_test.go
@@ -89,9 +89,10 @@ func Test_GetCodeActions_NoIssues_ReturnsNil(t *testing.T) {
 	var issues []snyk.Issue
 	providerMock := new(mockIssuesProvider)
 	providerMock.On("IssuesFor", mock.Anything, mock.Anything).Return(issues)
-	service := codeaction.CodeActionsService{
-		IssuesProvider: providerMock,
-	}
+	//service := codeaction.CodeActionsService{
+	//	IssuesProvider: providerMock,
+	//}
+	service := codeaction.NewService(providerMock, watcher.NewFileWatcher())
 	codeActionsParam := lsp.CodeActionParams{
 		TextDocument: sglsp.TextDocumentIdentifier{
 			URI: documentUriExample,

--- a/application/codeaction/codeaction_test.go
+++ b/application/codeaction/codeaction_test.go
@@ -72,7 +72,7 @@ func Test_GetCodeActions_FileIsDirty_ReturnsEmptyResults(t *testing.T) {
 		},
 	}
 	service, codeActionsParam, w := setupWithSingleIssue(fakeIssue)
-	w.FileChanged(codeActionsParam.TextDocument.URI) // File is dirty until it is saved
+	w.SetFileAsChanged(codeActionsParam.TextDocument.URI) // File is dirty until it is saved
 
 	// Act
 	actions := service.GetCodeActions(codeActionsParam)

--- a/application/codeaction/handlers.go
+++ b/application/codeaction/handlers.go
@@ -14,7 +14,7 @@ type TextDocumentCodeActionHandler func(context.Context, lsp.CodeActionParams) (
 type CodeActionResolveHandler func(context.Context, lsp.CodeAction) (*lsp.CodeAction, error)
 
 // ResolveCodeActionHandler returns a jrpc2.Handler that can be used to handle the "codeAction/resolve" LSP method
-func ResolveCodeActionHandler(service CodeActionsService) CodeActionResolveHandler {
+func ResolveCodeActionHandler(service *CodeActionsService) CodeActionResolveHandler {
 	logger := log.Logger.With().Str("method", "ResolveCodeActionHandler").Logger()
 
 	return func(ctx context.Context, params lsp.CodeAction) (*lsp.CodeAction, error) {
@@ -32,7 +32,7 @@ func ResolveCodeActionHandler(service CodeActionsService) CodeActionResolveHandl
 }
 
 // GetCodeActionHandler returns a jrpc2.Handler that can be used to handle the "textDocument/codeAction" LSP method
-func GetCodeActionHandler(service CodeActionsService) TextDocumentCodeActionHandler {
+func GetCodeActionHandler(service *CodeActionsService) TextDocumentCodeActionHandler {
 	const debounceDuration = 50 * time.Millisecond
 
 	// We share a mutex between all the handler calls to prevent concurrent runs.

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -102,7 +102,7 @@ func initHandlers(srv *jrpc2.Server, handlers handler.Map) {
 
 func textDocumentDidChangeHandler() jrpc2.Handler {
 	return handler.New(func(ctx context.Context, params sglsp.DidChangeTextDocumentParams) (any, error) {
-		di.FileWatcher().FileChanged(params.TextDocument.URI)
+		di.FileWatcher().SetFileAsChanged(params.TextDocument.URI)
 		return nil, nil
 	})
 }
@@ -413,7 +413,7 @@ func textDocumentDidSaveHandler() jrpc2.Handler {
 		logger := log.With().Str("method", "TextDocumentDidSaveHandler").Logger()
 
 		logger.Info().Interface("params", params).Msg("Receiving")
-		di.FileWatcher().FileSaved(params.TextDocument.URI)
+		di.FileWatcher().SetFileAsSaved(params.TextDocument.URI)
 		filePath := uri.PathFromUri(params.TextDocument.URI)
 
 		// todo can we push cache management down?

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -81,7 +81,7 @@ const textDocumentDidSaveOperation = "textDocument/didSave"
 func initHandlers(srv *jrpc2.Server, handlers handler.Map) {
 	handlers["initialize"] = initializeHandler(srv)
 	handlers["initialized"] = initializedHandler(srv)
-	handlers["textDocument/didChange"] = noOpHandler()
+	handlers["textDocument/didChange"] = textDocumentDidChangeHandler()
 	handlers["textDocument/didClose"] = noOpHandler()
 	handlers[textDocumentDidOpenOperation] = textDocumentDidOpenHandler()
 	handlers[textDocumentDidSaveOperation] = textDocumentDidSaveHandler()
@@ -98,6 +98,13 @@ func initHandlers(srv *jrpc2.Server, handlers handler.Map) {
 	handlers["workspace/didChangeConfiguration"] = workspaceDidChangeConfiguration(srv)
 	handlers["window/workDoneProgress/cancel"] = windowWorkDoneProgressCancelHandler()
 	handlers["workspace/executeCommand"] = executeCommandHandler(srv)
+}
+
+func textDocumentDidChangeHandler() jrpc2.Handler {
+	return handler.New(func(ctx context.Context, params sglsp.DidChangeTextDocumentParams) (any, error) {
+		di.FileWatcher().FileChanged(params.TextDocument.URI)
+		return nil, nil
+	})
 }
 
 // WorkspaceWillDeleteFilesHandler handles the workspace/willDeleteFiles message that's raised by the client
@@ -400,6 +407,7 @@ func textDocumentDidSaveHandler() jrpc2.Handler {
 		logger := log.With().Str("method", "TextDocumentDidSaveHandler").Logger()
 
 		logger.Info().Interface("params", params).Msg("Receiving")
+		di.FileWatcher().FileSaved(params.TextDocument.URI)
 		filePath := uri.PathFromUri(params.TextDocument.URI)
 
 		// todo can we push cache management down?

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -213,6 +213,7 @@ func initializeHandler(srv *jrpc2.Server) handler.Func {
 				TextDocumentSync: &sglsp.TextDocumentSyncOptionsOrKind{
 					Options: &sglsp.TextDocumentSyncOptions{
 						OpenClose:         true,
+						Change:            sglsp.TDSKIncremental,
 						WillSave:          true,
 						WillSaveWaitUntil: true,
 						Save:              &sglsp.SaveOptions{IncludeText: true},

--- a/application/watcher/file_watcher.go
+++ b/application/watcher/file_watcher.go
@@ -6,6 +6,7 @@ import (
 	sglsp "github.com/sourcegraph/go-lsp"
 )
 
+// FileWatcher is a simple in-memory file watcher that keeps track of files that were changed but not saved.
 type FileWatcher struct {
 	files map[sglsp.DocumentURI]bool
 	m     sync.RWMutex
@@ -17,19 +18,22 @@ func NewFileWatcher() *FileWatcher {
 	}
 }
 
-func (w *FileWatcher) FileChanged(uri sglsp.DocumentURI) {
+// SetFileAsChanged marks the file as having unsaved changes. Calling SetFileAsSaved will mark the file as "clean" again.
+func (w *FileWatcher) SetFileAsChanged(uri sglsp.DocumentURI) {
 	w.m.Lock()
 	defer w.m.Unlock()
 	w.files[uri] = true
 }
 
+// IsDirty returns true if the file has unsaved changes.
 func (w *FileWatcher) IsDirty(uri sglsp.DocumentURI) bool {
 	w.m.RLock()
 	defer w.m.RUnlock()
 	return w.files[uri]
 }
 
-func (w *FileWatcher) FileSaved(uri sglsp.DocumentURI) {
+// SetFileAsSaved marks the file as "clean".
+func (w *FileWatcher) SetFileAsSaved(uri sglsp.DocumentURI) {
 	w.m.Lock()
 	defer w.m.Unlock()
 	delete(w.files, uri)

--- a/application/watcher/file_watcher.go
+++ b/application/watcher/file_watcher.go
@@ -1,0 +1,36 @@
+package watcher
+
+import (
+	"sync"
+
+	sglsp "github.com/sourcegraph/go-lsp"
+)
+
+type FileWatcher struct {
+	files map[sglsp.DocumentURI]bool
+	m     sync.RWMutex
+}
+
+func NewFileWatcher() *FileWatcher {
+	return &FileWatcher{
+		files: make(map[sglsp.DocumentURI]bool),
+	}
+}
+
+func (w *FileWatcher) FileChanged(uri sglsp.DocumentURI) {
+	w.m.Lock()
+	defer w.m.Unlock()
+	w.files[uri] = true
+}
+
+func (w *FileWatcher) IsDirty(uri sglsp.DocumentURI) bool {
+	w.m.RLock()
+	defer w.m.RUnlock()
+	return w.files[uri]
+}
+
+func (w *FileWatcher) FileSaved(uri sglsp.DocumentURI) {
+	w.m.Lock()
+	defer w.m.Unlock()
+	delete(w.files, uri)
+}

--- a/application/watcher/file_watcher_test.go
+++ b/application/watcher/file_watcher_test.go
@@ -27,10 +27,10 @@ func Test_WhenFileSaved_FileIsNotDirty(t *testing.T) {
 	t.Parallel()
 	w := watcher.NewFileWatcher()
 	uri := uri2.PathToUri("path/to/file")
-	w.FileChanged(uri)
+	w.SetFileAsChanged(uri)
 
 	// Act
-	w.FileSaved(uri)
+	w.SetFileAsSaved(uri)
 
 	// Assert
 	assert.False(t, w.IsDirty(uri))
@@ -43,7 +43,7 @@ func Test_WhenFileChanged_FileIsDirty(t *testing.T) {
 	uri := uri2.PathToUri("path/to/file")
 
 	// Act
-	w.FileChanged(uri)
+	w.SetFileAsChanged(uri)
 
 	// Assert
 	assert.True(t, w.IsDirty(uri))

--- a/application/watcher/file_watcher_test.go
+++ b/application/watcher/file_watcher_test.go
@@ -1,0 +1,50 @@
+package watcher_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/application/watcher"
+	uri2 "github.com/snyk/snyk-ls/internal/uri"
+)
+
+func Test_WhenFileUnchanged_FileIsNotDirty(t *testing.T) {
+	// Arrange
+	t.Parallel()
+	w := watcher.NewFileWatcher()
+	uri := uri2.PathToUri("path/to/file")
+
+	// Act
+	isDirty := w.IsDirty(uri)
+
+	// Assert
+	assert.False(t, isDirty)
+}
+
+func Test_WhenFileSaved_FileIsNotDirty(t *testing.T) {
+	// Arrange
+	t.Parallel()
+	w := watcher.NewFileWatcher()
+	uri := uri2.PathToUri("path/to/file")
+	w.FileChanged(uri)
+
+	// Act
+	w.FileSaved(uri)
+
+	// Assert
+	assert.False(t, w.IsDirty(uri))
+}
+
+func Test_WhenFileChanged_FileIsDirty(t *testing.T) {
+	// Arrange
+	t.Parallel()
+	w := watcher.NewFileWatcher()
+	uri := uri2.PathToUri("path/to/file")
+
+	// Act
+	w.FileChanged(uri)
+
+	// Assert
+	assert.True(t, w.IsDirty(uri))
+}


### PR DESCRIPTION
### Description

Removes the code actions when the document is being edited as a temporary solution