### PR TITLE
chore: remove extra response body close

### DIFF
--- a/infrastructure/cli/install/releases.go
+++ b/infrastructure/cli/install/releases.go
@@ -77,8 +77,6 @@ func (r *CLIRelease) GetLatestRelease(ctx context.Context) (*Release, error) {
 		return nil, fmt.Errorf("failed to obtained Snyk CLI release from %q: %s ", releaseURL, resp.Status)
 	}
 
-	defer func(Body io.ReadCloser) { _ = Body.Close() }(resp.Body)
-
 	log.Ctx(ctx).Trace().Str("response_status", resp.Status).Msg("received")
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
### Description

Correction for linting PR (#452) which inadvertently added an extra response body close.

Adding the defer immediately after checking the response error prevents a potential memory leak on non-200 response code.