### PR TITLE
feat: create and send oss vulnerability issue panel as HTML [HEAD-149]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ tools:
 	@echo "==> Installing go-licenses"
 	@go install github.com/google/go-licenses@latest
 ifeq (,$(wildcard ./.bin/golangci-lint*))
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.55.2
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.54.2
 else
 	@echo "==> golangci-lint is already installed"
 endif

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ tools:
 	@echo "==> Installing go-licenses"
 	@go install github.com/google/go-licenses@latest
 ifeq (,$(wildcard ./.bin/golangci-lint*))
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.52.1
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.55.2
 else
 	@echo "==> golangci-lint is already installed"
 endif

--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/snyk/snyk-ls/domain/ide/notification"
 	"github.com/snyk/snyk-ls/domain/snyk"
@@ -100,11 +101,34 @@ func (n *scanNotifier) appendOssIssues(scanIssues []lsp.ScanIssue, folderPath st
 		}
 
 		scanIssues = append(scanIssues, lsp.ScanIssue{
-			Id:             additionalData.Key,
-			Title:          additionalData.Title,
-			Severity:       issue.Severity.String(),
-			FilePath:       issue.AffectedFilePath,
-			AdditionalData: additionalData,
+			Id:       additionalData.Key,
+			Title:    additionalData.Title,
+			Severity: issue.Severity.String(),
+			FilePath: issue.AffectedFilePath,
+			AdditionalData: lsp.OssIssueData{
+				License: additionalData.License,
+				Identifiers: lsp.OssIdentifiers{
+					CWE: issue.CWEs,
+					CVE: issue.CVEs,
+				},
+				Description:       additionalData.Description,
+				Language:          additionalData.Language,
+				PackageManager:    additionalData.PackageManager,
+				PackageName:       additionalData.PackageName,
+				Name:              additionalData.Name,
+				Version:           additionalData.Version,
+				Exploit:           additionalData.Exploit,
+				CVSSv3:            additionalData.CVSSv3,
+				CvssScore:         strconv.FormatFloat(additionalData.CvssScore, 'f', 2, 64), // convert float64 to string with 2 decimal places
+				FixedIn:           additionalData.FixedIn,
+				From:              additionalData.From,
+				UpgradePath:       additionalData.UpgradePath,
+				IsPatchable:       additionalData.IsPatchable,
+				IsUpgradable:      additionalData.IsUpgradable,
+				ProjectName:       additionalData.ProjectName,
+				DisplayTargetFile: additionalData.DisplayTargetFile,
+				Details:           additionalData.Details,
+			},
 		})
 	}
 

--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -2,7 +2,6 @@ package notification
 
 import (
 	"errors"
-	"strconv"
 
 	"github.com/snyk/snyk-ls/domain/ide/notification"
 	"github.com/snyk/snyk-ls/domain/snyk"
@@ -101,33 +100,11 @@ func (n *scanNotifier) appendOssIssues(scanIssues []lsp.ScanIssue, folderPath st
 		}
 
 		scanIssues = append(scanIssues, lsp.ScanIssue{
-			Id:       additionalData.Key,
-			Title:    additionalData.Title,
-			Severity: issue.Severity.String(),
-			FilePath: issue.AffectedFilePath,
-			AdditionalData: lsp.OssIssueData{
-				License: additionalData.License,
-				Identifiers: lsp.OssIdentifiers{
-					CWE: issue.CWEs,
-					CVE: issue.CVEs,
-				},
-				Description:       additionalData.Description,
-				Language:          additionalData.Language,
-				PackageManager:    additionalData.PackageManager,
-				PackageName:       additionalData.PackageName,
-				Name:              additionalData.Name,
-				Version:           additionalData.Version,
-				Exploit:           additionalData.Exploit,
-				CVSSv3:            additionalData.CVSSv3,
-				CvssScore:         strconv.FormatFloat(additionalData.CvssScore, 'f', 2, 64), // convert float64 to string with 2 decimal places
-				FixedIn:           additionalData.FixedIn,
-				From:              additionalData.From,
-				UpgradePath:       additionalData.UpgradePath,
-				IsPatchable:       additionalData.IsPatchable,
-				IsUpgradable:      additionalData.IsUpgradable,
-				ProjectName:       additionalData.ProjectName,
-				DisplayTargetFile: additionalData.DisplayTargetFile,
-			},
+			Id:             additionalData.Key,
+			Title:          additionalData.Title,
+			Severity:       issue.Severity.String(),
+			FilePath:       issue.AffectedFilePath,
+			AdditionalData: additionalData,
 		})
 	}
 

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -247,6 +247,7 @@ func Test_SendSuccess_SendsForOpenSource(t *testing.T) {
 				IsUpgradable:      false,
 				ProjectName:       "OSS ProjectName",
 				DisplayTargetFile: "OSS DisplayTargetFile",
+				Details:           "",
 			},
 		},
 	}
@@ -302,6 +303,7 @@ func Test_SendSuccess_SendsForOpenSource(t *testing.T) {
 				ProjectName:       "OSS ProjectName",
 				DisplayTargetFile: "OSS DisplayTargetFile",
 				Language:          "js",
+				Details:           "",
 			},
 		},
 	}

--- a/domain/snyk/issues.go
+++ b/domain/snyk/issues.go
@@ -128,6 +128,7 @@ type OssIssueData struct {
 	ProjectName       string      `json:"projectName"`
 	DisplayTargetFile string      `json:"displayTargetFile"`
 	Language          string      `json:"language"`
+	Details           string      `json:"details"`
 }
 
 type IaCIssueData struct {

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gomarkdown/markdown"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/exp/maps"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
@@ -33,9 +32,6 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/learn"
 	"github.com/snyk/snyk-ls/internal/product"
 )
