### PR TITLE
chore: add link to GH action in Slack notification

### DIFF
--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Slack Notification
         if: ${{ failure() || cancelled() }}
         with:
-          payload: '{"text": "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'
+          payload: '{"text": "GitHub build result: ${{ job.status }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'
  
         uses: slackapi/slack-github-action@v1.24
         env:


### PR DESCRIPTION
### Description

This should add a link to the failing GH action run. Variables taken from [the docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)
