### PR TITLE
feat: enable code actions for snyk learn

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -313,17 +313,25 @@ func (c *Config) CliSettings() *CliSettings {
 	return c.cliSettings
 }
 
-func (c *Config) Format() string { return c.format }
+func (c *Config) Format() string {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.format
+}
 func (c *Config) CLIDownloadLockFileName() string {
 	return filepath.Join(c.cliSettings.DefaultBinaryInstallPath(), "snyk-cli-download.lock")
 }
-func (c *Config) IsErrorReportingEnabled() bool          { return c.isErrorReportingEnabled.Get() }
-func (c *Config) IsSnykOssEnabled() bool                 { return c.isSnykOssEnabled.Get() }
-func (c *Config) IsSnykCodeEnabled() bool                { return c.isSnykCodeEnabled.Get() }
-func (c *Config) IsSnykIacEnabled() bool                 { return c.isSnykIacEnabled.Get() }
-func (c *Config) IsSnykContainerEnabled() bool           { return c.isSnykContainerEnabled.Get() }
-func (c *Config) IsSnykAdvisorEnabled() bool             { return c.isSnykAdvisorEnabled.Get() }
-func (c *Config) LogPath() string                        { return c.logPath }
+func (c *Config) IsErrorReportingEnabled() bool { return c.isErrorReportingEnabled.Get() }
+func (c *Config) IsSnykOssEnabled() bool        { return c.isSnykOssEnabled.Get() }
+func (c *Config) IsSnykCodeEnabled() bool       { return c.isSnykCodeEnabled.Get() }
+func (c *Config) IsSnykIacEnabled() bool        { return c.isSnykIacEnabled.Get() }
+func (c *Config) IsSnykContainerEnabled() bool  { return c.isSnykContainerEnabled.Get() }
+func (c *Config) IsSnykAdvisorEnabled() bool    { return c.isSnykAdvisorEnabled.Get() }
+func (c *Config) LogPath() string {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.logPath
+}
 func (c *Config) SnykApi() string                        { return c.snykApiUrl }
 func (c *Config) SnykCodeApi() string                    { return c.snykCodeApiUrl }
 func (c *Config) SnykCodeAnalysisTimeout() time.Duration { return c.snykCodeAnalysisTimeout }
@@ -433,9 +441,15 @@ func (c *Config) SetToken(token string) {
 		c.engine.GetConfiguration().Set(configuration.AUTHENTICATION_TOKEN, token)
 	}
 }
-func (c *Config) SetFormat(format string) { c.format = format }
+func (c *Config) SetFormat(format string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.format = format
+}
 
 func (c *Config) SetLogPath(logPath string) {
+	c.m.Lock()
+	defer c.m.Unlock()
 	c.logPath = logPath
 }
 
