### PR TITLE
fix: vuln count text only shows count for severity X when severity X > 0

### DIFF
--- a/infrastructure/oss/vulnerability_count.go
+++ b/infrastructure/oss/vulnerability_count.go
@@ -146,14 +146,31 @@ func (cliScanner *CLIScanner) removeVulnerabilityCountsFromCache(issues []snyk.I
 }
 
 func (v *VulnerabilityCountInformation) Text() string {
-	text := fmt.Sprintf(
-		"Vulnerabilities: %d | Critical: %d, High: %d, Medium: %d, Low: %d | Most Severe: %s",
-		v.total,
-		v.severityCounts[snyk.Critical],
-		v.severityCounts[snyk.High],
-		v.severityCounts[snyk.Medium],
-		v.severityCounts[snyk.Low],
-		v.mostSevereVulnerabilityId,
-	)
+	text := ""
+
+	if v.total > 0 {
+		text += fmt.Sprintf("Vulnerabilities: %d", v.total)
+
+		// amend text if there are Vulnerabilities
+		if v.severityCounts[snyk.Critical] > 0 {
+			text += fmt.Sprintf(" | Critical: %d", v.severityCounts[snyk.Critical])
+		}
+
+		if v.severityCounts[snyk.High] > 0 {
+			text += fmt.Sprintf(" | High: %d", v.severityCounts[snyk.High])
+		}
+
+		if v.severityCounts[snyk.Medium] > 0 {
+			text += fmt.Sprintf(" | Medium: %d", v.severityCounts[snyk.Medium])
+		}
+
+		if v.severityCounts[snyk.Low] > 0 {
+			text += fmt.Sprintf(" | Low: %d", v.severityCounts[snyk.Low])
+		}
+
+		// add most severe vulnerability id
+		text += fmt.Sprintf(" | Most Severe: %s", v.mostSevereVulnerabilityId)
+	}
+
 	return text
 }


### PR DESCRIPTION
### Description

_This PR should change the vulnerability count text to omit severities where the count is 0._


### Screenshots / GIFs

Before
<img width="906" alt="Screenshot 2023-11-23 at 16 05 25" src="https://github.com/snyk/snyk-ls/assets/16223568/f1c7c512-6ce3-41f5-84bf-baccbe9e3553">

After
<img width="754" alt="Screenshot 2023-11-23 at 16 06 12" src="https://github.com/snyk/snyk-ls/assets/16223568/96dd0eb8-953b-49db-9ce3-30e41046f0e1">
