### PR TITLE
chore: enable smoke tests for Standard environment [IDE-56]

### DIFF
--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -17,16 +17,16 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '3 * * * *'  # hourly
+    - cron: "3 * * * *" # hourly
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   instance-tests:
     strategy:
       matrix:
-        environment: [Standard, MT1, MT3] # MT3 is not available at the moment, don't block the CI. Should be: [Standard, MT1, MT2, MT3]
+        environment: [MT1, MT3]
     name: instance tests
     environment: ${{matrix.environment}}
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
 
       - name: Cache Go modules
         uses: actions/cache@v3
@@ -53,3 +53,31 @@ jobs:
           SNYK_API: ${{ secrets.SNYK_API }}
         run: |
           make instance-test
+
+  smoke-tests:
+    name: smoke tests (Standard)
+    runs-on: ubuntu-latest
+    environment: Standard
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Run Smoke Tests
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_API: ${{ secrets.SNYK_API }}
+        run: |
+          make smoke-test-all

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ instance-test:
 	@echo "==> Running instance tests with proxy"
 	@export SMOKE_TESTS=1 && cd application/server && go test -run Test_SmokeWorkspaceScanOssAndCode && cd -
 
+smoke-test-all:
+	@echo "==> Running all smoke tests with proxy"
+	@export SMOKE_TESTS=1 && cd application/server && go test -run Test_Smoke && cd -
+
 ## build: Build binary for default local system's OS and architecture.
 .PHONY: build
 build:


### PR DESCRIPTION
### Description

This PR enables:

- `Test_SmokeWorkspaceScanOssAndCode`
- `Test_SmokeWorkspaceScanIacAndCode`
- `Test_SmokeWorkspaceScanWithTwoUploadBatches`

for the Standard environment

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

