### PR TITLE
fix: architecture determination for download script

### DIFF
--- a/getLanguageServer.sh
+++ b/getLanguageServer.sh
@@ -24,7 +24,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 if [[ $ARCH == "x86_64" ]]; then
   ARCH="amd64"
-elif [[ $ARCH == "aarch64" ]]; then
+elif [[ $ARCH == "aarch64" ]] || [[ $ARCH == "arm64" ]]; then
   ARCH="arm64"
 else
   ARCH="386"
@@ -35,6 +35,22 @@ VERSION=$(curl -sSL --compressed https://static.snyk.io/snyk-ls/$PROTOCOL_VERSIO
 DESTINATION="/usr/local/bin/snyk-ls"
 DOWNLOAD_URL="https://static.snyk.io/snyk-ls/$PROTOCOL_VERSION/snyk-ls_${VERSION}_${OS}_${ARCH}"
 
+set +e
+if [[ -f $DESTINATION ]]; then
+  LS_VERSION=$($DESTINATION -v | xargs)
+  echo "Snyk Language Server ($LS_VERSION) is already installed at $DESTINATION"
+  mv -f $DESTINATION "$DESTINATION.$LS_VERSION"
+else
+  touch $DESTINATION
+fi
+
+# shellcheck disable=SC2181
+if [[ $? -gt 0 ]]; then
+  echo "$DESTINATION not writable, using $PWD as destination path"
+  DESTINATION="$PWD/snyk-ls"
+fi
+set -e
+
 echo
 echo "OS: $OS"
 echo "Architecture: $ARCH"
@@ -42,10 +58,10 @@ echo "Protocol Version: $PROTOCOL_VERSION"
 echo "Language Server version: $VERSION"
 echo "Destination Path: $DESTINATION"
 echo
-echo "Downloading from $DOWNLOAD_URL"
+echo "Downloading from $DOWNLOAD_URL and installing to $DESTINATION"
 echo
-curl -Lv --compressed $DOWNLOAD_URL > $DESTINATION
-chmod +x $DESTINATION
+curl -L --compressed "$DOWNLOAD_URL" > "$DESTINATION"
+chmod +x "$DESTINATION"
 echo
 echo "✨🎉 Snyk Language Server $VERSION installed to $DESTINATION."
 


### PR DESCRIPTION
### Description

Previously, the arm64 on mac was not detected correctly. Also, downloads failed if no write access to /usr/local/bin was granted. This PR fixes the arm64 detection and writes to the current working directory, if writing to /usr/local/bin fails

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
