### PR TITLE
fix: check pointer to avoid crash on failed HTTP requests

### DIFF
--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -180,6 +180,10 @@ func (s *SnykCodeHTTPClient) doCall(ctx context.Context,
 				Str("responseBody", string(responseBody)).
 				Str("snyk-request-id", requestId).
 				Msg("RECEIVED FROM REMOTE")
+		} else {
+			log.Trace().
+				Str("snyk-request-id", requestId).
+				Msg("RECEIVED FROM REMOTE")
 		}
 
 		if err != nil {

--- a/infrastructure/code/backend_service.go
+++ b/infrastructure/code/backend_service.go
@@ -174,10 +174,13 @@ func (s *SnykCodeHTTPClient) doCall(ctx context.Context,
 
 		response, body, err := s.httpCall(req)
 		responseBody = body
-		log.Trace().Str("response.Status", response.Status).
-			Str("responseBody", string(responseBody)).
-			Str("snyk-request-id", requestId).
-			Msg("RECEIVED FROM REMOTE")
+
+		if response != nil && responseBody != nil {
+			log.Trace().Str("response.Status", response.Status).
+				Str("responseBody", string(responseBody)).
+				Str("snyk-request-id", requestId).
+				Msg("RECEIVED FROM REMOTE")
+		}
 
 		if err != nil {
 			return nil, err // no retries for errors

--- a/infrastructure/code/backend_service_test.go
+++ b/infrastructure/code/backend_service_test.go
@@ -132,6 +132,17 @@ func TestSnykCodeBackendService_doCall_shouldRetry(t *testing.T) {
 	assert.Equal(t, 3, d.calls)
 }
 
+func TestSnykCodeBackendService_doCall_rejected(t *testing.T) {
+	testutil.UnitTest(t)
+	dummyClientFunc := func() *http.Client {
+		return &http.Client{}
+	}
+
+	s := NewHTTPRepository(performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), dummyClientFunc)
+	_, err := s.doCall(context.Background(), "GET", "https://127.0.0.1", nil)
+	assert.Error(t, err)
+}
+
 func TestSnykCodeBackendService_RunAnalysisSmoke(t *testing.T) {
 	testutil.SmokeTest(t)
 	config.CurrentConfig().SetSnykCodeEnabled(true)


### PR DESCRIPTION
### Description

if a request fails, the changed code didn't check the response pointer, which caused a crash of the application.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs


