### PR TITLE
fix: only check snykgov.io domain to check if fedramp

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -864,8 +864,7 @@ func (c *Config) IsFedramp() bool {
 
 	host := strings.ToLower(u.Hostname())
 
-	// fedramp instance should have the format https://*.fedramp*.snykgov.io
-	fedrampInstance := strings.Contains(host, "fedramp")
-	fedrampDomain := strings.HasSuffix(host, ".snykgov.io")
-	return fedrampInstance && fedrampDomain
+	// fedramp instance should have the format https://*.snykgov.io
+	snykgovDomain := strings.HasSuffix(host, ".snykgov.io")
+	return snykgovDomain
 }

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -244,7 +244,7 @@ func Test_ManageBinariesAutomatically(t *testing.T) {
 func Test_IsFedramp(t *testing.T) {
 	t.Run("short hostname", func(t *testing.T) {
 		c := New()
-		c.snykApiUrl = "https://api.snykgov.io"
+		c.snykApiUrl = "https://api.snyk.io"
 		assert.False(t, c.IsFedramp())
 	})
 
@@ -257,7 +257,7 @@ func Test_IsFedramp(t *testing.T) {
 	t.Run("non-fedramp hostname", func(t *testing.T) {
 		c := New()
 		c.snykApiUrl = "https://api.fedddddddddramp.snykgov.io"
-		assert.False(t, c.IsFedramp())
+		assert.True(t, c.IsFedramp())
 	})
 
 }

--- a/infrastructure/amplitude/client_test.go
+++ b/infrastructure/amplitude/client_test.go
@@ -174,7 +174,7 @@ func Test_AnalyticEvents(t *testing.T) {
 func Test_AnalyticEventsNotSentForFedramp(t *testing.T) {
 	s, fakeSegmentClient, c := setupUnitTest(t)
 	c.SetTelemetryEnabled(true)
-	c.UpdateApiEndpoints("https://api.fedramp.snykgov.io")
+	c.UpdateApiEndpoints("https://api.feddramp.snykgov.io")
 
 	s.PluginIsInstalled(ux.PluginIsInstalledProperties{})
 


### PR DESCRIPTION
### Description

Checking for a "fedramp" part in the instance name is most likely not resilient enough, so we decided to only check the domain.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
