### PR TITLE
feat: add Priority Score to Snyk Code Issues [HEAD-1187]

### DIFF
--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -220,6 +220,7 @@ func (n *scanNotifier) appendCodeIssues(scanIssues []lsp.ScanIssue, folderPath s
 				Text:               additionalData.Text,
 				Cols:               additionalData.Cols,
 				Rows:               additionalData.Rows,
+				PriorityScore:      additionalData.PriorityScore,
 
 				Markers: markers,
 				LeadURL: "",

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -113,6 +113,7 @@ func Test_SendSuccess_SendsForAllEnabledProducts(t *testing.T) {
 				Cols:               lsp2.Point{1, 1},
 				Rows:               lsp2.Point{1, 1},
 				Markers:            []lsp2.Marker{},
+				PriorityScore:      880,
 			},
 		},
 	}
@@ -186,6 +187,7 @@ func Test_SendSuccess_SendsForAllEnabledProducts(t *testing.T) {
 				Cols:               snyk.CodePoint{1, 1},
 				Rows:               snyk.CodePoint{1, 1},
 				Markers:            []snyk.Marker{},
+				PriorityScore:      880,
 			},
 		},
 	}

--- a/domain/snyk/issues.go
+++ b/domain/snyk/issues.go
@@ -80,6 +80,7 @@ type CodeIssueData struct {
 	Rows               CodePoint          `json:"rows"`
 	IsSecurityType     bool               `json:"isSecurityType"`
 	IsAutofixable      bool               `json:"isAutofixable"`
+	PriorityScore      int                `json:"priorityScore"`
 }
 
 type ExampleCommitFix struct {

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -350,6 +350,7 @@ func (s *SarifResponse) toIssues(baseDir string) (issues []snyk.Issue, err error
 				Rows:               [2]int{startLine, endLine},
 				IsSecurityType:     isSecurityType,
 				IsAutofixable:      result.Properties.IsAutofixable,
+				PriorityScore:      result.Properties.PriorityScore,
 			}
 
 			d := snyk.Issue{

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -640,6 +640,7 @@ func TestSnykCodeBackendService_convert_shouldConvertIssues(t *testing.T) {
 	assert.Equal(t, references, issue.References)
 	assert.Contains(t, issue.FormattedMessage, "Example Commit Fixes")
 	assert.Equal(t, markersForSampleSarifResponse(path), issue.AdditionalData.(snyk.CodeIssueData).Markers)
+	assert.Equal(t, 550, issue.AdditionalData.(snyk.CodeIssueData).PriorityScore)
 	assert.Equal(t, resp.Sarif.Runs[0].Tool.Driver.Rules[0].Properties.Cwe, issue.CWEs)
 }
 

--- a/internal/lsp/message_types.go
+++ b/internal/lsp/message_types.go
@@ -1074,6 +1074,7 @@ type CodeIssueData struct {
 	Cols               Point              `json:"cols"`
 	Rows               Point              `json:"rows"`
 	IsSecurityType     bool               `json:"isSecurityType"`
+	PriorityScore      int                `json:"priorityScore"`
 }
 
 type Point = [2]int


### PR DESCRIPTION
### Description

This PR adds the `PriorityScore` attribute to Snyk Code issues, enabling IDE integrations to display the severity score for code suggestions. 

The `PriorityScore` is propagated from the SARIF response and made available to the scan notification system.


### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

This change can see propagated in Visual Studio Code in the PR https://github.com/snyk/vscode-extension/pull/422

|Before|After|
|-|-|
|<img width="1612" alt="missing-priority-score" src="https://github.com/snyk/vscode-extension/assets/1948377/e48f1cbe-dc62-4766-9793-587f18401e9e">|<img width="1612" alt="added-priority-score" src="https://github.com/snyk/vscode-extension/assets/1948377/79fcdbca-7803-4f7a-9c7a-91313d8d2245">|


HEAD-1187
