### PR TITLE
fix: display hovers on windows [HEAD-420]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+# Dev Environment
+You'll need
+- Gnu Make
+- Bash
+- Python 3 (incl. requests module)
+- Go 1.21
+
 # Architecture
 
 Snyk language server acts as an integration point encompassing the following features:
@@ -86,7 +93,7 @@ the [getLanguageServer.sh](getLanguageServer.sh) script, which implements the sa
 as the Eclipse plugin for download.
 
 It is important to be aware of the variable `LS_PROTOCOL_VERSION`
-in [the goreleaser configuration](.goreleaser.yaml#L49). This controls the upload location
+in [the goreleaser configuration](.goreleaser.yaml#L53). This controls the upload location
 of the artifacts. The download URL is constructed as follows:
 
 ```https://static.snyk.io/snyk-ls/$LS_PROTOCOL_VERSION/snyk-ls_$VERSION_$OS_$ARCH```

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,16 @@ build-debug:
 	@make clean
 	@echo "==> Building binary..."
 	@echo "    running go build with debug flags"
-	@go build -o $(BUILD_DIR)/$(PROJECT_NAME) \
+
+ifeq ($(OS),Windows_NT)
+	@go build -o $(BUILD_DIR)/$(PROJECT_NAME).exe \
 		-ldflags=$(LDFLAGS_DEV) \
 		-gcflags="all=-N -l"
+else
+	@go build -o $(BUILD_DIR)/$(PROJECT_NAME) \
+		-ldflags=$(LDFLAGS_DEV)
+		-gcflags="all=-N -l"
+endif
 
 ## run: Compile and run LSP server.
 .PHONY: run

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -1,5 +1,5 @@
 /*
- * © 2022 Snyk Limited All rights reserved.
+ * © 2022-2023 Snyk Limited All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -473,7 +473,7 @@ func textDocumentDidSaveHandler() jrpc2.Handler {
 		autoScanEnabled := config.CurrentConfig().IsAutoScanEnabled()
 		if f != nil && autoScanEnabled {
 			f.ClearDiagnosticsFromFile(filePath)
-			di.HoverService().DeleteHover(params.TextDocument.URI)
+			di.HoverService().DeleteHover(filePath)
 			go f.ScanFile(bgCtx, filePath)
 		} else {
 			if autoScanEnabled {
@@ -490,7 +490,8 @@ func textDocumentHover() jrpc2.Handler {
 	return handler.New(func(_ context.Context, params hover.Params) (hover.Result, error) {
 		log.Info().Str("method", "TextDocumentHover").Interface("params", params).Msg("RECEIVING")
 
-		hoverResult := di.HoverService().GetHover(params.TextDocument.URI, converter.FromPosition(params.Position))
+		path := uri.PathFromUri(params.TextDocument.URI)
+		hoverResult := di.HoverService().GetHover(path, converter.FromPosition(params.Position))
 		return hoverResult, nil
 	})
 }

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -1091,7 +1091,7 @@ func Test_IntegrationHoverResults(t *testing.T) {
 
 	assert.Equal(t,
 		hoverResult.Contents.Value,
-		di.HoverService().GetHover(uri.PathToUri(testPath), converter.FromPosition(testPosition)).Contents.Value)
+		di.HoverService().GetHover(testPath, converter.FromPosition(testPosition)).Contents.Value)
 	assert.Equal(t, hoverResult.Contents.Kind, "markdown")
 }
 func Test_SmokeSnykCodeFileScan(t *testing.T) {

--- a/domain/ide/converter/converter.go
+++ b/domain/ide/converter/converter.go
@@ -175,7 +175,7 @@ func ToDiagnostics(issues []snyk.Issue) []lsp.Diagnostic {
 
 func ToHoversDocument(path string, issues []snyk.Issue) hover.DocumentHovers {
 	return hover.DocumentHovers{
-		Uri:   uri.PathToUri(path),
+		Path:  path,
 		Hover: ToHovers(issues),
 	}
 }

--- a/domain/ide/hover/fake_service.go
+++ b/domain/ide/hover/fake_service.go
@@ -17,8 +17,6 @@
 package hover
 
 import (
-	sglsp "github.com/sourcegraph/go-lsp"
-
 	ux2 "github.com/snyk/snyk-ls/domain/observability/ux"
 	"github.com/snyk/snyk-ls/domain/snyk"
 )
@@ -35,7 +33,7 @@ func NewFakeHoverService() *FakeHoverService {
 	}
 }
 
-func (t *FakeHoverService) DeleteHover(_ sglsp.DocumentURI) {
+func (t *FakeHoverService) DeleteHover(_ string) {
 	//TODO implement me
 	panic("implement me")
 }
@@ -51,7 +49,7 @@ func (t *FakeHoverService) ClearAllHovers() {
 	}
 }
 
-func (t *FakeHoverService) GetHover(_ sglsp.DocumentURI, pos snyk.Position) Result {
+func (t *FakeHoverService) GetHover(_ string, _ snyk.Position) Result {
 	//TODO implement me
 	panic("implement me")
 }

--- a/domain/ide/hover/model.go
+++ b/domain/ide/hover/model.go
@@ -32,7 +32,7 @@ type Hover[T Context] struct {
 }
 
 type DocumentHovers struct {
-	Uri   sglsp.DocumentURI
+	Path  string
 	Hover []Hover[Context]
 }
 

--- a/domain/ide/hover/service.go
+++ b/domain/ide/hover/service.go
@@ -147,7 +147,7 @@ func (s *DefaultHoverService) createHoverListener() {
 		result := <-s.hoverChan
 		log.Trace().
 			Str("method", "createHoverListener").
-			Str("uri", string(result.Path)).
+			Str("uri", result.Path).
 			Msg("reading hover from chan.")
 
 		s.registerHovers(result)

--- a/domain/snyk/auth_service_impl_test.go
+++ b/domain/snyk/auth_service_impl_test.go
@@ -140,7 +140,7 @@ func Test_Logout(t *testing.T) {
 	_, _ = service.Provider().Authenticate(context.Background())
 
 	hoverService.Channel() <- hover.DocumentHovers{
-		Uri:   "path/to/file.test",
+		Path:  "path/to/file.test",
 		Hover: hovers,
 	}
 


### PR DESCRIPTION
### Description

the colon in `C:\...` was url-encoded in the URI representation by VSCode, but the go URI library does not url encode this bit.

This led to the hover cache having a different key to associate hovers to files, so they weren't displayed.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-ls/assets/20150761/c7743273-315a-4262-9aad-c22640b65bdf)
