### PR TITLE
fix: incorrect iac scan status when an error occured.

### DIFF
--- a/infrastructure/iac/iac_test.go
+++ b/infrastructure/iac/iac_test.go
@@ -56,8 +56,10 @@ func Test_SuccessfulScanFile_TracksAnalytics(t *testing.T) {
 	analytics := ux2.NewTestAnalytics()
 	scanner := New(performance.NewLocalInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, cli.NewTestExecutor())
 
-	_, _ = scanner.Scan(context.Background(), "fake.yml", "")
+	issues, err := scanner.Scan(context.Background(), "fake.yml", "")
 
+	assert.Nil(t, err)
+	assert.Len(t, issues, 0)
 	assert.Len(t, analytics.GetAnalytics(), 1)
 	assert.Equal(t, ux2.AnalysisIsReadyProperties{
 		AnalysisType: ux2.InfrastructureAsCode,
@@ -72,8 +74,10 @@ func Test_ErroredWorkspaceScan_TracksAnalytics(t *testing.T) {
 	scanner := New(performance.NewLocalInstrumentor(), error_reporting.NewTestErrorReporter(), analytics, executor)
 
 	executor.ExecuteResponse = []byte("invalid JSON")
-	_, _ = scanner.Scan(context.Background(), "fake.yml", "")
+	issues, err := scanner.Scan(context.Background(), "fake.yml", "")
 
+	assert.NotNil(t, err)
+	assert.Len(t, issues, 0)
 	assert.Len(t, analytics.GetAnalytics(), 1)
 	assert.Equal(t, ux2.AnalysisIsReadyProperties{
 		AnalysisType: ux2.InfrastructureAsCode,
@@ -145,7 +149,7 @@ func Test_retrieveIssues_IgnoresParsingErrors(t *testing.T) {
 			},
 		},
 	}
-	issues, err := scanner.retrieveIssues(results, []snyk.Issue{}, "", nil)
+	issues, err := scanner.retrieveIssues(results, []snyk.Issue{}, "")
 
 	assert.NoError(t, err)
 	assert.Len(t, issues, 1)


### PR DESCRIPTION
### Description
Ensure that an IaC scan error causes the scan status to be set to Error instead of Success.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

![iac_error_tree_view](https://github.com/snyk/snyk-ls/assets/101886095/a5d41208-8681-4c19-bed6-51598a9a5802)
