### PR TITLE
feat: use relative paths for communication with Code API [HEAD-223]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/snyk-ls
 
-go 1.19
+go 1.20
 
 require (
 	github.com/adrg/xdg v0.4.0

--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -311,7 +311,7 @@ func (s *SnykCodeHTTPClient) RunAnalysis(
 		return nil, status, nil
 	}
 
-	issues := response.toIssues(baseDir)
+	issues, err := response.toIssues(baseDir)
 	return issues, status, err
 }
 

--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -113,16 +113,16 @@ func (s *SnykCodeHTTPClient) GetFilters(ctx context.Context) (configFiles []stri
 
 func (s *SnykCodeHTTPClient) CreateBundle(
 	ctx context.Context,
-	files map[string]string,
+	filesToFilehashes map[string]string,
 ) (string, []string, error) {
 
 	method := "code.CreateBundle"
-	log.Debug().Str("method", method).Msg("API: Creating bundle for " + strconv.Itoa(len(files)) + " files")
+	log.Debug().Str("method", method).Msg("API: Creating bundle for " + strconv.Itoa(len(filesToFilehashes)) + " files")
 
 	span := s.instrumentor.StartSpan(ctx, method)
 	defer s.instrumentor.Finish(span)
 
-	requestBody, err := json.Marshal(files)
+	requestBody, err := json.Marshal(filesToFilehashes)
 	if err != nil {
 		return "", nil, err
 	}
@@ -258,6 +258,7 @@ type AnalysisStatus struct {
 func (s *SnykCodeHTTPClient) RunAnalysis(
 	ctx context.Context,
 	options AnalysisOptions,
+	baseDir string,
 ) ([]snyk.Issue, AnalysisStatus, error) {
 	method := "code.RunAnalysis"
 	span := s.instrumentor.StartSpan(ctx, method)
@@ -310,7 +311,7 @@ func (s *SnykCodeHTTPClient) RunAnalysis(
 		return nil, status, nil
 	}
 
-	issues := response.toIssues()
+	issues := response.toIssues(baseDir)
 	return issues, status, err
 }
 

--- a/infrastructure/code/backend_service_interface.go
+++ b/infrastructure/code/backend_service_interface.go
@@ -54,6 +54,7 @@ type SnykCodeClient interface {
 	RunAnalysis(
 		ctx context.Context,
 		options AnalysisOptions,
+		baseDir string,
 	) (
 		[]snyk.Issue,
 		AnalysisStatus,

--- a/infrastructure/code/backend_service_pact_test.go
+++ b/infrastructure/code/backend_service_pact_test.go
@@ -197,7 +197,7 @@ func TestSnykCodeBackendServicePact(t *testing.T) { // nolint:gocognit // this i
 				severity:     0,
 			}
 
-			issues, _, err := client.RunAnalysis(context.Background(), analysisOptions)
+			issues, _, err := client.RunAnalysis(context.Background(), analysisOptions, "")
 
 			if err != nil {
 				return err

--- a/infrastructure/code/backend_service_test.go
+++ b/infrastructure/code/backend_service_test.go
@@ -124,7 +124,7 @@ func TestSnykCodeBackendService_RunAnalysisSmoke(t *testing.T) {
 			limitToFiles: limitToFiles,
 			severity:     0,
 		}
-		issues, callStatus, err := s.RunAnalysis(context.Background(), analysisOptions)
+		issues, callStatus, err := s.RunAnalysis(context.Background(), analysisOptions, "")
 		if err != nil {
 			return false
 		}

--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -121,7 +121,7 @@ func (b *Bundle) retrieveAnalysis(ctx context.Context) ([]snyk.Issue, error) {
 		if ctx.Err() != nil { // Cancellation requested
 			return []snyk.Issue{}, nil
 		}
-		issues, status, err := b.SnykCode.RunAnalysis(s.Context(), analysisOptions)
+		issues, status, err := b.SnykCode.RunAnalysis(s.Context(), analysisOptions, b.rootPath)
 
 		if err != nil {
 			logger.Error().Err(err).

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -484,6 +484,7 @@ func (sc *Scanner) createBundle(ctx context.Context,
 		if err != nil {
 			sc.errorReporter.CaptureErrorAndReportAsIssue(rootPath, err)
 		}
+		relativePath = EncodePath(relativePath)
 
 		bundleFile := getFileFrom(absoluteFilePath, fileContent)
 		bundleFiles[relativePath] = bundleFile

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -463,37 +463,33 @@ func (sc *Scanner) createBundle(ctx context.Context,
 	var limitToFiles []string
 	fileHashes := make(map[string]string)
 	bundleFiles := make(map[string]BundleFile)
-	for _, filePath := range filePaths {
+	for _, absoluteFilePath := range filePaths {
 		if ctx.Err() != nil {
 			return b, err // The cancellation error should be handled by the calling function
 		}
-		if !sc.BundleUploader.isSupported(span.Context(), filePath) {
+		if !sc.BundleUploader.isSupported(span.Context(), absoluteFilePath) {
 			continue
 		}
-		fileContent, err := loadContent(filePath)
+		fileContent, err := loadContent(absoluteFilePath)
 		if err != nil {
-			log.Error().Err(err).Str("filePath", filePath).Msg("could not load content of file")
+			log.Error().Err(err).Str("filePath", absoluteFilePath).Msg("could not load content of file")
 			continue
 		}
 
 		if !(len(fileContent) > 0 && len(fileContent) <= maxFileSize) {
 			continue
 		}
-		bundleFile := getFileFrom(filePath, fileContent)
-		bundleFiles[filePath] = bundleFile
-		fileHashes[filePath] = bundleFile.Hash
-		relativePath, err := filepath.Rel(rootPath, filePath)
+
+		relativePath, err := ToRelativeUnixPath(rootPath, absoluteFilePath)
 		if err != nil {
-			relativePath = filePath
-			if rootPath != "" {
-				errMsg := fmt.Sprint("could not get relative path for file: ", filePath, " and root path: ", rootPath)
-				sc.errorReporter.CaptureErrorAndReportAsIssue(rootPath, errors.Wrap(err, errMsg))
-			}
+			sc.errorReporter.CaptureErrorAndReportAsIssue(rootPath, err)
 		}
 
-		relativePath = filepath.ToSlash(relativePath)
+		bundleFile := getFileFrom(absoluteFilePath, fileContent)
+		bundleFiles[relativePath] = bundleFile
+		fileHashes[relativePath] = bundleFile.Hash
 
-		if changedFiles[filePath] {
+		if changedFiles[absoluteFilePath] {
 			limitToFiles = append(limitToFiles, relativePath)
 		}
 	}

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -186,7 +186,8 @@ func TestCreateBundle(t *testing.T) {
 			[]string{file},
 			map[string]bool{})
 		assert.Nil(t, err)
-		assert.Contains(t, bundle.Files, file)
+		relativePath, _ := ToRelativeUnixPath(tempDir, file)
+		assert.Contains(t, bundle.Files, relativePath)
 	})
 }
 

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -46,8 +45,9 @@ import (
 )
 
 // can we replace them with more succinct higher level integration tests?[keeping them for sanity for the time being]
-func setupDocs() (string, lsp.TextDocumentItem, lsp.TextDocumentItem, []byte, []byte) {
-	path, _ := os.MkdirTemp(xdg.DataHome, "firstDocTemp")
+func setupDocs(t *testing.T) (string, lsp.TextDocumentItem, lsp.TextDocumentItem, []byte, []byte) {
+	t.Helper()
+	path := t.TempDir()
 
 	content1 := []byte("test1")
 	_ = os.WriteFile(path+string(os.PathSeparator)+"test1.java", content1, 0660)
@@ -189,6 +189,40 @@ func TestCreateBundle(t *testing.T) {
 		relativePath, _ := ToRelativeUnixPath(tempDir, file)
 		assert.Contains(t, bundle.Files, relativePath)
 	})
+	t.Run("url-encodes files", func(t *testing.T) {
+		// Arrange
+		filesRelPaths := []string{
+			"path/to/file1.java",
+			"path/with spaces/file2.java",
+		}
+		expectedPaths := []string{
+			"path/to/file1.java",
+			"path/with%20spaces/file2.java",
+		}
+
+		_, scanner := setupTestScanner()
+		tempDir := t.TempDir()
+		var filesFullPaths []string
+		for _, fileRelPath := range filesRelPaths {
+			file := filepath.Join(tempDir, fileRelPath)
+			filesFullPaths = append(filesFullPaths, file)
+			_ = os.MkdirAll(filepath.Dir(file), 0700)
+			err := os.WriteFile(file, []byte("some content so the file won't be skipped"), 0600)
+			assert.Nil(t, err)
+		}
+
+		bundle, err := scanner.createBundle(context.Background(),
+			"testRequestId",
+			tempDir,
+			filesFullPaths,
+			map[string]bool{})
+
+		// Assert
+		assert.Nil(t, err)
+		for _, expectedPath := range expectedPaths {
+			assert.Contains(t, bundle.Files, expectedPath)
+		}
+	})
 }
 
 func setupCreateBundleTest(t *testing.T, extension string) (*FakeSnykCodeClient, string, *Scanner, string) {
@@ -222,19 +256,21 @@ func TestUploadAndAnalyze(t *testing.T) {
 				error_reporting.NewTestErrorReporter(),
 				ux2.NewTestAnalytics(),
 			)
-			path, firstDoc, _, content1, _ := setupDocs()
-			docs := []string{uri.PathFromUri(firstDoc.URI)}
-			defer func(path string) { _ = os.RemoveAll(path) }(path)
+			baseDir, firstDoc, _, content1, _ := setupDocs(t)
+			fullPath := uri.PathFromUri(firstDoc.URI)
+			docs := []string{fullPath}
 			metrics := c.newMetrics(len(docs), time.Time{})
 
-			_, _ = c.UploadAndAnalyze(context.Background(), docs, "", metrics, map[string]bool{})
+			_, _ = c.UploadAndAnalyze(context.Background(), docs, baseDir, metrics, map[string]bool{})
 
 			// verify that create bundle has been called on backend service
 			params := snykCodeMock.GetCallParams(0, CreateBundleOperation)
 			assert.NotNil(t, params)
 			assert.Equal(t, 1, len(params))
 			files := params[0].(map[string]string)
-			assert.Equal(t, files[uri.PathFromUri(firstDoc.URI)], util.Hash(content1))
+			relPath, err := ToRelativeUnixPath(baseDir, fullPath)
+			assert.Nil(t, err)
+			assert.Equal(t, files[relPath], util.Hash(content1))
 		},
 	)
 
@@ -257,7 +293,7 @@ func TestUploadAndAnalyze(t *testing.T) {
 
 			assert.NotNil(t, issues)
 			assert.Equal(t, 1, len(issues))
-			assert.True(t, reflect.DeepEqual(FakeIssue, issues[0]))
+			assert.Equal(t, FakeIssue, issues[0])
 
 			// verify that extend bundle has been called on backend service with additional file
 			params := snykCodeMock.GetCallParams(0, RunAnalysisOperation)

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -848,21 +848,6 @@ func Test_rule_cwe(t *testing.T) {
 	})
 }
 
-func Test_SarifResponse_filter_disabled_issues(t *testing.T) {
-	t.Run("should filter out disabled issues - all enabled", func(t *testing.T) {
-		_, issues, _ := setupConversionTests(t, true, true)
-		assert.Equal(t, 2, len(issues))
-	})
-	t.Run("should filter out disabled issues - code quality disabled", func(t *testing.T) {
-		_, issues, _ := setupConversionTests(t, true, false)
-		assert.Equal(t, 0, len(issues))
-	})
-	t.Run("should filter out disabled issues - code security disabled", func(t *testing.T) {
-		_, issues, _ := setupConversionTests(t, false, true)
-		assert.Equal(t, 2, len(issues))
-	})
-}
-
 func Test_getIssueId(t *testing.T) {
 	id := getIssueKey("java/DontUsePrintStackTrace", "file/path.java", 15, 17, 15, 35)
 	assert.Equal(t, "8423559307c17d15f5617ae2e29dbf02", id)

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -748,7 +748,8 @@ func setupConversionTests(t *testing.T,
 		t.Fatal(err, "couldn't unmarshal sarif response")
 	}
 
-	issues := analysisResponse.toIssues(temp)
+	issues, err := analysisResponse.toIssues(temp)
+	assert.Nil(t, err)
 
 	return path, issues, analysisResponse
 }

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -737,15 +737,21 @@ func setupConversionTests(t *testing.T,
 	if err != nil {
 		t.Fatal(err, "couldn't write test file")
 	}
+
+	relPath, err := ToRelativeUnixPath(temp, path)
+	if err != nil {
+		t.Fatal(err, "couldn't get relative path")
+	}
+
 	var analysisResponse SarifResponse
-	responseJson := getSarifResponseJson(path)
+	responseJson := getSarifResponseJson(relPath)
 	err = json.Unmarshal([]byte(responseJson), &analysisResponse)
 
 	if err != nil {
 		t.Fatal(err, "couldn't unmarshal sarif response")
 	}
 
-	issues := analysisResponse.toIssues()
+	issues := analysisResponse.toIssues(temp)
 
 	return path, issues, analysisResponse
 }
@@ -839,40 +845,6 @@ func Test_rule_cwe(t *testing.T) {
 			Cwe: []string{},
 		}}
 		assert.NotContains(t, cut.cwe(), "CWE:")
-	})
-}
-
-func Test_SarifResponse_reportDiagnostic(t *testing.T) {
-	t.Run("should report diagnostic when enabled Snyk Code Quality issue", func(t *testing.T) {
-		s := SarifResponse{}
-		c := config.New()
-		c.EnableSnykCodeQuality(true)
-		config.SetCurrentConfig(c)
-		assert.True(t, s.reportDiagnostic(snyk.Issue{IssueType: snyk.CodeQualityIssue}))
-	})
-
-	t.Run("should not report diagnostic when enabled Snyk Code Quality issue", func(t *testing.T) {
-		s := SarifResponse{}
-		c := config.New()
-		c.EnableSnykCodeQuality(false)
-		config.SetCurrentConfig(c)
-		assert.False(t, s.reportDiagnostic(snyk.Issue{IssueType: snyk.CodeQualityIssue}))
-	})
-
-	t.Run("should report diagnostic when enabled Snyk Code Security issue", func(t *testing.T) {
-		s := SarifResponse{}
-		c := config.New()
-		c.EnableSnykCodeSecurity(true)
-		config.SetCurrentConfig(c)
-		assert.True(t, s.reportDiagnostic(snyk.Issue{IssueType: snyk.CodeSecurityVulnerability}))
-	})
-
-	t.Run("should not report diagnostic when enabled Snyk Code Security issue", func(t *testing.T) {
-		s := SarifResponse{}
-		c := config.New()
-		c.EnableSnykCodeQuality(false)
-		config.SetCurrentConfig(c)
-		assert.False(t, s.reportDiagnostic(snyk.Issue{IssueType: snyk.CodeSecurityVulnerability}))
 	})
 }
 

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/adrg/xdg"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -728,23 +727,21 @@ func setupConversionTests(t *testing.T,
 	c := config.CurrentConfig()
 	c.EnableSnykCodeSecurity(activateSnykCodeSecurity)
 	c.EnableSnykCodeQuality(activateSnykCodeQuality)
-	temp, err := os.MkdirTemp(xdg.DataHome, "conversionTests")
-	if err != nil {
-		t.Fatal(err, "couldn't create directory for conversion tests")
-	}
-	path := filepath.Join(temp, "Dummy.java")
-	err = os.WriteFile(path, []byte(strings.Repeat("aa\n", 1000)), 0660)
+	temp := t.TempDir()
+	path := filepath.Join(temp, "File With Spaces.java")
+	err := os.WriteFile(path, []byte(strings.Repeat("aa\n", 1000)), 0660)
 	if err != nil {
 		t.Fatal(err, "couldn't write test file")
 	}
 
 	relPath, err := ToRelativeUnixPath(temp, path)
+	encodedPath := EncodePath(relPath)
 	if err != nil {
 		t.Fatal(err, "couldn't get relative path")
 	}
 
 	var analysisResponse SarifResponse
-	responseJson := getSarifResponseJson(relPath)
+	responseJson := getSarifResponseJson(encodedPath)
 	err = json.Unmarshal([]byte(responseJson), &analysisResponse)
 
 	if err != nil {

--- a/infrastructure/code/fake_snyk_code_api_service.go
+++ b/infrastructure/code/fake_snyk_code_api_service.go
@@ -215,6 +215,7 @@ var successfulResult = AnalysisStatus{
 func (f *FakeSnykCodeClient) RunAnalysis(
 	_ context.Context,
 	options AnalysisOptions,
+	baseDir string,
 ) ([]snyk.Issue, AnalysisStatus, error) {
 
 	FakeSnykCodeApiServiceMutex.Lock()

--- a/infrastructure/code/path.go
+++ b/infrastructure/code/path.go
@@ -28,9 +28,7 @@ func ToRelativeUnixPath(baseDir string, absoluteFilePath string) (string, error)
 }
 
 func ToAbsolutePath(baseDir string, relativePath string) string {
-	absolutePath := filepath.Join(baseDir, relativePath)
-
-	return absolutePath
+	return filepath.Join(baseDir, relativePath)
 }
 
 func EncodePath(relativePath string) string {
@@ -44,6 +42,6 @@ func EncodePath(relativePath string) string {
 	return encodedPath
 }
 
-func DecodePath(encodedRelativePath string) string {
-	return ""
+func DecodePath(encodedRelativePath string) (string, error) {
+	return url.PathUnescape(encodedRelativePath)
 }

--- a/infrastructure/code/path.go
+++ b/infrastructure/code/path.go
@@ -10,9 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Send for analysis: absolutePath -> relativePath -> encodeUri
-// Produce snyk.Issue results: decodeUri -> relativePath -> absolutePath
-
 func ToRelativeUnixPath(baseDir string, absoluteFilePath string) (string, error) {
 	relativePath, err := filepath.Rel(baseDir, absoluteFilePath)
 	if err != nil {

--- a/infrastructure/code/path.go
+++ b/infrastructure/code/path.go
@@ -2,7 +2,10 @@ package code
 
 import (
 	"fmt"
+	"net/url"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -31,7 +34,14 @@ func ToAbsolutePath(baseDir string, relativePath string) string {
 }
 
 func EncodePath(relativePath string) string {
-	return ""
+	segments := strings.Split(filepath.ToSlash(relativePath), "/")
+	encodedPath := ""
+	for _, segment := range segments {
+		encodedSegment := url.PathEscape(segment)
+		encodedPath = path.Join(encodedPath, encodedSegment)
+	}
+
+	return encodedPath
 }
 
 func DecodePath(encodedRelativePath string) string {

--- a/infrastructure/code/path.go
+++ b/infrastructure/code/path.go
@@ -1,0 +1,39 @@
+package code
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// Send for analysis: absolutePath -> relativePath -> encodeUri
+// Produce snyk.Issue results: decodeUri -> relativePath -> absolutePath
+
+func ToRelativeUnixPath(baseDir string, absoluteFilePath string) (string, error) {
+	relativePath, err := filepath.Rel(baseDir, absoluteFilePath)
+	if err != nil {
+		relativePath = absoluteFilePath
+		if baseDir != "" {
+			errMsg := fmt.Sprint("could not get relative path for file: ", absoluteFilePath, " and root path: ", baseDir)
+			return "", errors.Wrap(err, errMsg)
+		}
+	}
+
+	relativePath = filepath.ToSlash(relativePath) // treat all paths as unix paths
+	return relativePath, nil
+}
+
+func ToAbsolutePath(baseDir string, relativePath string) string {
+	absolutePath := filepath.Join(baseDir, relativePath)
+
+	return absolutePath
+}
+
+func EncodePath(relativePath string) string {
+	return ""
+}
+
+func DecodePath(encodedRelativePath string) string {
+	return ""
+}

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -402,10 +402,10 @@ func Test_scheduleNewScan_ContextCancelledAfterScanScheduled_NoScanRun(t *testin
 	workingDir, _ := os.Getwd()
 	targetPath, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 
 	// Act
 	scanner.scheduleRefreshScan(ctx, targetPath)
+	cancel()
 
 	// Assert
 	scheduledScanDuration := scanner.refreshScanWaitDuration + fakeCli.ExecuteDuration

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -301,15 +301,17 @@ func Test_Scan_SchedulesNewScan(t *testing.T) {
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		fakeCli)
-	scanner.scheduledScanDuration = 50 * time.Millisecond
-	path, _ := filepath.Abs(workingDir + "/testdata/package.json")
+	scanner.refreshScanWaitDuration = 50 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	targetFile, _ := filepath.Abs(workingDir + "/testdata/package.json")
 
 	// Act
-	_, _ = scanner.Scan(context.Background(), path, "")
+	_, _ = scanner.Scan(ctx, targetFile, "")
 
 	// Assert
 	assert.Eventually(t, func() bool {
-		return fakeCli.GetFinishedScans() == 2
+		return fakeCli.GetFinishedScans() >= 2
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
@@ -319,14 +321,14 @@ func Test_scheduleNewScan_CapturesAnalytics(t *testing.T) {
 	fakeCli := cli.NewTestExecutor()
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, fakeCli)
-	scanner.scheduledScanDuration = 50 * time.Millisecond
+	scanner.refreshScanWaitDuration = 50 * time.Millisecond
 	workingDir, _ := os.Getwd()
 	path, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	// Act
-	scanner.scheduleNewScan(ctx, path)
+	scanner.scheduleRefreshScan(ctx, path)
 
 	// Assert
 	assert.Eventually(t, func() bool {
@@ -348,17 +350,17 @@ func Test_scheduleNewScanWithProductDisabled_NoScanRun(t *testing.T) {
 	fakeCli.ExecuteDuration = time.Millisecond
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, fakeCli)
-	scanner.scheduledScanDuration = 50 * time.Millisecond
+	scanner.refreshScanWaitDuration = 50 * time.Millisecond
 	workingDir, _ := os.Getwd()
 	path, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	// Act
-	scanner.scheduleNewScan(ctx, path)
+	scanner.scheduleRefreshScan(ctx, path)
 
 	// Assert
-	time.Sleep(scanner.scheduledScanDuration + fakeCli.ExecuteDuration + 10*time.Millisecond)
+	time.Sleep(scanner.refreshScanWaitDuration + fakeCli.ExecuteDuration + 10*time.Millisecond)
 	assert.Equal(t, 0, fakeCli.GetFinishedScans())
 	assert.Len(t, analytics.GetAnalytics(), 0)
 }
@@ -371,7 +373,7 @@ func Test_scheduleNewScanTwice_RunsOnlyOnce(t *testing.T) {
 	fakeCli.ExecuteDuration = time.Millisecond
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, fakeCli)
-	scanner.scheduledScanDuration = 50 * time.Millisecond
+	scanner.refreshScanWaitDuration = 50 * time.Millisecond
 	workingDir, _ := os.Getwd()
 	targetPath, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
 	ctx1, cancel1 := context.WithCancel(context.Background())
@@ -380,11 +382,11 @@ func Test_scheduleNewScanTwice_RunsOnlyOnce(t *testing.T) {
 	t.Cleanup(cancel2)
 
 	// Act
-	scanner.scheduleNewScan(ctx1, targetPath)
-	scanner.scheduleNewScan(ctx2, targetPath)
+	scanner.scheduleRefreshScan(ctx1, targetPath)
+	scanner.scheduleRefreshScan(ctx2, targetPath)
 
 	// Assert
-	time.Sleep(3*(scanner.scheduledScanDuration+fakeCli.ExecuteDuration) + 5*time.Millisecond)
+	time.Sleep(3*(scanner.refreshScanWaitDuration+fakeCli.ExecuteDuration) + 5*time.Millisecond)
 	assert.Equal(t, 1, fakeCli.GetFinishedScans())
 }
 
@@ -396,17 +398,17 @@ func Test_scheduleNewScan_ContextCancelledAfterScanScheduled_NoScanRun(t *testin
 	fakeCli.ExecuteDuration = time.Millisecond
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, fakeCli)
-	scanner.scheduledScanDuration = 2 * time.Second
+	scanner.refreshScanWaitDuration = 2 * time.Second
 	workingDir, _ := os.Getwd()
 	targetPath, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	// Act
-	scanner.scheduleNewScan(ctx, targetPath)
-	cancel()
+	scanner.scheduleRefreshScan(ctx, targetPath)
 
 	// Assert
-	scheduledScanDuration := scanner.scheduledScanDuration + fakeCli.ExecuteDuration
+	scheduledScanDuration := scanner.refreshScanWaitDuration + fakeCli.ExecuteDuration
 	time.Sleep(scheduledScanDuration * 2) // Ensure enough time has passed for a scheduled scan to complete
 	assert.Equal(t, 0, fakeCli.GetFinishedScans())
 	assert.Len(t, analytics.GetAnalytics(), 0)
@@ -423,7 +425,6 @@ func Test_Scan_missingDisplayTargetFileDoesNotBreakAnalysis(t *testing.T) {
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		fakeCli)
-	scanner.scheduledScanDuration = 50 * time.Millisecond
 	filePath, _ := filepath.Abs(workingDir + "/testdata/package.json")
 
 	// Act


### PR DESCRIPTION
### Description

- Use relative url encoded paths when communicating with Snyk Code API. 
- Update Go to 1.20


### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
