### PR TITLE
refactor: replace map-based severity count with structured types [HEAD-879]

### DIFF
--- a/domain/ide/workspace/folder_test.go
+++ b/domain/ide/workspace/folder_test.go
@@ -517,7 +517,7 @@ func Test_processResults_ShouldCountSeverityByProduct(t *testing.T) {
 
 	scanData := snyk.ScanData{
 		Product:       product.ProductOpenSource,
-		SeverityCount: make(map[product.Product]*snyk.SeverityCount),
+		SeverityCount: make(map[product.Product]snyk.SeverityCount),
 		Issues: []snyk.Issue{
 			{Severity: snyk.Critical, Product: product.ProductOpenSource},
 			{Severity: snyk.Critical, Product: product.ProductOpenSource},
@@ -552,7 +552,7 @@ func Test_IncrementSeverityCount(t *testing.T) {
 
 	scanData := snyk.ScanData{
 		Product:       product.ProductOpenSource,
-		SeverityCount: make(map[product.Product]*snyk.SeverityCount),
+		SeverityCount: make(map[product.Product]snyk.SeverityCount),
 		Issues:        []snyk.Issue{issue},
 	}
 
@@ -564,6 +564,28 @@ func Test_IncrementSeverityCount(t *testing.T) {
 
 	// Assert
 	require.Equal(t, 1, scanData.SeverityCount[product.ProductOpenSource].Critical)
+}
+
+func Test_initializeSeverityCountForProductWhenScanDataIsEmpty(t *testing.T) {
+	c := testutil.UnitTest(t)
+
+	engineMock, gafConfig := setUpEngineMock(t, c)
+
+	NewMockFolderWithScanNotifier(notification.NewNotifier())
+
+	engineMock.EXPECT().GetConfiguration().AnyTimes().Return(gafConfig)
+	engineMock.EXPECT().InvokeWithInputAndConfig(localworkflows.WORKFLOWID_REPORT_ANALYTICS, gomock.Any(), gomock.Any()).Times(0)
+
+	scanData := snyk.ScanData{}
+
+	// Act
+	initializeSeverityCountForProduct(&scanData, "")
+
+	// Assert
+	require.Equal(t, 0, scanData.SeverityCount["unknown"].Critical)
+	require.Equal(t, 0, scanData.SeverityCount["unknown"].High)
+	require.Equal(t, 0, scanData.SeverityCount["unknown"].Medium)
+	require.Equal(t, 0, scanData.SeverityCount["unknown"].Low)
 }
 
 func NewMockFolder(notifier noti.Notifier) *Folder {

--- a/domain/snyk/scan_result_processor.go
+++ b/domain/snyk/scan_result_processor.go
@@ -32,7 +32,7 @@ type ScanData struct {
 	High              int
 	Medium            int
 	Low               int
-	SeverityCount     map[product.Product]*SeverityCount
+	SeverityCount     map[product.Product]SeverityCount
 }
 
 type SeverityCount struct {

--- a/domain/snyk/scan_result_processor.go
+++ b/domain/snyk/scan_result_processor.go
@@ -32,8 +32,16 @@ type ScanData struct {
 	High              int
 	Medium            int
 	Low               int
-	SeverityCount     map[product.Product]map[string]int
+	SeverityCount     map[product.Product]*SeverityCount
 }
+
+type SeverityCount struct {
+	Critical int
+	High     int
+	Medium   int
+	Low      int
+}
+
 type ScanResultProcessor = func(scanData ScanData)
 
 //type ScanResultProcessor = func(product product.Product, issues []Issue, err error)

--- a/domain/snyk/scanner.go
+++ b/domain/snyk/scanner.go
@@ -202,6 +202,7 @@ func (sc *DelegatingConcurrentScanner) Scan(
 					Err:               err,
 					DurationMs:        scanSpan.GetDurationMs(),
 					TimestampFinished: time.Now().UTC(),
+					SeverityCount:     make(map[product.Product]*SeverityCount),
 				}
 				processResults(data)
 				log.Info().Msgf("Scanning %s with %T: COMPLETE found %v issues", path, s, len(foundIssues))

--- a/domain/snyk/scanner.go
+++ b/domain/snyk/scanner.go
@@ -202,7 +202,6 @@ func (sc *DelegatingConcurrentScanner) Scan(
 					Err:               err,
 					DurationMs:        scanSpan.GetDurationMs(),
 					TimestampFinished: time.Now().UTC(),
-					SeverityCount:     make(map[product.Product]*SeverityCount),
 				}
 				processResults(data)
 				log.Info().Msgf("Scanning %s with %T: COMPLETE found %v issues", path, s, len(foundIssues))

--- a/infrastructure/cli/install/discovery_test.go
+++ b/infrastructure/cli/install/discovery_test.go
@@ -41,6 +41,9 @@ func TestDiscovery_DownloadURL(t *testing.T) {
 			Windows: &ReleaseAsset{
 				URL: "windows-download-url",
 			},
+			MacOSARM64: &ReleaseAsset{
+				URL: "macos-arm64-download-url",
+			},
 		},
 	}
 

--- a/internal/product/product.go
+++ b/internal/product/product.go
@@ -25,6 +25,7 @@ const (
 	ProductCode                 Product = "Snyk Code"
 	ProductInfrastructureAsCode Product = "Snyk IaC"
 	ProductContainer            Product = "Snyk Container"
+	ProductUnknown              Product = ""
 )
 
 const (


### PR DESCRIPTION
### Description

- Replaced map-based severity counts with a new `SeverityCount` struct for clear and type-safe code
- Introduced a `ProductUnknown` constant to gracefully handle unidentified products

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

