### PR TITLE
fix: ensure token is updated in app framework for default auth

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -418,6 +418,8 @@ func (c *Config) SetToken(token string) {
 	// update go application framework if using oauth
 	if c.authenticationMethod == lsp.OAuthAuthentication {
 		c.engine.GetConfiguration().Set(auth.CONFIG_KEY_OAUTH_TOKEN, token)
+	} else {
+		c.engine.GetConfiguration().Set(configuration.AUTHENTICATION_TOKEN, token)
 	}
 }
 func (c *Config) SetFormat(format string) { c.format = format }

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/server/lsp"
-	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
 func TestSetToken(t *testing.T) {

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/snyk/go-application-framework/pkg/auth"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/server/lsp"
+	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
 func TestSetToken(t *testing.T) {
@@ -38,6 +40,7 @@ func TestSetToken(t *testing.T) {
 		config.SetToken(token)
 		assert.Equal(t, config.Token(), token)
 		assert.NotEqual(t, config.Engine().GetConfiguration().Get(auth.CONFIG_KEY_OAUTH_TOKEN), token)
+		assert.Equal(t, config.Engine().GetConfiguration().Get(configuration.AUTHENTICATION_TOKEN), token)
 		config.SetToken(oldToken)
 	})
 	t.Run("OAuth Token authentication", func(t *testing.T) {


### PR DESCRIPTION
### Description

Token provided wasn't used for default authentication method when querying Snyk API.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
