### PR TITLE
fix: autoconfigure java/maven in background

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - goimports
@@ -23,10 +22,8 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - unconvert
     - unused
-    - varcheck
     - govet
     - gocyclo
     - dupl

--- a/application/config/automatic_config_test.go
+++ b/application/config/automatic_config_test.go
@@ -20,7 +20,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/adrg/xdg"
 	"github.com/stretchr/testify/assert"
@@ -102,7 +104,9 @@ func Test_FindBinaries(t *testing.T) {
 		c := New()
 		c.AddBinaryLocationsToPath([]string{dir})
 
-		assert.Contains(t, os.Getenv("JAVA_HOME"), dir)
+		assert.Eventually(t, func() bool {
+			return strings.Contains(os.Getenv("JAVA_HOME"), dir)
+		}, time.Second, time.Millisecond)
 	})
 
 	t.Run("search for binary in default places", func(t *testing.T) {
@@ -155,6 +159,8 @@ func Test_FindBinaries(t *testing.T) {
 
 		New()
 
-		assert.Contains(t, os.Getenv("PATH"), binDir)
+		assert.Eventually(t, func() bool {
+			return strings.Contains(os.Getenv("PATH"), dir)
+		}, time.Second, time.Millisecond)
 	})
 }

--- a/application/config/client_settings.go
+++ b/application/config/client_settings.go
@@ -68,7 +68,7 @@ func (c *Config) productEnablementFromEnv() {
 	if oss != "" {
 		parseBool, err := strconv.ParseBool(oss)
 		if err != nil {
-			log.Warn().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse oss config %s", oss)
+			log.Debug().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse oss config %s", oss)
 		}
 		c.isSnykOssEnabled.Set(parseBool)
 	}
@@ -76,7 +76,7 @@ func (c *Config) productEnablementFromEnv() {
 	if code != "" {
 		parseBool, err := strconv.ParseBool(code)
 		if err != nil {
-			log.Warn().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse code config %s", code)
+			log.Debug().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse code config %s", code)
 		}
 		c.isSnykCodeEnabled.Set(parseBool)
 	}
@@ -84,7 +84,7 @@ func (c *Config) productEnablementFromEnv() {
 	if iac != "" {
 		parseBool, err := strconv.ParseBool(iac)
 		if err != nil {
-			log.Warn().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse iac config %s", iac)
+			log.Debug().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse iac config %s", iac)
 		}
 		c.isSnykIacEnabled.Set(parseBool)
 	}
@@ -92,14 +92,14 @@ func (c *Config) productEnablementFromEnv() {
 	if container != "" {
 		parseBool, err := strconv.ParseBool(container)
 		if err != nil {
-			log.Warn().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse container config %s", container)
+			log.Debug().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse container config %s", container)
 		}
 		c.isSnykContainerEnabled.Set(parseBool)
 	}
 	if advisor != "" {
 		parseBool, err := strconv.ParseBool(advisor)
 		if err != nil {
-			log.Warn().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse advisor config %s", advisor)
+			log.Debug().Err(err).Str("method", "clientSettingsFromEnv").Msgf("couldn't parse advisor config %s", advisor)
 		}
 		c.isSnykAdvisorEnabled.Set(parseBool)
 	}

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -492,6 +492,8 @@ func snykCodeAnalysisTimeoutFromEnv() time.Duration {
 }
 
 func (c *Config) updatePath(pathExtension string) {
+	c.m.Lock()
+	defer c.m.Unlock()
 	if pathExtension == "" {
 		return
 	}

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -211,8 +211,8 @@ func New() *Config {
 
 func (c *Config) AddBinaryLocationsToPath(searchDirectories []string) {
 	c.defaultDirs = searchDirectories
-	c.determineJavaHome()
-	c.determineMavenHome()
+	go c.determineJavaHome()
+	go c.determineMavenHome()
 }
 
 func (c *Config) determineDeviceId() string {

--- a/application/di/init.go
+++ b/application/di/init.go
@@ -18,6 +18,7 @@ package di
 
 import (
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -92,18 +93,24 @@ func initDomain() {
 	)
 }
 
+//goland:noinspection GoBoolExpressions
 func initInfrastructure() {
-	config.CurrentConfig().AddBinaryLocationsToPath(
-		[]string{
+	var locations []string
+	if runtime.GOOS == "windows" {
+		locations = []string{
+			"C:\\Program Files",
+			"C:\\Program Files (x86)",
+		}
+	} else {
+		locations = []string{
 			filepath.Join(xdg.Home, ".sdkman"),
 			"/usr/lib",
 			"/usr/java",
 			"/opt",
 			"/Library",
-			"C:\\Program Files",
-			"C:\\Program Files (x86)",
-		},
-	)
+		}
+	}
+	config.CurrentConfig().AddBinaryLocationsToPath(locations)
 
 	errorReporter = sentry2.NewSentryErrorReporter()
 	installer = install.NewInstaller(errorReporter)

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -273,7 +273,7 @@ func updateCliConfig(settings lsp.Settings) {
 	cliSettings := &config.CliSettings{}
 	cliSettings.Insecure, err = strconv.ParseBool(settings.Insecure)
 	if err != nil {
-		log.Warn().Err(err).Msg("couldn't parse insecure setting")
+		log.Debug().Err(err).Msg("couldn't parse insecure setting")
 	}
 	cliSettings.AdditionalOssParameters = strings.Split(settings.AdditionalParams, " ")
 	cliSettings.SetPath(settings.CliPath)
@@ -285,7 +285,7 @@ func updateProductEnablement(settings lsp.Settings) {
 	parseBool, err := strconv.ParseBool(settings.ActivateSnykCode)
 	currentConfig := config.CurrentConfig()
 	if err != nil {
-		log.Warn().Err(err).Msg("couldn't parse code setting")
+		log.Debug().Err(err).Msg("couldn't parse code setting")
 	} else {
 		currentConfig.SetSnykCodeEnabled(parseBool)
 		currentConfig.EnableSnykCodeQuality(parseBool)
@@ -293,13 +293,13 @@ func updateProductEnablement(settings lsp.Settings) {
 	}
 	parseBool, err = strconv.ParseBool(settings.ActivateSnykOpenSource)
 	if err != nil {
-		log.Warn().Err(err).Msg("couldn't parse open source setting")
+		log.Debug().Err(err).Msg("couldn't parse open source setting")
 	} else {
 		currentConfig.SetSnykOssEnabled(parseBool)
 	}
 	parseBool, err = strconv.ParseBool(settings.ActivateSnykIac)
 	if err != nil {
-		log.Warn().Err(err).Msg("couldn't parse iac setting")
+		log.Debug().Err(err).Msg("couldn't parse iac setting")
 	} else {
 		currentConfig.SetSnykIacEnabled(parseBool)
 	}

--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -137,7 +137,7 @@ func (a *CliAuthenticationProvider) authenticate(ctx context.Context) error {
 
 			if url != "" {
 				a.authURL = url
-				log.Debug().Str("method", "authenticate").Msgf("found URL: %s", url)
+				log.Info().Str("method", "authenticate").Msgf("found URL: %s", url)
 			}
 		}
 
@@ -218,7 +218,8 @@ func (a *CliAuthenticationProvider) buildCLICmd(ctx context.Context, args ...str
 	cmd := exec.CommandContext(ctx, config.CurrentConfig().CliSettings().Path(), args...)
 	cmd.Env = cli.AppendCliEnvironmentVariables(os.Environ(), false)
 
-	log.Info().Str("command", cmd.String()).Interface("env", cmd.Env).Msg("running Snyk CLI command")
+	log.Info().Str("command", cmd.String()).Msg("running Snyk CLI command")
+	log.Debug().Str("command", cmd.String()).Interface("env", cmd.Env).Msg("env for Snyk CLI command")
 	return cmd
 }
 


### PR DESCRIPTION
### Description

Scanning the file system on Windows for java and maven to automatically configure, is not fast on Windows. This PR changes the auto-configuration to run in background.

Also removed unmaintained, dead linters.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
