### PR TITLE
feat: output protocol version when giving flag `-p`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ e.g. `export SNYK_DEBUG_LEVEL=debug`
 
 `-o <FORMAT>` allows to specify the output format (`md` or `html`) for issues
 
+`-p` outputs the supported Snyk protocol version for feature synchronization between client and server
+
 `-v ` prints the version of the Language Server
 
 ### Configuration

--- a/application/config/automatic_config.go
+++ b/application/config/automatic_config.go
@@ -29,7 +29,7 @@ import (
 func (c *Config) determineJavaHome() {
 	javaHome := os.Getenv("JAVA_HOME")
 	if javaHome != "" {
-		log.Info().Str("method", "determineJavaHome").Msgf("using JAVA_HOME from env %s", javaHome)
+		log.Debug().Str("method", "determineJavaHome").Msgf("using JAVA_HOME from env %s", javaHome)
 		c.updatePath(javaHome + string(os.PathSeparator) + "bin")
 		return
 	}
@@ -41,11 +41,11 @@ func (c *Config) determineJavaHome() {
 	if done {
 		return
 	}
-	log.Info().Str("method", "determineJavaHome").Msgf("detected java binary at %s", path)
+	log.Debug().Str("method", "determineJavaHome").Msgf("detected java binary at %s", path)
 	binDir := filepath.Dir(path)
 	javaHome = filepath.Dir(binDir)
 	c.updatePath(binDir)
-	log.Info().Str("method", "determineJavaHome").Msgf("setting JAVA_HOME to %s", javaHome)
+	log.Debug().Str("method", "determineJavaHome").Msgf("setting JAVA_HOME to %s", javaHome)
 	_ = os.Setenv("JAVA_HOME", javaHome)
 }
 

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -285,9 +285,12 @@ func (c *Config) Load() {
 func (c *Config) loadFile(fileName string) {
 	file, err := os.Open(fileName)
 	if err != nil {
-		log.Info().Str("method", "loadFile").Msg("Couldn't load " + fileName)
 		return
+	} else {
+		// this is done before server start, so no logger config & no problem outputting
+		fmt.Println("loading config file:", fileName)
 	}
+
 	defer func(file *os.File) { _ = file.Close() }(file)
 	env := gotenv.Parse(file)
 	for k, v := range env {
@@ -295,7 +298,7 @@ func (c *Config) loadFile(fileName string) {
 		if !exists {
 			err := os.Setenv(k, v)
 			if err != nil {
-				log.Warn().Str("method", "loadFile").Msg("Couldn't set environment variable " + k)
+				fmt.Println("Couldn't set environment variable ", k)
 			}
 		} else {
 			// add to path, don't ignore additional paths
@@ -305,7 +308,6 @@ func (c *Config) loadFile(fileName string) {
 		}
 	}
 	c.updatePath(".")
-	log.Debug().Str("fileName", fileName).Msg("loaded.")
 }
 
 func (c *Config) NonEmptyToken() bool {

--- a/main.go
+++ b/main.go
@@ -49,8 +49,9 @@ func main() {
 	if output != "" {
 		entrypoint.PrintLicenseText(output)
 	}
-
 	log.Trace().Interface("environment", os.Environ()).Msg("start environment")
+	println("LS Version:", config.Version)
+	println("LS Protocol Version:", config.LsProtocolVersion)
 	server.Start(c)
 	log.Info().Msg("Exiting...")
 }
@@ -61,6 +62,7 @@ func parseFlags(args []string, c *config.Config) (string, error) {
 	flags.SetOutput(&buf)
 
 	versionFlag := flags.Bool("v", false, "prints the version")
+	protocolVersionFlag := flags.Bool("p", false, "prints the Snyk ls protocol version used to sync client and server")
 	logLevelFlag := flags.String("l", "info", "sets the log-level to <trace|debug|info|warn|error|fatal>")
 	logPathFlag := flags.String("f", "", "sets the log file for the language server")
 	formatFlag := flags.String(
@@ -91,6 +93,10 @@ func parseFlags(args []string, c *config.Config) (string, error) {
 
 	if *versionFlag {
 		return buf.String(), fmt.Errorf(config.Version)
+	}
+
+	if *protocolVersionFlag {
+		return buf.String(), fmt.Errorf(config.LsProtocolVersion)
 	}
 
 	if *licensesFlag {

--- a/main_test.go
+++ b/main_test.go
@@ -82,6 +82,14 @@ func Test_shouldReturnErrorWithVersionStringOnFlag(t *testing.T) {
 	assert.Equal(t, config.Version, err.Error())
 }
 
+func Test_shouldReturnErrorWithProtocolVersionStringOnFlag(t *testing.T) {
+	args := []string{"snyk-ls", "-p"}
+	output, err := parseFlags(args, config.New())
+	assert.Error(t, err)
+	assert.Empty(t, output)
+	assert.Equal(t, config.LsProtocolVersion, err.Error())
+}
+
 func Test_shouldSetLoadConfigFromFlag(t *testing.T) {
 	file, err := os.CreateTemp(".", "configFlagTest")
 	if err != nil {


### PR DESCRIPTION
### Description

Adds flag `-p` to output the protocol version supported by the language server.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
