### PR TITLE
feat: respect new autofix payload [ZEN-632]

### DIFF
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -476,9 +476,18 @@ func createAutofixWorkspaceEdit(filePath string, fixedSourceCode string) (edit s
 
 // toAutofixSuggestionsIssues converts the HTTP json-first payload to the domain type
 func (s *AutofixResponse) toAutofixSuggestions(filePath string) (fixSuggestions []AutofixSuggestion) {
-	for _, fix := range s.AutofixSuggestions {
+	for _, suggestion := range s.AutofixSuggestions {
+		var newText string
+		// Deprecated autofix response used to pass a string. It passes value object with a fix id to map it to the backend for fix feedback purposes now.
+		switch fix := suggestion.(type) {
+		case string:
+			newText = fix
+		default:
+			newText = fix.(autofixResponseSingleFix).Value
+		}
+
 		d := AutofixSuggestion{
-			AutofixEdit: createAutofixWorkspaceEdit(filePath, fix),
+			AutofixEdit: createAutofixWorkspaceEdit(filePath, newText),
 		}
 		fixSuggestions = append(fixSuggestions, d)
 	}

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -869,3 +869,48 @@ func Test_getCodeIssueType(t *testing.T) {
 		assert.Equal(t, snyk.CodeQualityIssue, rule.getCodeIssueType())
 	})
 }
+
+// Tests deprecated payload convert
+func Test_DeprecatedAutofixResponse_toAutofixSuggestion(t *testing.T) {
+	response := AutofixResponse{
+		Status: "COMPLETE",
+	}
+	fixes := []string{"test1", "test2"}
+	for _, fix := range fixes {
+		response.AutofixSuggestions = append(response.AutofixSuggestions, fix)
+	}
+	filePath := "path/to/file.js"
+	edits := response.toAutofixSuggestions(filePath)
+	editValues := make([]string, 0)
+	for _, edit := range edits {
+		change := edit.AutofixEdit.Changes[filePath][0]
+		editValues = append(editValues, change.NewText)
+	}
+
+	assert.Contains(t, editValues, "test1", "test2")
+}
+
+func Test_AutofixResponse_toAutofixSuggestion(t *testing.T) {
+	response := AutofixResponse{
+		Status: "COMPLETE",
+	}
+	fixes := []autofixResponseSingleFix{{
+		Id:    "123e4567-e89b-12d3-a456-426614174000/1",
+		Value: "test1",
+	}, {
+		Id:    "123e4567-e89b-12d3-a456-426614174000/2",
+		Value: "test2",
+	}}
+	for _, fix := range fixes {
+		response.AutofixSuggestions = append(response.AutofixSuggestions, fix)
+	}
+	filePath := "path/to/file.js"
+	edits := response.toAutofixSuggestions(filePath)
+	editValues := make([]string, 0)
+	for _, edit := range edits {
+		change := edit.AutofixEdit.Changes[filePath][0]
+		editValues = append(editValues, change.NewText)
+	}
+
+	assert.Contains(t, editValues, "test1", "test2")
+}

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -29,11 +29,14 @@ func (e SnykAnalysisFailedError) Error() string { return e.Msg }
 // AutofixResponse is the json-based structure to which we can translate the results of the HTTP
 // request to Autofix upstream.
 type AutofixResponse struct {
-	Status             string                      `json:"status"`
-	AutofixSuggestions []autofixResponseSuggestion `json:"fixes"`
+	Status             string `json:"status"`
+	AutofixSuggestions []any  `json:"fixes"`
 }
 
-type autofixResponseSuggestion = string
+type autofixResponseSingleFix struct {
+	Id    string `json:"id"`
+	Value string `json:"value"`
+}
 
 type AutofixRequestKey struct {
 	Type     string `json:"type"`


### PR DESCRIPTION
### Description

Temporarily ensure we can work with both old and latest autofix response payload. The old payload won't be sent any more after https://snyksec.atlassian.net/browse/ZEN-632 is in production on Code backend.

Upstream API response change PR: https://github.com/snyk/sast-analysis-api/pull/334

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
