### PR TITLE
feat: add Slack Notification When Smoke Test Fails

### DIFF
--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -86,7 +86,5 @@ jobs:
         #if: ${{ failure() || cancelled() }}
         if: ${{ always()}}
         uses: slackapi/slack-github-action@v1.24
-        with:
-          status ${{job.status}}
         env:
           SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL }}'

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ always()}}
         with:
           # For posting a simple plain text message
-          payload: '{"text": "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }" }'
+          payload: '{"text": "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'
  
         uses: slackapi/slack-github-action@v1.24
         env:

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -92,3 +92,4 @@ jobs:
         uses: slackapi/slack-github-action@v1.24
         env:
           SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL }}'
+

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -83,8 +83,8 @@ jobs:
           make smoke-test-all
           
       - name: Slack Notification
-        #if: ${{ failure() || cancelled() }}
-        if: ${{ always()}}
+        if: ${{ failure() || cancelled() }}
+        #if: ${{ always()}}
         with:
           # For posting a simple plain text message
           payload: '{"text": "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -85,6 +85,10 @@ jobs:
       - name: Slack Notification
         #if: ${{ failure() || cancelled() }}
         if: ${{ always()}}
+        with:
+          # For posting a simple plain text message
+          slack-message: "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+ 
         uses: slackapi/slack-github-action@v1.24
         env:
           SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL }}'

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ always()}}
         with:
           # For posting a simple plain text message
-          slack-message: "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          slack-message: "Knuts test msg!! <3 "
  
         uses: slackapi/slack-github-action@v1.24
         env:

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ always()}}
         with:
           # For posting a simple plain text message
-          payload: '{"text": "Your message here" }'
+          payload: '{"text": "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }" }'
  
         uses: slackapi/slack-github-action@v1.24
         env:

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ always()}}
         with:
           # For posting a simple plain text message
-          slack-message: "Knuts test msg!! <3 "
+          payload: '{"text": "Your message here" }'
  
         uses: slackapi/slack-github-action@v1.24
         env:

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -81,3 +81,12 @@ jobs:
           SNYK_API: ${{ secrets.SNYK_API }}
         run: |
           make smoke-test-all
+          
+      - name: Slack Notification
+        #if: ${{ failure() || cancelled() }}
+        if: ${{ always()}}
+        uses: slackapi/slack-github-action@v1.24
+        with:
+          status ${{job.status}}
+        env:
+          SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL }}'


### PR DESCRIPTION
IDE-57

### Description

Adding Slack notification to #dx_local_alerts if the smoke test cases fail.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
