### PR TITLE
fix: IaC issue path

### DIFF
--- a/infrastructure/iac/types.go
+++ b/infrastructure/iac/types.go
@@ -39,6 +39,6 @@ type iacIssue struct {
 	LineNumber     int            `json:"lineNumber"`
 	Documentation  lsp.Uri        `json:"documentation"`
 	IacDescription iacDescription `json:"iacDescription"`
-	Path           []string       `json:"path"`
+	Path           []any          `json:"path"`
 	References     []string       `json:"references"`
 }


### PR DESCRIPTION
### Description

- Fixes the types for the IaC issue path. Currently the path is represented as a slice of string tokens, when in reality tokens can also be integers.

### Checklist

- [X] Tests added and all succeed
- [X] Linted