### PR TITLE
feat(autofix): support extensions endpoint [ML-185]

### DIFF
--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -78,8 +78,9 @@ type extendBundleRequest struct {
 }
 
 type filtersResponse struct {
-	ConfigFiles []string `json:"configFiles" pact:"min=1"`
-	Extensions  []string `json:"extensions" pact:"min=1"`
+	ConfigFiles       []string `json:"configFiles" pact:"min=1"`
+	Extensions        []string `json:"extensions" pact:"min=1"`
+	AutofixExtensions []string `json:"autofixExtensions" pact:"min=1"`
 }
 
 func NewHTTPRepository(
@@ -90,7 +91,12 @@ func NewHTTPRepository(
 	return &SnykCodeHTTPClient{client, instrumentor, errorReporter}
 }
 
-func (s *SnykCodeHTTPClient) GetFilters(ctx context.Context) (configFiles []string, extensions []string, err error) {
+func (s *SnykCodeHTTPClient) GetFilters(ctx context.Context) (
+	configFiles []string,
+	extensions []string,
+	autofixExtensions []string,
+	err error,
+) {
 	method := "code.GetFilters"
 	log.Debug().Str("method", method).Msg("API: Getting file extension filters")
 
@@ -99,16 +105,16 @@ func (s *SnykCodeHTTPClient) GetFilters(ctx context.Context) (configFiles []stri
 
 	responseBody, err := s.doCall(span.Context(), "GET", "/filters", nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var filters filtersResponse
 	err = json.Unmarshal(responseBody, &filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	log.Debug().Str("method", method).Msg("API: Finished getting filters")
-	return filters.ConfigFiles, filters.Extensions, nil
+	return filters.ConfigFiles, filters.Extensions, filters.AutofixExtensions, nil
 }
 
 func (s *SnykCodeHTTPClient) CreateBundle(

--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -92,9 +92,7 @@ func NewHTTPRepository(
 }
 
 func (s *SnykCodeHTTPClient) GetFilters(ctx context.Context) (
-	configFiles []string,
-	extensions []string,
-	autofixExtensions []string,
+	filters filtersResponse,
 	err error,
 ) {
 	method := "code.GetFilters"
@@ -105,16 +103,15 @@ func (s *SnykCodeHTTPClient) GetFilters(ctx context.Context) (
 
 	responseBody, err := s.doCall(span.Context(), "GET", "/filters", nil)
 	if err != nil {
-		return nil, nil, nil, err
+		return filtersResponse{ConfigFiles: nil, Extensions: nil, AutofixExtensions: nil}, err
 	}
 
-	var filters filtersResponse
 	err = json.Unmarshal(responseBody, &filters)
 	if err != nil {
-		return nil, nil, nil, err
+		return filtersResponse{ConfigFiles: nil, Extensions: nil, AutofixExtensions: nil}, err
 	}
 	log.Debug().Str("method", method).Msg("API: Finished getting filters")
-	return filters.ConfigFiles, filters.Extensions, filters.AutofixExtensions, nil
+	return filters, nil
 }
 
 func (s *SnykCodeHTTPClient) CreateBundle(

--- a/infrastructure/code/backend_service_interface.go
+++ b/infrastructure/code/backend_service_interface.go
@@ -37,7 +37,11 @@ type AutofixOptions struct {
 }
 
 type SnykCodeClient interface {
-	GetFilters(ctx context.Context) (configFiles []string, extensions []string, err error)
+	GetFilters(ctx context.Context) (
+		configFiles []string,
+		extensions []string,
+		autofixExtensions []string,
+		err error)
 
 	CreateBundle(
 		ctx context.Context,

--- a/infrastructure/code/backend_service_interface.go
+++ b/infrastructure/code/backend_service_interface.go
@@ -38,9 +38,7 @@ type AutofixOptions struct {
 
 type SnykCodeClient interface {
 	GetFilters(ctx context.Context) (
-		configFiles []string,
-		extensions []string,
-		autofixExtensions []string,
+		filters filtersResponse,
 		err error)
 
 	CreateBundle(

--- a/infrastructure/code/backend_service_pact_test.go
+++ b/infrastructure/code/backend_service_pact_test.go
@@ -236,7 +236,7 @@ func TestSnykCodeBackendServicePact(t *testing.T) { // nolint:gocognit // this i
 		})
 
 		test := func() error {
-			if _, _, err := client.GetFilters(context.Background()); err != nil {
+			if _, _, _, err := client.GetFilters(context.Background()); err != nil {
 				return err
 			}
 

--- a/infrastructure/code/backend_service_pact_test.go
+++ b/infrastructure/code/backend_service_pact_test.go
@@ -236,7 +236,7 @@ func TestSnykCodeBackendServicePact(t *testing.T) { // nolint:gocognit // this i
 		})
 
 		test := func() error {
-			if _, _, _, err := client.GetFilters(context.Background()); err != nil {
+			if _, err := client.GetFilters(context.Background()); err != nil {
 				return err
 			}
 

--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -99,8 +99,9 @@ func getIssueLangAndRuleId(issue snyk.Issue) (string, string, bool) {
 // in the `codeSettings` singleton.
 func (b *Bundle) isAutofixSupportedForExtension(ctx context.Context, file string) bool {
 	if getCodeSettings().autofixExtensions == nil {
-		// query
-		_, _, autofixExts, err := b.SnykCode.GetFilters(ctx)
+		// TODO: together with the endpoint redesign, this should use not the same `/filters` endpoint
+		// as the analysis one. Autofix should have a separate one.
+		filters, err := b.SnykCode.GetFilters(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("could not get filters")
 			return false
@@ -108,7 +109,7 @@ func (b *Bundle) isAutofixSupportedForExtension(ctx context.Context, file string
 
 		// It's not a mistake to have `..IfNotSet` here, because between the `GetFilters` and here
 		// things might have changed on the settings singleton. But we don't want to overlock it.
-		getCodeSettings().setAutofixExtensionsIfNotSet(autofixExts)
+		getCodeSettings().setAutofixExtensionsIfNotSet(filters.AutofixExtensions)
 	}
 
 	supported := getCodeSettings().autofixExtensions.Get(filepath.Ext(file))

--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -221,11 +221,12 @@ func (b *Bundle) createDeferredAutofixCodeAction(ctx context.Context, issue snyk
 				Msg("error converting to relative file path")
 			return nil
 		}
+		encodedRelativePath := EncodePath(relativePath)
 
 		autofixOptions := AutofixOptions{
 			bundleHash: b.BundleHash,
 			shardKey:   b.getShardKey(b.rootPath, config.CurrentConfig().Token()),
-			filePath:   relativePath,
+			filePath:   encodedRelativePath,
 			issue:      issue,
 		}
 

--- a/infrastructure/code/bundle_uploader.go
+++ b/infrastructure/code/bundle_uploader.go
@@ -118,7 +118,8 @@ func (b *BundleUploader) groupInBatches(
 
 func (b *BundleUploader) isSupported(ctx context.Context, file string) bool {
 	if b.supportedExtensions.Size() == 0 && b.supportedConfigFiles.Size() == 0 {
-		configFiles, extensions, err := b.SnykCode.GetFilters(ctx)
+		// autofixExtensions is not needed here
+		configFiles, extensions, _, err := b.SnykCode.GetFilters(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("could not get filters")
 			return false

--- a/infrastructure/code/bundle_uploader.go
+++ b/infrastructure/code/bundle_uploader.go
@@ -118,17 +118,17 @@ func (b *BundleUploader) groupInBatches(
 
 func (b *BundleUploader) isSupported(ctx context.Context, file string) bool {
 	if b.supportedExtensions.Size() == 0 && b.supportedConfigFiles.Size() == 0 {
-		// autofixExtensions is not needed here
-		configFiles, extensions, _, err := b.SnykCode.GetFilters(ctx)
+
+		filters, err := b.SnykCode.GetFilters(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("could not get filters")
 			return false
 		}
 
-		for _, ext := range extensions {
+		for _, ext := range filters.Extensions {
 			b.supportedExtensions.Store(ext, true)
 		}
-		for _, configFile := range configFiles {
+		for _, configFile := range filters.ConfigFiles {
 			// .gitignore and .dcignore should not be uploaded
 			// (https://github.com/snyk/code-client/blob/d6f6a2ce4c14cb4b05aa03fb9f03533d8cf6ca4a/src/files.ts#L138)
 			if configFile == ".gitignore" || configFile == ".dcignore" {

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -680,7 +680,6 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 		"should not add autofix after analysis when not enabled", func(t *testing.T) {
 			testutil.UnitTest(t)
 			autofixSetupAndCleanup(t)
-			config.CurrentConfig().SetSnykCodeEnabled(true)
 
 			snykCodeMock := &FakeSnykCodeClient{}
 			analytics := ux2.NewTestAnalytics()
@@ -713,7 +712,6 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 		func(t *testing.T) {
 			testutil.UnitTest(t)
 			autofixSetupAndCleanup(t)
-			config.CurrentConfig().SetSnykCodeEnabled(true)
 			getCodeSettings().isAutofixEnabled.Set(true)
 			getCodeSettings().setAutofixExtensionsIfNotSet([]string{".somenonexistent"})
 
@@ -747,7 +745,6 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 		"should run autofix after analysis when is enabled", func(t *testing.T) {
 			testutil.UnitTest(t)
 			autofixSetupAndCleanup(t)
-			config.CurrentConfig().SetSnykCodeEnabled(true)
 			getCodeSettings().isAutofixEnabled.Set(true)
 
 			snykCodeMock := &FakeSnykCodeClient{}
@@ -772,7 +769,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 
 			assert.Len(t, analytics.GetAnalytics(), 1)
 			assert.Len(t, issues[0].CodeActions, 2)
-			val, ok := (*issues[0].CodeActions[1].DeferredEdit)().Changes[issues[0].AffectedFilePath]
+			val, ok := (*issues[0].CodeActions[1].DeferredEdit)().Changes[EncodePath(issues[0].AffectedFilePath)]
 			assert.True(t, ok)
 			// If this fails, likely the format of autofix edits has changed to
 			// "hunk-like" ones rather than replacing the whole file

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -669,16 +669,17 @@ func TestIsSastEnabled(t *testing.T) {
 }
 
 func autofixSetupAndCleanup(t *testing.T) {
+	resetCodeSettings()
 	t.Cleanup(resetCodeSettings)
 	config.CurrentConfig().SetSnykCodeEnabled(true)
 	getCodeSettings().isAutofixEnabled.Set(false)
 }
 
 func TestUploadAnalyzeWithAutofix(t *testing.T) {
-	autofixSetupAndCleanup(t)
 	t.Run(
 		"should not add autofix after analysis when not enabled", func(t *testing.T) {
 			testutil.UnitTest(t)
+			autofixSetupAndCleanup(t)
 			config.CurrentConfig().SetSnykCodeEnabled(true)
 
 			snykCodeMock := &FakeSnykCodeClient{}
@@ -711,6 +712,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 		"should not run autofix after analysis when is enabled but have disallowed extension",
 		func(t *testing.T) {
 			testutil.UnitTest(t)
+			autofixSetupAndCleanup(t)
 			config.CurrentConfig().SetSnykCodeEnabled(true)
 			getCodeSettings().isAutofixEnabled.Set(true)
 			getCodeSettings().setAutofixExtensionsIfNotSet([]string{".somenonexistent"})
@@ -744,6 +746,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 	t.Run(
 		"should run autofix after analysis when is enabled", func(t *testing.T) {
 			testutil.UnitTest(t)
+			autofixSetupAndCleanup(t)
 			config.CurrentConfig().SetSnykCodeEnabled(true)
 			getCodeSettings().isAutofixEnabled.Set(true)
 

--- a/infrastructure/code/fake_snyk_code_api_service.go
+++ b/infrastructure/code/fake_snyk_code_api_service.go
@@ -165,16 +165,20 @@ func (f *FakeSnykCodeClient) GetAllCalls(op string) [][]any {
 }
 
 func (f *FakeSnykCodeClient) GetFilters(_ context.Context) (
-	configFiles []string,
-	extensions []string,
-	autofixExtensions []string,
+	filters filtersResponse,
 	err error,
 ) {
 	FakeSnykCodeApiServiceMutex.Lock()
 	defer FakeSnykCodeApiServiceMutex.Unlock()
-	params := []any{configFiles, extensions, autofixExtensions, err}
+	params := []any{filters.ConfigFiles,
+		filters.Extensions,
+		filters.AutofixExtensions,
+		err}
 	f.addCall(params, GetFiltersOperation)
-	return f.ConfigFiles, FakeFilters, FakeAutofixFilters, nil
+	return filtersResponse{ConfigFiles: f.ConfigFiles,
+		Extensions:        FakeFilters,
+		AutofixExtensions: FakeAutofixFilters,
+	}, nil
 }
 
 func (f *FakeSnykCodeClient) CreateBundle(_ context.Context,

--- a/infrastructure/code/pacts/snykls-snykcodeapi.json
+++ b/infrastructure/code/pacts/snykls-snykcodeapi.json
@@ -665,6 +665,9 @@
           "Content-Type": "application/json"
         },
         "body": {
+          "autofixExtensions": [
+            "string"
+          ],
           "configFiles": [
             "string"
           ],
@@ -673,6 +676,15 @@
           ]
         },
         "matchingRules": {
+          "$.body.autofixExtensions": {
+            "min": 1
+          },
+          "$.body.autofixExtensions[*].*": {
+            "match": "type"
+          },
+          "$.body.autofixExtensions[*]": {
+            "match": "type"
+          },
           "$.body.configFiles": {
             "min": 1
           },


### PR DESCRIPTION
Counterpart of the PR on the sast side which adds the filtering and prohibits the non-supported autofix extensions to have codeactions.

Side-effects:
- added `EncodePath(...)` as a followup to #267 

@bastiandoetsch, @michelkaporin, @asaf92 would you like to pick up from there and add pact testing etc? (not an expert)