### PR TITLE
Fix: html handling and clearing diagnostics

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -463,10 +463,13 @@ func textDocumentDidSaveHandler() jrpc2.Handler {
 		// todo can we push cache management down?
 		f := workspace.Get().GetFolderContaining(filePath)
 		autoScanEnabled := config.CurrentConfig().IsAutoScanEnabled()
-		if f != nil && autoScanEnabled {
+		if f != nil {
 			f.ClearDiagnosticsFromFile(filePath)
 			di.HoverService().DeleteHover(params.TextDocument.URI)
-			go f.ScanFile(bgCtx, filePath)
+
+			if autoScanEnabled {
+				go f.ScanFile(bgCtx, filePath)
+			}
 		} else {
 			if autoScanEnabled {
 				logger.Warn().Str("documentURI", filePath).Msg("Not scanning, file not part of workspace")

--- a/infrastructure/oss/parser/html_parser.go
+++ b/infrastructure/oss/parser/html_parser.go
@@ -55,7 +55,7 @@ func (h htmlParser) parseDependencies(deps []string, fileContent string) (depend
 	for _, dep := range deps {
 		dependency, err := h.dependencyFromString(dep)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		logger.Trace().Msgf("found dependency: %s", dependency)
 		before, _, found := strings.Cut(fileContent, dep)


### PR DESCRIPTION
### Description
* HTML parser now doesn't exit on the first error but just skips it and continues
* On document save, diagnostics are now also cleared even if autosave is disabled

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

