### PR TITLE
feat: add issue range to scan issues

### DIFF
--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strconv"
 
+	"github.com/snyk/snyk-ls/domain/ide/converter"
 	"github.com/snyk/snyk-ls/domain/ide/notification"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/lsp"
@@ -105,6 +106,7 @@ func (n *scanNotifier) appendOssIssues(scanIssues []lsp.ScanIssue, folderPath st
 			Title:    additionalData.Title,
 			Severity: issue.Severity.String(),
 			FilePath: issue.AffectedFilePath,
+			Range:    converter.ToRange(issue.Range),
 			AdditionalData: lsp.OssIssueData{
 				License: additionalData.License,
 				Identifiers: lsp.OssIdentifiers{
@@ -147,6 +149,7 @@ func (n *scanNotifier) appendIacIssues(scanIssues []lsp.ScanIssue, folderPath st
 			Title:    additionalData.Title,
 			Severity: issue.Severity.String(),
 			FilePath: issue.AffectedFilePath,
+			Range:    converter.ToRange(issue.Range),
 			AdditionalData: lsp.IacIssueData{
 				PublicId:      additionalData.PublicId,
 				Documentation: additionalData.Documentation,
@@ -209,6 +212,7 @@ func (n *scanNotifier) appendCodeIssues(scanIssues []lsp.ScanIssue, folderPath s
 			Title:    issue.Message,
 			Severity: issue.Severity.String(),
 			FilePath: issue.AffectedFilePath,
+			Range:    converter.ToRange(issue.Range),
 			AdditionalData: lsp.CodeIssueData{
 				Message:            additionalData.Message,
 				Rule:               additionalData.Rule,

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -214,12 +214,25 @@ func Test_SendSuccess_SendsForOpenSource(t *testing.T) {
 
 	const folderPath = "/test/oss/folderPath"
 
+	r := snyk.Range{
+		Start: snyk.Position{
+			Line:      1,
+			Character: 1,
+		},
+		End: snyk.Position{
+			Line:      1,
+			Character: 2,
+		},
+	}
+	lspTestRange := converter.ToRange(r)
+
 	expectedUIScanIssue := []lsp2.ScanIssue{
 		{
 			Id:       "OSS Key",
 			Title:    "OSS Title",
 			Severity: "critical",
 			FilePath: "ossAffectedFilePath",
+			Range:    lspTestRange,
 			AdditionalData: lsp2.OssIssueData{
 				License: "OSS License",
 				Identifiers: lsp2.OssIdentifiers{
@@ -252,19 +265,10 @@ func Test_SendSuccess_SendsForOpenSource(t *testing.T) {
 
 	issues := []snyk.Issue{
 		{ // OSS issue
-			ID:        "SNYK-JS-BABELTRAVERSE-5962463",
-			Severity:  snyk.Critical,
-			IssueType: 1,
-			Range: snyk.Range{
-				Start: snyk.Position{
-					Line:      1,
-					Character: 1,
-				},
-				End: snyk.Position{
-					Line:      1,
-					Character: 2,
-				},
-			},
+			ID:                  "SNYK-JS-BABELTRAVERSE-5962463",
+			Severity:            snyk.Critical,
+			IssueType:           1,
+			Range:               r,
 			Message:             "Incomplete List of Disallowed Inputs",
 			FormattedMessage:    "Incomplete List of Disallowed Inputs",
 			AffectedFilePath:    "ossAffectedFilePath",
@@ -327,6 +331,17 @@ func Test_SendSuccess_SendsForSnykCode(t *testing.T) {
 	scanNotifier, _ := notification2.NewScanNotifier(mockNotifier)
 
 	const folderPath = "/test/iac/folderPath"
+	r := snyk.Range{
+		Start: snyk.Position{
+			Line:      1,
+			Character: 1,
+		},
+		End: snyk.Position{
+			Line:      1,
+			Character: 2,
+		},
+	}
+	lspTestRange := converter.ToRange(r)
 
 	expectedCodeIssue := []lsp2.ScanIssue{
 		{
@@ -334,6 +349,7 @@ func Test_SendSuccess_SendsForSnykCode(t *testing.T) {
 			Title:    "codeMessage",
 			Severity: "low",
 			FilePath: "codeAffectedFilePath",
+			Range:    lspTestRange,
 			AdditionalData: lsp2.CodeIssueData{
 				Message:            "codeMessage",
 				Rule:               "codeRule",
@@ -352,19 +368,10 @@ func Test_SendSuccess_SendsForSnykCode(t *testing.T) {
 
 	scanIssues := []snyk.Issue{
 		{ // Code issue
-			ID:        "codeID",
-			Severity:  snyk.Low,
-			IssueType: 1,
-			Range: snyk.Range{
-				Start: snyk.Position{
-					Line:      1,
-					Character: 1,
-				},
-				End: snyk.Position{
-					Line:      1,
-					Character: 2,
-				},
-			},
+			ID:                  "codeID",
+			Severity:            snyk.Low,
+			IssueType:           1,
+			Range:               r,
 			Message:             "codeMessage",
 			FormattedMessage:    "codeFormattedMessage",
 			AffectedFilePath:    "codeAffectedFilePath",
@@ -408,6 +415,17 @@ func Test_SendSuccess_SendsForAllSnykIac(t *testing.T) {
 	scanNotifier, _ := notification2.NewScanNotifier(mockNotifier)
 
 	const folderPath = "/test/iac/folderPath"
+	r := snyk.Range{
+		Start: snyk.Position{
+			Line:      1,
+			Character: 1,
+		},
+		End: snyk.Position{
+			Line:      1,
+			Character: 2,
+		},
+	}
+	lspTestRange := converter.ToRange(r)
 
 	// expected message uses lsp2.ScanIssue && lsp2.CodeIssueData
 	expectedIacIssue := []lsp2.ScanIssue{
@@ -416,6 +434,7 @@ func Test_SendSuccess_SendsForAllSnykIac(t *testing.T) {
 			Title:    "iacTitle",
 			Severity: "critical",
 			FilePath: "iacAffectedFilePath",
+			Range:    lspTestRange,
 			AdditionalData: lsp2.IacIssueData{
 				PublicId:      "iacID",
 				Documentation: "iacDocumentation",
@@ -429,19 +448,10 @@ func Test_SendSuccess_SendsForAllSnykIac(t *testing.T) {
 
 	scanIssues := []snyk.Issue{
 		{ // IaC issue
-			ID:        "iacID",
-			Severity:  snyk.Critical,
-			IssueType: 1,
-			Range: snyk.Range{
-				Start: snyk.Position{
-					Line:      1,
-					Character: 1,
-				},
-				End: snyk.Position{
-					Line:      1,
-					Character: 2,
-				},
-			},
+			ID:                  "iacID",
+			Severity:            snyk.Critical,
+			IssueType:           1,
+			Range:               r,
 			Message:             "iacMessage",
 			FormattedMessage:    "iacFormattedMessage",
 			AffectedFilePath:    "iacAffectedFilePath",

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	notification2 "github.com/snyk/snyk-ls/application/server/notification"
+	"github.com/snyk/snyk-ls/domain/ide/converter"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	lsp2 "github.com/snyk/snyk-ls/internal/lsp"
 	"github.com/snyk/snyk-ls/internal/notification"
@@ -77,13 +78,25 @@ func Test_SendSuccess_SendsForAllEnabledProducts(t *testing.T) {
 
 	const folderPath = "/test/iac/folderPath"
 
-	// expected message uses lsp2.ScanIssue && lsp2.CodeIssueData
+	testRange := snyk.Range{
+		Start: snyk.Position{
+			Line:      1,
+			Character: 1,
+		},
+		End: snyk.Position{
+			Line:      1,
+			Character: 2,
+		},
+	}
+	lspTestRange := converter.ToRange(testRange)
+
 	expectedIacIssue := []lsp2.ScanIssue{
 		{
 			Id:       "098f6bcd4621d373cade4e832627b4f6",
 			Title:    "iacTitle",
 			Severity: "critical",
 			FilePath: "iacAffectedFilePath",
+			Range:    lspTestRange,
 			AdditionalData: lsp2.IacIssueData{
 				PublicId:      "iacID",
 				Documentation: "iacDocumentation",
@@ -101,6 +114,7 @@ func Test_SendSuccess_SendsForAllEnabledProducts(t *testing.T) {
 			Title:    "codeMessage",
 			Severity: "low",
 			FilePath: "codeAffectedFilePath",
+			Range:    lspTestRange,
 			AdditionalData: lsp2.CodeIssueData{
 				Message:            "codeMessage",
 				Rule:               "codeRule",
@@ -120,19 +134,10 @@ func Test_SendSuccess_SendsForAllEnabledProducts(t *testing.T) {
 
 	scanIssues := []snyk.Issue{
 		{ // IaC issue
-			ID:        "iacID",
-			Severity:  snyk.Critical,
-			IssueType: 1,
-			Range: snyk.Range{
-				Start: snyk.Position{
-					Line:      1,
-					Character: 1,
-				},
-				End: snyk.Position{
-					Line:      1,
-					Character: 2,
-				},
-			},
+			ID:                  "iacID",
+			Severity:            snyk.Critical,
+			IssueType:           1,
+			Range:               testRange,
 			Message:             "iacMessage",
 			FormattedMessage:    "iacFormattedMessage",
 			AffectedFilePath:    "iacAffectedFilePath",
@@ -153,19 +158,10 @@ func Test_SendSuccess_SendsForAllEnabledProducts(t *testing.T) {
 			},
 		},
 		{ // Code issue
-			ID:        "codeID",
-			Severity:  snyk.Low,
-			IssueType: 1,
-			Range: snyk.Range{
-				Start: snyk.Position{
-					Line:      1,
-					Character: 1,
-				},
-				End: snyk.Position{
-					Line:      1,
-					Character: 2,
-				},
-			},
+			ID:                  "codeID",
+			Severity:            snyk.Low,
+			IssueType:           1,
+			Range:               testRange,
 			Message:             "codeMessage",
 			FormattedMessage:    "codeFormattedMessage",
 			AffectedFilePath:    "codeAffectedFilePath",

--- a/internal/lsp/message_types.go
+++ b/internal/lsp/message_types.go
@@ -1025,11 +1025,12 @@ type SnykScanParams struct {
 
 type ScanIssue struct { // TODO - convert this to a generic type
 	// Unique key identifying an issue in the whole result set. Not the same as the Snyk issue ID.
-	Id             string `json:"id"`
-	Title          string `json:"title"`
-	Severity       string `json:"severity"`
-	FilePath       string `json:"filePath"`
-	AdditionalData any    `json:"additionalData,omitempty"`
+	Id             string      `json:"id"`
+	Title          string      `json:"title"`
+	Severity       string      `json:"severity"`
+	FilePath       string      `json:"filePath"`
+	Range          sglsp.Range `json:"range"`
+	AdditionalData any         `json:"additionalData,omitempty"`
 }
 
 // Snyk Open Source


### PR DESCRIPTION
### Description

Adds range information to scanIssues transferred via the custom $/snyk.scan message. This enables clients to display a range without having to analyse the diagnostics notifications.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
