### PR TITLE
fix: conditionally set analytics flag [HEAD-879]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -415,7 +415,7 @@ func (c *Config) SetSeverityFilter(severityFilter lsp.SeverityFilter) bool {
 	}
 
 	filterModified := c.filterSeverity != severityFilter
-	log.Debug().Str("method", "SetSeverityFilter").Msgf("Setting severity filter: %v", severityFilter)
+	log.Debug().Str("method", "SetSeverityFilter").Interface("severityFilter", severityFilter).Msg("Setting severity filter:")
 	c.filterSeverity = severityFilter
 	return filterModified
 }

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -420,7 +420,7 @@ func updateProductEnablement(settings lsp.Settings) {
 }
 
 func updateSeverityFilter(s lsp.SeverityFilter) {
-	log.Debug().Str("method", "updateSeverityFilter").Msgf("Updating severity filter: %v", s)
+	log.Debug().Str("method", "updateSeverityFilter").Interface("severityFilter", s).Msg("Updating severity filter:")
 	modified := config.CurrentConfig().SetSeverityFilter(s)
 
 	if modified {

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -145,7 +145,10 @@ func writeSettings(settings lsp.Settings, initialize bool) {
 	updateRuntimeInfo(settings)
 	updateAutoScan(settings)
 	updateSnykLearnCodeActions(settings)
-	config.CurrentConfig().SetAnalyticsEnabled(settings.EnableAnalytics)
+
+	if initialize {
+		config.CurrentConfig().SetAnalyticsEnabled(settings.EnableAnalytics)
+	}
 }
 
 func updateAuthenticationMethod(settings lsp.Settings) {

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -569,6 +569,18 @@ func Test_InitializeSettings(t *testing.T) {
 		assert.Equal(t, lsp.OAuthAuthentication, c.AuthenticationMethod())
 	})
 
+	t.Run("analytics is set to true", func(t *testing.T) {
+		testutil.UnitTest(t)
+		di.TestInit(t)
+		c := config.CurrentConfig()
+
+		assert.False(t, c.IsAnalyticsEnabled())
+
+		InitializeSettings(lsp.Settings{EnableAnalytics: true})
+
+		assert.True(t, c.IsAnalyticsEnabled())
+	})
+
 	t.Run("custom path configuration", func(t *testing.T) {
 		testutil.UnitTest(t)
 

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -283,7 +283,7 @@ func Test_UpdateSettings(t *testing.T) {
 			ScanningMode:                "manual",
 			AuthenticationMethod:        lsp.OAuthAuthentication,
 			SnykCodeApi:                 sampleSettings.SnykCodeApi,
-			EnableAnalytics:             true,
+			EnableAnalytics:             false, // when updating settings, this is always false [HEAD-975]
 		}
 
 		UpdateSettings(settings)


### PR DESCRIPTION
### Description

On the second time `writeSettings` is called, it doesn't get `enableAnalytics` flag. This change avoid this flag to be overridden after initialisation
