### PR TITLE
upgrade GAF with analytics endpoint fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/go-application-framework v0.0.0-20240103162526-aea591663ca6
+	github.com/snyk/go-application-framework v0.0.0-20240111143643-fa847b8a9a3b
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/go-application-framework v0.0.0-20240103162526-aea591663ca6 h1:x53bcGKTb+2PMuMnFLNXxRt8EbGnKy/B0xsBOBpB4B4=
-github.com/snyk/go-application-framework v0.0.0-20240103162526-aea591663ca6/go.mod h1:Yz/qxFyfhf0xbA+z8Vzr5IM9IDG+BS+2PiGaP1yAsEw=
+github.com/snyk/go-application-framework v0.0.0-20240111143643-fa847b8a9a3b h1:8fFjcaUZpjLV06AtIqtB7QRMYBH/5dxv2CJp319q2Gs=
+github.com/snyk/go-application-framework v0.0.0-20240111143643-fa847b8a9a3b/go.mod h1:Yz/qxFyfhf0xbA+z8Vzr5IM9IDG+BS+2PiGaP1yAsEw=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/infrastructure/analytics/pact_test.go
+++ b/infrastructure/analytics/pact_test.go
@@ -52,7 +52,7 @@ func TestAnalyticsProviderPact(t *testing.T) {
 		UponReceiving("A request to create analytics data").
 		WithRequest(dsl.Request{
 			Method: "POST",
-			Path:   dsl.String("/rest/api/orgs/" + orgUUID + "/analytics"),
+			Path:   dsl.String("/hidden/orgs/" + orgUUID + "/analytics"),
 			Body:   getExpectedBodyRequest(),
 		}).
 		WillRespondWith(dsl.Response{


### PR DESCRIPTION
### Description

Incorporate snyk/go-application-framework#122 which fixes the URL to the experimental analytics endpoint.

### Checklist

- [x] Tests added and all succeed
- ~~[ ] Linted~~
- ~~[ ] README.md updated, if user-facing~~
- ~~[ ] License file updated, if new 3rd-party dependency is introduced~~
