### PR TITLE
refactor: use commandData for ShowMessageRequest actions

### DIFF
--- a/application/codeaction/codeaction.go
+++ b/application/codeaction/codeaction.go
@@ -139,11 +139,7 @@ func (c *CodeActionsService) handleCommand(
 		CommandId: action.Command.Command,
 		Arguments: action.Command.Arguments,
 	}
-	executableCmd, err := command.CreateFromCommandData(cmd, server, authService, learnService, c.notifier, c.IssuesProvider, c.codeApiClient)
-	if err != nil {
-		return lsp.CodeAction{}, err
-	}
-	_, err = command.Service().ExecuteCommand(context.Background(), executableCmd)
+	_, err := command.Service().ExecuteCommandData(context.Background(), cmd, server)
 	if err != nil {
 		return lsp.CodeAction{}, err
 	}

--- a/application/codeaction/codeaction_test.go
+++ b/application/codeaction/codeaction_test.go
@@ -223,7 +223,7 @@ func Test_ResolveCodeAction_CommandIsExecuted(t *testing.T) {
 
 	serviceMock := command.Service().(*snyk.CommandServiceMock)
 	assert.Len(t, serviceMock.ExecutedCommands(), 1)
-	assert.Equal(t, serviceMock.ExecutedCommands()[0].Command().CommandId, c.Command)
+	assert.Equal(t, serviceMock.ExecutedCommands()[0].CommandId, c.Command)
 }
 
 func Test_ResolveCodeAction_KeyIsNull_ReturnsError(t *testing.T) {

--- a/application/codeaction/codeaction_test.go
+++ b/application/codeaction/codeaction_test.go
@@ -175,8 +175,10 @@ func Test_ResolveCodeAction_KeyDoesNotExist_ReturnError(t *testing.T) {
 }
 
 func Test_ResolveCodeAction_UnknownCommandIsReported(t *testing.T) {
+	testutil.UnitTest(t)
 	// Arrange
 	service := setupService()
+	command.SetService(command.NewService(nil, nil, nil, nil, nil))
 
 	id := lsp.CodeActionData(uuid.New())
 	c := &sglsp.Command{
@@ -201,6 +203,7 @@ func Test_ResolveCodeAction_UnknownCommandIsReported(t *testing.T) {
 }
 
 func Test_ResolveCodeAction_CommandIsExecuted(t *testing.T) {
+	testutil.UnitTest(t)
 	// Arrange
 	service := setupService()
 

--- a/application/di/init.go
+++ b/application/di/init.go
@@ -143,7 +143,7 @@ func initApplication() {
 	workspace.Set(w)
 	fileWatcher = watcher.NewFileWatcher()
 	codeActionService = codeaction.NewService(config.CurrentConfig(), w, fileWatcher, notifier, snykCodeClient)
-	command.SetService(command.NewService(authenticationService, notifier))
+	command.SetService(command.NewService(authenticationService, notifier, learnService, w, snykCodeClient))
 }
 
 /*

--- a/application/server/execute_command.go
+++ b/application/server/execute_command.go
@@ -25,9 +25,7 @@ import (
 	"github.com/rs/zerolog/log"
 	sglsp "github.com/sourcegraph/go-lsp"
 
-	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/ide/command"
-	"github.com/snyk/snyk-ls/domain/ide/workspace"
 	"github.com/snyk/snyk-ls/domain/snyk"
 )
 
@@ -42,14 +40,8 @@ func executeCommandHandler(srv *jrpc2.Server) jrpc2.Handler {
 		defer log.Info().Str("method", method).Interface("command", params).Msg("SENDING")
 
 		commandData := snyk.CommandData{CommandId: params.Command, Arguments: params.Arguments, Title: params.Command}
-		cmd, err := command.CreateFromCommandData(commandData, srv, di.AuthenticationService(), di.LearnService(), di.Notifier(), workspace.Get(), di.SnykCodeClient())
 
-		if err != nil {
-			log.Error().Err(err).Str("method", method).Msg("failed to create command")
-			return nil, err
-		}
-
-		result, err := command.Service().ExecuteCommand(bgCtx, cmd)
+		result, err := command.Service().ExecuteCommandData(bgCtx, commandData, srv)
 		logError(err, fmt.Sprintf("Error executing command %v", commandData))
 		return result, err
 	})

--- a/application/server/execute_command_test.go
+++ b/application/server/execute_command_test.go
@@ -120,7 +120,7 @@ func Test_loginCommand_StartsAuthentication(t *testing.T) {
 	loc := setupServer(t)
 
 	// reset to use real service
-	command.SetService(command.NewService(nil, nil))
+	command.SetService(command.NewService(di.AuthenticationService(), nil, nil, nil, nil))
 
 	config.CurrentConfig().SetAutomaticAuthentication(false)
 	_, err := loc.Client.Call(ctx, "initialize", nil)
@@ -147,7 +147,7 @@ func Test_executeCommand_shouldCopyAuthURLToClipboard(t *testing.T) {
 	loc := setupServer(t)
 
 	// reset to use real service
-	command.SetService(command.NewService(nil, nil))
+	command.SetService(command.NewService(di.AuthenticationService(), nil, nil, nil, nil))
 
 	authenticationMock := di.AuthenticationService().Provider().(*snyk.FakeAuthenticationProvider)
 	params := lsp.ExecuteCommandParams{Command: snyk.CopyAuthLinkCommand}

--- a/application/server/notification.go
+++ b/application/server/notification.go
@@ -238,12 +238,12 @@ func handleShowMessageRequest(srv lsp.Server, params snyk.ShowMessageRequest) {
 			log.Info().Str("method", "registerNotifier").Msg("Action map key not found")
 			return
 		}
-		if selectedCommand == nil {
-			log.Info().Str("method", "registerNotifier").Msg("Void command selected")
+		if selectedCommand.CommandId == "" {
+			log.Info().Str("method", "registerNotifier").Msg("No command provided")
 			return
 		}
 
-		_, err := command.Service().ExecuteCommand(context.Background(), selectedCommand)
+		_, err := command.Service().ExecuteCommandData(context.Background(), selectedCommand, srv)
 		if err != nil {
 			log.Error().
 				Err(err).

--- a/application/server/notification_test.go
+++ b/application/server/notification_test.go
@@ -208,12 +208,16 @@ func TestShowMessageRequest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.Command]()
+		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
 		expectedTitle := "test title"
-		data, err := command.CreateFromCommandData(snyk.CommandData{
+		// data, err := command.CreateFromCommandData(snyk.CommandData{
+		// 	CommandId: snyk.OpenBrowserCommand,
+		// 	Arguments: []any{"https://snyk.io"},
+		// }, loc.Server, di.AuthenticationService(), di.LearnService(), di.Notifier(), nil, nil)
+		data := snyk.CommandData{
 			CommandId: snyk.OpenBrowserCommand,
 			Arguments: []any{"https://snyk.io"},
-		}, loc.Server, di.AuthenticationService(), di.LearnService(), di.Notifier(), nil, nil)
+		}
 		assert.NoError(t, err)
 		actionCommandMap.Add(
 			snyk.MessageAction(expectedTitle),
@@ -255,19 +259,9 @@ func TestShowMessageRequest(t *testing.T) {
 			t.Fatal(err)
 		}
 		command.SetService(snyk.NewCommandServiceMock())
-		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.Command]()
-		data, err := command.CreateFromCommandData(
-			snyk.CommandData{CommandId: snyk.OpenBrowserCommand, Arguments: []any{"https://snyk.io"}},
-			loc.Server,
-			di.AuthenticationService(),
-			di.LearnService(),
-			di.Notifier(),
-			nil,
-			nil,
-		)
-		assert.NoError(t, err)
+		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
 
-		actionCommandMap.Add(snyk.MessageAction(selectedAction), data)
+		actionCommandMap.Add(snyk.MessageAction(selectedAction), snyk.CommandData{CommandId: snyk.OpenBrowserCommand, Arguments: []any{"https://snyk.io"}})
 
 		request := snyk.ShowMessageRequest{Message: "message", Type: snyk.Info, Actions: actionCommandMap}
 
@@ -279,7 +273,7 @@ func TestShowMessageRequest(t *testing.T) {
 				// verify that passed command is eventually executed
 				commandService := command.Service()
 				commandServiceMock := commandService.(*snyk.CommandServiceMock)
-				return commandServiceMock.ExecutedCommands()[0].Command().CommandId == snyk.OpenBrowserCommand
+				return commandServiceMock.ExecutedCommands()[0].CommandId == snyk.OpenBrowserCommand
 			},
 			2*time.Second,
 			10*time.Millisecond,

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -900,7 +900,7 @@ func Test_CodeActionResolve_ShouldExecuteCommands(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, expected, serviceMock.ExecutedCommands()[0].Command().CommandId)
+	assert.Equal(t, expected, serviceMock.ExecutedCommands()[0].CommandId)
 }
 
 func Test_SmokeWorkspaceScanOssAndCode(t *testing.T) {

--- a/domain/ide/command/command_service_test.go
+++ b/domain/ide/command/command_service_test.go
@@ -25,18 +25,6 @@ import (
 	"github.com/snyk/snyk-ls/domain/snyk"
 )
 
-type TestCommand struct {
-	executed bool
-}
-
-func (command *TestCommand) Command() snyk.CommandData {
-	return snyk.CommandData{}
-}
-func (command *TestCommand) Execute(_ context.Context) (any, error) {
-	command.executed = true
-	return nil, nil
-}
-
 func Test_ExecuteCommand(t *testing.T) {
 	authProvider := &snyk.FakeAuthenticationProvider{
 		ExpectedAuthURL: "https://auth.url",

--- a/domain/ide/command/command_service_test.go
+++ b/domain/ide/command/command_service_test.go
@@ -18,6 +18,9 @@ package command
 
 import (
 	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
 )
@@ -34,9 +37,17 @@ func (command *TestCommand) Execute(_ context.Context) (any, error) {
 	return nil, nil
 }
 
-// func Test_ExecuteCommand(t *testing.T) {
-// 	service := NewService(nil, nil, nil, nil, nil)
-// 	cmd := &TestCommand{}
-// 	_, _ = service.ExecuteCommandData(context.Background(), cmd)
-// 	assert.True(t, cmd.executed)
-// }
+func Test_ExecuteCommand(t *testing.T) {
+	authProvider := &snyk.FakeAuthenticationProvider{
+		ExpectedAuthURL: "https://auth.url",
+	}
+	authenticationService := snyk.NewAuthenticationService(authProvider, nil, nil, nil)
+	service := NewService(authenticationService, nil, nil, nil, nil)
+	cmd := snyk.CommandData{
+		CommandId: snyk.CopyAuthLinkCommand,
+	}
+
+	url, _ := service.ExecuteCommandData(context.Background(), cmd, nil)
+
+	assert.Equal(t, "https://auth.url", url)
+}

--- a/domain/ide/command/command_service_test.go
+++ b/domain/ide/command/command_service_test.go
@@ -18,9 +18,6 @@ package command
 
 import (
 	"context"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
 )
@@ -37,9 +34,9 @@ func (command *TestCommand) Execute(_ context.Context) (any, error) {
 	return nil, nil
 }
 
-func Test_ExecuteCommand(t *testing.T) {
-	service := NewService(nil, nil)
-	cmd := &TestCommand{}
-	_, _ = service.ExecuteCommand(context.Background(), cmd)
-	assert.True(t, cmd.executed)
-}
+// func Test_ExecuteCommand(t *testing.T) {
+// 	service := NewService(nil, nil, nil, nil, nil)
+// 	cmd := &TestCommand{}
+// 	_, _ = service.ExecuteCommandData(context.Background(), cmd)
+// 	assert.True(t, cmd.executed)
+// }

--- a/domain/snyk/command.go
+++ b/domain/snyk/command.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 
 	"github.com/snyk/go-application-framework/pkg/auth"
+
+	"github.com/snyk/snyk-ls/internal/lsp"
 )
 
 const (
@@ -70,25 +72,27 @@ type CommandData struct {
 type CommandName string
 
 type CommandService interface {
-	ExecuteCommand(ctx context.Context, command Command) (any, error)
+	ExecuteCommandData(ctx context.Context, commandData CommandData, server lsp.Server) (any, error)
 }
 
 type CommandServiceMock struct {
 	m                sync.Mutex
-	executedCommands []Command
+	executedCommands []CommandData
 }
 
 func NewCommandServiceMock() *CommandServiceMock {
 	return &CommandServiceMock{}
 }
 
-func (service *CommandServiceMock) ExecuteCommand(_ context.Context, command Command) (any, error) {
+// todo:test
+func (service *CommandServiceMock) ExecuteCommandData(_ context.Context, command CommandData, server lsp.Server) (any, error) {
 	service.m.Lock()
 	service.executedCommands = append(service.executedCommands, command)
 	service.m.Unlock()
 	return nil, nil
 }
-func (service *CommandServiceMock) ExecutedCommands() []Command {
+
+func (service *CommandServiceMock) ExecutedCommands() []CommandData {
 	service.m.Lock()
 	cmds := service.executedCommands
 	service.m.Unlock()

--- a/domain/snyk/message.go
+++ b/domain/snyk/message.go
@@ -29,7 +29,7 @@ const (
 )
 
 type ShowMessageRequest struct {
-	Message string                                             `json:"message"`
-	Type    MessageType                                        `json:"type"`
-	Actions *data_structure.OrderedMap[MessageAction, Command] `json:"actions"`
+	Message string                                                 `json:"message"`
+	Type    MessageType                                            `json:"type"`
+	Actions *data_structure.OrderedMap[MessageAction, CommandData] `json:"actions"`
 }

--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -25,12 +25,10 @@ import (
 	"strings"
 	"time"
 
-	pkgerrors "github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	sglsp "github.com/sourcegraph/go-lsp"
 
 	"github.com/snyk/snyk-ls/application/config"
-	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/ide/notification"
 	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
 	"github.com/snyk/snyk-ls/domain/observability/performance"
@@ -352,29 +350,17 @@ func (b *Bundle) autofixFunc(ctx context.Context, issue snyk.Issue) func() *snyk
 	return editFn
 }
 
-func (b *Bundle) autofixFeedbackActions(fixId string) (*data_structure.OrderedMap[snyk.MessageAction, snyk.Command], error) {
-	createCommandData := func(positive bool) (snyk.Command, error) {
-		commandData := snyk.CommandData{
+func (b *Bundle) autofixFeedbackActions(fixId string) (*data_structure.OrderedMap[snyk.MessageAction, snyk.CommandData], error) {
+	createCommandData := func(positive bool) snyk.CommandData {
+		return snyk.CommandData{
 			Title:     snyk.CodeSubmitFixFeedback,
 			CommandId: snyk.CodeSubmitFixFeedback,
 			Arguments: []any{fixId, positive},
 		}
-
-		cmd, err := command.CreateFromCommandData(commandData, nil, nil, nil, nil, nil, b.SnykCode)
-		if err != nil {
-			message := "couldn't create code submit fix feedback command"
-			log.Err(err).Str("method", "autofixFeedbackActions").Msg(message)
-			b.errorReporter.CaptureError(pkgerrors.Wrap(err, message))
-		}
-
-		return cmd, err
 	}
-	actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.Command]()
-	positiveFeedbackCmd, err1 := createCommandData(true)
-	negativeFeedbackCmd, err2 := createCommandData(false)
-	if err1 != nil || err2 != nil {
-		return nil, errors.Join(err1, err2)
-	}
+	actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
+	positiveFeedbackCmd := createCommandData(true)
+	negativeFeedbackCmd := createCommandData(false)
 
 	actionCommandMap.Add("👍", positiveFeedbackCmd)
 	actionCommandMap.Add("👎", negativeFeedbackCmd)

--- a/infrastructure/code/bundle_test.go
+++ b/infrastructure/code/bundle_test.go
@@ -23,7 +23,6 @@ import (
 	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/observability/performance"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/data_structure"
@@ -152,7 +151,7 @@ func Test_AutofixMessages(t *testing.T) {
 		assert.Equal(t, "Congratulations! 🎉 You’ve just fixed this SNYK-123 issue. Was this fix helpful?", successMsgRequest.Message)
 
 		// Compare button action commands
-		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.Command]()
+		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
 		commandData1 := snyk.CommandData{
 			Title:     snyk.CodeSubmitFixFeedback,
 			CommandId: snyk.CodeSubmitFixFeedback,
@@ -163,19 +162,17 @@ func Test_AutofixMessages(t *testing.T) {
 			CommandId: snyk.CodeSubmitFixFeedback,
 			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", false},
 		}
-		cmd1, _ := command.CreateFromCommandData(commandData1, nil, nil, nil, nil, nil, nil)
-		cmd2, _ := command.CreateFromCommandData(commandData2, nil, nil, nil, nil, nil, nil)
 		positiveFeedback := snyk.MessageAction("👍")
 		negativeFeedback := snyk.MessageAction("👎")
-		actionCommandMap.Add(positiveFeedback, cmd1)
-		actionCommandMap.Add(negativeFeedback, cmd2)
+		actionCommandMap.Add(positiveFeedback, commandData1)
+		actionCommandMap.Add(negativeFeedback, commandData2)
 
 		assert.Equal(t, actionCommandMap.Keys(), successMsgRequest.Actions.Keys())
 
 		buttonAction1, _ := successMsgRequest.Actions.Get(positiveFeedback)
 		buttonAction2, _ := successMsgRequest.Actions.Get(negativeFeedback)
-		assert.Equal(t, cmd1.Command(), buttonAction1.Command())
-		assert.Equal(t, cmd2.Command(), buttonAction2.Command())
+		assert.Equal(t, commandData1, buttonAction1)
+		assert.Equal(t, commandData2, buttonAction2)
 	})
 
 	t.Run("Shows error message when no fix available", func(t *testing.T) {

--- a/infrastructure/code/sast_enabled.go
+++ b/infrastructure/code/sast_enabled.go
@@ -17,11 +17,9 @@
 package code
 
 import (
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	sglsp "github.com/sourcegraph/go-lsp"
 
-	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/data_structure"
 )
@@ -45,21 +43,15 @@ func (sc *Scanner) isSastEnabled() bool {
 
 	if !sastResponse.SastEnabled {
 		// this is processed in the listener registered to translate into the right client protocol
-		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.Command]()
+		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
 		commandData := snyk.CommandData{
 			Title:     snyk.OpenBrowserCommand,
 			CommandId: snyk.OpenBrowserCommand,
 			Arguments: []any{getCodeEnablementUrl()},
 		}
-		cmd, err := command.CreateFromCommandData(commandData, nil, nil, sc.learnService, sc.notifier, nil, nil)
-		if err != nil {
-			message := "couldn't create open browser command"
-			log.Err(err).Str("method", method).Msg(message)
-			sc.errorReporter.CaptureError(errors.Wrap(err, message))
-		} else {
-			actionCommandMap.Add(enableSnykCodeMessageActionItemTitle, cmd)
-		}
-		actionCommandMap.Add(closeMessageActionItemTitle, nil)
+
+		actionCommandMap.Add(enableSnykCodeMessageActionItemTitle, commandData)
+		actionCommandMap.Add(closeMessageActionItemTitle, snyk.CommandData{})
 
 		sc.notifier.Send(snyk.ShowMessageRequest{
 			Message: codeDisabledInOrganisationMessageText,

--- a/infrastructure/code/sast_enabled_test.go
+++ b/infrastructure/code/sast_enabled_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/config"
-	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
@@ -152,25 +151,14 @@ func TestIsSastEnabled(t *testing.T) {
 				errorReporter: error_reporting.NewTestErrorReporter(),
 				notifier:      notifier,
 			}
-			actionMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.Command]()
+			actionMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
 
-			data, err := command.CreateFromCommandData(
-				snyk.CommandData{
-					Title:     snyk.OpenBrowserCommand,
-					CommandId: snyk.OpenBrowserCommand,
-					Arguments: []any{getCodeEnablementUrl()},
-				},
-				nil,
-				nil,
-				nil,
-				notifier,
-				nil,
-				nil,
-			)
-			assert.NoError(t, err)
-
-			actionMap.Add(enableSnykCodeMessageActionItemTitle, data)
-			actionMap.Add(closeMessageActionItemTitle, nil)
+			actionMap.Add(enableSnykCodeMessageActionItemTitle, snyk.CommandData{
+				Title:     snyk.OpenBrowserCommand,
+				CommandId: snyk.OpenBrowserCommand,
+				Arguments: []any{getCodeEnablementUrl()},
+			})
+			actionMap.Add(closeMessageActionItemTitle, snyk.CommandData{})
 			expectedShowMessageRequest := snyk.ShowMessageRequest{
 				Message: codeDisabledInOrganisationMessageText,
 				Type:    snyk.Warning,


### PR DESCRIPTION
### Description

Addresses [this comment](https://github.com/snyk/snyk-ls/pull/311#discussion_r1213311622).

Uses value object instead of full dependency to work with ShowMessageRequest.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
