### PR TITLE
fix: sentry tracing and update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Thumbs.db
 .DS_Store
 ._*
 webidentity.json
+
+infrastructure/snyk_api/pacts/snykls-snykapi.json
+infrastructure/code/pacts/snykls-snykcodeapi.json

--- a/.snyk
+++ b/.snyk
@@ -4,48 +4,48 @@ version: v1.25.0
 ignore:
   'snyk:lic:golang:github.com:hashicorp:go-uuid:MPL-2.0':
     - '*':
-      reason: >-
+    - reason: >-
         https://docs.google.com/spreadsheets/d/1gOS6DzCAb9O9RzJqFaD52y5QRkcA5XGgiaOJeQEZ-Ao/edit#gid=0
-      expires: 2099-07-21T16:46:25.562Z
-      created: 2023-03-22T16:46:25.566Z
+    - expires: 2099-07-21T16:46:25.562Z
+    - created: 2023-03-22T16:46:25.566Z
   'snyk:lic:golang:github.com:hashicorp:hcl:MPL-2.0':
     - '*':
-      reason: >-
+    - reason: >-
         https://docs.google.com/spreadsheets/d/1gOS6DzCAb9O9RzJqFaD52y5QRkcA5XGgiaOJeQEZ-Ao/edit#gid=0
-      expires: 2099-07-21T16:46:25.562Z
-      created: 2023-03-22T16:46:25.566Z
+    - expires: 2099-07-21T16:46:25.562Z
+    - created: 2023-03-22T16:46:25.566Z
   'snyk:lic:golang:github.com:hashicorp:go-version:MPL-2.0':
     - '*':
-      reason: >-
+    - reason: >-
         https://docs.google.com/spreadsheets/d/1gOS6DzCAb9O9RzJqFaD52y5QRkcA5XGgiaOJeQEZ-Ao/edit#gid=0
-      expires: 2099-07-21T16:46:25.562Z
-      created: 2022-06-21T16:46:25.566Z
+    - expires: 2099-07-21T16:46:25.562Z
+    - created: 2022-06-21T16:46:25.566Z
   'snyk:lic:golang:github.com:hashicorp:logutils:MPL-2.0':
     - '*':
-      reason: >-
+    - reason: >-
         https://docs.google.com/spreadsheets/d/1gOS6DzCAb9O9RzJqFaD52y5QRkcA5XGgiaOJeQEZ-Ao/edit#gid=0
-      expires: 2099-07-21T16:46:25.562Z
-      created: 2022-06-21T16:46:25.566Z
+    - expires: 2099-07-21T16:46:25.562Z
+    - created: 2022-06-21T16:46:25.566Z
   'snyk:lic:golang:golang.design:x:clipboard:GPL-3.0':
     - '*':
-      reason: False positive, package uses MIT license
-      expires: 2099-07-21T16:46:25.562Z
-      created: 2022-06-21T16:46:25.566Z
+    - reason: 'False positive, package uses MIT license'
+    - expires: 2099-07-21T16:46:25.562Z
+    - created: 2022-06-21T16:46:25.566Z
   SNYK-CC-K8S-44:
-    - 'infrastructure/iac/testdata/RBAC-copy.yaml > [DocId: 1] > clusterrole > rules[0] > verbs':
-      reason: Test data
-      expires: 2099-08-18T11:28:11.797Z
-      created: 2022-07-19T11:28:11.800Z
-    - 'infrastructure/iac/testdata/RBAC-copy.yaml > [DocId: 1] > clusterrole > rules[0] > resources':
-      reason: Test data
-      expires: 2099-08-18T11:29:16.008Z
-      created: 2022-07-19T11:29:16.011Z
-    - 'infrastructure/iac/testdata/RBAC.yaml > [DocId: 1] > clusterrole > rules[0] > verbs':
-      reason: Test data
-      expires: 2099-08-18T11:29:20.184Z
-      created: 2022-07-19T11:29:20.187Z
-    - 'infrastructure/iac/testdata/RBAC.yaml > [DocId: 1] > clusterrole > rules[0] > resources':
-      reason: Test data
-      expires: 2099-08-18T11:29:24.503Z
-      created: 2022-07-19T11:29:24.505Z
+    - 'infrastructure/iac/testdata/RBAC-copy.yaml > [DocId: 1] > rules[0] > verbs':
+        reason: None Given
+        expires: 2099-07-13T13:34:42.506Z
+        created: 2023-06-13T13:34:42.511Z
+    - 'infrastructure/iac/testdata/RBAC-copy.yaml > [DocId: 1] > rules[0] > resources':
+        reason: None Given
+        expires: 2099-07-13T13:35:19.396Z
+        created: 2023-06-13T13:35:19.401Z
+    - 'infrastructure/iac/testdata/RBAC.yaml > [DocId: 1] > rules[0] > verbs':
+        reason: None Given
+        expires: 2099-07-13T13:35:55.757Z
+        created: 2023-06-13T13:35:55.761Z
+    - 'infrastructure/iac/testdata/RBAC.yaml > [DocId: 1] > rules[0] > resources':
+        reason: None Given
+        expires: 2099-07-13T13:36:28.381Z
+        created: 2023-06-13T13:36:28.385Z
 patch: {}

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448
+	github.com/snyk/go-application-framework v0.0.0-20230614130554-b66a702d7528
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/stretchr/testify v1.8.2
 	github.com/subosito/gotenv v1.4.2
@@ -40,7 +40,7 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 // indirect
+	github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -354,10 +354,10 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448 h1:jZhlN2gNmhOjNQdE0SwHnNaNZki1557ZT/azuMnS664=
-github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448/go.mod h1:QMdFROeuG06UULLD2hzN/P9RlKE6Ma6eskMwAqVOMkM=
-github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 h1:CsLoEIHxq4i3d9di8RoN3J3D1/oK20oroEZUGShor0o=
-github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
+github.com/snyk/go-application-framework v0.0.0-20230614130554-b66a702d7528 h1:9D2zvqLKRRzou7evXRBgZn+uhE8qFRLXrihLMxzPMHY=
+github.com/snyk/go-application-framework v0.0.0-20230614130554-b66a702d7528/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
+github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb h1:UwbUBfe1u5MYLhtCNOsFEM98tfEUWqgmaXam/UxU88Q=
+github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d h1:afLbh+ltiygTOB37ymZVwKlJwWZn+86syPTbrrOAydY=
 github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=

--- a/infrastructure/sentry/init.go
+++ b/infrastructure/sentry/init.go
@@ -39,7 +39,10 @@ func initializeSentry() {
 		Release:          config.Version,
 		Debug:            config.IsDevelopment(),
 		BeforeSend:       beforeSend,
+		EnableTracing:    true,
 		TracesSampleRate: 1,
+		HTTPClient:       config.CurrentConfig().Engine().GetNetworkAccess().GetUnauthorizedHttpClient(),
+		AttachStacktrace: true,
 	})
 	if err != nil {
 		log.Error().Str("method", "Initialize").Msg(err.Error())


### PR DESCRIPTION
### Description

Updated dependencies
 - new go application framework supporting the new user agent
 - update rest of dependencies to latest

Fixed Tracing/RequestID
 - Sentry tracing should now work much better (we didn't explicitly enable it previously)
 - RequestIDs should stay the same across calls, as Sentry is not dropping the transaction anymore

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
