### PR TITLE
fix: autofix in eclipse

### DIFF
--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -380,6 +380,7 @@ type AutofixStatus struct {
 func (s *SnykCodeHTTPClient) RunAutofix(
 	ctx context.Context,
 	options AutofixOptions,
+	baseDir string,
 ) ([]AutofixSuggestion,
 	AutofixStatus,
 	error,
@@ -432,7 +433,7 @@ func (s *SnykCodeHTTPClient) RunAutofix(
 		return nil, status, nil
 	}
 
-	suggestions := response.toAutofixSuggestions(options.filePath)
+	suggestions := response.toAutofixSuggestions(baseDir, options.filePath)
 	return suggestions, AutofixStatus{message: response.Status}, nil
 }
 

--- a/infrastructure/code/backend_service_interface.go
+++ b/infrastructure/code/backend_service_interface.go
@@ -66,6 +66,7 @@ type SnykCodeClient interface {
 	RunAutofix(
 		ctx context.Context,
 		options AutofixOptions,
+		baseDir string,
 	) ([]AutofixSuggestion,
 		AutofixStatus,
 		error,

--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -285,7 +285,7 @@ func (b *Bundle) autofixFunc(ctx context.Context, issue snyk.Issue) func() *snyk
 		// channel.
 		pollFunc := func() (edit *snyk.WorkspaceEdit, complete bool) {
 			log.Info().Msg("polling")
-			fixSuggestions, fixStatus, err := b.SnykCode.RunAutofix(s.Context(), autofixOptions)
+			fixSuggestions, fixStatus, err := b.SnykCode.RunAutofix(s.Context(), autofixOptions, b.rootPath)
 			edit = nil
 			complete = false
 			if err != nil {

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -451,7 +451,7 @@ func (r *result) getMarkers(baseDir string) ([]snyk.Marker, error) {
 }
 
 // createAutofixWorkspaceEdit turns the returned fix into an edit.
-func createAutofixWorkspaceEdit(filePath string, fixedSourceCode string) (edit snyk.WorkspaceEdit) {
+func createAutofixWorkspaceEdit(absoluteFilePath string, fixedSourceCode string) (edit snyk.WorkspaceEdit) {
 	singleTextEdit := snyk.TextEdit{
 		Range: snyk.Range{
 			// TODO(alex.gronskiy): should be changed to an actual hunk-like edit instead of
@@ -466,15 +466,15 @@ func createAutofixWorkspaceEdit(filePath string, fixedSourceCode string) (edit s
 		NewText: fixedSourceCode,
 	}
 	edit.Changes = make(map[string][]snyk.TextEdit)
-	edit.Changes[filePath] = []snyk.TextEdit{singleTextEdit}
+	edit.Changes[absoluteFilePath] = []snyk.TextEdit{singleTextEdit}
 	return edit
 }
 
 // toAutofixSuggestionsIssues converts the HTTP json-first payload to the domain type
-func (s *AutofixResponse) toAutofixSuggestions(filePath string) (fixSuggestions []AutofixSuggestion) {
+func (s *AutofixResponse) toAutofixSuggestions(baseDir string, filePath string) (fixSuggestions []AutofixSuggestion) {
 	for _, suggestion := range s.AutofixSuggestions {
 		d := AutofixSuggestion{
-			AutofixEdit: createAutofixWorkspaceEdit(filePath, suggestion.Value),
+			AutofixEdit: createAutofixWorkspaceEdit(ToAbsolutePath(baseDir, filePath), suggestion.Value),
 		}
 		fixSuggestions = append(fixSuggestions, d)
 	}

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -872,10 +872,10 @@ func Test_AutofixResponse_toAutofixSuggestion(t *testing.T) {
 	}}
 	response.AutofixSuggestions = append(response.AutofixSuggestions, fixes...)
 	filePath := "path/to/file.js"
-	edits := response.toAutofixSuggestions(filePath)
+	edits := response.toAutofixSuggestions("/users/git", filePath)
 	editValues := make([]string, 0)
 	for _, edit := range edits {
-		change := edit.AutofixEdit.Changes[filePath][0]
+		change := edit.AutofixEdit.Changes[ToAbsolutePath("/users/git", filePath)][0]
 		editValues = append(editValues, change.NewText)
 	}
 

--- a/infrastructure/code/fake_snyk_code_api_service.go
+++ b/infrastructure/code/fake_snyk_code_api_service.go
@@ -256,6 +256,7 @@ func (f *FakeSnykCodeClient) RunAnalysis(
 func (f *FakeSnykCodeClient) RunAutofix(
 	_ context.Context,
 	options AutofixOptions,
+	baseDir string,
 ) ([]AutofixSuggestion, AutofixStatus, error) {
 	<-time.After(f.AnalysisDuration)
 	FakeSnykCodeApiServiceMutex.Lock()


### PR DESCRIPTION
### Description

Fixes Eclipse plugin failing due to working with relative paths.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
