### PR TITLE
chore: disable sentry performance measurements

### DIFF
--- a/application/di/init.go
+++ b/application/di/init.go
@@ -122,7 +122,7 @@ func initInfrastructure() {
 	errorReporter = sentry.NewSentryErrorReporter(notifier)
 	installer = install.NewInstaller(errorReporter, networkAccess.GetUnauthorizedHttpClient)
 	learnService = learn.New(c, networkAccess.GetUnauthorizedHttpClient, errorReporter)
-	instrumentor = sentry.NewInstrumentor()
+	instrumentor = performance.NewLocalInstrumentor()
 	snykApiClient = snyk_api.NewSnykApiClient(networkAccess.GetHttpClient)
 	analytics = amplitude.NewAmplitudeClient(snyk.AuthenticationCheck, errorReporter)
 	authProvider := cliauth.NewCliAuthenticationProvider(errorReporter)
@@ -225,10 +225,4 @@ func LearnService() learn.Service {
 	initMutex.Lock()
 	defer initMutex.Unlock()
 	return learnService
-}
-
-func SnykCodeClient() code.SnykCodeClient {
-	initMutex.Lock()
-	defer initMutex.Unlock()
-	return snykCodeClient
 }

--- a/application/di/test_init.go
+++ b/application/di/test_init.go
@@ -54,7 +54,7 @@ func TestInit(t *testing.T) {
 	snyk.DefaultOpenBrowserFunc = func(url string) {}
 	notifier = domainNotify.NewNotifier()
 	analytics = ux.NewTestAnalytics()
-	instrumentor = performance.NewTestInstrumentor()
+	instrumentor = performance.NewLocalInstrumentor()
 	errorReporter = er.NewTestErrorReporter()
 	installer = install.NewFakeInstaller()
 	authProvider := snyk.NewFakeCliAuthenticationProvider()

--- a/domain/ide/codelens/codelens_test.go
+++ b/domain/ide/codelens/codelens_test.go
@@ -56,7 +56,7 @@ func Test_GetCodeLensForPath(t *testing.T) {
 
 	filePath, dir := code.TempWorkdirWithVulnerabilities(t)
 	folder := workspace.NewFolder(dir, "dummy", di.Scanner(), di.HoverService(), di.ScanNotifier(), di.Notifier())
-	workspace.Set(workspace.New(performance.NewTestInstrumentor(), di.Scanner(), di.HoverService(), di.ScanNotifier(), di.Notifier()))
+	workspace.Set(workspace.New(performance.NewLocalInstrumentor(), di.Scanner(), di.HoverService(), di.ScanNotifier(), di.Notifier()))
 	workspace.Get().AddFolder(folder)
 	folder.ScanFile(context.Background(), filePath)
 

--- a/domain/ide/command/logout_test.go
+++ b/domain/ide/command/logout_test.go
@@ -53,7 +53,7 @@ func TestLogoutCommand_Execute_ClearsIssues(t *testing.T) {
 	scanner := snyk.NewTestScanner()
 	scanner.Issues = []snyk.Issue{{ID: "issue-1"}}
 
-	w := workspace.New(performance.NewTestInstrumentor(), scanner, hoverService, scanNotifier, notifier)
+	w := workspace.New(performance.NewLocalInstrumentor(), scanner, hoverService, scanNotifier, notifier)
 	folder := workspace.NewFolder(
 		t.TempDir(),
 		t.Name(),

--- a/domain/ide/workspace/workspace_test.go
+++ b/domain/ide/workspace/workspace_test.go
@@ -39,7 +39,7 @@ func Test_GetFolderTrust_shouldReturnTrustedAndUntrustedFolders(t *testing.T) {
 	scanner := &snyk.TestScanner{}
 	scanNotifier := snyk.NewMockScanNotifier()
 	notifier := notification.NewNotifier()
-	w := New(performance.NewTestInstrumentor(), scanner, nil, nil, notifier)
+	w := New(performance.NewLocalInstrumentor(), scanner, nil, nil, notifier)
 	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
 	config.CurrentConfig().SetTrustedFolders([]string{trustedDummy})
 	w.AddFolder(NewFolder(trustedDummy, trustedDummy, scanner, nil, scanNotifier, notifier))
@@ -58,7 +58,7 @@ func Test_TrustFoldersAndScan_shouldAddFoldersToTrustedFoldersAndTriggerScan(t *
 	scanner := &snyk.TestScanner{}
 	scanNotifier := snyk.NewMockScanNotifier()
 	notifier := notification.NewNotifier()
-	w := New(performance.NewTestInstrumentor(), scanner, nil, nil, notifier)
+	w := New(performance.NewLocalInstrumentor(), scanner, nil, nil, notifier)
 	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
 	trustedFolder := NewFolder(trustedDummy, trustedDummy, scanner, nil, scanNotifier, notifier)
 	w.AddFolder(trustedFolder)
@@ -84,7 +84,7 @@ func Test_AddAndRemoveFoldersAndTriggerScan(t *testing.T) {
 
 	scanner := &snyk.TestScanner{}
 	scanNotifier := snyk.NewMockScanNotifier()
-	w := New(performance.NewTestInstrumentor(), scanner, nil, scanNotifier, notification.NewNotifier())
+	w := New(performance.NewLocalInstrumentor(), scanner, nil, scanNotifier, notification.NewNotifier())
 	toBeRemovedFolder := NewFolder(toBeRemovedAbsolutePathAfterConversions, toBeRemoved, scanner, nil, scanNotifier, notification.NewNotifier())
 	w.AddFolder(toBeRemovedFolder)
 

--- a/domain/snyk/auth_service_impl_test.go
+++ b/domain/snyk/auth_service_impl_test.go
@@ -123,7 +123,7 @@ func Test_Logout(t *testing.T) {
 	hoverService := hover.NewFakeHoverService()
 	scanner := snyk.NewTestScanner()
 	scanNotifier, _ := appNotification.NewScanNotifier(notifier)
-	w := workspace.New(performance.NewTestInstrumentor(), scanner, hoverService, scanNotifier, notifier)
+	w := workspace.New(performance.NewLocalInstrumentor(), scanner, hoverService, scanNotifier, notifier)
 	workspace.Set(w)
 	f := workspace.NewFolder("", "", scanner, hoverService, scanNotifier, notifier)
 	w.AddFolder(f)

--- a/domain/snyk/scanner_test.go
+++ b/domain/snyk/scanner_test.go
@@ -68,7 +68,7 @@ func setupScanner(testProductScanners ...ProductScanner) (
 	authenticationService := NewAuthenticationService(authenticationProvider, analytics, er, notifier)
 	scanner = NewDelegatingScanner(
 		initialize.NewDelegatingInitializer(),
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		analytics,
 		scanNotifier,
 		apiClient,

--- a/infrastructure/code/backend_service_pact_test.go
+++ b/infrastructure/code/backend_service_pact_test.go
@@ -264,7 +264,7 @@ func setupPact(t *testing.T) {
 	config.CurrentConfig().UpdateApiEndpoints("http://localhost")
 	config.CurrentConfig().SetOrganization(orgUUID)
 
-	client = NewHTTPRepository(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), func() *http.Client { return http.DefaultClient })
+	client = NewHTTPRepository(performance.NewLocalInstrumentor(), error_reporting.NewTestErrorReporter(), func() *http.Client { return http.DefaultClient })
 }
 
 func getPutPostHeaderMatcher() dsl.MapMatcher {

--- a/infrastructure/code/backend_service_test.go
+++ b/infrastructure/code/backend_service_test.go
@@ -62,7 +62,7 @@ func clientFunc() *http.Client {
 func TestSnykCodeBackendService_CreateBundle(t *testing.T) {
 	testutil.SmokeTest(t)
 
-	s := NewHTTPRepository(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), clientFunc)
+	s := NewHTTPRepository(performance.NewLocalInstrumentor(), error_reporting.NewTestErrorReporter(), clientFunc)
 	files := map[string]string{}
 	randomAddition := fmt.Sprintf("\n public void random() { System.out.println(\"%d\") }", time.Now().UnixMicro())
 	files[path1] = util.Hash([]byte(content + randomAddition))
@@ -74,7 +74,7 @@ func TestSnykCodeBackendService_CreateBundle(t *testing.T) {
 
 func TestSnykCodeBackendService_ExtendBundle(t *testing.T) {
 	testutil.SmokeTest(t)
-	s := NewHTTPRepository(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), clientFunc)
+	s := NewHTTPRepository(performance.NewLocalInstrumentor(), error_reporting.NewTestErrorReporter(), clientFunc)
 	var removedFiles []string
 	files := map[string]string{}
 	files[path1] = util.Hash([]byte(content))
@@ -124,7 +124,7 @@ func TestSnykCodeBackendService_doCall_shouldRetry(t *testing.T) {
 			Transport: d,
 		}
 	}
-	s := NewHTTPRepository(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), dummyClientFunc)
+	s := NewHTTPRepository(performance.NewLocalInstrumentor(), error_reporting.NewTestErrorReporter(), dummyClientFunc)
 	_, err := s.doCall(context.Background(), "GET", "https://httpstat.us/500", nil)
 	assert.Error(t, err)
 	assert.Equal(t, 3, d.calls)
@@ -134,7 +134,7 @@ func TestSnykCodeBackendService_RunAnalysisSmoke(t *testing.T) {
 	testutil.SmokeTest(t)
 	config.CurrentConfig().SetSnykCodeEnabled(true)
 
-	s := NewHTTPRepository(performance.NewTestInstrumentor(), error_reporting.NewTestErrorReporter(), clientFunc)
+	s := NewHTTPRepository(performance.NewLocalInstrumentor(), error_reporting.NewTestErrorReporter(), clientFunc)
 	shardKey := util.Hash([]byte("/"))
 	var removedFiles []string
 	files := map[string]string{}

--- a/infrastructure/code/bundle_test.go
+++ b/infrastructure/code/bundle_test.go
@@ -120,7 +120,7 @@ func Test_AutofixMessages(t *testing.T) {
 	bundle := Bundle{
 		SnykCode:     &fakeSnykCode,
 		notifier:     mockNotifier,
-		instrumentor: performance.NewTestInstrumentor(),
+		instrumentor: performance.NewLocalInstrumentor(),
 	}
 
 	t.Run("Shows attempt message when fix requested", func(t *testing.T) {

--- a/infrastructure/code/bundle_uploader_test.go
+++ b/infrastructure/code/bundle_uploader_test.go
@@ -38,7 +38,7 @@ func Test_Bundler_Upload(t *testing.T) {
 
 	t.Run("adds files to bundle", func(t *testing.T) {
 		snykCodeService := &FakeSnykCodeClient{}
-		var bundleUploader = BundleUploader{SnykCode: snykCodeService, instrumentor: performance.NewTestInstrumentor()}
+		var bundleUploader = BundleUploader{SnykCode: snykCodeService, instrumentor: performance.NewLocalInstrumentor()}
 		documentURI, bundleFile := createTempFileInDir("bundleDoc.java", 10, temporaryDir, t)
 		bundleFileMap := map[string]BundleFile{}
 		bundleFileMap[documentURI] = bundleFile
@@ -53,7 +53,7 @@ func Test_Bundler_Upload(t *testing.T) {
 
 	t.Run("when loads of files breaks down in 4MB bundles", func(t *testing.T) {
 		snykCodeService := &FakeSnykCodeClient{}
-		var bundler = BundleUploader{SnykCode: snykCodeService, instrumentor: performance.NewTestInstrumentor()}
+		var bundler = BundleUploader{SnykCode: snykCodeService, instrumentor: performance.NewLocalInstrumentor()}
 
 		bundleFileMap := map[string]BundleFile{}
 		var missingFiles []string
@@ -92,7 +92,7 @@ func createTempFileInDir(name string, size int, temporaryDir string, t *testing.
 func Test_IsSupportedLanguage(t *testing.T) {
 	const unsupportedFile = "C:\\some\\path\\Test.rs"
 	snykCodeMock := &FakeSnykCodeClient{}
-	bundler := NewBundler(snykCodeMock, performance.NewTestInstrumentor())
+	bundler := NewBundler(snykCodeMock, performance.NewLocalInstrumentor())
 
 	t.Run("should return true for supported languages", func(t *testing.T) {
 		path := "C:\\some\\path\\Test.java"
@@ -128,7 +128,7 @@ func Test_IsSupported_ConfigFile(t *testing.T) {
 	snykCodeMock := &FakeSnykCodeClient{
 		ConfigFiles: configFilesFromFiltersEndpoint,
 	}
-	bundler := NewBundler(snykCodeMock, performance.NewTestInstrumentor())
+	bundler := NewBundler(snykCodeMock, performance.NewLocalInstrumentor())
 	dir, _ := os.Getwd()
 
 	t.Run("should return true for supported config files", func(t *testing.T) {

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -169,7 +169,7 @@ func TestCreateBundle(t *testing.T) {
 			ConfigFiles: []string{configFile},
 		}
 		scanner := New(
-			NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+			NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 			&snyk_api.FakeApiClient{CodeEnabled: true},
 			error_reporting.NewTestErrorReporter(),
 			ux2.NewTestAnalytics(),
@@ -254,7 +254,7 @@ func setupTestScanner(t *testing.T) (*FakeSnykCodeClient, *Scanner) {
 		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&learn.Lesson{}, nil).AnyTimes()
 	scanner := New(
-		NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+		NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 		&snyk_api.FakeApiClient{CodeEnabled: true},
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
@@ -276,7 +276,7 @@ func TestUploadAndAnalyze(t *testing.T) {
 			testutil.UnitTest(t)
 			snykCodeMock := &FakeSnykCodeClient{}
 			c := New(
-				NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+				NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				ux2.NewTestAnalytics(),
@@ -306,7 +306,7 @@ func TestUploadAndAnalyze(t *testing.T) {
 			testutil.UnitTest(t)
 			snykCodeMock := &FakeSnykCodeClient{}
 			c := New(
-				NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+				NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				ux2.NewTestAnalytics(),
@@ -343,7 +343,7 @@ func TestUploadAndAnalyze(t *testing.T) {
 			snykCodeMock := &FakeSnykCodeClient{}
 			analytics := ux2.NewTestAnalytics()
 			c := New(
-				NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+				NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,
@@ -514,7 +514,7 @@ func Test_Scan(t *testing.T) {
 		testutil.UnitTest(t)
 		snykCodeMock := &FakeSnykCodeClient{}
 		c := New(
-			NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+			NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 			&snyk_api.FakeApiClient{CodeEnabled: false},
 			error_reporting.NewTestErrorReporter(),
 			ux2.NewTestAnalytics(),
@@ -628,7 +628,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 			snykCodeMock := &FakeSnykCodeClient{}
 			analytics := ux2.NewTestAnalytics()
 			c := New(
-				NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+				NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,
@@ -664,7 +664,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 			snykCodeMock := &FakeSnykCodeClient{}
 			analytics := ux2.NewTestAnalytics()
 			c := New(
-				NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+				NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,
@@ -698,7 +698,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 			snykCodeMock := &FakeSnykCodeClient{}
 			analytics := ux2.NewTestAnalytics()
 			c := New(
-				NewBundler(snykCodeMock, performance.NewTestInstrumentor()),
+				NewBundler(snykCodeMock, performance.NewLocalInstrumentor()),
 				&snyk_api.FakeApiClient{CodeEnabled: true},
 				error_reporting.NewTestErrorReporter(),
 				analytics,

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -44,7 +44,7 @@ import (
 // todo test issue parsing & conversion
 
 func Test_determineTargetFile(t *testing.T) {
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),
@@ -65,7 +65,7 @@ func Test_SuccessfulScanFile_TracksAnalytics(t *testing.T) {
 	p, _ := filepath.Abs(workingDir + "/testdata/package.json")
 
 	scanner := New(
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		analytics,
 		executor,
@@ -83,7 +83,7 @@ func Test_SuccessfulScanFile_TracksAnalytics(t *testing.T) {
 
 func Test_FindRange(t *testing.T) {
 	scanner := New(
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),
@@ -144,7 +144,7 @@ func Test_introducingPackageAndVersionJava(t *testing.T) {
 
 func Test_ContextCanceled_Scan_DoesNotScan(t *testing.T) {
 	cliMock := cli.NewTestExecutor()
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cliMock,
@@ -177,7 +177,7 @@ func mavenTestIssue() ossIssue {
 }
 
 func TestUnmarshalOssJsonSingle(t *testing.T) {
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),
@@ -200,7 +200,7 @@ func TestUnmarshalOssJsonSingle(t *testing.T) {
 }
 
 func TestUnmarshalOssJsonArray(t *testing.T) {
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),
@@ -223,7 +223,7 @@ func TestUnmarshalOssJsonArray(t *testing.T) {
 }
 
 func TestUnmarshalOssErroneousJson(t *testing.T) {
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),
@@ -280,7 +280,7 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 	folderPath := workingDir
 	fakeCli := cli.NewTestExecutor()
 	fakeCli.ExecuteDuration = time.Second
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		fakeCli,
@@ -325,7 +325,7 @@ func sampleIssue() ossIssue {
 
 func Test_prepareScanCommand_ExpandsAdditionalParameters(t *testing.T) {
 	testutil.UnitTest(t)
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),
@@ -348,7 +348,7 @@ func Test_Scan_SchedulesNewScan(t *testing.T) {
 	workingDir, _ := os.Getwd()
 	fakeCli := cli.NewTestExecutorWithResponseFromFile(path.Join(workingDir, "testdata/oss-result.json"))
 	fakeCli.ExecuteDuration = time.Millisecond
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		fakeCli,
@@ -375,7 +375,7 @@ func Test_scheduleNewScan_CapturesAnalytics(t *testing.T) {
 	fakeCli := cli.NewTestExecutor()
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		analytics,
 		fakeCli,
@@ -411,7 +411,7 @@ func Test_scheduleNewScanWithProductDisabled_NoScanRun(t *testing.T) {
 	fakeCli.ExecuteDuration = time.Millisecond
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		analytics,
 		fakeCli,
@@ -441,7 +441,7 @@ func Test_scheduleNewScanTwice_RunsOnlyOnce(t *testing.T) {
 	fakeCli.ExecuteDuration = time.Millisecond
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		analytics,
 		fakeCli,
@@ -473,7 +473,7 @@ func Test_scheduleNewScan_ContextCancelledAfterScanScheduled_NoScanRun(t *testin
 	fakeCli.ExecuteDuration = time.Millisecond
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		analytics,
 		fakeCli,
@@ -505,7 +505,7 @@ func Test_Scan_missingDisplayTargetFileDoesNotBreakAnalysis(t *testing.T) {
 		"testdata/oss-result-without-targetFile.json"))
 	fakeCli.ExecuteDuration = time.Millisecond
 	scanner := New(
-		performance.NewTestInstrumentor(),
+		performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		fakeCli,

--- a/infrastructure/oss/vulnerability_count_test.go
+++ b/infrastructure/oss/vulnerability_count_test.go
@@ -150,7 +150,7 @@ func TestVulnerabilityCountImpl_ProcessVulnerabilityCount_GroupByRange(t *testin
 
 func TestScanner_toInlineValueAndAddToCache_shouldAddInlineValueToCache(t *testing.T) {
 	testutil.UnitTest(t)
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),
@@ -174,7 +174,7 @@ func TestScanner_toInlineValueAndAddToCache_shouldAddInlineValueToCache(t *testi
 
 func TestScanner_addVulnerabilityCountsAsInlineValuesToCache(t *testing.T) {
 	testutil.UnitTest(t)
-	scanner := New(performance.NewTestInstrumentor(),
+	scanner := New(performance.NewLocalInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
 		ux2.NewTestAnalytics(),
 		cli.NewTestExecutor(),


### PR DESCRIPTION
### Description

Substitutes the sentry instrumentor with a local one. Renamed the one used for testing, which only works locally, to localInstrumentor.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
