### PR TITLE
feat: add SNYK_OAUTH_TOKEN when spawning CLI [HEAD-114]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -41,6 +42,7 @@ import (
 	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/subosito/gotenv"
 	"github.com/xtgo/uuid"
+	"golang.org/x/oauth2"
 
 	"github.com/snyk/snyk-ls/infrastructure/cli/filename"
 	"github.com/snyk/snyk-ls/internal/concurrency"
@@ -763,4 +765,13 @@ func (c *Config) LogLevel() string {
 
 func (c *Config) Logger() zerolog.Logger {
 	return c.logger
+}
+
+func (c *Config) TokenAsOAuthToken() oauth2.Token {
+	var oauthToken oauth2.Token
+	err := json.Unmarshal([]byte(currentConfig.Token()), &oauthToken)
+	if err != nil {
+		log.Err(err).Msg("failed to unmarshal oauth token")
+	}
+	return oauthToken
 }

--- a/infrastructure/cli/environment.go
+++ b/infrastructure/cli/environment.go
@@ -35,6 +35,7 @@ const (
 	IntegrationEnvironmentEnvVarKey     = "SNYK_INTEGRATION_ENVIRONMENT"
 	IntegrationEnvironmentVersionEnvVar = "SNYK_INTEGRATION_ENVIRONMENT_VERSION"
 	IntegrationEnvironmentEnvVarValue   = "language-server"
+	SnykOauthTokenEnvVar                = "SNYK_OAUTH_TOKEN"
 )
 
 // AppendCliEnvironmentVariables Returns the input array with additional variables used in the CLI run in the form of "key=value".
@@ -46,12 +47,12 @@ func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updat
 
 	// remove any existing env vars that we are going to set
 	valuesToRemove := map[string]bool{
-		ApiEnvVar:   true,
-		TokenEnvVar: true,
-		configuration.AUTHENTICATION_BEARER_TOKEN: true,
-		DisableAnalyticsEnvVar:                    true,
-		auth.CONFIG_KEY_OAUTH_TOKEN:               true,
-		configuration.FF_OAUTH_AUTH_FLOW_ENABLED:  true,
+		ApiEnvVar:                                true,
+		TokenEnvVar:                              true,
+		SnykOauthTokenEnvVar:                     true,
+		DisableAnalyticsEnvVar:                   true,
+		auth.CONFIG_KEY_OAUTH_TOKEN:              true,
+		configuration.FF_OAUTH_AUTH_FLOW_ENABLED: true,
 	}
 
 	for _, s := range currentEnv {
@@ -67,8 +68,7 @@ func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updat
 		if currentConfig.AuthenticationMethod() == lsp.OAuthAuthentication {
 			oAuthToken := currentConfig.TokenAsOAuthToken()
 			if len(oAuthToken.AccessToken) > 0 {
-				updatedEnv = append(updatedEnv, configuration.AUTHENTICATION_BEARER_TOKEN+"="+oAuthToken.AccessToken)
-				updatedEnv = append(updatedEnv, strings.ToUpper(configuration.FF_OAUTH_AUTH_FLOW_ENABLED+"=1"))
+				updatedEnv = append(updatedEnv, SnykOauthTokenEnvVar+"="+oAuthToken.AccessToken)
 			}
 		} else {
 			updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())

--- a/infrastructure/cli/environment.go
+++ b/infrastructure/cli/environment.go
@@ -46,11 +46,12 @@ func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updat
 
 	// remove any existing env vars that we are going to set
 	valuesToRemove := map[string]bool{
-		ApiEnvVar:                                true,
-		TokenEnvVar:                              true,
-		DisableAnalyticsEnvVar:                   true,
-		auth.CONFIG_KEY_OAUTH_TOKEN:              true,
-		configuration.FF_OAUTH_AUTH_FLOW_ENABLED: true,
+		ApiEnvVar:   true,
+		TokenEnvVar: true,
+		configuration.AUTHENTICATION_BEARER_TOKEN: true,
+		DisableAnalyticsEnvVar:                    true,
+		auth.CONFIG_KEY_OAUTH_TOKEN:               true,
+		configuration.FF_OAUTH_AUTH_FLOW_ENABLED:  true,
 	}
 
 	for _, s := range currentEnv {
@@ -64,8 +65,11 @@ func AppendCliEnvironmentVariables(currentEnv []string, appendToken bool) (updat
 	if appendToken {
 		// there can only be one - highlander principle
 		if currentConfig.AuthenticationMethod() == lsp.OAuthAuthentication {
-			updatedEnv = append(updatedEnv, auth.CONFIG_KEY_OAUTH_TOKEN+"="+currentConfig.Token())
-			updatedEnv = append(updatedEnv, strings.ToUpper(configuration.FF_OAUTH_AUTH_FLOW_ENABLED+"=1"))
+			oAuthToken := currentConfig.TokenAsOAuthToken()
+			if len(oAuthToken.AccessToken) > 0 {
+				updatedEnv = append(updatedEnv, configuration.AUTHENTICATION_BEARER_TOKEN+"="+oAuthToken.AccessToken)
+				updatedEnv = append(updatedEnv, strings.ToUpper(configuration.FF_OAUTH_AUTH_FLOW_ENABLED+"=1"))
+			}
 		} else {
 			updatedEnv = append(updatedEnv, TokenEnvVar+"="+currentConfig.Token())
 		}

--- a/infrastructure/cli/environment_test.go
+++ b/infrastructure/cli/environment_test.go
@@ -55,13 +55,13 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		testutil.UnitTest(t)
 		c := config.CurrentConfig()
 		c.SetAuthenticationMethod(lsp.OAuthAuthentication)
-		c.SetToken("testToken")
+		c.SetToken("{\"access_token\": \"testToken\"}")
 		tokenVar := TokenEnvVar + "={asdf}"
 		inputEnv := []string{tokenVar}
 
 		updatedEnv := AppendCliEnvironmentVariables(inputEnv, true)
 
-		assert.Contains(t, updatedEnv, auth.CONFIG_KEY_OAUTH_TOKEN+"="+config.CurrentConfig().Token())
+		assert.Contains(t, updatedEnv, configuration.AUTHENTICATION_BEARER_TOKEN+"="+c.TokenAsOAuthToken().AccessToken)
 		assert.Contains(t, updatedEnv, strings.ToUpper(configuration.FF_OAUTH_AUTH_FLOW_ENABLED+"=1"))
 		assert.NotContains(t, updatedEnv, tokenVar)
 	})
@@ -75,7 +75,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 
 		updatedEnv := AppendCliEnvironmentVariables(inputEnv, true)
 
-		assert.Contains(t, updatedEnv, "SNYK_TOKEN="+config.CurrentConfig().Token())
+		assert.Contains(t, updatedEnv, "SNYK_TOKEN="+c.Token())
 		assert.NotContains(t, updatedEnv, oauthVar)
 	})
 	t.Run("Adds Snyk Token to env", func(t *testing.T) {
@@ -86,18 +86,18 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 
 		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
 
-		assert.Contains(t, updatedEnv, "SNYK_TOKEN="+config.CurrentConfig().Token())
+		assert.Contains(t, updatedEnv, "SNYK_TOKEN="+c.Token())
 	})
 
 	t.Run("Adds OAuth Token to env", func(t *testing.T) {
 		testutil.UnitTest(t)
 		c := config.CurrentConfig()
 		c.SetAuthenticationMethod(lsp.OAuthAuthentication)
-		c.SetToken("testToken")
+		c.SetToken("{\"access_token\": \"testToken\"}")
 
 		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
 
-		assert.Contains(t, updatedEnv, auth.CONFIG_KEY_OAUTH_TOKEN+"="+config.CurrentConfig().Token())
+		assert.Contains(t, updatedEnv, configuration.AUTHENTICATION_BEARER_TOKEN+"="+c.TokenAsOAuthToken().AccessToken)
 	})
 
 	t.Run("Disables analytics, if telemetry disabled", func(t *testing.T) {

--- a/infrastructure/cli/environment_test.go
+++ b/infrastructure/cli/environment_test.go
@@ -17,11 +17,8 @@
 package cli
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/snyk/go-application-framework/pkg/auth"
-	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -61,8 +58,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 
 		updatedEnv := AppendCliEnvironmentVariables(inputEnv, true)
 
-		assert.Contains(t, updatedEnv, configuration.AUTHENTICATION_BEARER_TOKEN+"="+c.TokenAsOAuthToken().AccessToken)
-		assert.Contains(t, updatedEnv, strings.ToUpper(configuration.FF_OAUTH_AUTH_FLOW_ENABLED+"=1"))
+		assert.Contains(t, updatedEnv, SnykOauthTokenEnvVar+"="+c.TokenAsOAuthToken().AccessToken)
 		assert.NotContains(t, updatedEnv, tokenVar)
 	})
 	t.Run("Removes existing oauth env variables", func(t *testing.T) {
@@ -70,7 +66,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		c := config.CurrentConfig()
 		c.SetAuthenticationMethod(lsp.TokenAuthentication)
 		c.SetToken("testToken")
-		oauthVar := auth.CONFIG_KEY_OAUTH_TOKEN + "={asdf}"
+		oauthVar := SnykOauthTokenEnvVar + "={asdf}"
 		inputEnv := []string{oauthVar}
 
 		updatedEnv := AppendCliEnvironmentVariables(inputEnv, true)
@@ -97,7 +93,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 
 		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
 
-		assert.Contains(t, updatedEnv, configuration.AUTHENTICATION_BEARER_TOKEN+"="+c.TokenAsOAuthToken().AccessToken)
+		assert.Contains(t, updatedEnv, SnykOauthTokenEnvVar+"="+c.TokenAsOAuthToken().AccessToken)
 	})
 
 	t.Run("Disables analytics, if telemetry disabled", func(t *testing.T) {


### PR DESCRIPTION
### Description

When using CLI, the OAuth2 token should not be refreshed. Therefore, we use the SNYK_OAUTH_TOKEN variable, instead of INTERNAL_OAUTH_TOKEN_STORAGE.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
