### PR TITLE
fix: removed partial encoding from x-snyk-ide header

### DIFF
--- a/infrastructure/snyk_api/snyk_api.go
+++ b/infrastructure/snyk_api/snyk_api.go
@@ -18,7 +18,6 @@ package snyk_api
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"

--- a/infrastructure/snyk_api/snyk_api.go
+++ b/infrastructure/snyk_api/snyk_api.go
@@ -114,8 +114,7 @@ func (s *SnykApiClientImpl) doCall(method string,
 		return nil, NewSnykApiError(requestErr.Error(), 0)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	clientID := base64.URLEncoding.EncodeToString([]byte(config.Version))
-	req.Header.Set("x-snyk-ide", "snyk-ls-"+clientID)
+	req.Header.Set("x-snyk-ide", "snyk-ls-"+config.Version)
 
 	log.Trace().Str("requestBody", string(requestBody)).Msg("SEND TO REMOTE")
 	response, err := s.httpClientFunc().Do(req)


### PR DESCRIPTION
### Description

_This PR should remove the base64 encoding when sending the `x-snyk-ide` header_