-
-//go:embed template/details.html
-var detailsHtmlTemplate string
 
 var issuesSeverity = map[string]snyk.Severity{
 	"critical": snyk.Critical,
@@ -222,158 +218,6 @@ func toIssue(
 		CVEs:                issue.Identifiers.CVE,
 		AdditionalData:      issue.toAdditionalData(affectedFilePath, scanResult),
 	}
-}
-
-func replaceVariableInHtml(html string, variableName string, variableValue string) string {
-	return strings.ReplaceAll(html, fmt.Sprintf("${%s}", variableName), variableValue)
-}
-
-func getIdentifiers(issue *ossIssue) string {
-	identifierList := []string{}
-
-	issueTypeString := "Vulnerability"
-	if len(issue.License) > 0 {
-		issueTypeString = "License"
-	}
-
-	for _, id := range issue.Identifiers.CVE {
-		url := "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + id
-		htmlAnchor := fmt.Sprintf("<a href='%s'>%s</a>", url, id)
-		identifierList = append(identifierList, htmlAnchor)
-	}
-
-	for _, id := range issue.Identifiers.CWE {
-		linkId := strings.ReplaceAll(strings.ToUpper(id), "CWE-", "")
-		htmlAnchor := fmt.Sprintf("<a href='https://cwe.mitre.org/data/definitions/%s.html'>%s</a>", linkId, id)
-		identifierList = append(identifierList, htmlAnchor)
-	}
-
-	if issue.CvssScore > 0 {
-		htmlAnchor := fmt.Sprintf("CVSS %.1f", issue.CvssScore)
-		identifierList = append(identifierList, htmlAnchor)
-	}
-
-	htmlAnchor := fmt.Sprintf("<a href='https://snyk.io/vuln/%s'>%s</a>", issue.Id, strings.ToUpper(issue.Id))
-	identifierList = append(identifierList, htmlAnchor)
-
-	return fmt.Sprintf("%s %s", issueTypeString, strings.Join(identifierList, " "))
-}
-
-func getExploitMaturity(issue *ossIssue) string {
-	if len(issue.Exploit) > 0 {
-		return fmt.Sprintf("<div class='summary-item maturity'><div class='label font-light'>Exploit maturity</div>"+
-			"<div class='content'>%s</div></div>", issue.Exploit)
-	} else {
-		return ""
-	}
-}
-
-func getIntroducedBy(issue *ossIssue) string {
-	m := make(map[string]string)
-
-	if len(issue.From) > 0 {
-		for _, v := range issue.matchingIssues {
-			if len(v.From) > 0 {
-				module := v.From[1]
-				url := fmt.Sprintf("https://app.snyk.io/test/%s/%s", issue.PackageManager, module)
-				htmlAnchor := fmt.Sprintf("<a href='%s'>%s</a>", url, module)
-				m[module] = htmlAnchor
-			}
-		}
-
-		return fmt.Sprintf("<div class='summary-item introduced-through'><div class='label font-light'>Introduced through</div>"+
-			"<div class='content'>%s</div></div>", strings.Join(maps.Values(m), ", "))
-	} else {
-		return ""
-	}
-}
-
-func getLearnLink(issue *ossIssue) string {
-	if issue.lesson == nil {
-		return ""
-	}
-
-	return fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>",
-		issue.lesson.Url)
-}
-
-func getFixedIn(issue *ossIssue) string {
-	if len(issue.FixedIn) == 0 {
-		return "Not fixed"
-	}
-
-	result := "%s@%v"
-	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
-}
-
-func getOutdatedDependencyMessage(vuln *ossIssue) string {
-	remediationAdvice := fmt.Sprintf("Your dependencies are out of date, "+
-		"otherwise you would be using a newer %s than %s@%s.", vuln.Name, vuln.Name, vuln.Version)
-
-	if vuln.PackageManager == "npm" || vuln.PackageManager == "yarn" || vuln.PackageManager == "yarn-workspace" {
-		remediationAdvice += "Try relocking your lockfile or deleting <code>node_modules</code> and reinstalling" +
-			" your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
-	} else {
-		remediationAdvice += "Try reinstalling your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
-	}
-	return remediationAdvice
-}
-
-func getDetailedPaths(issue *ossIssue) string {
-	detailedPathHtml := ""
-
-	for _, vuln := range issue.matchingIssues {
-		hasUpgradePath := len(vuln.UpgradePath) > 0
-		introducedThrough := strings.Join(vuln.From, " > ")
-		isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
-		remediationAdvice := "none"
-		upgradeMessage := ""
-
-		if vuln.IsUpgradable || vuln.IsPatchable {
-			if hasUpgradePath {
-				upgradeMessage = "Upgrade to " + vuln.UpgradePath[1].(string)
-			}
-
-			if isOutdated {
-				if vuln.IsPatchable {
-					remediationAdvice = upgradeMessage
-				} else {
-					remediationAdvice = getOutdatedDependencyMessage(&vuln)
-				}
-			} else {
-				remediationAdvice = upgradeMessage
-			}
-		}
-
-		detailedPathHtml += fmt.Sprintf(`<div class="summary-item path">
-						<div class="label font-light">Introduced through</div>
-						<div class="content">%s</div>
-					</div>
-					<div class="summary-item remediation">
-						<div class="label font-light">Remediation</div>
-						<div class="content">%s</div>
-					</div>`, introducedThrough, remediationAdvice)
-	}
-
-	return detailedPathHtml
-}
-
-func getDetailsHtml(issue *ossIssue) string {
-	overview := markdown.ToHTML([]byte(issue.Description), nil, nil)
-
-	html := replaceVariableInHtml(detailsHtmlTemplate, "issueId", issue.Id)
-	html = replaceVariableInHtml(html, "issueTitle", issue.Title)
-	html = replaceVariableInHtml(html, "severityText", issue.Severity)
-	html = replaceVariableInHtml(html, "vulnerableModule", issue.Name)
-	html = replaceVariableInHtml(html, "overview", string(overview))
-	html = replaceVariableInHtml(html, "identifiers", getIdentifiers(issue))
-	html = replaceVariableInHtml(html, "exploitMaturity", getExploitMaturity(issue))
-	html = replaceVariableInHtml(html, "introducedThrough", getIntroducedBy(issue))
-	html = replaceVariableInHtml(html, "learnLink", getLearnLink(issue))
-	html = replaceVariableInHtml(html, "fixedIn", getFixedIn(issue))
-	html = replaceVariableInHtml(html, "detailedPaths", getDetailedPaths(issue))
-
-	return html
 }
 
 func (o ossIssue) toAdditionalData(filepath string, scanResult *scanResult) snyk.OssIssueData {

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -306,6 +306,49 @@ func getFixedIn(issue *ossIssue) string {
 	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
 }
 
+/**
+function fillDetailedPaths() {
+      const paths = document.querySelector('.detailed-paths')!;
+      paths.innerHTML = ''; // reset node
+
+      vulnerability.matchingIdVulnerabilities.forEach(vuln => {
+        const introducedThrough = vuln.from.join(' > ');
+
+        const isOutdated = vuln.upgradePath && vuln.upgradePath[1] === vuln.from[1];
+
+        // The logic as in registry
+        // https://github.com/snyk/registry/blob/5fe141a3c5eeb6b2c5e62cfa2b5a8643df29403d/frontend/src/components/IssueCardVulnerablePath/IssueCardVulnerablePath.vue#L109
+        let remediationAdvice: string;
+        const upgradeMessage = `Upgrade to ${vuln.upgradePath[1]}`;
+
+        if (vuln.isUpgradable || vuln.isPatchable) {
+          if (isOutdated) {
+            remediationAdvice = vuln.isPatchable ? upgradeMessage : getOutdatedDependencyMessage(vuln);
+          } else {
+            remediationAdvice = upgradeMessage;
+          }
+        } else {
+          remediationAdvice = 'none';
+        }
+
+        const html = `
+        <div class="summary-item path">
+          <div class="label font-light">Introduced through</div>
+          <div class="content">${introducedThrough}</div>
+        </div>
+        <div class="summary-item remediation">
+          <div class="label font-light">Remediation</div>
+          <div class="content">${remediationAdvice}</div>
+        </div>`;
+
+        const path = document.createElement('div');
+        path.className = 'detailed-path';
+        path.innerHTML = html;
+        paths.append(path);
+      });
+    }
+*/
+
 func getDetailedPaths(issue *ossIssue) string {
 	detailedPathHtml := ""
 
@@ -313,11 +356,17 @@ func getDetailedPaths(issue *ossIssue) string {
 		hasUpgradePath := len(vuln.UpgradePath) > 0
 		introducedThrough := strings.Join(vuln.From, " > ")
 		isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
-		upgradeMessage := "Upgrade to " + vuln.UpgradePath[1].(string)
 		remediationAdvice := "none"
+		upgradeMessage := ""
 
 		if vuln.IsUpgradable || vuln.IsPatchable {
+			if hasUpgradePath {
+				upgradeMessage = "Upgrade to " + vuln.UpgradePath[1].(string)
+			}
+
 			if isOutdated && vuln.IsPatchable {
+				remediationAdvice = upgradeMessage
+			} else if isOutdated {
 				remediationAdvice = upgradeMessage
 			} else {
 				remediationAdvice = fmt.Sprintf("Your dependencies are out of date, "+

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -306,6 +306,17 @@ func getFixedIn(issue *ossIssue) string {
 	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
 }
 
+func getDetailedPaths(issue *ossIssue) string {
+	for _, vuln := range issue.matchingIssues {
+		introducedThrough := strings.Join(vuln.From, " > ")
+		isOutdated := len(vuln.UpgradePath) > 0 && vuln.UpgradePath[1] == vuln.From[1]
+		upgradeMessage := "Upgrade to " + vuln.UpgradePath[1].(string)
+		remediationAdvice :=
+	}
+
+	return ""
+}
+
 func getDetailsHtml(issue *ossIssue) string {
 	overview := markdown.ToHTML([]byte(issue.Description), nil, nil)
 
@@ -319,6 +330,7 @@ func getDetailsHtml(issue *ossIssue) string {
 	html = replaceVariableInHtml(html, "introducedThrough", getIntroducedBy(issue))
 	html = replaceVariableInHtml(html, "learnLink", getLearnLink(issue))
 	html = replaceVariableInHtml(html, "fixedIn", getFixedIn(issue))
+	html = replaceVariableInHtml(html, "detailedPaths", getDetailedPaths(issue))
 
 	return html
 }

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -84,6 +84,7 @@ func (i *ossIssue) AddSnykLearnAction(learnService learn.Service, ep error_repor
 					Arguments: []any{lesson.Url},
 				},
 			}
+			i.lesson = lesson
 			log.Debug().Str("method", "oss.issue.AddSnykLearnAction").Msgf("Learn action: %v", action)
 		}
 	}
@@ -189,6 +190,7 @@ func toIssue(
 		}
 	}
 
+	// find all issues with the same id
 	matchingIssues := []ossIssue{}
 	for _, otherIssue := range scanResult.Vulnerabilities {
 		if otherIssue.Id == issue.Id {
@@ -286,6 +288,24 @@ func getIntroducedBy(issue *ossIssue) string {
 	}
 }
 
+func getLearnLink(issue *ossIssue) string {
+	if issue.lesson == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>",
+		issue.lesson.Url)
+}
+
+func getFixedIn(issue *ossIssue) string {
+	if len(issue.FixedIn) == 0 {
+		return "Not fixed"
+	}
+
+	result := "%s@%v"
+	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
+}
+
 func getDetailsHtml(issue *ossIssue) string {
 	overview := markdown.ToHTML([]byte(issue.Description), nil, nil)
 
@@ -297,6 +317,8 @@ func getDetailsHtml(issue *ossIssue) string {
 	html = replaceVariableInHtml(html, "identifiers", getIdentifiers(issue))
 	html = replaceVariableInHtml(html, "exploitMaturity", getExploitMaturity(issue))
 	html = replaceVariableInHtml(html, "introducedThrough", getIntroducedBy(issue))
+	html = replaceVariableInHtml(html, "learnLink", getLearnLink(issue))
+	html = replaceVariableInHtml(html, "fixedIn", getFixedIn(issue))
 
 	return html
 }

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -187,10 +187,10 @@ func toIssue(
 	}
 
 	// find all issues with the same id
-	matchingIssues := []ossIssue{}
+	matchingIssues := []*ossIssue{}
 	for _, otherIssue := range scanResult.Vulnerabilities {
 		if otherIssue.Id == issue.Id {
-			matchingIssues = append(matchingIssues, otherIssue)
+			matchingIssues = append(matchingIssues, &otherIssue)
 		}
 	}
 	issue.matchingIssues = matchingIssues

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -306,48 +306,18 @@ func getFixedIn(issue *ossIssue) string {
 	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
 }
 
-/**
-function fillDetailedPaths() {
-      const paths = document.querySelector('.detailed-paths')!;
-      paths.innerHTML = ''; // reset node
+func getOutdatedDependencyMessage(vuln *ossIssue) string {
+	remediationAdvice := fmt.Sprintf("Your dependencies are out of date, "+
+		"otherwise you would be using a newer %s than %s@%s.", vuln.Name, vuln.Name, vuln.Version)
 
-      vulnerability.matchingIdVulnerabilities.forEach(vuln => {
-        const introducedThrough = vuln.from.join(' > ');
-
-        const isOutdated = vuln.upgradePath && vuln.upgradePath[1] === vuln.from[1];
-
-        // The logic as in registry
-        // https://github.com/snyk/registry/blob/5fe141a3c5eeb6b2c5e62cfa2b5a8643df29403d/frontend/src/components/IssueCardVulnerablePath/IssueCardVulnerablePath.vue#L109
-        let remediationAdvice: string;
-        const upgradeMessage = `Upgrade to ${vuln.upgradePath[1]}`;
-
-        if (vuln.isUpgradable || vuln.isPatchable) {
-          if (isOutdated) {
-            remediationAdvice = vuln.isPatchable ? upgradeMessage : getOutdatedDependencyMessage(vuln);
-          } else {
-            remediationAdvice = upgradeMessage;
-          }
-        } else {
-          remediationAdvice = 'none';
-        }
-
-        const html = `
-        <div class="summary-item path">
-          <div class="label font-light">Introduced through</div>
-          <div class="content">${introducedThrough}</div>
-        </div>
-        <div class="summary-item remediation">
-          <div class="label font-light">Remediation</div>
-          <div class="content">${remediationAdvice}</div>
-        </div>`;
-
-        const path = document.createElement('div');
-        path.className = 'detailed-path';
-        path.innerHTML = html;
-        paths.append(path);
-      });
-    }
-*/
+	if vuln.PackageManager == "npm" || vuln.PackageManager == "yarn" || vuln.PackageManager == "yarn-workspace" {
+		remediationAdvice += "Try relocking your lockfile or deleting <code>node_modules</code> and reinstalling" +
+			" your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+	} else {
+		remediationAdvice += "Try reinstalling your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+	}
+	return remediationAdvice
+}
 
 func getDetailedPaths(issue *ossIssue) string {
 	detailedPathHtml := ""
@@ -364,20 +334,14 @@ func getDetailedPaths(issue *ossIssue) string {
 				upgradeMessage = "Upgrade to " + vuln.UpgradePath[1].(string)
 			}
 
-			if isOutdated && vuln.IsPatchable {
-				remediationAdvice = upgradeMessage
-			} else if isOutdated {
-				remediationAdvice = upgradeMessage
-			} else {
-				remediationAdvice = fmt.Sprintf("Your dependencies are out of date, "+
-					"otherwise you would be using a newer %s than %s@%s.", vuln.Name, vuln.Name, vuln.Version)
-
-				if vuln.PackageManager == "npm" || vuln.PackageManager == "yarn" || vuln.PackageManager == "yarn-workspace" {
-					remediationAdvice += "Try relocking your lockfile or deleting <code>node_modules</code> and reinstalling" +
-						"your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+			if isOutdated {
+				if vuln.IsPatchable {
+					remediationAdvice = upgradeMessage
 				} else {
-					remediationAdvice += "Try reinstalling your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+					remediationAdvice = getOutdatedDependencyMessage(&vuln)
 				}
+			} else {
+				remediationAdvice = upgradeMessage
 			}
 		}
 

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -17,11 +17,8 @@
 package oss
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/gomarkdown/markdown"
@@ -214,7 +211,7 @@ func toIssue(
 
 func (o ossIssue) toAdditionalData(filepath string, scanResult *scanResult) snyk.OssIssueData {
 	var additionalData snyk.OssIssueData
-	additionalData.Key = getIssueKey(filepath, o)
+	additionalData.Key = o.Id
 	additionalData.Title = o.Title
 	additionalData.Name = o.Name
 	additionalData.LineNumber = o.LineNumber
@@ -283,9 +280,4 @@ func convertScanResultToIssues(
 		duplicateCheckMap[duplicateKey] = true
 	}
 	return issues
-}
-
-func getIssueKey(affectedFilePath string, issue ossIssue) string {
-	id := sha256.Sum256([]byte(affectedFilePath + strconv.Itoa(issue.LineNumber) + issue.Id))
-	return hex.EncodeToString(id[:16])
 }

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -307,14 +307,34 @@ func getFixedIn(issue *ossIssue) string {
 }
 
 func getDetailedPaths(issue *ossIssue) string {
+	detailedPathHtml := ""
+
 	for _, vuln := range issue.matchingIssues {
+		// hasUpgradePath := len(vuln.UpgradePath) > 0
 		introducedThrough := strings.Join(vuln.From, " > ")
-		isOutdated := len(vuln.UpgradePath) > 0 && vuln.UpgradePath[1] == vuln.From[1]
-		upgradeMessage := "Upgrade to " + vuln.UpgradePath[1].(string)
-		remediationAdvice :=
+		// isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
+		// upgradeMessage := "Upgrade to " + vuln.UpgradePath[1].(string)
+		remediationAdvice := "none"
+
+		// if vuln.IsUpgradable || vuln.IsPatchable {
+		// 	if isOutdated && vuln.IsPatchable {
+		// 		remediationAdvice = upgradeMessage
+		// 	} else {
+		// 		remediationAdvice = "Your dependencies are out of date, otherwise you would be using a newer ${vulnerability.name} than ${vulnerability.name}@${vulnerability.version}." // TODO: complete this
+		// 	}
+		// }
+
+		detailedPathHtml += fmt.Sprintf(`<div class="summary-item path">
+						<div class="label font-light">Introduced through</div>
+						<div class="content">%s</div>
+					</div>
+					<div class="summary-item remediation">
+						<div class="label font-light">Remediation</div>
+						<div class="content">%s</div>
+					</div>`, introducedThrough, remediationAdvice)
 	}
 
-	return ""
+	return detailedPathHtml
 }
 
 func getDetailsHtml(issue *ossIssue) string {

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -310,19 +310,27 @@ func getDetailedPaths(issue *ossIssue) string {
 	detailedPathHtml := ""
 
 	for _, vuln := range issue.matchingIssues {
-		// hasUpgradePath := len(vuln.UpgradePath) > 0
+		hasUpgradePath := len(vuln.UpgradePath) > 0
 		introducedThrough := strings.Join(vuln.From, " > ")
-		// isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
-		// upgradeMessage := "Upgrade to " + vuln.UpgradePath[1].(string)
+		isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
+		upgradeMessage := "Upgrade to " + vuln.UpgradePath[1].(string)
 		remediationAdvice := "none"
 
-		// if vuln.IsUpgradable || vuln.IsPatchable {
-		// 	if isOutdated && vuln.IsPatchable {
-		// 		remediationAdvice = upgradeMessage
-		// 	} else {
-		// 		remediationAdvice = "Your dependencies are out of date, otherwise you would be using a newer ${vulnerability.name} than ${vulnerability.name}@${vulnerability.version}." // TODO: complete this
-		// 	}
-		// }
+		if vuln.IsUpgradable || vuln.IsPatchable {
+			if isOutdated && vuln.IsPatchable {
+				remediationAdvice = upgradeMessage
+			} else {
+				remediationAdvice = fmt.Sprintf("Your dependencies are out of date, "+
+					"otherwise you would be using a newer %s than %s@%s.", vuln.Name, vuln.Name, vuln.Version)
+
+				if vuln.PackageManager == "npm" || vuln.PackageManager == "yarn" || vuln.PackageManager == "yarn-workspace" {
+					remediationAdvice += "Try relocking your lockfile or deleting <code>node_modules</code> and reinstalling" +
+						"your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+				} else {
+					remediationAdvice += "Try reinstalling your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+				}
+			}
+		}
 
 		detailedPathHtml += fmt.Sprintf(`<div class="summary-item path">
 						<div class="label font-light">Introduced through</div>

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -142,7 +142,7 @@ func getDetailedPaths(issue *ossIssue) string {
 				if vuln.IsPatchable {
 					remediationAdvice = upgradeMessage
 				} else {
-					remediationAdvice = getOutdatedDependencyMessage(&vuln)
+					remediationAdvice = getOutdatedDependencyMessage(vuln)
 				}
 			} else {
 				remediationAdvice = upgradeMessage

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -60,7 +60,7 @@ func getIdentifiers(issue *ossIssue) string {
 	htmlAnchor := fmt.Sprintf("<a href='https://snyk.io/vuln/%s'>%s</a>", issue.Id, strings.ToUpper(issue.Id))
 	identifierList = append(identifierList, htmlAnchor)
 
-	return fmt.Sprintf("%s %s", issueTypeString, strings.Join(identifierList, "<span class='delimiter' />"))
+	return fmt.Sprintf("%s %s", issueTypeString, strings.Join(identifierList, "<span class='delimiter'> </span> "))
 }
 
 func getExploitMaturity(issue *ossIssue) string {

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -127,7 +127,7 @@ func getDetailedPaths(issue *ossIssue) string {
 	detailedPathHtml := ""
 
 	for _, vuln := range issue.matchingIssues {
-		hasUpgradePath := len(vuln.UpgradePath) > 0
+		hasUpgradePath := len(vuln.UpgradePath) > 1
 		introducedThrough := strings.Join(vuln.From, " > ")
 		isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
 		remediationAdvice := "none"

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -77,7 +77,7 @@ func getIntroducedBy(issue *ossIssue) string {
 
 	if len(issue.From) > 0 {
 		for _, v := range issue.matchingIssues {
-			if len(v.From) > 0 {
+			if len(v.From) > 1 {
 				module := v.From[1]
 				url := fmt.Sprintf("https://app.snyk.io/test/%s/%s", issue.PackageManager, module)
 				htmlAnchor := fmt.Sprintf("<a href='%s'>%s</a>", url, module)

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -1,0 +1,181 @@
+/*
+ * © 2022-2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"github.com/gomarkdown/markdown"
+	"golang.org/x/exp/maps"
+)
+
+//go:embed template/details.html
+var detailsHtmlTemplate string
+
+func replaceVariableInHtml(html string, variableName string, variableValue string) string {
+	return strings.ReplaceAll(html, fmt.Sprintf("${%s}", variableName), variableValue)
+}
+
+func getIdentifiers(issue *ossIssue) string {
+	identifierList := []string{""}
+
+	issueTypeString := "Vulnerability"
+	if len(issue.License) > 0 {
+		issueTypeString = "License"
+	}
+
+	for _, id := range issue.Identifiers.CVE {
+		url := "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + id
+		htmlAnchor := fmt.Sprintf("<a href='%s'>%s</a>", url, id)
+		identifierList = append(identifierList, htmlAnchor)
+	}
+
+	for _, id := range issue.Identifiers.CWE {
+		linkId := strings.ReplaceAll(strings.ToUpper(id), "CWE-", "")
+		htmlAnchor := fmt.Sprintf("<a href='https://cwe.mitre.org/data/definitions/%s.html'>%s</a>", linkId, id)
+		identifierList = append(identifierList, htmlAnchor)
+	}
+
+	if issue.CvssScore > 0 {
+		htmlAnchor := fmt.Sprintf("<span>CVSS %.1f</span>", issue.CvssScore)
+		identifierList = append(identifierList, htmlAnchor)
+	}
+
+	htmlAnchor := fmt.Sprintf("<a href='https://snyk.io/vuln/%s'>%s</a>", issue.Id, strings.ToUpper(issue.Id))
+	identifierList = append(identifierList, htmlAnchor)
+
+	return fmt.Sprintf("%s %s", issueTypeString, strings.Join(identifierList, "<span class='delimiter' />"))
+}
+
+func getExploitMaturity(issue *ossIssue) string {
+	if len(issue.Exploit) > 0 {
+		return fmt.Sprintf("<div class='summary-item maturity'><div class='label font-light'>Exploit maturity</div>"+
+			"<div class='content'>%s</div></div>", issue.Exploit)
+	} else {
+		return ""
+	}
+}
+
+func getIntroducedBy(issue *ossIssue) string {
+	m := make(map[string]string)
+
+	if len(issue.From) > 0 {
+		for _, v := range issue.matchingIssues {
+			if len(v.From) > 0 {
+				module := v.From[1]
+				url := fmt.Sprintf("https://app.snyk.io/test/%s/%s", issue.PackageManager, module)
+				htmlAnchor := fmt.Sprintf("<a href='%s'>%s</a>", url, module)
+				m[module] = htmlAnchor
+			}
+		}
+
+		return fmt.Sprintf("<div class='summary-item introduced-through'><div class='label font-light'>Introduced through</div>"+
+			"<div class='content'>%s</div></div>", strings.Join(maps.Values(m), ", "))
+	} else {
+		return ""
+	}
+}
+
+func getLearnLink(issue *ossIssue) string {
+	if issue.lesson == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>",
+		issue.lesson.Url)
+}
+
+func getFixedIn(issue *ossIssue) string {
+	if len(issue.FixedIn) == 0 {
+		return "Not fixed"
+	}
+
+	result := "%s@%v"
+	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
+}
+
+func getOutdatedDependencyMessage(vuln *ossIssue) string {
+	remediationAdvice := fmt.Sprintf("Your dependencies are out of date, "+
+		"otherwise you would be using a newer %s than %s@%s.", vuln.Name, vuln.Name, vuln.Version)
+
+	if vuln.PackageManager == "npm" || vuln.PackageManager == "yarn" || vuln.PackageManager == "yarn-workspace" {
+		remediationAdvice += "Try relocking your lockfile or deleting <code>node_modules</code> and reinstalling" +
+			" your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+	} else {
+		remediationAdvice += "Try reinstalling your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+	}
+	return remediationAdvice
+}
+
+func getDetailedPaths(issue *ossIssue) string {
+	detailedPathHtml := ""
+
+	for _, vuln := range issue.matchingIssues {
+		hasUpgradePath := len(vuln.UpgradePath) > 0
+		introducedThrough := strings.Join(vuln.From, " > ")
+		isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
+		remediationAdvice := "none"
+		upgradeMessage := ""
+
+		if vuln.IsUpgradable || vuln.IsPatchable {
+			if hasUpgradePath {
+				upgradeMessage = "Upgrade to " + vuln.UpgradePath[1].(string)
+			}
+
+			if isOutdated {
+				if vuln.IsPatchable {
+					remediationAdvice = upgradeMessage
+				} else {
+					remediationAdvice = getOutdatedDependencyMessage(&vuln)
+				}
+			} else {
+				remediationAdvice = upgradeMessage
+			}
+		}
+
+		detailedPathHtml += fmt.Sprintf(`<div class="summary-item path">
+						<div class="label font-light">Introduced through</div>
+						<div class="content">%s</div>
+					</div>
+					<div class="summary-item remediation">
+						<div class="label font-light">Remediation</div>
+						<div class="content">%s</div>
+					</div>`, introducedThrough, remediationAdvice)
+	}
+
+	return detailedPathHtml
+}
+
+func getDetailsHtml(issue *ossIssue) string {
+	overview := markdown.ToHTML([]byte(issue.Description), nil, nil)
+
+	html := replaceVariableInHtml(detailsHtmlTemplate, "issueId", issue.Id)
+	html = replaceVariableInHtml(html, "issueTitle", issue.Title)
+	html = replaceVariableInHtml(html, "severityText", issue.Severity)
+	html = replaceVariableInHtml(html, "vulnerableModule", issue.Name)
+	html = replaceVariableInHtml(html, "overview", string(overview))
+	html = replaceVariableInHtml(html, "identifiers", getIdentifiers(issue))
+	html = replaceVariableInHtml(html, "exploitMaturity", getExploitMaturity(issue))
+	html = replaceVariableInHtml(html, "introducedThrough", getIntroducedBy(issue))
+	html = replaceVariableInHtml(html, "learnLink", getLearnLink(issue))
+	html = replaceVariableInHtml(html, "fixedIn", getFixedIn(issue))
+	html = replaceVariableInHtml(html, "detailedPaths", getDetailedPaths(issue))
+
+	return html
+}

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -1,0 +1,101 @@
+/*
+ * © 2022-2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	_ "embed"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/internal/testutil"
+)
+
+func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
+	_ = testutil.UnitTest(t)
+	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
+	sort.Strings(expectedVariables)
+
+	issue := &ossIssue{
+		Title:       "myTitle",
+		Name:        "myIssue",
+		Severity:    "SuperCritical",
+		Id:          "randomId",
+		Description: "- list",
+		From:        []string{"1", "2", "3", "4"},
+	}
+
+	issue2 := &ossIssue{
+		Title:       "myTitle2",
+		Name:        "myIssue2",
+		Severity:    "SuperCritical",
+		Id:          "randomId2",
+		Description: "- list2",
+		From:        []string{"5", "6", "7", "8"},
+	}
+
+	issue.matchingIssues = append(issue.matchingIssues, issue)
+	issue.matchingIssues = append(issue.matchingIssues, issue2)
+
+	// invoke methode under test
+	issueDetailsPanelHtml := getDetailsHtml(issue)
+
+	// compare
+	reg := regexp.MustCompile("\\$\\{\\w+\\}")
+	actualVariables := reg.FindAllString(issueDetailsPanelHtml, -1)
+	sort.Strings(actualVariables)
+	actualVariables = slices.Compact(actualVariables)
+
+	assert.Equal(t, expectedVariables, actualVariables)
+
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.Name))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.Id))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.Title))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.Severity))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issue.From, " > ")))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issue2.From, " > ")))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, "<li>list</li>"))
+	assert.False(t, strings.Contains(issueDetailsPanelHtml, "Learn about this vulnerability"))
+}
+
+func Test_OssDetailsPanel_html_withLearn(t *testing.T) {
+	_ = testutil.UnitTest(t)
+
+	lesson := &learn.Lesson{Url: "something"}
+
+	issue := &ossIssue{
+		Title:       "myTitle",
+		Name:        "myIssue",
+		Severity:    "SuperCritical",
+		Id:          "randomId",
+		Description: "- list",
+		From:        []string{"1", "2", "3", "4"},
+		lesson:      lesson,
+	}
+
+	issue.matchingIssues = append(issue.matchingIssues, issue)
+
+	// invoke methode under test
+	issueDetailsPanelHtml := getDetailsHtml(issue)
+
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, "Learn about this vulnerability"))
+}

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -59,7 +59,7 @@ func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	issueDetailsPanelHtml := getDetailsHtml(issue)
 
 	// compare
-	reg := regexp.MustCompile("\\$\\{\\w+\\}")
+	reg := regexp.MustCompile(`\$\{\w+\}`)
 	actualVariables := reg.FindAllString(issueDetailsPanelHtml, -1)
 	slices.Sort(actualVariables)
 	actualVariables = slices.Compact(actualVariables)

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -20,7 +20,6 @@ import (
 	_ "embed"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 
@@ -33,7 +32,7 @@ import (
 func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	_ = testutil.UnitTest(t)
 	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
-	sort.Strings(expectedVariables)
+	slices.Sort(expectedVariables)
 
 	issue := &ossIssue{
 		Title:       "myTitle",
@@ -62,7 +61,7 @@ func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	// compare
 	reg := regexp.MustCompile("\\$\\{\\w+\\}")
 	actualVariables := reg.FindAllString(issueDetailsPanelHtml, -1)
-	sort.Strings(actualVariables)
+	slices.Sort(actualVariables)
 	actualVariables = slices.Compact(actualVariables)
 
 	assert.Equal(t, expectedVariables, actualVariables)

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  ${headerEnd}
+</head>
+<body>
+<div class="suggestion">
+  <section class="suggestion--header">
+    <div class="severity">
+      <img id="severity-icon" src="${severityIcon}" alt="${severityText}"/>
+    </div>
+    <div class="suggestion-text">${issueTitle}</div>
+    <div class="identifiers">${identifiers}</div>
+    <!---<div class="learn">
+      <img class="icon" src="${images['learn-icon']}" />
+      <a class="learn--link"></a>
+    </div>-->
+  </section>
+  <section class="delimiter-top summary">
+    <div class="summary-item module">
+      <div class="label font-light">Vulnerable module</div>
+      <div class="content">${vulnerableModule}</div>
+    </div>
+    <div class="summary-item introduced-through">
+      <div class="label font-light">Introduced through</div>
+      <div class="content"></div>
+    </div>
+    <div class="summary-item fixed-in">
+      <div class="label font-light">Fixed in</div>
+      <div class="content"></div>
+    </div>
+    ${exploitMaturity}
+  </section>
+  <section class="delimiter-top summary">
+    <h2>Detailed paths</h2>
+    <div class="detailed-paths"></div>
+  </section>
+  <section class="delimiter-top">
+    <div id="overview" class="vulnerability-overview">${overview}</div>
+  </section>
+</div>
+<!--<script nonce="${nonce}" src="${scriptUri}"></script>-->
+</body>
+</html>

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -4,12 +4,62 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
+    .suggestion {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+    }
+
+    .suggestion .suggestion-text {
+      padding: 0.4rem 0;
+      margin-bottom: 0.8rem;
+      font-size: 1.8rem;
+      font-weight: 500;
+      line-height: 2.4rem;
+    }
+
+    .severity {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 0;
+      float: left;
+      margin: 0 1rem 0 0;
+      text-align: center;
+    }
+
+    .severity .icon {
+      width: 32px;
+      height: 32px;
+    }
+
+    .icon {
+      vertical-align: middle;
+      width: 16px;
+      height: 16px;
+    }
+
+    .identifiers {
+      font-size: 1.3rem;
+      line-height: 2rem;
+    }
+
+    .vscode-dark .light-only {
+      display: none;
+    }
+
+    .vscode-light .dark-only {
+      display: none;
+    }
+
     .learn {
       opacity: 0;
       height: 0;
       margin-top: 0;
       font-size: 1.3rem;
     }
+
     .learn.show {
       margin-top: 6px;
       opacity: 1;
@@ -17,9 +67,11 @@
       transition-duration: 500ms;
       transition-property: height, opacity, margin-top;
     }
+
     .learn--link {
       margin-left: 3px;
     }
+
     .learn__code .learn--link {
     }
 
@@ -64,6 +116,5 @@
     document.getElementById("learn").className = "learn show"
   }
 </script>
-<!--<script nonce="${nonce}" src="${scriptUri}"></script>-->
 </body>
 </html>

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -23,10 +23,7 @@
       <div class="label font-light">Vulnerable module</div>
       <div class="content">${vulnerableModule}</div>
     </div>
-    <div class="summary-item introduced-through">
-      <div class="label font-light">Introduced through</div>
-      <div class="content"></div>
-    </div>
+    ${introducedThrough}
     <div class="summary-item fixed-in">
       <div class="label font-light">Fixed in</div>
       <div class="content"></div>

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -53,7 +53,7 @@
   </section>
   <section class="delimiter-top summary">
     <h2>Detailed paths</h2>
-    <div class="detailed-paths"></div>
+    <div class="detailed-paths">${detailedPaths}</div>
   </section>
   <section class="delimiter-top">
     <div id="overview" class="vulnerability-overview">${overview}</div>

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -3,20 +3,41 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    .learn {
+      opacity: 0;
+      height: 0;
+      margin-top: 0;
+      font-size: 1.3rem;
+    }
+    .learn.show {
+      margin-top: 6px;
+      opacity: 1;
+      height: auto;
+      transition-duration: 500ms;
+      transition-property: height, opacity, margin-top;
+    }
+    .learn--link {
+      margin-left: 3px;
+    }
+    .learn__code .learn--link {
+    }
+
+  </style>
   ${headerEnd}
 </head>
 <body>
 <div class="suggestion">
   <section class="suggestion--header">
     <div class="severity">
-      <img id="severity-icon" src="${severityIcon}" alt="${severityText}"/>
+      <img id="severity-icon" src="${severityIcon}" alt="${severityText}" class="icon"/>
     </div>
     <div class="suggestion-text">${issueTitle}</div>
     <div class="identifiers">${identifiers}</div>
-    <!---<div class="learn">
-      <img class="icon" src="${images['learn-icon']}" />
-      <a class="learn--link"></a>
-    </div>-->
+    <div class="learn" id="learn">
+      <img class="icon" src="${learnIcon}" alt="learnIcon" />
+      ${learnLink}
+    </div>
   </section>
   <section class="delimiter-top summary">
     <div class="summary-item module">
@@ -26,7 +47,7 @@
     ${introducedThrough}
     <div class="summary-item fixed-in">
       <div class="label font-light">Fixed in</div>
-      <div class="content"></div>
+      <div class="content">${fixedIn}</div>
     </div>
     ${exploitMaturity}
   </section>
@@ -38,6 +59,11 @@
     <div id="overview" class="vulnerability-overview">${overview}</div>
   </section>
 </div>
+<script>
+  if (document.getElementById("learn--link")) {
+    document.getElementById("learn").className = "learn show"
+  }
+</script>
 <!--<script nonce="${nonce}" src="${scriptUri}"></script>-->
 </body>
 </html>

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' ${cspSource}; style-src 'nonce-${nonce}' ${cspSource}; script-src 'nonce-${nonce}';">
+  <style nonce="${nonce}">
     .suggestion {
       position: relative;
       display: flex;
@@ -111,7 +112,7 @@
     <div id="overview" class="vulnerability-overview">${overview}</div>
   </section>
 </div>
-<script>
+<script nonce="${nonce}">
   if (document.getElementById("learn--link")) {
     document.getElementById("learn").className = "learn show"
   }

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -55,6 +55,7 @@ type ossIssue struct {
 	IsPatchable    bool        `json:"isPatchable"`
 	License        string      `json:"license,omitempty"`
 	Language       string      `json:"language,omitempty"`
+	matchingIssues []ossIssue  `json:"-"`
 }
 
 type licensesPolicy struct {

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -19,6 +19,7 @@ package oss
 import (
 	"time"
 
+	"github.com/snyk/snyk-ls/infrastructure/learn"
 	"github.com/snyk/snyk-ls/internal/lsp"
 )
 
@@ -34,28 +35,29 @@ type reference struct {
 }
 
 type ossIssue struct {
-	Id             string      `json:"id"`
-	Name           string      `json:"name"`
-	Title          string      `json:"title"`
-	Severity       string      `json:"severity"`
-	LineNumber     int         `json:"lineNumber"`
-	Description    string      `json:"description"`
-	References     []reference `json:"references,omitempty"`
-	Version        string      `json:"version"`
-	PackageManager string      `json:"packageManager"`
-	PackageName    string      `json:"packageName"`
-	From           []string    `json:"from"`
-	Identifiers    identifiers `json:"identifiers,omitempty"`
-	FixedIn        []string    `json:"fixedIn,omitempty"`
-	UpgradePath    []any       `json:"upgradePath,omitempty"`
-	IsUpgradable   bool        `json:"isUpgradable,omitempty"`
-	CVSSv3         string      `json:"CVSSv3,omitempty"`
-	CvssScore      float64     `json:"cvssScore,omitempty"`
-	Exploit        string      `json:"exploit,omitempty"`
-	IsPatchable    bool        `json:"isPatchable"`
-	License        string      `json:"license,omitempty"`
-	Language       string      `json:"language,omitempty"`
-	matchingIssues []ossIssue  `json:"-"`
+	Id             string        `json:"id"`
+	Name           string        `json:"name"`
+	Title          string        `json:"title"`
+	Severity       string        `json:"severity"`
+	LineNumber     int           `json:"lineNumber"`
+	Description    string        `json:"description"`
+	References     []reference   `json:"references,omitempty"`
+	Version        string        `json:"version"`
+	PackageManager string        `json:"packageManager"`
+	PackageName    string        `json:"packageName"`
+	From           []string      `json:"from"`
+	Identifiers    identifiers   `json:"identifiers,omitempty"`
+	FixedIn        []string      `json:"fixedIn,omitempty"`
+	UpgradePath    []any         `json:"upgradePath,omitempty"`
+	IsUpgradable   bool          `json:"isUpgradable,omitempty"`
+	CVSSv3         string        `json:"CVSSv3,omitempty"`
+	CvssScore      float64       `json:"cvssScore,omitempty"`
+	Exploit        string        `json:"exploit,omitempty"`
+	IsPatchable    bool          `json:"isPatchable"`
+	License        string        `json:"license,omitempty"`
+	Language       string        `json:"language,omitempty"`
+	matchingIssues []ossIssue    `json:"-"`
+	lesson         *learn.Lesson `json:"-"`
 }
 
 type licensesPolicy struct {

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -56,7 +56,7 @@ type ossIssue struct {
 	IsPatchable    bool          `json:"isPatchable"`
 	License        string        `json:"license,omitempty"`
 	Language       string        `json:"language,omitempty"`
-	matchingIssues []ossIssue    `json:"-"`
+	matchingIssues []*ossIssue   `json:"-"`
 	lesson         *learn.Lesson `json:"-"`
 }
 

--- a/internal/lsp/message_types.go
+++ b/internal/lsp/message_types.go
@@ -1053,6 +1053,7 @@ type OssIssueData struct {
 	IsUpgradable      bool           `json:"isUpgradable"`
 	ProjectName       string         `json:"projectName"`
 	DisplayTargetFile string         `json:"displayTargetFile"`
+	Details           string         `json:"details,omitempty"`
 }
 
 type OssIdentifiers struct {


### PR DESCRIPTION
### Description
Send a detailed view of an OSS Issue as an HTML from Language Server.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

