### PR TITLE
fix: enable oauth feature flag in cli calls when using oauth2

### DIFF
--- a/application/di/init.go
+++ b/application/di/init.go
@@ -86,6 +86,7 @@ func initDomain() {
 		instrumentor,
 		analytics,
 		scanNotifier,
+		snykApiClient,
 		snykCodeScanner,
 		infrastructureAsCodeScanner,
 		openSourceScanner,
@@ -156,8 +157,8 @@ func TestInit(t *testing.T) {
 	errorReporter = errorreporting.NewTestErrorReporter()
 	installer = install.NewFakeInstaller()
 	authProvider := auth2.NewFakeCliAuthenticationProvider()
-	fakeApiClient := &snyk_api.FakeApiClient{CodeEnabled: true}
-	authenticationService = services.NewAuthenticationService(fakeApiClient, authProvider, analytics, errorReporter)
+	snykApiClient = &snyk_api.FakeApiClient{CodeEnabled: true}
+	authenticationService = services.NewAuthenticationService(snykApiClient, authProvider, analytics, errorReporter)
 	cliInitializer = cli2.NewInitializer(errorReporter, installer)
 	authInitializer := auth2.NewInitializer(authenticationService, errorReporter, analytics)
 	scanInitializer = initialize.NewDelegatingInitializer(
@@ -169,7 +170,7 @@ func TestInit(t *testing.T) {
 	snykCli = cli2.NewExecutor(authenticationService, errorReporter, analytics)
 	snykCodeBundleUploader = code2.NewBundler(snykCodeClient, instrumentor)
 	scanNotifier, _ = appNotification.NewScanNotifier(notification.NewNotifier())
-	snykCodeScanner = code2.New(snykCodeBundleUploader, fakeApiClient, errorReporter, analytics)
+	snykCodeScanner = code2.New(snykCodeBundleUploader, snykApiClient, errorReporter, analytics)
 	openSourceScanner = oss.New(instrumentor, errorReporter, analytics, snykCli)
 	infrastructureAsCodeScanner = iac.New(instrumentor, errorReporter, analytics, snykCli)
 	scanner = snyk.NewDelegatingScanner(
@@ -177,6 +178,7 @@ func TestInit(t *testing.T) {
 		instrumentor,
 		analytics,
 		scanNotifier,
+		snykApiClient,
 		snykCodeScanner,
 		infrastructureAsCodeScanner,
 		openSourceScanner,

--- a/domain/snyk/scanner.go
+++ b/domain/snyk/scanner.go
@@ -120,10 +120,7 @@ func (sc *DelegatingConcurrentScanner) Scan(
 	}
 
 	// refresh auth by issuing a request to the API
-	_, err = sc.snykApiClient.GetActiveUser()
-	if err != nil {
-		log.Debug().Err(err).Msg("Retrieving active user failed, re-auth may be required")
-	}
+	_, _ = sc.snykApiClient.GetActiveUser()
 
 	waitGroup := &sync.WaitGroup{}
 	for _, scanner := range sc.scanners {

--- a/domain/snyk/scanner_test.go
+++ b/domain/snyk/scanner_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/ide/initialize"
 	"github.com/snyk/snyk-ls/domain/observability/performance"
 	"github.com/snyk/snyk-ls/domain/observability/ux"
+	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
@@ -42,6 +43,7 @@ func TestScan_UsesEnabledProductLinesOnly(t *testing.T) {
 		performance.NewTestInstrumentor(),
 		ux.NewTestAnalytics(),
 		NewMockScanNotifier(),
+		&snyk_api.FakeApiClient{CodeEnabled: false},
 		enabledScanner,
 		disabledScanner,
 	)
@@ -70,6 +72,7 @@ func TestScan_whenProductScannerEnabled_SendsAnalysisTriggered(t *testing.T) {
 		performance.NewTestInstrumentor(),
 		analytics,
 		NewMockScanNotifier(),
+		&snyk_api.FakeApiClient{CodeEnabled: false},
 		enabledScanner,
 		disabledScanner,
 	)
@@ -92,6 +95,7 @@ func TestScan_whenNoProductScannerEnabled_SendsNoAnalytics(t *testing.T) {
 		performance.NewTestInstrumentor(),
 		analytics,
 		NewMockScanNotifier(),
+		&snyk_api.FakeApiClient{CodeEnabled: false},
 		disabledScanner,
 	)
 
@@ -108,6 +112,7 @@ func Test_userNotAuthenticated_ScanSkipped(t *testing.T) {
 		performance.NewTestInstrumentor(),
 		ux.NewTestAnalytics(),
 		NewMockScanNotifier(),
+		&snyk_api.FakeApiClient{CodeEnabled: false},
 		productScanner,
 	)
 	config.CurrentConfig().SetToken("")
@@ -131,6 +136,7 @@ func Test_ScanStarted_TokenChanged_ScanCancelled(t *testing.T) {
 		performance.NewTestInstrumentor(),
 		ux.NewTestAnalytics(),
 		NewMockScanNotifier(),
+		&snyk_api.FakeApiClient{CodeEnabled: false},
 		productScanner,
 	)
 	done := make(chan bool)
@@ -161,6 +167,7 @@ func TestScan_whenProductScannerEnabled_SendsInProgress(t *testing.T) {
 		performance.NewTestInstrumentor(),
 		analytics,
 		scanNotifier,
+		&snyk_api.FakeApiClient{CodeEnabled: false},
 		enabledScanner,
 	)
 

--- a/infrastructure/cli/cli.go
+++ b/infrastructure/cli/cli.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"context"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -93,17 +92,6 @@ func (c SnykCli) doExecute(ctx context.Context, cmd []string, workingDir string,
 		shouldRetry := c.HandleErrors(ctx, string(output))
 		if firstAttempt && shouldRetry {
 			output, err = c.doExecute(ctx, cmd, workingDir, false)
-		}
-	} else {
-		// ignore explicitly the errors as the following lines are only for debug output
-		pipe, stderrReadErr := command.StderrPipe()
-		if stderrReadErr != nil {
-			stderr, stderrReadErr := io.ReadAll(pipe)
-			if stderrReadErr != nil {
-				log.Debug().Str("method", "SnykCli.doExecute").Str("cli output stderr", string(stderr)).Send()
-			} else {
-				log.Debug().Err(stderrReadErr).Str("method", "SnykCli.doExecute").Msg("couldn't retrieve stderr")
-			}
 		}
 	}
 	return output, err

--- a/infrastructure/cli/environment.go
+++ b/infrastructure/cli/environment.go
@@ -17,7 +17,10 @@
 package cli
 
 import (
+	"strings"
+
 	"github.com/snyk/go-application-framework/pkg/auth"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/server/lsp"
@@ -52,6 +55,7 @@ func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updat
 		// there can only be one - highlander principle
 		if currentConfig.GetAuthenticationMethod() == lsp.OAuthAuthentication {
 			updatedEnv = append(updatedEnv, auth.CONFIG_KEY_OAUTH_TOKEN+"="+currentConfig.Token())
+			updatedEnv = append(updatedEnv, strings.ToUpper(configuration.FF_OAUTH_AUTH_FLOW_ENABLED+"=1"))
 		} else {
 			updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
 		}
@@ -69,6 +73,5 @@ func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updat
 	}
 	updatedEnv = append(updatedEnv, IntegrationEnvironmentEnvVarKey+"="+IntegrationEnvironmentEnvVarValue)
 	updatedEnv = append(updatedEnv, IntegrationEnvironmentVersionEnvVar+"="+config.Version)
-
 	return
 }

--- a/infrastructure/oauth/oauth_provider.go
+++ b/infrastructure/oauth/oauth_provider.go
@@ -19,6 +19,7 @@ package oauth
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
 	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 
@@ -32,11 +33,13 @@ type oAuthProvider struct {
 }
 
 func NewOAuthProvider(config configuration.Configuration, authenticator auth.Authenticator) snyk.AuthenticationProvider {
+	log.Debug().Msg("creating new OAuth provider")
 	return &oAuthProvider{authenticator: authenticator, config: config}
 }
 
-func (p *oAuthProvider) Authenticate(ctx context.Context) (string, error) {
+func (p *oAuthProvider) Authenticate(_ context.Context) (string, error) {
 	err := p.authenticator.Authenticate()
+	log.Debug().Msg("authenticated with OAuth")
 	return p.config.GetString(auth.CONFIG_KEY_OAUTH_TOKEN), err
 }
 
@@ -44,13 +47,13 @@ func (p *oAuthProvider) SetAuthURL(url string) {
 	p.authURL = url
 }
 
-func (p *oAuthProvider) ClearAuthentication(ctx context.Context) error {
+func (p *oAuthProvider) ClearAuthentication(_ context.Context) error {
 	p.config.Set(auth.CONFIG_KEY_OAUTH_TOKEN, "")
 	p.config.Set(configuration.AUTHENTICATION_TOKEN, "")
 	p.config.Set(configuration.AUTHENTICATION_BEARER_TOKEN, "")
 	return nil
 }
 
-func (p *oAuthProvider) AuthURL(ctx context.Context) string {
+func (p *oAuthProvider) AuthURL(_ context.Context) string {
 	return p.authURL
 }

--- a/infrastructure/oss/oss.go
+++ b/infrastructure/oss/oss.go
@@ -286,6 +286,7 @@ func (oss *Scanner) handleError(path string, err error, res []byte, cmd []string
 		exitError := err.(*exec.ExitError)
 		errorOutput := string(res) + "\n\n\nSTDERR:\n" + string(exitError.Stderr)
 		err = errors.Wrap(err, fmt.Sprintf("Snyk CLI error executing %v. Output: %s", cmd, errorOutput))
+		log.Debug().Err(err).Str("method", "oss.handleError").Msg(errorOutput)
 		switch errorType.ExitCode() {
 		case 1:
 			return false

--- a/infrastructure/services/auth_service.go
+++ b/infrastructure/services/auth_service.go
@@ -19,6 +19,7 @@ package services
 import (
 	"context"
 	"errors"
+	"reflect"
 
 	"github.com/rs/zerolog/log"
 
@@ -50,7 +51,7 @@ func (a *AuthenticationService) Provider() snyk.AuthenticationProvider {
 func (a *AuthenticationService) Authenticate(ctx context.Context) (string, error) {
 	token, err := a.Provider().Authenticate(ctx)
 	if token == "" || err != nil {
-		log.Error().Err(err).Msg("Failed to authenticate")
+		log.Error().Err(err).Msgf("Failed to authenticate using auth provider %v", reflect.TypeOf(a.Provider()))
 		return "", err
 	}
 	a.UpdateCredentials(token, true)


### PR DESCRIPTION
### Description

Sets additional environment variable to enable oauth when CLI is spawned. Also adds debug output and a "token-refresh" API call before scans are executed.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
