### PR TITLE
fix: remove redundant encode in Code scans

### DIFF
--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -24,10 +24,7 @@ import (
 	"io"
 	"math"
 	"net/http"
-	"net/url"
-	"path"
 	"strconv"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -323,23 +320,12 @@ func (s *SnykCodeHTTPClient) analysisRequestBody(options *AnalysisOptions) ([]by
 	if config.CurrentConfig().GetOrganization() != "" {
 		orgName = config.CurrentConfig().GetOrganization()
 	}
-	var encodedLimitToFiles []string
-	for _, file := range options.limitToFiles {
-		segments := strings.Split(file, "/")
-		encodedPath := ""
-		for _, segment := range segments {
-			encodedSegment := url.PathEscape(segment)
-			encodedPath = path.Join(encodedPath, encodedSegment)
-		}
-
-		encodedLimitToFiles = append(encodedLimitToFiles, encodedPath)
-	}
 
 	request := AnalysisRequest{
 		Key: AnalysisRequestKey{
 			Type:         "file",
 			Hash:         options.bundleHash,
-			LimitToFiles: encodedLimitToFiles,
+			LimitToFiles: options.limitToFiles,
 		},
 		Legacy:          false,
 		AnalysisContext: newCodeRequestContext(orgName),

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -754,34 +754,6 @@ func setupConversionTests(t *testing.T,
 	return path, issues, analysisResponse
 }
 
-func Test_analysisRequestBody_ContainsUrlEncodedPaths(t *testing.T) {
-	options := &AnalysisOptions{
-		bundleHash: "test-hash",
-		shardKey:   "test-key",
-		limitToFiles: []string{
-			"file1.java",
-			"path/to/file2.java",
-			"path/with space/file3.java",
-		},
-		severity: 0,
-	}
-
-	expectedLimitToFiles := []string{
-		"file1.java",
-		"path/to/file2.java",
-		"path/with%20space/file3.java",
-	}
-
-	bytes, err := (&SnykCodeHTTPClient{}).analysisRequestBody(options)
-	assert.Nil(t, err)
-
-	var request AnalysisRequest
-	err = json.Unmarshal(bytes, &request)
-	assert.Nil(t, err)
-
-	assert.Equal(t, expectedLimitToFiles, request.Key.LimitToFiles)
-}
-
 func TestSnykCodeBackendService_analysisRequestBodyIsCorrect(t *testing.T) {
 	testutil.UnitTest(t)
 


### PR DESCRIPTION
### Description

Redundant limitToFiles encode is happening currently, resulting in encoding encoded chars.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
