### PR TITLE
fix: do not use pointer for matchingIssues in ossIssue struct

### DIFF
--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -187,10 +187,10 @@ func toIssue(
 	}
 
 	// find all issues with the same id
-	matchingIssues := []*ossIssue{}
+	matchingIssues := []ossIssue{}
 	for _, otherIssue := range scanResult.Vulnerabilities {
 		if otherIssue.Id == issue.Id {
-			matchingIssues = append(matchingIssues, &otherIssue)
+			matchingIssues = append(matchingIssues, otherIssue)
 		}
 	}
 	issue.matchingIssues = matchingIssues

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -110,11 +110,11 @@ func getFixedIn(issue *ossIssue) string {
 	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
 }
 
-func getOutdatedDependencyMessage(vuln ossIssue) string {
+func getOutdatedDependencyMessage(issue ossIssue) string {
 	remediationAdvice := fmt.Sprintf("Your dependencies are out of date, "+
-		"otherwise you would be using a newer %s than %s@%s.", vuln.Name, vuln.Name, vuln.Version)
+		"otherwise you would be using a newer %s than %s@%s.", issue.Name, issue.Name, issue.Version)
 
-	if vuln.PackageManager == "npm" || vuln.PackageManager == "yarn" || vuln.PackageManager == "yarn-workspace" {
+	if issue.PackageManager == "npm" || issue.PackageManager == "yarn" || issue.PackageManager == "yarn-workspace" {
 		remediationAdvice += "Try relocking your lockfile or deleting <code>node_modules</code> and reinstalling" +
 			" your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
 	} else {
@@ -126,23 +126,23 @@ func getOutdatedDependencyMessage(vuln ossIssue) string {
 func getDetailedPaths(issue *ossIssue) string {
 	detailedPathHtml := ""
 
-	for _, vuln := range issue.matchingIssues {
-		hasUpgradePath := len(vuln.UpgradePath) > 1
-		introducedThrough := strings.Join(vuln.From, " > ")
-		isOutdated := hasUpgradePath && vuln.UpgradePath[1] == vuln.From[1]
+	for _, matchingIssue := range issue.matchingIssues {
+		hasUpgradePath := len(matchingIssue.UpgradePath) > 1
+		introducedThrough := strings.Join(matchingIssue.From, " > ")
+		isOutdated := hasUpgradePath && matchingIssue.UpgradePath[1] == matchingIssue.From[1]
 		remediationAdvice := "none"
 		upgradeMessage := ""
 
-		if vuln.IsUpgradable || vuln.IsPatchable {
+		if matchingIssue.IsUpgradable || matchingIssue.IsPatchable {
 			if hasUpgradePath {
-				upgradeMessage = "Upgrade to " + vuln.UpgradePath[1].(string)
+				upgradeMessage = "Upgrade to " + matchingIssue.UpgradePath[1].(string)
 			}
 
 			if isOutdated {
-				if vuln.IsPatchable {
+				if matchingIssue.IsPatchable {
 					remediationAdvice = upgradeMessage
 				} else {
-					remediationAdvice = getOutdatedDependencyMessage(vuln)
+					remediationAdvice = getOutdatedDependencyMessage(matchingIssue)
 				}
 			} else {
 				remediationAdvice = upgradeMessage

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -110,7 +110,7 @@ func getFixedIn(issue *ossIssue) string {
 	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
 }
 
-func getOutdatedDependencyMessage(vuln *ossIssue) string {
+func getOutdatedDependencyMessage(vuln ossIssue) string {
 	remediationAdvice := fmt.Sprintf("Your dependencies are out of date, "+
 		"otherwise you would be using a newer %s than %s@%s.", vuln.Name, vuln.Name, vuln.Version)
 

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -110,7 +110,7 @@ func getFixedIn(issue *ossIssue) string {
 	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
 }
 
-func getOutdatedDependencyMessage(issue ossIssue) string {
+func getOutdatedDependencyMessage(issue *ossIssue) string {
 	remediationAdvice := fmt.Sprintf("Your dependencies are out of date, "+
 		"otherwise you would be using a newer %s than %s@%s.", issue.Name, issue.Name, issue.Version)
 
@@ -142,7 +142,7 @@ func getDetailedPaths(issue *ossIssue) string {
 				if matchingIssue.IsPatchable {
 					remediationAdvice = upgradeMessage
 				} else {
-					remediationAdvice = getOutdatedDependencyMessage(matchingIssue)
+					remediationAdvice = getOutdatedDependencyMessage(&matchingIssue)
 				}
 			} else {
 				remediationAdvice = upgradeMessage

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -34,7 +34,7 @@ func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
 	slices.Sort(expectedVariables)
 
-	issue := &ossIssue{
+	issue := ossIssue{
 		Title:       "myTitle",
 		Name:        "myIssue",
 		Severity:    "SuperCritical",
@@ -43,7 +43,7 @@ func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 		From:        []string{"1", "2", "3", "4"},
 	}
 
-	issue2 := &ossIssue{
+	issue2 := ossIssue{
 		Title:       "myTitle2",
 		Name:        "myIssue2",
 		Severity:    "SuperCritical",
@@ -56,7 +56,7 @@ func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	issue.matchingIssues = append(issue.matchingIssues, issue2)
 
 	// invoke methode under test
-	issueDetailsPanelHtml := getDetailsHtml(issue)
+	issueDetailsPanelHtml := getDetailsHtml(&issue)
 
 	// compare
 	reg := regexp.MustCompile(`\$\{\w+\}`)
@@ -81,7 +81,7 @@ func Test_OssDetailsPanel_html_withLearn(t *testing.T) {
 
 	lesson := &learn.Lesson{Url: "something"}
 
-	issue := &ossIssue{
+	issue := ossIssue{
 		Title:       "myTitle",
 		Name:        "myIssue",
 		Severity:    "SuperCritical",
@@ -94,7 +94,7 @@ func Test_OssDetailsPanel_html_withLearn(t *testing.T) {
 	issue.matchingIssues = append(issue.matchingIssues, issue)
 
 	// invoke methode under test
-	issueDetailsPanelHtml := getDetailsHtml(issue)
+	issueDetailsPanelHtml := getDetailsHtml(&issue)
 
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, "Learn about this vulnerability"))
 }

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -56,7 +56,7 @@ type ossIssue struct {
 	IsPatchable    bool          `json:"isPatchable"`
 	License        string        `json:"license,omitempty"`
 	Language       string        `json:"language,omitempty"`
-	matchingIssues []*ossIssue   `json:"-"`
+	matchingIssues []ossIssue    `json:"-"`
 	lesson         *learn.Lesson `json:"-"`
 }
 


### PR DESCRIPTION
### Description

_This PR fixes an issue in the IDE's details panel not showing the details path correctly._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
