### PR TITLE
refactor: added caching in code scans for ignore rules [HEAD-279]

### DIFF
--- a/infrastructure/filefilter/filter_test.go
+++ b/infrastructure/filefilter/filter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/snyk/snyk-ls/infrastructure/filefilter"
 	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/util"
 )
 
 type ignoreFilesTestCase struct {
@@ -25,6 +26,91 @@ type ignoreFilesTestCase struct {
 }
 
 func Test_FindNonIgnoredFiles(t *testing.T) {
+	cases := testCases(t)
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			setupIgnoreFilesTest(t, testCase)
+
+			filter := filefilter.NewFileFilter(testCase.repoPath)
+			var files []string
+			for f := range filter.FindNonIgnoredFiles() {
+				files = append(files, f)
+			}
+
+			assertFilesFiltered(t, testCase, files)
+		})
+	}
+}
+
+func Test_FindNonIgnoredFiles_MultipleWorkDirs(t *testing.T) {
+	// Arrange - set 2 repos with different ignore rules. Each repo will have foo.go and bar.go files.
+	// In repo A, foo.go will be ignored, and in repo B, bar.go will be ignored.
+	tempDir := t.TempDir()
+	cases := []ignoreFilesTestCase{{
+		repoPath:          filepath.Join(tempDir, "A"),
+		ignoreFilePath:    ".gitignore",
+		ignoreFileContent: "bar.go\n",
+		expectedFiles:     []string{"foo.go"},
+		expectedExcludes:  []string{"bar.go"},
+	}, {
+		repoPath:          filepath.Join(tempDir, "B"),
+		ignoreFilePath:    ".gitignore",
+		ignoreFileContent: "foo.go\n",
+		expectedFiles:     []string{"bar.go"},
+		expectedExcludes:  []string{"foo.go"},
+	}}
+	for _, testCase := range cases {
+		setupIgnoreFilesTest(t, testCase)
+	}
+
+	for _, testCase := range cases {
+		files := util.ChannelToSlice(filefilter.FindNonIgnoredFiles(testCase.repoPath)) // Act
+		assertFilesFiltered(t, testCase, files)                                         // Assert
+	}
+}
+
+func Test_FindNonIgnoredFile_FilesChanged_ReturnsCorrectResults(t *testing.T) {
+	repoFolder := t.TempDir()
+	type fileChangesTestCase struct {
+		ignoreFilesTestCase
+		expectedAddedFiles    []string
+		expectedAddedExcludes []string
+	}
+	testCase := fileChangesTestCase{
+		ignoreFilesTestCase: ignoreFilesTestCase{
+			repoPath:          repoFolder,
+			ignoreFilePath:    ".gitignore",
+			ignoreFileContent: "*.go\n",
+			expectedFiles:     []string{"foo.js", "bar.js"},
+			expectedExcludes:  []string{"foo.go", "bar.go"},
+		},
+		expectedAddedFiles:    []string{"foo2.js", "bar2.js"},
+		expectedAddedExcludes: []string{"foo2.go", "bar2.go"},
+	}
+	setupIgnoreFilesTest(t, testCase.ignoreFilesTestCase)
+	fileFilter := filefilter.NewFileFilter(repoFolder)
+	originalFilteredFiles := util.ChannelToSlice(fileFilter.FindNonIgnoredFiles()) // Calling it a first time
+
+	// Act - Changing folder content
+	for _, file := range testCase.expectedAddedFiles {
+		fileAbsPath := filepath.Join(repoFolder, file)
+		testutil.CreateFileOrFail(t, fileAbsPath, []byte("some content to avoid skipping"))
+	}
+	for _, file := range testCase.expectedAddedExcludes {
+		fileAbsPath := filepath.Join(repoFolder, file)
+		testutil.CreateFileOrFail(t, fileAbsPath, []byte("some content to avoid skipping"))
+	}
+	newFilteredFiles := util.ChannelToSlice(fileFilter.FindNonIgnoredFiles())
+
+	// Assert - Make sure the added files have been filtered correctly
+	assert.NotEqual(t, originalFilteredFiles, newFilteredFiles)
+	testCase.expectedFiles = append(testCase.expectedFiles, testCase.expectedAddedFiles...)
+	testCase.expectedExcludes = append(testCase.expectedExcludes, testCase.expectedAddedExcludes...)
+	assertFilesFiltered(t, testCase.ignoreFilesTestCase, newFilteredFiles)
+}
+
+func testCases(t *testing.T) []ignoreFilesTestCase {
 	cases := []ignoreFilesTestCase{
 		{
 			name:              "Does not ignore files when no ignored file is present",
@@ -79,56 +165,11 @@ exclude:
 			expectedExcludes:  []string{"file2.java"},
 		},
 	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			setupIgnoreFilesTest(t, testCase)
-
-			var files []string
-			for f := range filefilter.FindNonIgnoredFiles(testCase.repoPath) {
-				files = append(files, f)
-			}
-
-			assertFilesFiltered(t, testCase, files)
-		})
-	}
+	return cases
 }
 
