### PR TITLE
fix: use relative filepaths in calls to engine following #264

### DIFF
--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -185,10 +185,20 @@ func (b *Bundle) createDeferredAutofixCodeAction(ctx context.Context, issue snyk
 		s := b.instrumentor.StartSpan(ctx, method)
 		defer b.instrumentor.Finish(s)
 
+		relativePath, err := ToRelativeUnixPath(b.rootPath, issue.AffectedFilePath)
+		if err != nil {
+			log.Error().
+				Err(err).Str("method", method).
+				Str("rootPath", b.rootPath).
+				Str("AffectedFilePath", issue.AffectedFilePath).
+				Msg("error converting to relative file path")
+			return nil
+		}
+
 		autofixOptions := AutofixOptions{
 			bundleHash: b.BundleHash,
 			shardKey:   b.getShardKey(b.rootPath, config.CurrentConfig().Token()),
-			filePath:   issue.AffectedFilePath,
+			filePath:   relativePath,
 			issue:      issue,
 		}
 


### PR DESCRIPTION
### Description

This follows upon #264 to use relative paths in calls to autofix

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
