### PR TITLE
fix: end position for code results

### DIFF
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -285,7 +285,7 @@ func (s *SarifResponse) toIssues(baseDir string) (issues []snyk.Issue, err error
 			startLine := position.StartLine - 1
 			endLine := util.Max(position.EndLine-1, startLine)
 			startCol := position.StartColumn - 1
-			endCol := util.Max(position.EndColumn, 0)
+			endCol := util.Max(position.EndColumn-1, 0)
 
 			myRange := snyk.Range{
 				Start: snyk.Position{

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -633,6 +633,8 @@ func TestSnykCodeBackendService_convert_shouldConvertIssues(t *testing.T) {
 	assert.Equal(t, snyk.CodeQualityIssue, issue.IssueType)
 	assert.Equal(t, snyk.Low, issue.Severity)
 	assert.Equal(t, path, issue.AffectedFilePath)
+	assert.Equal(t, snyk.Range{Start: snyk.Position{Line: 5, Character: 6}, End: snyk.Position{Line: 5,
+		Character: 6}}, issue.Range)
 	assert.Equal(t, product.ProductCode, issue.Product)
 	assert.Equal(t, issueDescriptionURL, issue.IssueDescriptionURL)
 	assert.Equal(t, references, issue.References)


### PR DESCRIPTION
### Description

The marker for code results reaches one character too far, this fix changes this.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs
Before
![image](https://github.com/snyk/snyk-ls/assets/101886095/91de7d63-3501-4133-9db0-38a4c9bf70f4)
After
<img width="71" alt="image" src="https://github.com/snyk/snyk-ls/assets/101886095/dc02f8a0-938c-42d8-9bee-49d48c53168e">

