### PR TITLE
fix: use in memory config instead of file based

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -230,8 +230,8 @@ func New() *Config {
 }
 
 func initWorkFlowEngine(c *Config) {
-	c.engine = app.CreateAppEngine()
-	conf := c.engine.GetConfiguration()
+	conf := configuration.NewInMemory()
+	c.engine = app.CreateAppEngineWithOptions(app.WithConfiguration(conf))
 	c.storage = NewStorage()
 	conf.SetStorage(c.storage)
 	conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)


### PR DESCRIPTION
### Description
The gaf configuration was incorrectly being populated from the CLI config file instead of using an in-memory object.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

