### PR TITLE
feat: redact token in logging [HEAD-1019]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ COMMIT := $(shell git show -s --format=%h)
 LDFLAGS_DEV := "-X 'github.com/snyk/snyk-ls/application/config.Development=true' -X 'github.com/snyk/snyk-ls/application/config.Version=v$(VERSION)-SNAPSHOT-$(COMMIT)'"
 
 NOCACHE := "-count=1"
-VERBOSE := "-v"
 TIMEOUT := "-timeout=45m"
 
 
@@ -71,13 +70,13 @@ race-test:
 	@echo "==> Running integration tests with race-detector..."
 	@mkdir -p $(BUILD_DIR)
 	@export INTEG_TESTS=true
-	@go test $(NOCACHE) $(TIMEOUT) $(VERBOSE) -race -failfast ./...
+	@go test $(NOCACHE) $(TIMEOUT) -race -failfast ./...
 
 .PHONY: proxy-test
 proxy-test:
 	@echo "==> Running integration tests with proxy"
 	@docker build -t "snyk-ls:$(VERSION)" -f .github/docker-based-tests/Dockerfile .
-	@docker run --rm --cap-add=NET_ADMIN --name "snyk-ls" --env "SNYK_TOKEN=$(SNYK_TOKEN)" snyk-ls:$(VERSION) go test -failfast $(NOCACHE) $(TIMEOUT) $(VERBOSE) ./...
+	@docker run --rm --cap-add=NET_ADMIN --name "snyk-ls" --env "SNYK_TOKEN=$(SNYK_TOKEN)" snyk-ls:$(VERSION) go test -failfast $(NOCACHE) $(TIMEOUT) ./...
 
 instance-test:
 	@echo "==> Running instance tests with proxy"

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -190,8 +190,10 @@ func initializeHandler(srv *jrpc2.Server, c *config.Config) handler.Func {
 	return handler.New(func(ctx context.Context, params lsp.InitializeParams) (any, error) {
 		method := "initializeHandler"
 		logger := log.With().Str("method", method).Logger()
-		logger.Info().Any("params", params).Msg("RECEIVING")
+		// we can only log, after we add the token to the list of forbidden outputs
+		defer logger.Info().Any("params", params).Msg("RECEIVING")
 		InitializeSettings(params.InitializationOptions)
+
 		c.SetClientCapabilities(params.Capabilities)
 		setClientInformation(params)
 		di.Analytics().Initialise()

--- a/internal/logging/scrubbingLogWriter.go
+++ b/internal/logging/scrubbingLogWriter.go
@@ -23,8 +23,8 @@ import (
 )
 
 type scrubbingWriter struct {
-	writer   zerolog.LevelWriter
-	scubDict map[string]bool
+	writer    zerolog.LevelWriter
+	scrubDict map[string]bool
 }
 
 func (w *scrubbingWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
@@ -33,8 +33,8 @@ func (w *scrubbingWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err 
 
 func NewScrubbingWriter(writer zerolog.LevelWriter, scrubDict map[string]bool) zerolog.LevelWriter {
 	return &scrubbingWriter{
-		writer:   writer,
-		scubDict: scrubDict,
+		writer:    writer,
+		scrubDict: scrubDict,
 	}
 }
 
@@ -44,7 +44,7 @@ func (w *scrubbingWriter) Write(p []byte) (n int, err error) {
 
 func (w *scrubbingWriter) scrub(p []byte) []byte {
 	s := string(p)
-	for term := range w.scubDict {
+	for term := range w.scrubDict {
 		s = strings.Replace(s, term, "***", -1)
 	}
 	return []byte(s)

--- a/internal/logging/scrubbingLogWriter.go
+++ b/internal/logging/scrubbingLogWriter.go
@@ -1,0 +1,51 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+type scrubbingWriter struct {
+	writer   zerolog.LevelWriter
+	scubDict map[string]bool
+}
+
+func (w *scrubbingWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
+	return w.writer.WriteLevel(level, w.scrub(p))
+}
+
+func NewScrubbingWriter(writer zerolog.LevelWriter, scrubDict map[string]bool) zerolog.LevelWriter {
+	return &scrubbingWriter{
+		writer:   writer,
+		scubDict: scrubDict,
+	}
+}
+
+func (w *scrubbingWriter) Write(p []byte) (n int, err error) {
+	return w.writer.Write(w.scrub(p))
+}
+
+func (w *scrubbingWriter) scrub(p []byte) []byte {
+	s := string(p)
+	for term := range w.scubDict {
+		s = strings.Replace(s, term, "***", -1)
+	}
+	return []byte(s)
+}

--- a/internal/logging/scrubbingLogWriter_test.go
+++ b/internal/logging/scrubbingLogWriter_test.go
@@ -1,0 +1,66 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWriter struct {
+	written []byte
+}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	m.written = p
+	return len(p), nil
+}
+
+func (m *mockWriter) WriteLevel(_ zerolog.Level, p []byte) (n int, err error) {
+	m.written = p
+	return len(p), nil
+}
+
+func TestScrubbingWriter_Write(t *testing.T) {
+	scrubDict := map[string]bool{
+		"password": true,
+	}
+
+	mockWriter := &mockWriter{}
+
+	writer := NewScrubbingWriter(mockWriter, scrubDict)
+
+	_, _ = writer.Write([]byte("password"))
+
+	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
+}
+
+func TestScrubbingWriter_WriteLevel(t *testing.T) {
+	scrubDict := map[string]bool{
+		"password": true,
+	}
+
+	mockWriter := &mockWriter{}
+
+	writer := NewScrubbingWriter(mockWriter, scrubDict)
+
+	_, _ = writer.WriteLevel(zerolog.InfoLevel, []byte("password"))
+
+	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
+}


### PR DESCRIPTION
### Description

We don't want to output the token in LS, so we now direct all log output through a filter/scrubber

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
