### PR TITLE
fix: squiggly line remains between scans

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -449,7 +449,8 @@ func textDocumentDidOpenHandler() jrpc2.Handler {
 			return nil, nil
 		}
 
-		issues := folder.DocumentDiagnosticsFromCache(filePath)
+		issues, _ := folder.DocumentDiagnosticsFromCache(filePath)
+
 		filteredIssues := workspace.FilterIssues(issues, config.CurrentConfig().DisplayableIssueTypes())
 
 		if len(filteredIssues) > 0 {

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -389,7 +389,8 @@ func Test_TextDocumentCodeLenses_shouldReturnCodeLenses(t *testing.T) {
 		t,
 		func() bool {
 			path := uri.PathFromUri(didOpenParams.TextDocument.URI)
-			return workspace.Get().GetFolderContaining(path).DocumentDiagnosticsFromCache(path) != nil
+			issues, ok := workspace.Get().GetFolderContaining(path).DocumentDiagnosticsFromCache(path)
+			return ok && len(issues) > 0
 		},
 		50*time.Second,
 		time.Millisecond,
@@ -446,7 +447,8 @@ func Test_TextDocumentCodeLenses_dirtyFileShouldFilterCodeFixLenses(t *testing.T
 		t,
 		func() bool {
 			path := uri.PathFromUri(didOpenParams.TextDocument.URI)
-			return workspace.Get().GetFolderContaining(path).DocumentDiagnosticsFromCache(path) != nil
+			issues, ok := workspace.Get().GetFolderContaining(path).DocumentDiagnosticsFromCache(path)
+			return ok && len(issues) > 0
 		},
 		50*time.Second,
 		time.Millisecond,

--- a/domain/ide/codelens/codelens.go
+++ b/domain/ide/codelens/codelens.go
@@ -30,7 +30,8 @@ func GetFor(filePath string) (lenses []sglsp.CodeLens) {
 		return lenses
 	}
 
-	issues := f.DocumentDiagnosticsFromCache(filePath)
+	issues, _ := f.DocumentDiagnosticsFromCache(filePath)
+
 	for _, issue := range issues {
 		for _, command := range issue.CodelensCommands {
 			lenses = append(lenses, getCodeLensFromCommand(issue, command))

--- a/domain/ide/codelens/codelens_test.go
+++ b/domain/ide/codelens/codelens_test.go
@@ -60,7 +60,9 @@ func Test_GetCodeLensForPath(t *testing.T) {
 	workspace.Get().AddFolder(folder)
 	folder.ScanFile(context.Background(), filePath)
 
-	assert.NotNil(t, folder.DocumentDiagnosticsFromCache(filePath))
+	issues, _ := folder.DocumentDiagnosticsFromCache(filePath)
+
+	assert.NotNil(t, issues)
 
 	lenses := GetFor(filePath)
 

--- a/domain/ide/hover/fake_service.go
+++ b/domain/ide/hover/fake_service.go
@@ -22,15 +22,21 @@ import (
 )
 
 type FakeHoverService struct {
-	hovers chan DocumentHovers
-	calls  int
+	hovers        chan DocumentHovers
+	calls         int
+	DeletedIssues map[string][]string // Track DeleteHoverForIssue calls
 }
 
 func NewFakeHoverService() *FakeHoverService {
 	return &FakeHoverService{
-		calls:  0,
-		hovers: make(chan DocumentHovers, 10000),
+		calls:         0,
+		hovers:        make(chan DocumentHovers, 10000),
+		DeletedIssues: make(map[string][]string),
 	}
+}
+
+func (t *FakeHoverService) DeleteHoverForIssue(path string, issueID string) {
+	t.DeletedIssues[path] = append(t.DeletedIssues[path], issueID)
 }
 
 func (t *FakeHoverService) DeleteHover(_ string) {

--- a/domain/ide/hover/service.go
+++ b/domain/ide/hover/service.go
@@ -29,6 +29,7 @@ import (
 
 type Service interface {
 	DeleteHover(path string)
+	DeleteHoverForIssue(path string, issueID string)
 	Channel() chan DocumentHovers
 	ClearAllHovers()
 	GetHover(path string, pos snyk.Position) Result
@@ -78,6 +79,18 @@ func (s *DefaultHoverService) registerHovers(result DocumentHovers) {
 
 			s.hovers[key] = append(s.hovers[key], newHover)
 			s.hoverIndexes[hoverIndex] = true
+		}
+	}
+}
+
+func (s *DefaultHoverService) DeleteHoverForIssue(path string, issueID string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for i, hover := range s.hovers[path] {
+		if hover.Id == issueID {
+			s.hovers[path] = append(s.hovers[path][:i], s.hovers[path][i+1:]...)
+			break
 		}
 	}
 }

--- a/domain/ide/hover/service_test.go
+++ b/domain/ide/hover/service_test.go
@@ -56,6 +56,42 @@ func Test_registerHovers(t *testing.T) {
 	assert.Equal(t, len(target.hoverIndexes), 1)
 }
 
+func Test_DeleteHoverForIssue(t *testing.T) {
+	// Arrange
+	target := NewDefaultService(ux2.NewTestAnalytics()).(*DefaultHoverService)
+	path := "file:///UsersFolder/aUser/aRepositoryName/index.js"
+	issueID := "javascript/HardcodedSecret"
+
+	target.hovers[path] = []Hover[Context]{
+		{
+			Id: "other-issue-id",
+			Range: snyk.Range{
+				Start: snyk.Position{Line: 2, Character: 30},
+				End:   snyk.Position{Line: 2, Character: 40},
+			},
+			Message: "Other hover",
+		},
+		{
+			Id: issueID, // Issue ID to delete
+			Range: snyk.Range{
+				Start: snyk.Position{Line: 1, Character: 10},
+				End:   snyk.Position{Line: 1, Character: 20},
+			},
+			Message: "Hover for deletion",
+		},
+	}
+
+	// Act
+	target.DeleteHoverForIssue(path, issueID)
+
+	// Assert
+	remainingHovers := target.hovers[path]
+	assert.Equal(t, 1, len(remainingHovers), "Hover count should be 1 after deletion")
+	for _, hover := range remainingHovers {
+		assert.NotEqual(t, issueID, hover.Id, "Deleted hover should not be present")
+	}
+}
+
 func Test_DeleteHover(t *testing.T) {
 	target := NewDefaultService(ux2.NewTestAnalytics()).(*DefaultHoverService)
 	documentUri := setupFakeHover()

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -188,26 +188,20 @@ func (f *Folder) processResults(scanData snyk.ScanData) {
 		return
 	}
 
-	// [DEBUG:IDE-132] The key used in `createDedupMap()` is `issue.ID + "|" + issue.AffectedFilePath`.
-	// [DEBUG:IDE-132] `documentDiagnosticCache.Load` and `documentDiagnosticCache.Store` use `issue.AffectedFilePath` as a key.
-	// [DEBUG:IDE-132] There is a mismatch between with the keys used for caching and deduplication.
 	dedupMap := f.createDedupMap()
 
 	// TODO: perform issue diffing (current <-> newly reported)
 	// Update diagnostic cache
 	for _, issue := range scanData.Issues {
-		// [DEBUG:IDE-132]
 		cachedIssues, _ := f.documentDiagnosticCache.Load(issue.AffectedFilePath)
 		if cachedIssues == nil {
 			cachedIssues = []snyk.Issue{}
 		}
-		// [DEBUG:IDE-132] The mismatch causes that the dedupMap is always empty, so the condition is always true.
 		if !dedupMap[f.getUniqueIssueID(issue)] {
 			cachedIssues = append(cachedIssues, issue)
 			incrementSeverityCount(&scanData, issue)
 		}
 
-		// [DEBUG:IDE-132]
 		f.documentDiagnosticCache.Store(issue.AffectedFilePath, cachedIssues)
 
 	}

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -188,25 +188,27 @@ func (f *Folder) processResults(scanData snyk.ScanData) {
 		return
 	}
 
+	// [DEBUG:IDE-132] The key used in `createDedupMap()` is `issue.ID + "|" + issue.AffectedFilePath`.
+	// [DEBUG:IDE-132] `documentDiagnosticCache.Load` and `documentDiagnosticCache.Store` use `issue.AffectedFilePath` as a key.
+	// [DEBUG:IDE-132] There is a mismatch between with the keys used for caching and deduplication.
 	dedupMap := f.createDedupMap()
 
 	// TODO: perform issue diffing (current <-> newly reported)
 	// Update diagnostic cache
 	for _, issue := range scanData.Issues {
-		uniqueIssueId := f.getUniqueIssueID(issue)
-
-		cachedIssues, _ := f.documentDiagnosticCache.Load(uniqueIssueId)
-
+		// [DEBUG:IDE-132]
+		cachedIssues, _ := f.documentDiagnosticCache.Load(issue.AffectedFilePath)
 		if cachedIssues == nil {
 			cachedIssues = []snyk.Issue{}
 		}
-
-		if !dedupMap[uniqueIssueId] {
+		// [DEBUG:IDE-132] The mismatch causes that the dedupMap is always empty, so the condition is always true.
+		if !dedupMap[f.getUniqueIssueID(issue)] {
 			cachedIssues = append(cachedIssues, issue)
 			incrementSeverityCount(&scanData, issue)
 		}
 
-		f.documentDiagnosticCache.Store(uniqueIssueId, cachedIssues)
+		// [DEBUG:IDE-132]
+		f.documentDiagnosticCache.Store(issue.AffectedFilePath, cachedIssues)
 
 	}
 	log.Debug().Str("method", "processResults").Interface("scanData", scanData).Msg("Finished processing results. Sending analytics.")

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -188,21 +188,26 @@ func (f *Folder) processResults(scanData snyk.ScanData) {
 		return
 	}
 
+	// [DEBUG:IDE-132] The key used in `createDedupMap()` is `issue.ID + "|" + issue.AffectedFilePath`.
+	// [DEBUG:IDE-132] `documentDiagnosticCache.Load` and `documentDiagnosticCache.Store` use `issue.AffectedFilePath` as a key.
+	// [DEBUG:IDE-132] There is a mismatch between with the keys used for caching and deduplication.
 	dedupMap := f.createDedupMap()
 
 	// TODO: perform issue diffing (current <-> newly reported)
 	// Update diagnostic cache
 	for _, issue := range scanData.Issues {
+		// [DEBUG:IDE-132]
 		cachedIssues, _ := f.documentDiagnosticCache.Load(issue.AffectedFilePath)
 		if cachedIssues == nil {
 			cachedIssues = []snyk.Issue{}
 		}
-
+		// [DEBUG:IDE-132] The mismatch causes that the dedupMap is always empty, so the condition is always true.
 		if !dedupMap[f.getUniqueIssueID(issue)] {
 			cachedIssues = append(cachedIssues, issue)
 			incrementSeverityCount(&scanData, issue)
 		}
 
+		// [DEBUG:IDE-132]
 		f.documentDiagnosticCache.Store(issue.AffectedFilePath, cachedIssues)
 
 	}

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -188,27 +188,25 @@ func (f *Folder) processResults(scanData snyk.ScanData) {
 		return
 	}
 
-	// [DEBUG:IDE-132] The key used in `createDedupMap()` is `issue.ID + "|" + issue.AffectedFilePath`.
-	// [DEBUG:IDE-132] `documentDiagnosticCache.Load` and `documentDiagnosticCache.Store` use `issue.AffectedFilePath` as a key.
-	// [DEBUG:IDE-132] There is a mismatch between with the keys used for caching and deduplication.
 	dedupMap := f.createDedupMap()
 
 	// TODO: perform issue diffing (current <-> newly reported)
 	// Update diagnostic cache
 	for _, issue := range scanData.Issues {
-		// [DEBUG:IDE-132]
-		cachedIssues, _ := f.documentDiagnosticCache.Load(issue.AffectedFilePath)
+		uniqueIssueId := f.getUniqueIssueID(issue)
+
+		cachedIssues, _ := f.documentDiagnosticCache.Load(uniqueIssueId)
+
 		if cachedIssues == nil {
 			cachedIssues = []snyk.Issue{}
 		}
-		// [DEBUG:IDE-132] The mismatch causes that the dedupMap is always empty, so the condition is always true.
-		if !dedupMap[f.getUniqueIssueID(issue)] {
+
+		if !dedupMap[uniqueIssueId] {
 			cachedIssues = append(cachedIssues, issue)
 			incrementSeverityCount(&scanData, issue)
 		}
 
-		// [DEBUG:IDE-132]
-		f.documentDiagnosticCache.Store(issue.AffectedFilePath, cachedIssues)
+		f.documentDiagnosticCache.Store(uniqueIssueId, cachedIssues)
 
 	}
 	log.Debug().Str("method", "processResults").Interface("scanData", scanData).Msg("Finished processing results. Sending analytics.")


### PR DESCRIPTION
### Description

🚧 **Work in Progress**

**Commit 1**: 
In the process of addressing the issue with the squiggly lines not appearing as expected, a potential bug was identified related to our caching mechanism. It appears that there is a discrepancy in the keys being used to fetch from and store data in the cache.

The keys for the deduplication map are constructed using both the issue ID and the affected file path, while the document diagnostic cache has been using only the affected file path. This inconsistency could lead to issues not being recognized as duplicates.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

**Problem: when the file is saved, the squiggly line disappears**




