### PR TITLE
fix: mapping of critical oss issues [HEAD-986]

### DIFF
--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -36,7 +36,7 @@ import (
 )
 
 var issuesSeverity = map[string]snyk.Severity{
-	"critical": snyk.High,
+	"critical": snyk.Critical,
 	"high":     snyk.High,
 	"low":      snyk.Low,
 	"medium":   snyk.Medium,

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -45,7 +45,7 @@ import (
 func Test_toIssueSeverity(t *testing.T) {
 	testutil.UnitTest(t)
 	issue := ossIssue{Severity: "critical"}
-	assert.Equal(t, snyk.High, issue.ToIssueSeverity())
+	assert.Equal(t, snyk.Critical, issue.ToIssueSeverity())
 	issue = ossIssue{Severity: "high"}
 	assert.Equal(t, snyk.High, issue.ToIssueSeverity())
 	issue = ossIssue{Severity: "medium"}


### PR DESCRIPTION
### Description

Critical OSS issues were incorrectly mapped to high instead of critical. 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

