### PR TITLE
fix: propagate iac error to UI

### DIFF
--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -146,14 +146,13 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 		noCancellation := ctx.Err() == nil
 		if noCancellation { // Only reports errors that are not intentional cancellations
 			iac.errorReporter.CaptureErrorAndReportAsIssue(path, err)
-			return issues, err
 		} else { // If the scan was cancelled, return empty results
 			return issues, nil
 		}
 	}
 
 	issues = iac.retrieveIssues(scanResults, issues, workspacePath, err)
-	return issues, nil
+	return issues, err
 }
 
 func (iac *Scanner) retrieveIssues(scanResults []iacScanResult,

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -146,6 +146,7 @@ func (iac *Scanner) Scan(ctx context.Context, path string, _ string) (issues []s
 		noCancellation := ctx.Err() == nil
 		if noCancellation { // Only reports errors that are not intentional cancellations
 			iac.errorReporter.CaptureErrorAndReportAsIssue(path, err)
+			return issues, err
 		} else { // If the scan was cancelled, return empty results
 			return issues, nil
 		}

--- a/infrastructure/iac/iac_test.go
+++ b/infrastructure/iac/iac_test.go
@@ -68,8 +68,9 @@ func Test_ErroredWorkspaceScan_TracksAnalytics(t *testing.T) {
 	scanner := New(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, executor)
 
 	executor.ExecuteResponse = []byte("invalid JSON")
-	_, _ = scanner.Scan(context.Background(), "fake.yml", "")
+	_, err := scanner.Scan(context.Background(), "fake.yml", "")
 
+	assert.Error(t, err)
 	assert.Len(t, analytics.GetAnalytics(), 1)
 	assert.Equal(t, ux2.AnalysisIsReadyProperties{
 		AnalysisType: ux2.InfrastructureAsCode,


### PR DESCRIPTION
### Description

If the error is not reported from the scanner interface, VSCE UI will shows as scan successful with 0 issues found. This PR fixes this.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
