### PR TITLE
fix: crash upon type mapping in Autofix

### DIFF
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -473,17 +473,8 @@ func createAutofixWorkspaceEdit(filePath string, fixedSourceCode string) (edit s
 // toAutofixSuggestionsIssues converts the HTTP json-first payload to the domain type
 func (s *AutofixResponse) toAutofixSuggestions(filePath string) (fixSuggestions []AutofixSuggestion) {
 	for _, suggestion := range s.AutofixSuggestions {
-		var newText string
-		// Deprecated autofix response used to pass a string. It passes value object with a fix id to map it to the backend for fix feedback purposes now.
-		switch fix := suggestion.(type) {
-		case string:
-			newText = fix
-		default:
-			newText = fix.(autofixResponseSingleFix).Value
-		}
-
 		d := AutofixSuggestion{
-			AutofixEdit: createAutofixWorkspaceEdit(filePath, newText),
+			AutofixEdit: createAutofixWorkspaceEdit(filePath, suggestion.Value),
 		}
 		fixSuggestions = append(fixSuggestions, d)
 	}

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -859,26 +859,6 @@ func Test_getCodeIssueType(t *testing.T) {
 	})
 }
 
-// Tests deprecated payload convert
-func Test_DeprecatedAutofixResponse_toAutofixSuggestion(t *testing.T) {
-	response := AutofixResponse{
-		Status: "COMPLETE",
-	}
-	fixes := []string{"test1", "test2"}
-	for _, fix := range fixes {
-		response.AutofixSuggestions = append(response.AutofixSuggestions, fix)
-	}
-	filePath := "path/to/file.js"
-	edits := response.toAutofixSuggestions(filePath)
-	editValues := make([]string, 0)
-	for _, edit := range edits {
-		change := edit.AutofixEdit.Changes[filePath][0]
-		editValues = append(editValues, change.NewText)
-	}
-
-	assert.Contains(t, editValues, "test1", "test2")
-}
-
 func Test_AutofixResponse_toAutofixSuggestion(t *testing.T) {
 	response := AutofixResponse{
 		Status: "COMPLETE",
@@ -890,9 +870,7 @@ func Test_AutofixResponse_toAutofixSuggestion(t *testing.T) {
 		Id:    "123e4567-e89b-12d3-a456-426614174000/2",
 		Value: "test2",
 	}}
-	for _, fix := range fixes {
-		response.AutofixSuggestions = append(response.AutofixSuggestions, fix)
-	}
+	response.AutofixSuggestions = append(response.AutofixSuggestions, fixes...)
 	filePath := "path/to/file.js"
 	edits := response.toAutofixSuggestions(filePath)
 	editValues := make([]string, 0)

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -29,8 +29,8 @@ func (e SnykAnalysisFailedError) Error() string { return e.Msg }
 // AutofixResponse is the json-based structure to which we can translate the results of the HTTP
 // request to Autofix upstream.
 type AutofixResponse struct {
-	Status             string `json:"status"`
-	AutofixSuggestions []any  `json:"fixes"`
+	Status             string                     `json:"status"`
+	AutofixSuggestions []autofixResponseSingleFix `json:"fixes"`
 }
 
 type autofixResponseSingleFix struct {


### PR DESCRIPTION
### Description

Fixes crash when mapping a type. It's redundant now, since we moved backend to the new payload.

```
panic: interface conversion: interface {} is map[string]interface {}, not code.autofixResponseSingleFix

goroutine 469 [running]:
github.com/snyk/snyk-ls/infrastructure/code.(*AutofixResponse).toAutofixSuggestions(0xc0022c96e0, {0xc003255357, 0x1e}, {0xc002ffc068, 0x6})
	/Users/bdoetsch/workspace/snyk-ls/infrastructure/code/convert.go:490 +0x34e
github.com/snyk/snyk-ls/infrastructure/code.(*SnykCodeHTTPClient).RunAutofix(_, {_, _}, {{0xc00012ebc0, 0x40}, {0xc002c1e900, 0x40}, {0xc002ffc068, 0x6}, {{0xc002221fa0, ...}, ...}}, ...)
	/Users/bdoetsch/workspace/snyk-ls/infrastructure/code/backend_service.go:436 +0x149b
github.com/snyk/snyk-ls/infrastructure/code.(*Bundle).autofixFunc.func1.1()
	/Users/bdoetsch/workspace/snyk-ls/infrastructure/code/bundle.go:288 +0x188
github.com/snyk/snyk-ls/infrastructure/code.(*Bundle).autofixFunc.func1()
	/Users/bdoetsch/workspace/snyk-ls/infrastructure/code/bundle.go:320 +0x996
github.com/snyk/snyk-ls/domain/ide/command.(*fixCodeIssue).Execute(0xc0027022a0, {0x100bd1a10, 0xc00012c018})
	/Users/bdoetsch/workspace/snyk-ls/domain/ide/command/code_fix.go:67 +0x759
github.com/snyk/snyk-ls/domain/ide/command.(*serviceImpl).ExecuteCommand(0xc0001b8360, {0x100bd1a10, 0xc00012c018}, {0x100bceef8, 0xc0027022a0})
	/Users/bdoetsch/workspace/snyk-ls/domain/ide/command/command_service.go:62 +0x208
github.com/snyk/snyk-ls/application/server.executeCommandHandler.func1({0x100bd1a80, 0xc002f3adb0}, {{0xc00012dc00, 0xd}, {0xc002cc04c0, 0x3, 0x4}})
	/Users/bdoetsch/workspace/snyk-ls/application/server/execute_command.go:52 +0x5f0
reflect.Value.call({0x100a57d20, 0xc000228870, 0x13}, {0x100b22f7e, 0x4}, {0xc002f3af00, 0x2, 0x2})
	/usr/local/opt/go/libexec/src/reflect/value.go:586 +0xeb4
reflect.Value.Call({0x100a57d20, 0xc000228870, 0x13}, {0xc002f3af00, 0x2, 0x2})
	/usr/local/opt/go/libexec/src/reflect/value.go:370 +0xb7
github.com/creachadair/jrpc2/handler.(*FuncInfo).Wrap.func8({0x100bd1a80, 0xc002f3adb0}, 0xc002cc0480)
	/Users/bdoetsch/workspace/go/pkg/mod/github.com/creachadair/jrpc2@v1.0.0/handler/handler.go:230 +0x23d
github.com/creachadair/jrpc2.(*Server).invoke(0xc0001de000, {0x100bd19d8, 0xc001c36320}, 0xc0001b9180, 0xc002cc0480)
	/Users/bdoetsch/workspace/go/pkg/mod/github.com/creachadair/jrpc2@v1.0.0/server.go:387 +0x242
github.com/creachadair/jrpc2.(*Server).dispatchLocked.func1()
	/Users/bdoetsch/workspace/go/pkg/mod/github.com/creachadair/jrpc2@v1.0.0/server.go:259 +0x1f5
github.com/creachadair/jrpc2.(*Server).serve.func1()
	/Users/bdoetsch/workspace/go/pkg/mod/github.com/creachadair/jrpc2@v1.0.0/server.go:180 +0x90
created by github.com/creachadair/jrpc2.(*Server).serve
	/Users/bdoetsch/workspace/go/pkg/mod/github.com/creachadair/jrpc2@v1.0.0/server.go:178 +0x231
```

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
