### PR TITLE
refactor: rename `smoke-test-all` to `instance-standard-test` [IDE-56]

### DIFF
--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -54,8 +54,8 @@ jobs:
         run: |
           make instance-test
 
-  smoke-tests:
-    name: smoke tests (Standard)
+  instance-standard-test:
+    name: instance tests (Standard)
     runs-on: ubuntu-latest
     environment: Standard
     steps:
@@ -75,19 +75,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
-      - name: Run Smoke Tests
+      - name: Run Instance Tests on Standard Environment
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_API: ${{ secrets.SNYK_API }}
         run: |
-          make smoke-test-all
-          
+          make instance-standard-test
+
       - name: Slack Notification
         if: ${{ failure() || cancelled() }}
         with:
           payload: '{"text": "GitHub build result: ${{ job.status }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'
- 
+
         uses: slackapi/slack-github-action@v1.24
         env:
-          SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL }}'
-
+          SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ instance-test:
 	@echo "==> Running instance tests with proxy"
 	@export SMOKE_TESTS=1 && cd application/server && go test -run Test_SmokeWorkspaceScanOssAndCode && cd -
 
-smoke-test-all:
-	@echo "==> Running all smoke tests with proxy"
+instance-standard-test:
+	@echo "==> Running instance tests for the Standard environment with proxy"
 	@export SMOKE_TESTS=1 && cd application/server && go test -run Test_Smoke && cd -
 
 ## build: Build binary for default local system's OS and architecture.


### PR DESCRIPTION
### Description

The `smoke-test-all` make target was misleading as it did not run all available smoke tests but rather a specific subset and only for the standard environment.

#### Changes
- Renamed `smoke-test-all` target to `instance-standard-test` in the Makefile.
- Updated the job name in GHA file to `instance tests (Standard)`.
- Updated the echo statement in the Makefile to _"==> Running instance tests for the Standard environment with proxy"_ for clarity.

Issue discussed [here](https://github.com/snyk/snyk-ls/pull/436#discussion_r1463045382)

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
