### PR TITLE
fix: add auth header to local code engine requests as well [HEAD-1017]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -392,6 +392,11 @@ func (c *Config) SetSnykCodeApi(snykCodeApiUrl string) {
 		return
 	}
 	c.snykCodeApiUrl = snykCodeApiUrl
+
+	config := c.engine.GetConfiguration()
+	additionalURLs := config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS)
+	additionalURLs = append(additionalURLs, c.snykCodeApiUrl)
+	config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, additionalURLs)
 }
 
 func (c *Config) SetErrorReportingEnabled(enabled bool) { c.isErrorReportingEnabled.Set(enabled) }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/go-application-framework v0.0.0-20231026115736-80ebca949279
+	github.com/snyk/go-application-framework v0.0.0-20231109165353-559819e512a1
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/go-application-framework v0.0.0-20231109165353-559819e512a1
+	github.com/snyk/go-application-framework v0.0.0-20231110103323-3eaa1fdef343
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/go-application-framework v0.0.0-20231026115736-80ebca949279 h1:VJUTUqOgXokh48WVjhyP/PD5orijQD3vv8yaprN1UOk=
-github.com/snyk/go-application-framework v0.0.0-20231026115736-80ebca949279/go.mod h1:YGuE2uaW3PG7Q3CcVpCdu/tOFhv5eUjcTNlYIcw6FDo=
+github.com/snyk/go-application-framework v0.0.0-20231109165353-559819e512a1 h1:az849g+NG9fctSD04Y90JN5ytnGFW1qMsm0FhBWdVW8=
+github.com/snyk/go-application-framework v0.0.0-20231109165353-559819e512a1/go.mod h1:YGuE2uaW3PG7Q3CcVpCdu/tOFhv5eUjcTNlYIcw6FDo=
 github.com/snyk/go-httpauth v0.0.0-20230726132335-d454674305a7 h1:m8C34vcouY2vEvow2gV/uAZ0LKiV7vhwC5HI15nUDX4=
 github.com/snyk/go-httpauth v0.0.0-20230726132335-d454674305a7/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/go-application-framework v0.0.0-20231109165353-559819e512a1 h1:az849g+NG9fctSD04Y90JN5ytnGFW1qMsm0FhBWdVW8=
-github.com/snyk/go-application-framework v0.0.0-20231109165353-559819e512a1/go.mod h1:YGuE2uaW3PG7Q3CcVpCdu/tOFhv5eUjcTNlYIcw6FDo=
+github.com/snyk/go-application-framework v0.0.0-20231110103323-3eaa1fdef343 h1:lfP5avIiuswcx/d/VvTEj2vQ7FQaoeepV2nHIkP82Hw=
+github.com/snyk/go-application-framework v0.0.0-20231110103323-3eaa1fdef343/go.mod h1:YGuE2uaW3PG7Q3CcVpCdu/tOFhv5eUjcTNlYIcw6FDo=
 github.com/snyk/go-httpauth v0.0.0-20230726132335-d454674305a7 h1:m8C34vcouY2vEvow2gV/uAZ0LKiV7vhwC5HI15nUDX4=
 github.com/snyk/go-httpauth v0.0.0-20230726132335-d454674305a7/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/infrastructure/code/sast_local_engine_test.go
+++ b/infrastructure/code/sast_local_engine_test.go
@@ -17,8 +17,10 @@
 package code
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -71,5 +73,8 @@ func TestIsLocalEngine(t *testing.T) {
 		mockedSastResponse.LocalCodeEngine.Enabled = true
 		scanner.updateCodeApiLocalEngine(mockedSastResponse)
 		assert.Equal(t, mockedSastResponse.LocalCodeEngine.Url, config.CurrentConfig().SnykCodeApi())
+		additionalAuthUrls := config.CurrentConfig().Engine().GetConfiguration().GetStringSlice(configuration.
+			AUTHENTICATION_ADDITIONAL_URLS)
+		assert.True(t, slices.Contains(additionalAuthUrls, mockedSastResponse.LocalCodeEngine.Url))
 	})
 }


### PR DESCRIPTION
### Description
Enable adding auth headers for traffic to local code engine if configured.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
