### PR TITLE
feat: spawn CLI with oauth token information

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ Right now the language server supports the following actions:
   - payload:
   ```json5
   {
-    "token": "the snyk token"
+    "token": "the snyk token" // this can be an oauth2.Token string or a legacy token
   }
   ```
-
+  - See https://pkg.go.dev/golang.org/x/oauth2@v0.6.0#Token for more details regarding oauth tokens.
+  
 - Cli Path Notification
   - method: `$/snyk.isAvailableCli`
   - payload:
@@ -181,7 +182,7 @@ within `initializationOptions?: LSPAny;` we support the following settings:
   "enableTelemetry":  "true", // Whether user analytics can be tracked
   "manageBinariesAutomatically": "true", // Whether CLI/LS binaries will be downloaded & updated automatically
   "cliPath":  "/a/patch/snyk-cli", // The path where the CLI can be found, or where it should be downloaded to
-  "token":  "secret-token", // The Snyk token, e.g.: snyk config get api
+  "token":  "secret-token", // The Snyk token, e.g.: snyk config get api or a token from oauth flow
   "automaticAuthentication": "true", // Whether LS will automatically authenticate on scan start (default: true)
   "enableTrustedFoldersFeature": "true", // Whether LS will prompt to trust a folder (default: true)
   "trustedFolders": ["/a/trusted/path", "/another/trusted/path"], // An array of folder that should be trusted
@@ -197,6 +198,7 @@ within `initializationOptions?: LSPAny;` we support the following settings:
     "low": true,
   },
   "scanningMode": "auto" // Specifies the mode for scans: "auto" for background scans or "manual" for scans on command
+  "authenticationMethod": "token" // Specifies the authentication method to use: "token" for Snyk API token or "oauth" for Snyk OAuth flow. Default is token.
 }
 ```
 

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/snyk/go-application-framework/pkg/app"
+	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	sglsp "github.com/sourcegraph/go-lsp"
@@ -414,6 +415,10 @@ func (c *Config) SetToken(token string) {
 	c.tokenChangeChannels = []chan string{}
 
 	c.token = token
+	// update go application framework if using oauth
+	if c.authenticationMethod == lsp.OAuthAuthentication {
+		c.engine.GetConfiguration().Set(auth.CONFIG_KEY_OAUTH_TOKEN, token)
+	}
 }
 func (c *Config) SetFormat(format string) { c.format = format }
 

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -22,17 +22,32 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/server/lsp"
 )
 
 func TestSetToken(t *testing.T) {
-	SetCurrentConfig(New())
-	oldToken := CurrentConfig().Token()
-	CurrentConfig().SetToken("asdf")
-	assert.Equal(t, CurrentConfig().Token(), "asdf")
-	CurrentConfig().SetToken(oldToken)
+	t.Run("Legacy Token authentication", func(t *testing.T) {
+		config := New()
+		SetCurrentConfig(config)
+		oldToken := CurrentConfig().Token()
+		CurrentConfig().SetToken("asdf")
+		assert.Equal(t, CurrentConfig().Token(), "asdf")
+		CurrentConfig().SetToken(oldToken)
+		assert.NotEqual(t, CurrentConfig().Engine().GetConfiguration().Get(auth.CONFIG_KEY_OAUTH_TOKEN), oldToken)
+	})
+	t.Run("OAuth Token authentication", func(t *testing.T) {
+		config := New()
+		SetCurrentConfig(config)
+		config.authenticationMethod = lsp.OAuthAuthentication
+		oldToken := CurrentConfig().Token()
+		CurrentConfig().SetToken("asdf")
+		assert.Equal(t, CurrentConfig().Token(), "asdf")
+		CurrentConfig().SetToken(oldToken)
+		assert.Equal(t, CurrentConfig().Engine().GetConfiguration().Get(auth.CONFIG_KEY_OAUTH_TOKEN), oldToken)
+	})
 }
 
 func TestConfigDefaults(t *testing.T) {

--- a/infrastructure/cli/environment.go
+++ b/infrastructure/cli/environment.go
@@ -16,7 +16,12 @@
 
 package cli
 
-import "github.com/snyk/snyk-ls/application/config"
+import (
+	"github.com/snyk/go-application-framework/pkg/auth"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/application/server/lsp"
+)
 
 const (
 	OrganizationEnvVar                  = "SNYK_CFG_ORG"
@@ -44,7 +49,12 @@ func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updat
 	}
 
 	if appendToken {
-		updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
+		// there can only be one - highlander principle
+		if currentConfig.GetAuthenticationMethod() == lsp.OAuthAuthentication {
+			updatedEnv = append(updatedEnv, auth.CONFIG_KEY_OAUTH_TOKEN+"="+currentConfig.Token())
+		} else {
+			updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
+		}
 	}
 	if currentConfig.SnykApi() != "" {
 		updatedEnv = append(updatedEnv, ApiEnvVar+"="+currentConfig.SnykApi())

--- a/infrastructure/cli/environment_test.go
+++ b/infrastructure/cli/environment_test.go
@@ -19,9 +19,11 @@ package cli
 import (
 	"testing"
 
+	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/application/server/lsp"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
@@ -46,6 +48,27 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_ENVIRONMENT="+IntegrationEnvironmentEnvVarValue)
 		assert.Contains(t, updatedEnv, "SNYK_INTEGRATION_ENVIRONMENT_VERSION="+config.Version)
 		assert.NotContains(t, updatedEnv, "SNYK_CFG_DISABLE_ANALYTICS=1")
+	})
+	t.Run("Adds Snyk Token to env", func(t *testing.T) {
+		testutil.UnitTest(t)
+		c := config.CurrentConfig()
+		c.SetAuthenticationMethod(lsp.TokenAuthentication)
+		c.SetToken("testToken")
+
+		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
+
+		assert.Contains(t, updatedEnv, "SNYK_TOKEN="+config.CurrentConfig().Token())
+	})
+
+	t.Run("Adds OAuth Token to env", func(t *testing.T) {
+		testutil.UnitTest(t)
+		c := config.CurrentConfig()
+		c.SetAuthenticationMethod(lsp.OAuthAuthentication)
+		c.SetToken("testToken")
+
+		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
+
+		assert.Contains(t, updatedEnv, auth.CONFIG_KEY_OAUTH_TOKEN+"="+config.CurrentConfig().Token())
 	})
 
 	t.Run("Disables analytics, if telemetry disabled", func(t *testing.T) {


### PR DESCRIPTION
### Description

In order to provide correct credentials to spawned CLI instances, language server needs to add this information to the environment. This PR takes care of that and also of providing a token, transmitted from the IDE, to the Go Application Framework.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
