### PR TITLE
feat: register token refresh callback

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -172,6 +172,7 @@ type Config struct {
 	engine                       workflow.Engine
 	enableSnykLearnCodeActions   bool
 	logger                       zerolog.Logger
+	storage                      StorageWithCallbacks
 }
 
 func CurrentConfig() *Config {
@@ -230,7 +231,10 @@ func New() *Config {
 
 func initWorkFlowEngine(c *Config) {
 	c.engine = app.CreateAppEngine()
-	c.engine.GetConfiguration().Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
+	conf := c.engine.GetConfiguration()
+	c.storage = NewStorage()
+	conf.SetStorage(c.storage)
+	conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 	err := localworkflows.InitWhoAmIWorkflow(c.engine)
 	if err != nil {
 		log.Err(err).Msg("Failed to initialize WhoAmI workflow")
@@ -776,4 +780,8 @@ func (c *Config) TokenAsOAuthToken() oauth2.Token {
 		log.Err(err).Msg("failed to unmarshal oauth token")
 	}
 	return oauthToken
+}
+
+func (c *Config) Storage() StorageWithCallbacks {
+	return c.storage
 }

--- a/application/config/storage.go
+++ b/application/config/storage.go
@@ -1,0 +1,70 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import "github.com/snyk/go-application-framework/pkg/configuration"
+
+type StorageCallbackFunc func(string, any)
+
+type StorageWithCallbacks interface {
+	configuration.Storage
+	RegisterCallback(key string, callback StorageCallbackFunc)
+	UnRegisterCallback(key string)
+}
+
+type storage struct {
+	data      map[string]any
+	callbacks map[string]StorageCallbackFunc
+}
+
+type storageOption func(*storage)
+
+func (s *storage) Set(key string, value any) error {
+	callback := s.callbacks[key]
+	s.data[key] = value
+
+	if callback != nil {
+		callback(key, value)
+	}
+	return nil
+}
+
+func NewStorage(opts ...storageOption) StorageWithCallbacks {
+	s := &storage{
+		data:      make(map[string]any),
+		callbacks: make(map[string]StorageCallbackFunc),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func (s *storage) RegisterCallback(key string, callback StorageCallbackFunc) {
+	s.callbacks[key] = callback
+}
+
+func (s *storage) UnRegisterCallback(key string) {
+	s.callbacks[key] = nil
+}
+
+func WithCallbacks(callbacks map[string]StorageCallbackFunc) func(*storage) {
+	return func(s *storage) {
+		s.callbacks = callbacks
+	}
+}

--- a/application/config/storage_test.go
+++ b/application/config/storage_test.go
@@ -1,0 +1,43 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_StorageCallsRegisterCallbacksForKeys(t *testing.T) {
+	called := make(chan bool, 1)
+	callbacks := map[string]StorageCallbackFunc{}
+	myCallback := func(_ string, _ any) { called <- true }
+
+	key := "test"
+	value := "test"
+	callbacks[key] = myCallback
+	s := NewStorage(WithCallbacks(callbacks)).(*storage)
+
+	err := s.Set(key, value)
+
+	assert.NoError(t, err)
+	assert.Equal(t, value, s.data[key])
+	assert.Eventuallyf(t, func() bool {
+		return <-called
+	}, 5*time.Second, time.Millisecond, "callback was not called")
+}

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -18,20 +18,26 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/creachadair/jrpc2"
 	"github.com/google/uuid"
+	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/observability/ux"
+	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/lsp"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
@@ -49,6 +55,82 @@ var sampleSettings = lsp.Settings{
 	Token:                      "token",
 	SnykCodeApi:                "https://deeproxy.fake.snyk.io",
 	EnableSnykLearnCodeActions: "true",
+}
+
+func Test_configureOauth_registersStorageCallback(t *testing.T) {
+	testutil.UnitTest(t)
+	di.TestInit(t)
+	c := config.CurrentConfig()
+	c.SetAuthenticationMethod(lsp.OAuthAuthentication)
+
+	// a token that's set into the configuration
+	token := oauth2.Token{
+		AccessToken:  t.Name(),
+		RefreshToken: t.Name(),
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}
+
+	configureOAuth(c, auth.RefreshToken)
+
+	tokenReceived := make(chan bool, 1)
+	di.Notifier().CreateListener(func(params any) {
+		msg, ok := params.(lsp.AuthenticationParams)
+		assert.True(t, ok, "Received unexpected message type %v", params)
+		assert.Contains(t, msg.Token, token.AccessToken)
+		tokenReceived <- true
+	})
+	marshal, err := json.Marshal(token)
+	assert.NoError(t, err)
+	err = c.Storage().Set(auth.CONFIG_KEY_OAUTH_TOKEN, string(marshal))
+	assert.NoError(t, err)
+	assert.Eventuallyf(t, func() bool {
+		return <-tokenReceived
+	}, 5*time.Second, 100*time.Millisecond, "token should have been received")
+}
+
+func Test_configureOauth_oauthProvider_created_with_injected_refreshMethod(t *testing.T) {
+	testutil.UnitTest(t)
+	di.TestInit(t)
+	c := config.CurrentConfig()
+	c.SetAuthenticationMethod(lsp.OAuthAuthentication)
+
+	// an expired token that's set into the configuration
+	token := oauth2.Token{
+		AccessToken:  t.Name(),
+		RefreshToken: t.Name(),
+		Expiry:       time.Now().Add(-1 * time.Hour),
+	}
+
+	tokenBytes, err := json.Marshal(token)
+	assert.NoError(t, err)
+
+	c.SetToken(string(tokenBytes))
+
+	// refresh func is replaced with func that sends true into a channel when called
+	triggeredChan := make(chan bool, 1)
+	testFunc := func(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+		triggeredChan <- true
+		token.Expiry = time.Now().Add(1 * time.Hour)
+		return token, nil
+	}
+
+	// test interface to be able to access the Authenticator (oauthProvider implements it)
+	type providerWithAccessibleAuthenticator interface {
+		snyk.AuthenticationProvider
+		Authenticator() auth.Authenticator
+	}
+
+	configureOAuth(c, testFunc)
+
+	provider, ok := di.AuthenticationService().Provider().(providerWithAccessibleAuthenticator)
+	assert.True(t, ok, "provider should be of type providerWithAccessibleAuthenticator")
+
+	// AddAuthenticationHeader will trigger the refresh method
+	_ = provider.Authenticator().AddAuthenticationHeader(httptest.NewRequest("GET", "/", nil))
+
+	assert.Eventuallyf(t, func() bool {
+		return <-triggeredChan
+	}, 5*time.Second, 100*time.Millisecond, "refresh should have been triggered")
 }
 
 func Test_WorkspaceDidChangeConfiguration_Push(t *testing.T) {

--- a/domain/snyk/auth_service.go
+++ b/domain/snyk/auth_service.go
@@ -24,7 +24,7 @@ type AuthenticationService interface {
 
 	Provider() AuthenticationProvider
 
-	// UpdateToken stores the token in the configuration, and sends a $/snyk.hasAuthenticated notification to the
+	// UpdateCredentials stores the token in the configuration, and sends a $/snyk.hasAuthenticated notification to the
 	// client if sendNotification is true
 	UpdateCredentials(newToken string, sendNotification bool)
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/go-application-framework v0.0.0-20230424061336-2c406400541a
+	github.com/snyk/go-application-framework v0.0.0-20230427082826-36a5ebba2767
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/stretchr/testify v1.8.2
 	github.com/subosito/gotenv v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/go-application-framework v0.0.0-20230424061336-2c406400541a h1:8NCWXZk5sFEsYRg7dxPCL+ers9d/PgaWQ1Lq9hm3vHA=
-github.com/snyk/go-application-framework v0.0.0-20230424061336-2c406400541a/go.mod h1:vh4egVjz3y+keFRGr0+uaifHNHmcXjDXk/8U7UwHg9E=
+github.com/snyk/go-application-framework v0.0.0-20230427082826-36a5ebba2767 h1:+BT2jWWLmRYq2s6mZOQWWX/wC2xsgMynl9JPt7xX5jI=
+github.com/snyk/go-application-framework v0.0.0-20230427082826-36a5ebba2767/go.mod h1:vh4egVjz3y+keFRGr0+uaifHNHmcXjDXk/8U7UwHg9E=
 github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 h1:CsLoEIHxq4i3d9di8RoN3J3D1/oK20oroEZUGShor0o=
 github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/infrastructure/oauth/oauth_provider.go
+++ b/infrastructure/oauth/oauth_provider.go
@@ -57,3 +57,7 @@ func (p *oAuthProvider) ClearAuthentication(_ context.Context) error {
 func (p *oAuthProvider) AuthURL(_ context.Context) string {
 	return p.authURL
 }
+
+func (p *oAuthProvider) Authenticator() auth.Authenticator {
+	return p.authenticator
+}

--- a/infrastructure/services/auth_service.go
+++ b/infrastructure/services/auth_service.go
@@ -69,15 +69,17 @@ func (a *AuthenticationService) Authenticate(ctx context.Context) (string, error
 func (a *AuthenticationService) UpdateCredentials(newToken string, sendNotification bool) {
 	c := config.CurrentConfig()
 	oldToken := c.Token()
+	if oldToken == newToken {
+		return
+	}
+
 	c.SetToken(newToken)
 
 	if sendNotification {
 		a.notifier.Send(lsp.AuthenticationParams{Token: newToken})
 	}
 
-	if oldToken != newToken {
-		a.analytics.Identify()
-	}
+	a.analytics.Identify()
 }
 
 func (a *AuthenticationService) Logout(ctx context.Context) {


### PR DESCRIPTION
### Description

Depends on: https://github.com/snyk/go-application-framework/pull/54 (which depends on https://github.com/snyk/go-application-framework/pull/51)

Language Server must notify its client when a token is refrefreshed. With this PR, it registers a custom token refresher func in Go Application Framework that adds credential updates to Language Server on token refresh.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
