### PR TITLE
fix: UI reporting success when product errors

### DIFF
--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -361,5 +361,9 @@ func (f *Folder) sendScanResults(processedProduct product.Product, issuesByFile 
 		productIssues = append(productIssues, issues...)
 	}
 
-	f.scanNotifier.SendSuccess(f.Path(), productIssues)
+	if processedProduct != "" {
+		f.scanNotifier.SendSuccess(processedProduct, f.Path(), productIssues)
+	} else {
+		f.scanNotifier.SendSuccessForAllProducts(f.Path(), productIssues)
+	}
 }

--- a/domain/snyk/scan_notifier.go
+++ b/domain/snyk/scan_notifier.go
@@ -4,6 +4,7 @@ import "github.com/snyk/snyk-ls/internal/product"
 
 type ScanNotifier interface {
 	SendInProgress(folderPath string)
-	SendSuccess(folderPath string, issues []Issue)
+	SendSuccess(product product.Product, folderPath string, issues []Issue)
+	SendSuccessForAllProducts(folderPath string, issues []Issue)
 	SendError(product product.Product, folderPath string)
 }

--- a/domain/snyk/scan_notifier_mock.go
+++ b/domain/snyk/scan_notifier_mock.go
@@ -18,7 +18,11 @@ func (m *MockScanNotifier) SendInProgress(folderPath string) {
 	m.inProgressCalls = append(m.inProgressCalls, folderPath)
 }
 
-func (m *MockScanNotifier) SendSuccess(folderPath string, issues []Issue) {
+func (m *MockScanNotifier) SendSuccessForAllProducts(folderPath string, issues []Issue) {
+	m.successCalls = append(m.successCalls, folderPath)
+}
+
+func (m *MockScanNotifier) SendSuccess(product product.Product, folderPath string, issues []Issue) {
 	m.successCalls = append(m.successCalls, folderPath)
 }
 

--- a/infrastructure/code/bundle_uploader.go
+++ b/infrastructure/code/bundle_uploader.go
@@ -116,13 +116,13 @@ func (b *BundleUploader) groupInBatches(
 	return batches
 }
 
-func (b *BundleUploader) isSupported(ctx context.Context, file string) bool {
+func (b *BundleUploader) isSupported(ctx context.Context, file string) (bool, error) {
 	if b.supportedExtensions.Size() == 0 && b.supportedConfigFiles.Size() == 0 {
 
 		filters, err := b.SnykCode.GetFilters(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("could not get filters")
-			return false
+			return false, err
 		}
 
 		for _, ext := range filters.Extensions {
@@ -143,7 +143,7 @@ func (b *BundleUploader) isSupported(ctx context.Context, file string) bool {
 	_, isSupportedExtension := b.supportedExtensions.Load(fileExtension)
 	_, isSupportedConfigFile := b.supportedConfigFiles.Load(fileName)
 
-	return isSupportedExtension || isSupportedConfigFile
+	return isSupportedExtension || isSupportedConfigFile, nil
 }
 
 func loadContent(filePath string) ([]byte, error) {

--- a/infrastructure/code/bundle_uploader_test.go
+++ b/infrastructure/code/bundle_uploader_test.go
@@ -96,13 +96,13 @@ func Test_IsSupportedLanguage(t *testing.T) {
 
 	t.Run("should return true for supported languages", func(t *testing.T) {
 		path := "C:\\some\\path\\Test.java"
-		supported := bundler.isSupported(context.Background(), path)
+		supported, _ := bundler.isSupported(context.Background(), path)
 		assert.True(t, supported)
 	})
 
 	t.Run("should return false for unsupported languages", func(t *testing.T) {
 		path := unsupportedFile
-		supported := bundler.isSupported(context.Background(), path)
+		supported, _ := bundler.isSupported(context.Background(), path)
 		assert.False(t, supported)
 	})
 
@@ -134,20 +134,20 @@ func Test_IsSupported_ConfigFile(t *testing.T) {
 	t.Run("should return true for supported config files", func(t *testing.T) {
 		for _, file := range expectedConfigFiles {
 			path := filepath.Join(dir, file)
-			supported := bundler.isSupported(context.Background(), path)
+			supported, _ := bundler.isSupported(context.Background(), path)
 			assert.True(t, supported)
 		}
 	})
 	t.Run("should exclude .gitignore and .dcignore", func(t *testing.T) {
 		for _, file := range []string{".gitignore", ".dcignore"} {
 			path := filepath.Join(dir, file)
-			supported := bundler.isSupported(context.Background(), path)
+			supported, _ := bundler.isSupported(context.Background(), path)
 			assert.False(t, supported)
 		}
 	})
 	t.Run("should return false for unsupported config files", func(t *testing.T) {
 		path := "C:\\some\\path\\.unsupported"
-		supported := bundler.isSupported(context.Background(), path)
+		supported, _ := bundler.isSupported(context.Background(), path)
 		assert.False(t, supported)
 	})
 

--- a/infrastructure/code/bundle_uploader_test.go
+++ b/infrastructure/code/bundle_uploader_test.go
@@ -108,8 +108,8 @@ func Test_IsSupportedLanguage(t *testing.T) {
 
 	t.Run("should cache supported extensions", func(t *testing.T) {
 		path := unsupportedFile
-		bundler.isSupported(context.Background(), path)
-		bundler.isSupported(context.Background(), path)
+		_, _ = bundler.isSupported(context.Background(), path)
+		_, _ = bundler.isSupported(context.Background(), path)
 		assert.Len(t, snykCodeMock.Calls, 1)
 	})
 }
@@ -153,8 +153,8 @@ func Test_IsSupported_ConfigFile(t *testing.T) {
 
 	t.Run("should cache supported extensions", func(t *testing.T) {
 		path := "C:\\some\\path\\Test.rs"
-		bundler.isSupported(context.Background(), path)
-		bundler.isSupported(context.Background(), path)
+		_, _ = bundler.isSupported(context.Background(), path)
+		_, _ = bundler.isSupported(context.Background(), path)
 		assert.Len(t, snykCodeMock.Calls, 1)
 	})
 }

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -355,7 +355,11 @@ func (sc *Scanner) createBundle(ctx context.Context,
 		if ctx.Err() != nil {
 			return b, err // The cancellation error should be handled by the calling function
 		}
-		if !sc.BundleUploader.isSupported(span.Context(), absoluteFilePath) {
+		supported, err := sc.BundleUploader.isSupported(span.Context(), absoluteFilePath)
+		if err != nil {
+			return b, err
+		}
+		if !supported {
 			continue
 		}
 		fileContent, err := loadContent(absoluteFilePath)


### PR DESCRIPTION
### Description

- Snyk Code didn't propagate error from GetFilters, resulting in UI showing success when API error happens
- UI was reporting success when IaC scan would finish, but Code is still running

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
