### PR TITLE
refactor: limit number of cores in file filtering

### DIFF
--- a/infrastructure/filefilter/filter.go
+++ b/infrastructure/filefilter/filter.go
@@ -116,13 +116,11 @@ func (f *FileFilter) processFolder(folderPath string, files, globs []string, res
 		hashFailed = true
 	} else {
 		cacheEntry, found := f.cache.Load(folderPath)
-		if found {
-			if hash == cacheEntry.Hash {
-				for _, file := range cacheEntry.Results {
-					results <- file
-				}
-				return
+		if found && hash == cacheEntry.Hash { // Cache hit - returning cached results
+			for _, file := range cacheEntry.Results {
+				results <- file
 			}
+			return
 		}
 	}
 

--- a/infrastructure/filefilter/filter_benchmark_test.go
+++ b/infrastructure/filefilter/filter_benchmark_test.go
@@ -16,10 +16,11 @@ func BenchmarkFindNonIgnoredFiles(b *testing.B) {
 	b.Log("Cloning remoteRepo...")
 	repo := cloneRepo(b, remoteRepo, remoteRepoHash)
 	b.Log("Repo cloned")
+	filter := filefilter.NewFileFilter(repo)
 	b.ResetTimer() // reset timer to not include the clone time
 	for i := 0; i < b.N; i++ {
 		b.Log("Finding non ignored files in ", repo)
-		filesCh := filefilter.FindNonIgnoredFiles(repo)
+		filesCh := filter.FindNonIgnoredFiles()
 		for range filesCh { // drain the channel
 		}
 		b.Log("Finished benchmark iteration ", i)

--- a/internal/util/math_extensions.go
+++ b/internal/util/math_extensions.go
@@ -4,9 +4,24 @@ type ordered interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~float32 | ~float64
 }
 
-func Max[T ordered](a, b T) T {
-	if a > b {
-		return a
+func Max[T ordered](values ...T) T {
+	max := values[0]
+	for _, v := range values {
+		if v > max {
+			max = v
+		}
 	}
-	return b
+
+	return max
+}
+
+func Min[T ordered](values ...T) T {
+	min := values[0]
+	for _, v := range values {
+		if v < min {
+			min = v
+		}
+	}
+
+	return min
 }


### PR DESCRIPTION
### Description

Limits the number of CPU cores used for checking filtering rules