### PR TITLE
chore: configures secret scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+orbs:
+  prodsec: snyk/prodsec-orb@1.0
+
+workflows:
+  version: 2
+  CICD:
+    jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: hammerhead-alerts

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,10 @@
+# add false positives here
+
+4634a347642138f0d0ce4913412de1ef452967cb:infrastructure/code/pacts/snykls-snykcodeapi.json:generic-api-key:72
+4c6048fb0de0ca6dd305cd1233299fbff4e91676:infrastructure/code/pacts/snykls-snykcodeapi.json:generic-api-key:18
+4c6048fb0de0ca6dd305cd1233299fbff4e91676:infrastructure/code/pacts/snykls-snykcodeapi.json:generic-api-key:72
+4c6048fb0de0ca6dd305cd1233299fbff4e91676:infrastructure/code/pacts/snykls-snykcodeapi.json:generic-api-key:130
+
+# file no longer exists
+96052e30cc5493da444d729b55f32d6a3b2915a4:internal/observability/infrastructure/segment/keys.go:generic-api-key:4
+96052e30cc5493da444d729b55f32d6a3b2915a4:internal/observability/infrastructure/segment/keys.go:generic-api-key:5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

This PR adds secrets scanning to the repository. Developers should use the provided pre-commit hooks to prevent the secrets from being pushed to the repository. See https://pre-commit.com/ for details.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
