### PR TITLE
fix: exclude `--all-projects` from package scan cli call

### DIFF
--- a/infrastructure/cli/cli_fake.go
+++ b/infrastructure/cli/cli_fake.go
@@ -32,6 +32,7 @@ type TestExecutor struct {
 	startedScans    int
 	finishedScans   int
 	counterLock     sync.RWMutex
+	cmd             []string
 }
 
 func NewTestExecutor() *TestExecutor {
@@ -62,7 +63,12 @@ func (t *TestExecutor) GetFinishedScans() int {
 	return t.finishedScans
 }
 
-func (t *TestExecutor) Execute(ctx context.Context, _ []string, _ string) (resp []byte, err error) {
+func (t *TestExecutor) GetCommand() []string {
+	return t.cmd
+}
+
+func (t *TestExecutor) Execute(ctx context.Context, cmd []string, _ string) (resp []byte, err error) {
+	t.cmd = cmd
 	err = ctx.Err()
 	if err != nil { // Checking for ctx cancellation before faking CLI execution
 		return resp, err

--- a/infrastructure/oss/cli_package_scan.go
+++ b/infrastructure/oss/cli_package_scan.go
@@ -67,11 +67,18 @@ func (cliScanner *CLIScanner) ScanPackages(
 	notCached := cliScanner.updateCachedDependencies(dependencies)
 
 	if len(notCached) > 0 {
-		commandFunc := func(_ []string) (deps []string) {
+		commandFunc := func(_ []string, _ map[string]bool) (deps []string) {
 			for _, d := range notCached {
 				deps = append(deps, d.ArtifactID+"@"+d.Version)
 			}
-			return cliScanner.prepareScanCommand(deps)
+
+			blacklist := map[string]bool{
+				"":               true,
+				"--all-projects": true,
+				"--dev":          true,
+			}
+
+			return cliScanner.prepareScanCommand(deps, blacklist)
 		}
 		_, err := cliScanner.scanInternal(ctx, path, commandFunc)
 		if err != nil {

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -40,6 +40,8 @@ import (
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
+const testDataPackageJson = "/testdata/package.json"
+
 // todo test issue parsing & conversion
 
 func Test_toIssueSeverity(t *testing.T) {
@@ -77,7 +79,7 @@ func Test_SuccessfulScanFile_TracksAnalytics(t *testing.T) {
 	executor := cli.NewTestExecutor()
 	fileContent, _ := os.ReadFile(workingDir + "/testdata/oss-result.json")
 	executor.ExecuteResponse = fileContent
-	p, _ := filepath.Abs(workingDir + "/testdata/package.json")
+	p, _ := filepath.Abs(workingDir + testDataPackageJson)
 
 	scanner := NewCLIScanner(
 		performance.NewInstrumentor(),
@@ -302,7 +304,7 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 		c,
 	)
 	wg := sync.WaitGroup{}
-	p, _ := filepath.Abs(workingDir + "/testdata/package.json")
+	p, _ := filepath.Abs(workingDir + testDataPackageJson)
 
 	// Act
 	for i := 0; i < concurrentScanRequests; i++ {
@@ -352,7 +354,7 @@ func Test_prepareScanCommand_ExpandsAdditionalParameters(t *testing.T) {
 	}
 	c.SetCliSettings(&settings)
 
-	cmd := scanner.prepareScanCommand([]string{"a"})
+	cmd := scanner.prepareScanCommand([]string{"a"}, map[string]bool{})
 
 	assert.Contains(t, cmd, "--all-projects")
 	assert.Contains(t, cmd, "-d")
@@ -376,7 +378,7 @@ func Test_Scan_SchedulesNewScan(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	t.Cleanup(cancel)
-	targetFile, _ := filepath.Abs(workingDir + "/testdata/package.json")
+	targetFile, _ := filepath.Abs(workingDir + testDataPackageJson)
 
 	// Act
 	_, _ = scanner.Scan(ctx, targetFile, "")
@@ -403,7 +405,7 @@ func Test_scheduleNewScan_CapturesAnalytics(t *testing.T) {
 
 	scanner.refreshScanWaitDuration = 50 * time.Millisecond
 	workingDir, _ := os.Getwd()
-	p, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
+	p, _ := filepath.Abs(path.Join(workingDir, testDataPackageJson))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -440,7 +442,7 @@ func Test_scheduleNewScanWithProductDisabled_NoScanRun(t *testing.T) {
 
 	scanner.refreshScanWaitDuration = 50 * time.Millisecond
 	workingDir, _ := os.Getwd()
-	p, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
+	p, _ := filepath.Abs(path.Join(workingDir, testDataPackageJson))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -471,7 +473,7 @@ func Test_scheduleNewScanTwice_RunsOnlyOnce(t *testing.T) {
 
 	scanner.refreshScanWaitDuration = 50 * time.Millisecond
 	workingDir, _ := os.Getwd()
-	targetPath, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
+	targetPath, _ := filepath.Abs(path.Join(workingDir, testDataPackageJson))
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	t.Cleanup(cancel1)
@@ -504,7 +506,7 @@ func Test_scheduleNewScan_ContextCancelledAfterScanScheduled_NoScanRun(t *testin
 
 	scanner.refreshScanWaitDuration = 2 * time.Second
 	workingDir, _ := os.Getwd()
-	targetPath, _ := filepath.Abs(path.Join(workingDir, "/testdata/package.json"))
+	targetPath, _ := filepath.Abs(path.Join(workingDir, testDataPackageJson))
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Act
@@ -535,7 +537,7 @@ func Test_Scan_missingDisplayTargetFileDoesNotBreakAnalysis(t *testing.T) {
 		notification.NewNotifier(),
 		c,
 	)
-	filePath, _ := filepath.Abs(workingDir + "/testdata/package.json")
+	filePath, _ := filepath.Abs(workingDir + testDataPackageJson)
 
 	// Act
 	analysis, err := scanner.Scan(context.Background(), filePath, "")


### PR DESCRIPTION
### Description

fix: exclude `--all-projects` from package scan cli call

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