-func Test_FindNonIgnoredFiles_MultipleWorkDirs(t *testing.T) {
-	// Arrange - set 2 repos with different ignore rules. Each repo will have foo.go and bar.go files.
-	// In repo A, foo.go will be ignored, and in repo B, bar.go will be ignored.
-	tempDir := t.TempDir()
-	testCases := []ignoreFilesTestCase{{
-		repoPath:          filepath.Join(tempDir, "A"),
-		ignoreFilePath:    ".gitignore",
-		ignoreFileContent: "bar.go\n",
-		expectedFiles:     []string{"foo.go"},
-		expectedExcludes:  []string{"bar.go"},
-	}, {
-		repoPath:          filepath.Join(tempDir, "B"),
-		ignoreFilePath:    ".gitignore",
-		ignoreFileContent: "foo.go\n",
-		expectedFiles:     []string{"bar.go"},
-		expectedExcludes:  []string{"foo.go"},
-	}}
-	for _, testCase := range testCases {
-		setupIgnoreFilesTest(t, testCase)
-	}
-
-	for _, testCase := range testCases {
-		files := collectFilteredFiles(testCase.repoPath)
-		assertFilesFiltered(t, testCase, files)
-	}
-}
-
-func collectFilteredFiles(repoPath string) []string {
-	var files []string
-	for f := range filefilter.FindNonIgnoredFiles(repoPath) {
-		files = append(files, f)
-	}
-	return files
-}
-
+// setupIgnoreFilesTest creates the ignore file and the files to be filtered, including the expected files and excludes.
+// The ignore file and the files to be filtered are created in the testCase.repoPath folder.
 func setupIgnoreFilesTest(t *testing.T, testCase ignoreFilesTestCase) {
 	t.Helper()
 	allFiles := append(testCase.expectedFiles, testCase.expectedExcludes...)
@@ -141,6 +182,8 @@ func setupIgnoreFilesTest(t *testing.T, testCase ignoreFilesTestCase) {
 	}
 }
 
+// assertFilesFiltered asserts that the "expectedFile"s are contained in the files slice,
+// and the "expectedExclude" are not.
 func assertFilesFiltered(t *testing.T, testCase ignoreFilesTestCase, files []string) {
 	t.Helper()
 	for _, expectedFile := range testCase.expectedFiles {

--- a/internal/util/collections.go
+++ b/internal/util/collections.go
@@ -1,0 +1,10 @@
+package util
+
+// channelToSlice converts a channel to a slice by reading all values from the channel.
+func ChannelToSlice[t any](channel <-chan t) []t {
+	slice := make([]t, 0)
+	for f := range channel {
+		slice = append(slice, f)
+	}
+	return slice
+}


### PR DESCRIPTION
### Description

Add caching to the file filtering in Snyk Code scans to prevent repeating CPU heavy calculations
