### PR TITLE
fix/HEAD-1066_fix-navigation-and-manifest-file-determination

### DIFF
--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -342,11 +342,13 @@ func (cliScanner *CLIScanner) handleError(path string, err error, res []byte, cm
 }
 
 func (cliScanner *CLIScanner) determineTargetFile(displayTargetFile string) string {
-	targetFile := lockFilesToManifestMap[displayTargetFile]
-	if targetFile == "" {
+	fileName := filepath.Base(displayTargetFile)
+	targetFileName := lockFilesToManifestMap[fileName]
+	if targetFileName == "" {
 		return displayTargetFile
 	}
-	return targetFile
+	targetFileName = strings.Replace(displayTargetFile, fileName, targetFileName, 1)
+	return targetFileName
 }
 
 func (cliScanner *CLIScanner) retrieveIssues(

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -67,6 +67,7 @@ func Test_determineTargetFile(t *testing.T) {
 	assert.Equal(t, "package.json", scanner.determineTargetFile("package-lock.json"))
 	assert.Equal(t, "pom.xml", scanner.determineTargetFile("pom.xml"))
 	assert.Equal(t, "asdf", scanner.determineTargetFile("asdf"))
+	assert.Equal(t, "js/package.json", scanner.determineTargetFile("js/package-lock.json"))
 }
 
 func Test_SuccessfulScanFile_TracksAnalytics(t *testing.T) {


### PR DESCRIPTION
### Description

fix: correctly map lock file in multi-repo projects

- fixes navigation for Snyk Open Source in VSCode custom UI
- fixes highlighting and navigation in target files

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-ls/assets/20150761/a3ab26df-6cf4-4223-bcb2-da0da4a1c6be)