### PR TITLE
feat: update files that use old security-rules URLs

### DIFF
--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -439,7 +439,7 @@ func newIacCommand(codeActionTitle string, issueURL *url.URL) *snyk.CommandData 
 }
 
 func (iac *Scanner) createIssueURL(id string) *url.URL {
-	parse, err := url.Parse("https://snyk.io/security-rules/" + id)
+	parse, err := url.Parse("https://security.snyk.io/rules/cloud/" + id)
 	if err != nil {
 		iac.errorReporter.CaptureError(errors.Wrap(err, "unable to create issue link for iac issue "+id))
 	}

--- a/infrastructure/iac/iac_test.go
+++ b/infrastructure/iac/iac_test.go
@@ -158,7 +158,7 @@ func Test_createIssueDataForCustomUI_SuccessfullyParses(t *testing.T) {
 		Title:    sampleIssue.Title,
 		PublicId: sampleIssue.PublicID,
 		// Documentation is a URL which is constructed from the PublicID
-		Documentation: "https://snyk.io/security-rules/PublicID",
+		Documentation: "https://security.snyk.io/rules/cloud/PublicID",
 		LineNumber:    sampleIssue.LineNumber,
 		Issue:         sampleIssue.IacDescription.Issue,
 		Impact:        sampleIssue.IacDescription.Impact,

--- a/infrastructure/iac/testdata/RBAC-iac-result.json
+++ b/infrastructure/iac/testdata/RBAC-iac-result.json
@@ -46,7 +46,7 @@
         "resolve": "Set only the necessary permissions required"
       },
       "lineNumber": 7,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-44",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-44",
       "isGeneratedByCustomRule": false,
       "path": [
         "[DocId: 1]",
@@ -78,7 +78,7 @@
         "resolve": "Set only the necessary permissions required"
       },
       "lineNumber": 7,
-      "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-44",
+      "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-K8S-44",
       "isGeneratedByCustomRule": false,
       "path": [
         "[DocId: 1]",


### PR DESCRIPTION
### What this does

This is part of cloud rules migration project
Update files that use old security-rules URLs
[IaC](https://snyk.io/security-rules/) and [Cloud rules](https://snyk.io/security-rules/cloud/) urls will be pointed to [security.snyk.io/XXXXXXX](http://security.snyk.io/XXXXXXX).

This PR will be merged after redirecting all env (dev and prod) with Akamai

Based on [spike ticket ](https://snyksec.atlassian.net/jira/software/c/projects/APOLLO11/boards/311?modal=detail&selectedIssue=APOLLO11-1142).

### Missed anything?
- [ ] [Observability](https://www.notion.so/snyk/Monitoring-bb8ed62f7f6541d1963f1be0410d0469) (logs, metrics, alerts, events)
- [ ] [Audit Logs](https://www.notion.so/snyk/Audit-logs-6c41fa22931c45d8b6db6bbeaa954e66) is a valuable way for customers to keep track of their Snyk instance(s)
- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] [Tests written](https://www.notion.so/snyk/Testing-at-Snyk-1f1b6c533ba545dcbfc32a0f93808d15)
- [ ] Security aspects considered? Unhappy paths?
- [ ] For front end changes, have you accounted for accessibility?
- [ ] Have you reviewed the [DB migration guide](https://www.notion.so/snyk/Registry-DB-Migrations-The-How-When-And-Problems-8501fc9b4c8a4cbb8bafbd06af9672ce)? ([#ask-db-migration-buddies](https://snyk.slack.com/archives/C0140BJUX44))
- [ ] Commit messages and bodies explain what and why, and [follow our format](https://www.notion.so/snyk/Release-Publish-and-Deploy-Process-7a731eb98f0745d0b808ace62f666afb)

### More information

- [Jira ticket APOLLO11-1173](https://snyksec.atlassian.net/browse/APOLLO11-1173)

