### PR TITLE
fix: autofix payload to pass context

### DIFF
--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -766,7 +766,7 @@ func TestSnykCodeBackendService_analysisRequestBodyIsCorrect(t *testing.T) {
 			Shard:        analysisOpts.shardKey,
 		},
 		Legacy:          false,
-		AnalysisContext: newCodeRequestContext(org),
+		AnalysisContext: newCodeRequestContext(),
 	}
 
 	// act

--- a/infrastructure/code/sarif_types.go
+++ b/infrastructure/code/sarif_types.go
@@ -175,31 +175,3 @@ type run struct {
 	Results    []result      `json:"results"`
 	Properties runProperties `json:"ruleProperties"`
 }
-
-type AnalysisRequestKey struct {
-	Type         string   `json:"type"`
-	Hash         string   `json:"hash"`
-	LimitToFiles []string `json:"limitToFiles,omitempty"`
-	Shard        string   `json:"shard"`
-}
-
-type codeRequestContextOrg struct {
-	Name        string          `json:"name"`
-	DisplayName string          `json:"displayName"`
-	PublicId    string          `json:"publicId"`
-	Flags       map[string]bool `json:"flags"`
-}
-
-type codeRequestContext struct {
-	Initiator string                `json:"initiator"`
-	Flow      string                `json:"flow,omitempty"`
-	Org       codeRequestContextOrg `json:"org,omitempty"`
-}
-
-type AnalysisRequest struct {
-	Key             AnalysisRequestKey `json:"key"`
-	Severity        int                `json:"severity,omitempty"`
-	Prioritized     bool               `json:"prioritized,omitempty"`
-	Legacy          bool               `json:"legacy"`
-	AnalysisContext codeRequestContext `json:"analysisContext"`
-}

--- a/infrastructure/code/sarif_utils.go
+++ b/infrastructure/code/sarif_utils.go
@@ -16,8 +16,15 @@
 
 package code
 
-func newCodeRequestContext(orgName string) codeRequestContext {
+import "github.com/snyk/snyk-ls/application/config"
+
+func newCodeRequestContext() codeRequestContext {
 	unknown := "unknown"
+	orgName := unknown
+	if config.CurrentConfig().Organization() != "" {
+		orgName = config.CurrentConfig().Organization()
+	}
+
 	return codeRequestContext{
 		Initiator: "IDE",
 		Flow:      "language-server",

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -26,6 +26,34 @@ type SnykAnalysisFailedError struct {
 
 func (e SnykAnalysisFailedError) Error() string { return e.Msg }
 
+type AnalysisRequestKey struct {
+	Type         string   `json:"type"`
+	Hash         string   `json:"hash"`
+	LimitToFiles []string `json:"limitToFiles,omitempty"`
+	Shard        string   `json:"shard"`
+}
+
+type codeRequestContextOrg struct {
+	Name        string          `json:"name"`
+	DisplayName string          `json:"displayName"`
+	PublicId    string          `json:"publicId"`
+	Flags       map[string]bool `json:"flags"`
+}
+
+type codeRequestContext struct {
+	Initiator string                `json:"initiator"`
+	Flow      string                `json:"flow,omitempty"`
+	Org       codeRequestContextOrg `json:"org,omitempty"`
+}
+
+type AnalysisRequest struct {
+	Key             AnalysisRequestKey `json:"key"`
+	Severity        int                `json:"severity,omitempty"`
+	Prioritized     bool               `json:"prioritized,omitempty"`
+	Legacy          bool               `json:"legacy"`
+	AnalysisContext codeRequestContext `json:"analysisContext"`
+}
+
 // AutofixResponse is the json-based structure to which we can translate the results of the HTTP
 // request to Autofix upstream.
 type AutofixResponse struct {
@@ -50,8 +78,8 @@ type AutofixRequestKey struct {
 }
 
 type AutofixRequest struct {
-	Key            AutofixRequestKey  `json:"key"`
-	AutofixContext codeRequestContext `json:"autofixContext"`
+	Key             AutofixRequestKey  `json:"key"`
+	AnalysisContext codeRequestContext `json:"analysisContext"`
 }
 
 // Should implement `error` interface
@@ -68,6 +96,7 @@ type AutofixSuggestion struct {
 }
 
 type AutofixFeedback struct {
-	FixId    string `json:"fixId"`
-	Feedback string `json:"feedback"`
+	FixId           string             `json:"fixId"`
+	Feedback        string             `json:"feedback"`
+	AnalysisContext codeRequestContext `json:"analysisContext"`
 }


### PR DESCRIPTION
### Description

Ensures we pass context in the payload when issuing Autofix or submitting feedback. Backend [expects](https://github.com/snyk/sast-analysis-api/blob/ac24c806120be337bac94f77018343e785b8ca9a/src/controllers/autofix.ts#L75) the attribute to be named "analysisContext", not "autofixContext".

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