@@ -468,8 +482,8 @@ func (c *Config) ConfigureLogging(server lsp.Server) {
 	clientWriter := lsp.New(server)
 	writers := []io.Writer{clientWriter}
 
-	if c.logPath != "" {
-		c.logFile, err = os.OpenFile(c.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if c.LogPath() != "" {
+		c.logFile, err = os.OpenFile(c.LogPath(), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 		if err != nil {
 			log.Err(err).Msg("couldn't open logfile")
 		} else {
@@ -479,6 +493,8 @@ func (c *Config) ConfigureLogging(server lsp.Server) {
 	}
 
 	writer := zerolog.MultiLevelWriter(writers...)
+	c.m.Lock()
+	defer c.m.Unlock()
 	log.Logger = zerolog.New(writer).With().Timestamp().Logger()
 	c.logger = log.Logger
 }
@@ -753,6 +769,8 @@ func (c *Config) SetSnykLearnCodeActionsEnabled(enabled bool) {
 }
 
 func (c *Config) SetLogLevel(level string) {
+	c.m.Lock()
+	defer c.m.Unlock()
 	parseLevel, err := zerolog.ParseLevel(level)
 	if err == nil {
 		zerolog.SetGlobalLevel(parseLevel)
@@ -760,10 +778,14 @@ func (c *Config) SetLogLevel(level string) {
 }
 
 func (c *Config) LogLevel() string {
+	c.m.Lock()
+	defer c.m.Unlock()
 	return zerolog.GlobalLevel().String()
 }
 
 func (c *Config) Logger() zerolog.Logger {
+	c.m.Lock()
+	defer c.m.Unlock()
 	return c.logger
 }
 

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -222,7 +222,7 @@ func New() *Config {
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to initialize workflow engine")
 	}
-	c.enableSnykLearnCodeActions = false
+	c.enableSnykLearnCodeActions = true
 
 	c.clientSettingsFromEnv()
 	return c

--- a/application/di/init.go
+++ b/application/di/init.go
@@ -20,10 +20,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
-	"testing"
 
 	"github.com/adrg/xdg"
-	"github.com/golang/mock/gomock"
 
 	"github.com/snyk/snyk-ls/application/codeaction"
 	"github.com/snyk/snyk-ls/application/config"
@@ -45,7 +43,6 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/code"
 	"github.com/snyk/snyk-ls/infrastructure/iac"
 	"github.com/snyk/snyk-ls/infrastructure/learn"
-	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
 	"github.com/snyk/snyk-ls/infrastructure/oss"
 	"github.com/snyk/snyk-ls/infrastructure/sentry"
 	"github.com/snyk/snyk-ls/infrastructure/services"
@@ -151,66 +148,6 @@ func initApplication() {
 	fileWatcher = watcher.NewFileWatcher()
 	codeActionService = codeaction.NewService(config.CurrentConfig(), w, fileWatcher, notifier)
 	command.ResetService()
-}
-
-// TODO this is becoming a hot mess we need to unify integ. test strategies
-func TestInit(t *testing.T) {
-	initMutex.Lock()
-	defer initMutex.Unlock()
-	t.Helper()
-	// we don't want to open browsers when testing
-	snyk.DefaultOpenBrowserFunc = func(url string) {}
-	notifier = domainNotify.NewNotifier()
-	analytics = ux.NewTestAnalytics()
-	instrumentor = performance.NewTestInstrumentor()
-	errorReporter = er.NewTestErrorReporter()
-	installer = install.NewFakeInstaller()
-	authProvider := cliauth.NewFakeCliAuthenticationProvider()
-	snykApiClient = &snyk_api.FakeApiClient{CodeEnabled: true}
-	authenticationService = services.NewAuthenticationService(snykApiClient, authProvider, analytics, errorReporter, notifier)
-	cliInitializer = cli.NewInitializer(errorReporter, installer, notifier)
-	authInitializer := cliauth.NewInitializer(authenticationService, errorReporter, analytics, notifier)
-	scanInitializer = initialize.NewDelegatingInitializer(
-		cliInitializer,
-		authInitializer,
-	)
-	fakeClient := &code.FakeSnykCodeClient{}
-	snykCodeClient = fakeClient
-	snykCli = cli.NewExecutor(authenticationService, errorReporter, analytics, notifier)
-	snykCodeBundleUploader = code.NewBundler(snykCodeClient, instrumentor)
-	scanNotifier, _ = appNotification.NewScanNotifier(notifier)
-	// mock Learn Service
-	learnMock := mock_learn.NewMockService(gomock.NewController(t))
-	learnMock.
-		EXPECT().
-		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(learn.Lesson{}, nil).AnyTimes()
-	learnService = learnMock
-	snykCodeScanner = code.New(snykCodeBundleUploader, snykApiClient, errorReporter, analytics, learnService, notifier)
-	openSourceScanner = oss.New(instrumentor, errorReporter, analytics, snykCli, learnService, notifier)
-	infrastructureAsCodeScanner = iac.New(instrumentor, errorReporter, analytics, snykCli)
-	scanner = snyk.NewDelegatingScanner(
-		scanInitializer,
-		instrumentor,
-		analytics,
-		scanNotifier,
-		snykApiClient,
-		snykCodeScanner,
-		infrastructureAsCodeScanner,
-		openSourceScanner,
-	)
-	hoverService = hover.NewDefaultService(analytics)
-	command.SetService(&snyk.CommandServiceMock{})
-	// don't use getters or it'll deadlock
-	w := workspace.New(instrumentor, scanner, hoverService, scanNotifier, notifier)
-	workspace.Set(w)
-	fileWatcher = watcher.NewFileWatcher()
-	codeActionService = codeaction.NewService(config.CurrentConfig(), w, fileWatcher, notifier)
-	t.Cleanup(
-		func() {
-			fakeClient.Clear()
-		},
-	)
 }
 
 /*

--- a/application/di/init.go
+++ b/application/di/init.go
@@ -179,7 +179,14 @@ func TestInit(t *testing.T) {
 	snykCli = cli.NewExecutor(authenticationService, errorReporter, analytics, notifier)
 	snykCodeBundleUploader = code.NewBundler(snykCodeClient, instrumentor)
 	scanNotifier, _ = appNotification.NewScanNotifier(notifier)
-	snykCodeScanner = code.New(snykCodeBundleUploader, snykApiClient, errorReporter, analytics, mock_learn.NewMockService(gomock.NewController(t)), notifier)
+	// mock Learn Service
+	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	learnMock.
+		EXPECT().
+		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(learn.Lesson{}, nil).AnyTimes()
+	learnService = learnMock
+	snykCodeScanner = code.New(snykCodeBundleUploader, snykApiClient, errorReporter, analytics, learnService, notifier)
 	openSourceScanner = oss.New(instrumentor, errorReporter, analytics, snykCli, learnService, notifier)
 	infrastructureAsCodeScanner = iac.New(instrumentor, errorReporter, analytics, snykCli)
 	scanner = snyk.NewDelegatingScanner(

--- a/application/di/test_init.go
+++ b/application/di/test_init.go
@@ -1,0 +1,107 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package di
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/snyk/snyk-ls/application/codeaction"
+	"github.com/snyk/snyk-ls/application/config"
+	appNotification "github.com/snyk/snyk-ls/application/server/notification"
+	"github.com/snyk/snyk-ls/application/watcher"
+	"github.com/snyk/snyk-ls/domain/ide/command"
+	"github.com/snyk/snyk-ls/domain/ide/hover"
+	"github.com/snyk/snyk-ls/domain/ide/initialize"
+	"github.com/snyk/snyk-ls/domain/ide/workspace"
+	er "github.com/snyk/snyk-ls/domain/observability/error_reporting"
+	"github.com/snyk/snyk-ls/domain/observability/performance"
+	"github.com/snyk/snyk-ls/domain/observability/ux"
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/cli"
+	cliauth "github.com/snyk/snyk-ls/infrastructure/cli/auth"
+	"github.com/snyk/snyk-ls/infrastructure/cli/install"
+	"github.com/snyk/snyk-ls/infrastructure/code"
+	"github.com/snyk/snyk-ls/infrastructure/iac"
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
+	"github.com/snyk/snyk-ls/infrastructure/oss"
+	"github.com/snyk/snyk-ls/infrastructure/services"
+	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
+	domainNotify "github.com/snyk/snyk-ls/internal/notification"
+)
+
+// TODO this is becoming a hot mess we need to unify integ. test strategies
+func TestInit(t *testing.T) {
+	initMutex.Lock()
+	defer initMutex.Unlock()
+	t.Helper()
+	// we don't want to open browsers when testing
+	snyk.DefaultOpenBrowserFunc = func(url string) {}
+	notifier = domainNotify.NewNotifier()
+	analytics = ux.NewTestAnalytics()
+	instrumentor = performance.NewTestInstrumentor()
+	errorReporter = er.NewTestErrorReporter()
+	installer = install.NewFakeInstaller()
+	authProvider := cliauth.NewFakeCliAuthenticationProvider()
+	snykApiClient = &snyk_api.FakeApiClient{CodeEnabled: true}
+	authenticationService = services.NewAuthenticationService(snykApiClient, authProvider, analytics, errorReporter, notifier)
+	cliInitializer = cli.NewInitializer(errorReporter, installer, notifier)
+	authInitializer := cliauth.NewInitializer(authenticationService, errorReporter, analytics, notifier)
+	scanInitializer = initialize.NewDelegatingInitializer(
+		cliInitializer,
+		authInitializer,
+	)
+	fakeClient := &code.FakeSnykCodeClient{}
+	snykCodeClient = fakeClient
+	snykCli = cli.NewExecutor(authenticationService, errorReporter, analytics, notifier)
+	snykCodeBundleUploader = code.NewBundler(snykCodeClient, instrumentor)
+	scanNotifier, _ = appNotification.NewScanNotifier(notifier)
+	// mock Learn Service
+	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	learnMock.
+		EXPECT().
+		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(learn.Lesson{}, nil).AnyTimes()
+	learnService = learnMock
+	snykCodeScanner = code.New(snykCodeBundleUploader, snykApiClient, errorReporter, analytics, learnService, notifier)
+	openSourceScanner = oss.New(instrumentor, errorReporter, analytics, snykCli, learnService, notifier)
+	infrastructureAsCodeScanner = iac.New(instrumentor, errorReporter, analytics, snykCli)
+	scanner = snyk.NewDelegatingScanner(
+		scanInitializer,
+		instrumentor,
+		analytics,
+		scanNotifier,
+		snykApiClient,
+		snykCodeScanner,
+		infrastructureAsCodeScanner,
+		openSourceScanner,
+	)
+	hoverService = hover.NewDefaultService(analytics)
+	command.SetService(&snyk.CommandServiceMock{})
+	// don't use getters or it'll deadlock
+	w := workspace.New(instrumentor, scanner, hoverService, scanNotifier, notifier)
+	workspace.Set(w)
+	fileWatcher = watcher.NewFileWatcher()
+	codeActionService = codeaction.NewService(config.CurrentConfig(), w, fileWatcher, notifier)
+	t.Cleanup(
+		func() {
+			fakeClient.Clear()
+		},
+	)
+}

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
 
@@ -33,6 +34,8 @@ import (
 	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
 	"github.com/snyk/snyk-ls/domain/observability/performance"
 	ux2 "github.com/snyk/snyk-ls/domain/observability/ux"
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/testutil"
@@ -198,7 +201,7 @@ func TestCreateBundle(t *testing.T) {
 			"path/with%20spaces/file2.java",
 		}
 
-		_, scanner := setupTestScanner()
+		_, scanner := setupTestScanner(t)
 		tempDir := t.TempDir()
 		var filesFullPaths []string
 		for _, fileRelPath := range filesRelPaths {
@@ -238,19 +241,24 @@ func sliceToChannel(slice []string) <-chan string {
 func setupCreateBundleTest(t *testing.T, extension string) (*FakeSnykCodeClient, string, *Scanner, string) {
 	testutil.UnitTest(t)
 	dir := t.TempDir()
-	snykCodeMock, c := setupTestScanner()
+	snykCodeMock, c := setupTestScanner(t)
 	file := filepath.Join(dir, "file."+extension)
 	return snykCodeMock, dir, c, file
 }
 
-func setupTestScanner() (*FakeSnykCodeClient, *Scanner) {
+func setupTestScanner(t *testing.T) (*FakeSnykCodeClient, *Scanner) {
 	snykCodeMock := &FakeSnykCodeClient{}
+	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	learnMock.
+		EXPECT().
+		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(learn.Lesson{}, nil).AnyTimes()
 	scanner := New(
 		NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
 		&snyk_api.FakeApiClient{CodeEnabled: true},
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
-		nil,
+		learnMock,
 		notification.NewNotifier(),
 	)
 
@@ -258,6 +266,11 @@ func setupTestScanner() (*FakeSnykCodeClient, *Scanner) {
 }
 
 func TestUploadAndAnalyze(t *testing.T) {
+	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	learnMock.
+		EXPECT().
+		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(learn.Lesson{}, nil).AnyTimes()
 	t.Run(
 		"should create bundle when hash empty", func(t *testing.T) {
 			testutil.UnitTest(t)
@@ -267,7 +280,7 @@ func TestUploadAndAnalyze(t *testing.T) {
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				ux2.NewTestAnalytics(),
-				nil,
+				learnMock,
 				notification.NewNotifier(),
 			)
 			baseDir, firstDoc, _, content1, _ := setupDocs(t)
@@ -297,7 +310,7 @@ func TestUploadAndAnalyze(t *testing.T) {
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				ux2.NewTestAnalytics(),
-				nil,
+				learnMock,
 				notification.NewNotifier(),
 			)
 			diagnosticUri, path := TempWorkdirWithVulnerabilities(t)
@@ -334,7 +347,7 @@ func TestUploadAndAnalyze(t *testing.T) {
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,
-				nil,
+				learnMock,
 				notification.NewNotifier(),
 			)
 			diagnosticUri, path := TempWorkdirWithVulnerabilities(t)
@@ -362,7 +375,7 @@ func Test_Scan(t *testing.T) {
 	t.Run("Should update changed files", func(t *testing.T) {
 		testutil.UnitTest(t)
 		// Arrange
-		snykCodeMock, scanner := setupTestScanner()
+		snykCodeMock, scanner := setupTestScanner(t)
 		wg := sync.WaitGroup{}
 		changedFilesRelPaths := []string{ // File paths relative to the repo base
 			"file0.go",
@@ -411,7 +424,7 @@ func Test_Scan(t *testing.T) {
 	t.Run("Should reset changed files after successful scan", func(t *testing.T) {
 		testutil.UnitTest(t)
 		// Arrange
-		_, scanner := setupTestScanner()
+		_, scanner := setupTestScanner(t)
 		wg := sync.WaitGroup{}
 		tempDir := t.TempDir()
 
@@ -432,7 +445,7 @@ func Test_Scan(t *testing.T) {
 	t.Run("Should not mark folders as changed files", func(t *testing.T) {
 		testutil.UnitTest(t)
 		// Arrange
-		snykCodeMock, scanner := setupTestScanner()
+		snykCodeMock, scanner := setupTestScanner(t)
 
 		tempDir, _, _ := setupIgnoreWorkspace(t)
 
@@ -449,7 +462,7 @@ func Test_Scan(t *testing.T) {
 		// Arrange
 		testutil.UnitTest(t)
 		tempDir, _, _ := setupIgnoreWorkspace(t)
-		fakeClient, scanner := setupTestScanner()
+		fakeClient, scanner := setupTestScanner(t)
 		fakeClient.AnalysisDuration = time.Second
 		wg := sync.WaitGroup{}
 
@@ -472,7 +485,7 @@ func Test_Scan(t *testing.T) {
 		testutil.UnitTest(t)
 		tempDir, _, _ := setupIgnoreWorkspace(t)
 		tempDir2, _, _ := setupIgnoreWorkspace(t)
-		fakeClient, scanner := setupTestScanner()
+		fakeClient, scanner := setupTestScanner(t)
 		fakeClient.AnalysisDuration = time.Second
 		wg := sync.WaitGroup{}
 
@@ -601,6 +614,12 @@ func autofixSetupAndCleanup(t *testing.T) {
 }
 
 func TestUploadAnalyzeWithAutofix(t *testing.T) {
+	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	learnMock.
+		EXPECT().
+		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(learn.Lesson{}, nil).AnyTimes()
+
 	t.Run(
 		"should not add autofix after analysis when not enabled", func(t *testing.T) {
 			testutil.UnitTest(t)
@@ -613,7 +632,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,
-				nil,
+				learnMock,
 				notification.NewNotifier(),
 			)
 			diagnosticUri, path := TempWorkdirWithVulnerabilities(t)
@@ -649,7 +668,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,
-				nil,
+				learnMock,
 				notification.NewNotifier(),
 			)
 			diagnosticUri, path := TempWorkdirWithVulnerabilities(t)
@@ -683,7 +702,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,
-				nil,
+				learnMock,
 				notification.NewNotifier(),
 			)
 			diagnosticUri, path := TempWorkdirWithVulnerabilities(t)


### PR DESCRIPTION
### Description

This PR changes the default to add code actions to open issue related code actions to true, enabling it for VSCode, Eclipse & all LSP enabled Editors using Snyk Language Server. 

Notes: Test Initialization was moved from `init.go` to `test_init.go` therefore the big line change.

Only real changes are:
- config.go:L25 (changing default for learn code actions to true)

The rest is testing & mocking.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
