### PR TITLE
refactor: extract issue enhancer funtionality [IDE-175]

### DIFF
--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -20,22 +20,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
-	sglsp "github.com/sourcegraph/go-lsp"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/ide/notification"
 	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
 	"github.com/snyk/snyk-ls/domain/observability/performance"
 	"github.com/snyk/snyk-ls/domain/snyk"
-	"github.com/snyk/snyk-ls/infrastructure/learn"
-	"github.com/snyk/snyk-ls/internal/data_structure"
 	"github.com/snyk/snyk-ls/internal/progress"
-	"github.com/snyk/snyk-ls/internal/util"
 )
 
 type Bundle struct {
@@ -49,8 +44,8 @@ type Bundle struct {
 	missingFiles  []string
 	limitToFiles  []string
 	rootPath      string
-	learnService  learn.Service
 	notifier      notification.Notifier
+	issueEnhancer IssueEnhancer
 }
 
 func (b *Bundle) Upload(ctx context.Context, uploadBatch *UploadBatch) error {
@@ -66,7 +61,8 @@ func (b *Bundle) extendBundle(ctx context.Context, uploadBatch *UploadBatch) err
 	var removeFiles []string
 	var err error
 	if uploadBatch.hasContent() {
-		b.BundleHash, b.missingFiles, err = b.SnykCode.ExtendBundle(ctx, b.BundleHash, uploadBatch.documents, removeFiles)
+		b.BundleHash, b.missingFiles, err = b.SnykCode.ExtendBundle(ctx, b.BundleHash, uploadBatch.documents,
+			removeFiles)
 		log.Debug().Str("requestId", b.requestId).Interface(
 			"missingFiles",
 			b.missingFiles,
@@ -148,7 +144,7 @@ func (b *Bundle) retrieveAnalysis(ctx context.Context) ([]snyk.Issue, error) {
 				Msg("sending diagnostics...")
 			p.EndWithMessage("Analysis complete.")
 
-			b.addIssueActions(ctx, issues)
+			b.issueEnhancer.addIssueActions(ctx, issues, b.BundleHash)
 
 			return issues, nil
 		} else if status.message == "ANALYZING" {
@@ -165,225 +161,4 @@ func (b *Bundle) retrieveAnalysis(ctx context.Context) ([]snyk.Issue, error) {
 		time.Sleep(1 * time.Second)
 		p.Report(status.percentage)
 	}
-}
-
-// Adds code actions and code lenses for issues found
-func (b *Bundle) addIssueActions(ctx context.Context, issues []snyk.Issue) {
-	method := "addCodeActions"
-
-	autoFixEnabled := getCodeSettings().isAutofixEnabled.Get()
-	learnEnabled := config.CurrentConfig().IsSnykLearnCodeActionsEnabled()
-	log.Info().Str("method", method).Msg("Autofix is enabled: " + strconv.FormatBool(autoFixEnabled))
-	log.Info().Str("method", method).Msg("Snyk Learn is enabled: " + strconv.FormatBool(learnEnabled))
-
-	if !autoFixEnabled && !learnEnabled {
-		log.Trace().Msg("Autofix | Snyk Learn code actions are disabled, not adding code actions")
-		return
-	}
-
-	for i := range issues {
-		issueData, ok := issues[i].AdditionalData.(snyk.CodeIssueData)
-		if !ok {
-			log.Error().Str("method", method).Msg("Failed to fetch additional data")
-			continue
-		}
-
-		if autoFixEnabled && issueData.IsAutofixable {
-			codeAction := *b.createDeferredAutofixCodeAction(ctx, issues[i])
-			issues[i].CodeActions = append(issues[i].CodeActions, codeAction)
-
-			codeActionId := *codeAction.Uuid
-			issues[i].CodelensCommands = append(issues[i].CodelensCommands, snyk.CommandData{
-				Title:     "⚡ Fix this issue: " + issueTitle(issues[i]),
-				CommandId: snyk.CodeFixCommand,
-				Arguments: []any{
-					codeActionId,
-					issues[i].AffectedFilePath,
-					issues[i].Range,
-				},
-			})
-			issueData.HasAIFix = true
-			issues[i].AdditionalData = issueData
-		}
-
-		if learnEnabled {
-			action := b.createOpenSnykLearnCodeAction(issues[i])
-			if action != nil {
-				issues[i].CodeActions = append(issues[i].CodeActions, *action)
-			}
-		}
-	}
-}
-
-func getShardKey(folderPath string, authToken string) string {
-	if len(folderPath) > 0 {
-		return util.Hash([]byte(folderPath))
-	}
-	if len(authToken) > 0 {
-		return util.Hash([]byte(authToken))
-	}
-
-	return ""
-}
-
-func (b *Bundle) autofixFunc(ctx context.Context, issue snyk.Issue) func() *snyk.WorkspaceEdit {
-	editFn := func() *snyk.WorkspaceEdit {
-		method := "code.enhanceWithAutofixSuggestionEdits"
-		s := b.instrumentor.StartSpan(ctx, method)
-		defer b.instrumentor.Finish(s)
-
-		progress := progress.NewTracker(true)
-		fixMsg := "Attempting to fix " + issueTitle(issue) + " (Snyk)"
-		progress.BeginWithMessage(fixMsg, "")
-		b.notifier.SendShowMessage(sglsp.Info, fixMsg)
-
-		relativePath, err := ToRelativeUnixPath(b.rootPath, issue.AffectedFilePath)
-		if err != nil {
-			log.Error().
-				Err(err).Str("method", method).
-				Str("rootPath", b.rootPath).
-				Str("AffectedFilePath", issue.AffectedFilePath).
-				Msg("error converting to relative file path")
-			b.notifier.SendShowMessage(sglsp.MTError, "Something went wrong. Please contact Snyk support.")
-			return nil
-		}
-		encodedRelativePath := EncodePath(relativePath)
-
-		autofixOptions := AutofixOptions{
-			bundleHash: b.BundleHash,
-			shardKey:   getShardKey(b.rootPath, config.CurrentConfig().Token()),
-			filePath:   encodedRelativePath,
-			issue:      issue,
-		}
-
-		// Polling function just calls the endpoint and registers result, signaling `done` to the
-		// channel.
-		pollFunc := func() (fix *AutofixSuggestion, complete bool) {
-			log.Info().Msg("polling")
-			fixSuggestions, fixStatus, err := b.SnykCode.GetAutofixSuggestions(s.Context(), autofixOptions, b.rootPath)
-			fix = nil
-			complete = false
-			if err != nil {
-				log.Error().
-					Err(err).Str("method", method).Str("requestId", b.requestId).
-					Str("stage", "requesting autofix").Msg("error requesting autofix")
-				complete = true
-			} else if fixStatus.message == completeStatus {
-				if len(fixSuggestions) > 0 {
-					// TODO(alex.gronskiy): currently, only the first ([0]) fix suggestion goes into the fix
-					fix = &fixSuggestions[0]
-				} else {
-					log.Info().Str("method", method).Str("requestId", b.requestId).Msg("No good fix could be computed.")
-				}
-				complete = true
-			}
-			return fix, complete
-		}
-
-		// Actual polling loop.
-		pollingTicker := time.NewTicker(1 * time.Second)
-		defer pollingTicker.Stop()
-		timeoutTimer := time.NewTimer(2 * time.Minute)
-		defer timeoutTimer.Stop()
-		for {
-			select {
-			case <-timeoutTimer.C:
-				log.Error().Str("method", "GetAutofixSuggestions").Str("requestId", b.requestId).Msg("timeout requesting autofix")
-				b.notifier.SendShowMessage(sglsp.MTError, "Something went wrong. Please try again. Request ID: "+b.requestId)
-				return nil
-			case <-pollingTicker.C:
-				fix, complete := pollFunc()
-				if !complete {
-					continue
-				}
-
-				if fix == nil {
-					b.notifier.SendShowMessage(sglsp.MTError, "Oh snap! 😔 The fix did not remediate the issue and was not applied.")
-					return nil
-				}
-
-				progress.End()
-				// send feedback asynchronously, so people can actually see the changes done by the fix
-				go func() {
-					actionCommandMap, err := b.autofixFeedbackActions(fix.FixId)
-					successMessage := "Congratulations! 🎉 You’ve just fixed this " + issueTitle(issue) + " issue."
-					if err != nil {
-						b.notifier.SendShowMessage(sglsp.Info, successMessage)
-					} else {
-						// sleep to give client side to actually apply & review the fix
-						time.Sleep(2 * time.Second)
-						b.notifier.Send(snyk.ShowMessageRequest{
-							Message: successMessage + " Was this fix helpful?",
-							Type:    snyk.Info,
-							Actions: actionCommandMap,
-						})
-					}
-				}()
-				return &fix.AutofixEdit
-			}
-		}
-	}
-
-	return editFn
-}
-
-func (b *Bundle) autofixFeedbackActions(fixId string) (*data_structure.OrderedMap[snyk.MessageAction, snyk.CommandData], error) {
-	createCommandData := func(positive bool) snyk.CommandData {
-		return snyk.CommandData{
-			Title:     snyk.CodeSubmitFixFeedback,
-			CommandId: snyk.CodeSubmitFixFeedback,
-			Arguments: []any{fixId, positive},
-		}
-	}
-	actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
-	positiveFeedbackCmd := createCommandData(true)
-	negativeFeedbackCmd := createCommandData(false)
-
-	actionCommandMap.Add("👍", positiveFeedbackCmd)
-	actionCommandMap.Add("👎", negativeFeedbackCmd)
-
-	return actionCommandMap, nil
-}
-
-// returns the deferred code action CodeAction which calls autofix.
-func (b *Bundle) createDeferredAutofixCodeAction(ctx context.Context, issue snyk.Issue) *snyk.CodeAction {
-	autofixEditCallback := b.autofixFunc(ctx, issue)
-
-	action, err := snyk.NewDeferredCodeAction("⚡ Fix this issue: "+issueTitle(issue)+" (Snyk)", &autofixEditCallback, nil)
-	if err != nil {
-		log.Error().Msg("failed to create deferred autofix code action")
-		b.notifier.SendShowMessage(sglsp.MTError, "Something went wrong. Please contact Snyk support.")
-		return nil
-	}
-	return &action
-}
-
-func (b *Bundle) createOpenSnykLearnCodeAction(issue snyk.Issue) (ca *snyk.CodeAction) {
-	title := fmt.Sprintf("Learn more about %s (Snyk)", issueTitle(issue))
-	lesson, err := b.learnService.GetLesson(issue.Ecosystem, issue.ID, issue.CWEs, issue.CVEs, issue.IssueType)
-	if err != nil {
-		log.Err(err).Msg("failed to get lesson")
-		b.errorReporter.CaptureError(err)
-		return nil
-	}
-
-	if lesson != nil && lesson.Url != "" {
-		ca = &snyk.CodeAction{
-			Title: title,
-			Command: &snyk.CommandData{
-				Title:     title,
-				CommandId: snyk.OpenBrowserCommand,
-				Arguments: []any{lesson.Url},
-			},
-		}
-	}
-	return ca
-}
-
-func issueTitle(issue snyk.Issue) string {
-	if issue.AdditionalData != nil && issue.AdditionalData.(snyk.CodeIssueData).Title != "" {
-		return issue.AdditionalData.(snyk.CodeIssueData).Title
-	}
-
-	return issue.ID
 }

--- a/infrastructure/code/bundle_test.go
+++ b/infrastructure/code/bundle_test.go
@@ -19,16 +19,8 @@ package code
 import (
 	"context"
 	"testing"
-	"time"
 
-	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/snyk/snyk-ls/domain/observability/performance"
-	"github.com/snyk/snyk-ls/domain/snyk"
-	"github.com/snyk/snyk-ls/internal/data_structure"
-	"github.com/snyk/snyk-ls/internal/notification"
-	"github.com/snyk/snyk-ls/internal/util"
 )
 
 var bundleWithFiles = &UploadBatch{
@@ -41,33 +33,6 @@ var bundleWithMultipleFiles = &UploadBatch{
 		"file":    {},
 		"another": {},
 	},
-}
-
-func Test_getShardKey(t *testing.T) {
-	const testToken = "TEST"
-	t.Run("should return root path hash", func(t *testing.T) {
-		// Case 1: rootPath exists
-		sampleRootPath := "C:\\GIT\\root"
-		// deepcode ignore HardcodedPassword/test: false positive
-		token := testToken
-		assert.Equal(t, util.Hash([]byte(sampleRootPath)), getShardKey(sampleRootPath, token))
-	})
-
-	t.Run("should return token hash", func(t *testing.T) {
-		// Case 2: rootPath empty, token exists
-		sampleRootPath := ""
-		// deepcode ignore HardcodedPassword/test: false positive
-		token := testToken
-		assert.Equal(t, util.Hash([]byte(token)), getShardKey(sampleRootPath, token))
-	})
-
-	t.Run("should return empty shard key", func(t *testing.T) {
-		// Case 3: No token, no rootPath set
-		sampleRootPath := ""
-		// deepcode ignore HardcodedPassword/test: false positive
-		token := ""
-		assert.Equal(t, "", getShardKey(sampleRootPath, token))
-	})
 }
 
 func Test_BundleGroup_AddBundle(t *testing.T) {
@@ -111,129 +76,5 @@ func Test_BundleGroup_AddBundle(t *testing.T) {
 		assert.Equal(t, 2, fakeSnykCode.TotalBundleCount)
 		assert.Equal(t, 2, fakeSnykCode.ExtendedBundleCount)
 		assert.NotEqual(t, oldHash, newHash)
-	})
-}
-
-func Test_AutofixMessages(t *testing.T) {
-	fakeSnykCode := FakeSnykCodeClient{}
-	mockNotifier := notification.NewMockNotifier()
-	bundle := Bundle{
-		SnykCode:     &fakeSnykCode,
-		notifier:     mockNotifier,
-		instrumentor: performance.NewInstrumentor(),
-	}
-
-	t.Run("Shows attempt message when fix requested", func(t *testing.T) {
-		fn := bundle.autofixFunc(context.Background(), FakeIssue)
-		fn()
-
-		assert.Contains(t, mockNotifier.SentMessages(), sglsp.ShowMessageParams{
-			Type:    sglsp.Info,
-			Message: "Attempting to fix SNYK-123 (Snyk)",
-		})
-	})
-
-	t.Run("Shows success message when fix provided", func(t *testing.T) {
-		fn := bundle.autofixFunc(context.Background(), FakeIssue)
-		fn()
-		var feedbackMessageReq snyk.ShowMessageRequest
-		assert.Eventually(t, func() bool {
-			messages := mockNotifier.SentMessages()
-			if messages == nil || len(messages) < 2 {
-				return false
-			}
-			for _, message := range messages {
-				if _, ok := message.(snyk.ShowMessageRequest); ok {
-					feedbackMessageReq = message.(snyk.ShowMessageRequest)
-					break
-				}
-			}
-			return snyk.Info == feedbackMessageReq.Type &&
-				"Congratulations! 🎉 You’ve just fixed this SNYK-123 issue. Was this fix helpful?" == feedbackMessageReq.Message
-		}, 10*time.Second, 1*time.Second)
-
-		// Compare button action commands
-		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
-		commandData1 := snyk.CommandData{
-			Title:     snyk.CodeSubmitFixFeedback,
-			CommandId: snyk.CodeSubmitFixFeedback,
-			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", true},
-		}
-		commandData2 := snyk.CommandData{
-			Title:     snyk.CodeSubmitFixFeedback,
-			CommandId: snyk.CodeSubmitFixFeedback,
-			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", false},
-		}
-		positiveFeedback := snyk.MessageAction("👍")
-		negativeFeedback := snyk.MessageAction("👎")
-		actionCommandMap.Add(positiveFeedback, commandData1)
-		actionCommandMap.Add(negativeFeedback, commandData2)
-
-		assert.Equal(t, actionCommandMap.Keys(), feedbackMessageReq.Actions.Keys())
-
-		buttonAction1, _ := feedbackMessageReq.Actions.Get(positiveFeedback)
-		buttonAction2, _ := feedbackMessageReq.Actions.Get(negativeFeedback)
-		assert.Equal(t, commandData1, buttonAction1)
-		assert.Equal(t, commandData2, buttonAction2)
-	})
-
-	t.Run("Shows success message when fix for test-issue provided", func(t *testing.T) {
-		// NOTE(alex.gronskiy): Code can return `<lang>/<ruleID>/test` ruleID
-		fakeTestIssue := FakeIssue
-		fakeTestIssue.ID = fakeTestIssue.ID + "/test"
-		fn := bundle.autofixFunc(context.Background(), fakeTestIssue)
-		fn()
-
-		var feedbackMessageReq snyk.ShowMessageRequest
-		assert.Eventually(t, func() bool {
-			messages := mockNotifier.SentMessages()
-			if messages == nil || len(messages) < 2 {
-				return false
-			}
-			for _, message := range messages {
-				if _, ok := message.(snyk.ShowMessageRequest); ok {
-					feedbackMessageReq = message.(snyk.ShowMessageRequest)
-					break
-				}
-			}
-			return snyk.Info == feedbackMessageReq.Type &&
-				"Congratulations! 🎉 You’ve just fixed this SNYK-123 issue. Was this fix helpful?" == feedbackMessageReq.Message
-		}, 10*time.Second, 1*time.Second)
-
-		// Compare button action commands
-		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
-		commandData1 := snyk.CommandData{
-			Title:     snyk.CodeSubmitFixFeedback,
-			CommandId: snyk.CodeSubmitFixFeedback,
-			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", true},
-		}
-		commandData2 := snyk.CommandData{
-			Title:     snyk.CodeSubmitFixFeedback,
-			CommandId: snyk.CodeSubmitFixFeedback,
-			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", false},
-		}
-		positiveFeedback := snyk.MessageAction("👍")
-		negativeFeedback := snyk.MessageAction("👎")
-		actionCommandMap.Add(positiveFeedback, commandData1)
-		actionCommandMap.Add(negativeFeedback, commandData2)
-
-		assert.Equal(t, actionCommandMap.Keys(), feedbackMessageReq.Actions.Keys())
-
-		buttonAction1, _ := feedbackMessageReq.Actions.Get(positiveFeedback)
-		buttonAction2, _ := feedbackMessageReq.Actions.Get(negativeFeedback)
-		assert.Equal(t, commandData1, buttonAction1)
-		assert.Equal(t, commandData2, buttonAction2)
-	})
-
-	t.Run("Shows error message when no fix available", func(t *testing.T) {
-		fakeSnykCode.NoFixSuggestions = true
-
-		fn := bundle.autofixFunc(context.Background(), FakeIssue)
-		fn()
-
-		assert.Contains(t, mockNotifier.SentMessages(), sglsp.ShowMessageParams{
-			Type:    sglsp.MTError,
-			Message: "Oh snap! 😔 The fix did not remediate the issue and was not applied.",
-		})
 	})
 }

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -378,15 +378,14 @@ func (sc *Scanner) createBundle(ctx context.Context,
 		errorReporter: sc.errorReporter,
 		limitToFiles:  limitToFiles,
 		notifier:      sc.notifier,
-		issueEnhancer: IssueEnhancer{
-			SnykCode:      sc.BundleUploader.SnykCode,
-			instrumentor:  sc.BundleUploader.instrumentor,
-			errorReporter: sc.errorReporter,
-			learnService:  sc.learnService,
-			notifier:      sc.notifier,
-			requestId:     requestId,
-			rootPath:      rootPath,
-		},
+		issueEnhancer: newIssueEnhancer(
+			sc.BundleUploader.SnykCode,
+			sc.BundleUploader.instrumentor,
+			sc.errorReporter,
+			sc.notifier,
+			sc.learnService,
+			requestId,
+			rootPath),
 	}
 	var err error
 	if len(fileHashes) > 0 {

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -377,8 +377,16 @@ func (sc *Scanner) createBundle(ctx context.Context,
 		rootPath:      rootPath,
 		errorReporter: sc.errorReporter,
 		limitToFiles:  limitToFiles,
-		learnService:  sc.learnService,
 		notifier:      sc.notifier,
+		issueEnhancer: IssueEnhancer{
+			SnykCode:      sc.BundleUploader.SnykCode,
+			instrumentor:  sc.BundleUploader.instrumentor,
+			errorReporter: sc.errorReporter,
+			learnService:  sc.learnService,
+			notifier:      sc.notifier,
+			requestId:     requestId,
+			rootPath:      rootPath,
+		},
 	}
 	var err error
 	if len(fileHashes) > 0 {

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -46,6 +46,26 @@ type IssueEnhancer struct {
 	rootPath      string
 }
 
+func newIssueEnhancer(
+	SnykCode SnykCodeClient,
+	instrumentor performance.Instrumentor,
+	errorReporter error_reporting.ErrorReporter,
+	notifier notification.Notifier,
+	learnService learn.Service,
+	requestId string,
+	rootPath string,
+) IssueEnhancer {
+	return IssueEnhancer{
+		SnykCode:      SnykCode,
+		instrumentor:  instrumentor,
+		errorReporter: errorReporter,
+		notifier:      notifier,
+		learnService:  learnService,
+		requestId:     requestId,
+		rootPath:      rootPath,
+	}
+}
+
 // Adds code actions and code lenses for issues found
 func (b *IssueEnhancer) addIssueActions(ctx context.Context, issues []snyk.Issue, bundleHash string) {
 	method := "addCodeActions"

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -1,0 +1,270 @@
+/*
+ * © 2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	sglsp "github.com/sourcegraph/go-lsp"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/domain/ide/notification"
+	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
+	"github.com/snyk/snyk-ls/domain/observability/performance"
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/internal/data_structure"
+	"github.com/snyk/snyk-ls/internal/progress"
+	"github.com/snyk/snyk-ls/internal/util"
+)
+
+type IssueEnhancer struct {
+	SnykCode      SnykCodeClient
+	instrumentor  performance.Instrumentor
+	errorReporter error_reporting.ErrorReporter
+	notifier      notification.Notifier
+	learnService  learn.Service
+	requestId     string
+	rootPath      string
+}
+
+// Adds code actions and code lenses for issues found
+func (b *IssueEnhancer) addIssueActions(ctx context.Context, issues []snyk.Issue, bundleHash string) {
+	method := "addCodeActions"
+
+	autoFixEnabled := getCodeSettings().isAutofixEnabled.Get()
+	learnEnabled := config.CurrentConfig().IsSnykLearnCodeActionsEnabled()
+	log.Info().Str("method", method).Msg("Autofix is enabled: " + strconv.FormatBool(autoFixEnabled))
+	log.Info().Str("method", method).Msg("Snyk Learn is enabled: " + strconv.FormatBool(learnEnabled))
+
+	if !autoFixEnabled && !learnEnabled {
+		log.Trace().Msg("Autofix | Snyk Learn code actions are disabled, not adding code actions")
+		return
+	}
+
+	for i := range issues {
+		issueData, ok := issues[i].AdditionalData.(snyk.CodeIssueData)
+		if !ok {
+			log.Error().Str("method", method).Msg("Failed to fetch additional data")
+			continue
+		}
+
+		if autoFixEnabled && issueData.IsAutofixable {
+			codeAction := *b.createDeferredAutofixCodeAction(ctx, issues[i], bundleHash)
+			issues[i].CodeActions = append(issues[i].CodeActions, codeAction)
+
+			codeActionId := *codeAction.Uuid
+			issues[i].CodelensCommands = append(issues[i].CodelensCommands, snyk.CommandData{
+				Title:     "⚡ Fix this issue: " + issueTitle(issues[i]),
+				CommandId: snyk.CodeFixCommand,
+				Arguments: []any{
+					codeActionId,
+					issues[i].AffectedFilePath,
+					issues[i].Range,
+				},
+			})
+			issueData.HasAIFix = true
+			issues[i].AdditionalData = issueData
+		}
+
+		if learnEnabled {
+			action := b.createOpenSnykLearnCodeAction(issues[i])
+			if action != nil {
+				issues[i].CodeActions = append(issues[i].CodeActions, *action)
+			}
+		}
+	}
+}
+
+// returns the deferred code action CodeAction which calls autofix.
+func (b *IssueEnhancer) createDeferredAutofixCodeAction(ctx context.Context, issue snyk.Issue,
+	bundleHash string) *snyk.CodeAction {
+	autofixEditCallback := b.autofixFunc(ctx, issue, bundleHash)
+
+	action, err := snyk.NewDeferredCodeAction("⚡ Fix this issue: "+issueTitle(issue)+" (Snyk)", &autofixEditCallback, nil)
+	if err != nil {
+		log.Error().Msg("failed to create deferred autofix code action")
+		b.notifier.SendShowMessage(sglsp.MTError, "Something went wrong. Please contact Snyk support.")
+		return nil
+	}
+	return &action
+}
+
+func (b *IssueEnhancer) autofixFunc(ctx context.Context, issue snyk.Issue,
+	bundleHash string) func() *snyk.WorkspaceEdit {
+	editFn := func() *snyk.WorkspaceEdit {
+		method := "code.enhanceWithAutofixSuggestionEdits"
+		s := b.instrumentor.StartSpan(ctx, method)
+		defer b.instrumentor.Finish(s)
+
+		progress := progress.NewTracker(true)
+		fixMsg := "Attempting to fix " + issueTitle(issue) + " (Snyk)"
+		progress.BeginWithMessage(fixMsg, "")
+		b.notifier.SendShowMessage(sglsp.Info, fixMsg)
+
+		relativePath, err := ToRelativeUnixPath(b.rootPath, issue.AffectedFilePath)
+		if err != nil {
+			log.Error().
+				Err(err).Str("method", method).
+				Str("rootPath", b.rootPath).
+				Str("AffectedFilePath", issue.AffectedFilePath).
+				Msg("error converting to relative file path")
+			b.notifier.SendShowMessage(sglsp.MTError, "Something went wrong. Please contact Snyk support.")
+			return nil
+		}
+		encodedRelativePath := EncodePath(relativePath)
+
+		autofixOptions := AutofixOptions{
+			bundleHash: bundleHash,
+			shardKey:   getShardKey(b.rootPath, config.CurrentConfig().Token()),
+			filePath:   encodedRelativePath,
+			issue:      issue,
+		}
+
+		// Polling function just calls the endpoint and registers result, signaling `done` to the
+		// channel.
+		pollFunc := func() (fix *AutofixSuggestion, complete bool) {
+			log.Info().Msg("polling")
+			fixSuggestions, fixStatus, err := b.SnykCode.GetAutofixSuggestions(s.Context(), autofixOptions, b.rootPath)
+			fix = nil
+			complete = false
+			if err != nil {
+				log.Error().
+					Err(err).Str("method", method).Str("requestId", b.requestId).
+					Str("stage", "requesting autofix").Msg("error requesting autofix")
+				complete = true
+			} else if fixStatus.message == completeStatus {
+				if len(fixSuggestions) > 0 {
+					// TODO(alex.gronskiy): currently, only the first ([0]) fix suggestion goes into the fix
+					fix = &fixSuggestions[0]
+				} else {
+					log.Info().Str("method", method).Str("requestId", b.requestId).Msg("No good fix could be computed.")
+				}
+				complete = true
+			}
+			return fix, complete
+		}
+
+		// Actual polling loop.
+		pollingTicker := time.NewTicker(1 * time.Second)
+		defer pollingTicker.Stop()
+		timeoutTimer := time.NewTimer(2 * time.Minute)
+		defer timeoutTimer.Stop()
+		for {
+			select {
+			case <-timeoutTimer.C:
+				log.Error().Str("method", "GetAutofixSuggestions").Str("requestId", b.requestId).Msg("timeout requesting autofix")
+				b.notifier.SendShowMessage(sglsp.MTError, "Something went wrong. Please try again. Request ID: "+b.requestId)
+				return nil
+			case <-pollingTicker.C:
+				fix, complete := pollFunc()
+				if !complete {
+					continue
+				}
+
+				if fix == nil {
+					b.notifier.SendShowMessage(sglsp.MTError, "Oh snap! 😔 The fix did not remediate the issue and was not applied.")
+					return nil
+				}
+
+				progress.End()
+				// send feedback asynchronously, so people can actually see the changes done by the fix
+				go func() {
+					actionCommandMap, err := b.autofixFeedbackActions(fix.FixId)
+					successMessage := "Congratulations! 🎉 You’ve just fixed this " + issueTitle(issue) + " issue."
+					if err != nil {
+						b.notifier.SendShowMessage(sglsp.Info, successMessage)
+					} else {
+						// sleep to give client side to actually apply & review the fix
+						time.Sleep(2 * time.Second)
+						b.notifier.Send(snyk.ShowMessageRequest{
+							Message: successMessage + " Was this fix helpful?",
+							Type:    snyk.Info,
+							Actions: actionCommandMap,
+						})
+					}
+				}()
+				return &fix.AutofixEdit
+			}
+		}
+	}
+
+	return editFn
+}
+
+func (b *IssueEnhancer) autofixFeedbackActions(fixId string) (*data_structure.OrderedMap[snyk.MessageAction, snyk.CommandData], error) {
+	createCommandData := func(positive bool) snyk.CommandData {
+		return snyk.CommandData{
+			Title:     snyk.CodeSubmitFixFeedback,
+			CommandId: snyk.CodeSubmitFixFeedback,
+			Arguments: []any{fixId, positive},
+		}
+	}
+	actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
+	positiveFeedbackCmd := createCommandData(true)
+	negativeFeedbackCmd := createCommandData(false)
+
+	actionCommandMap.Add("👍", positiveFeedbackCmd)
+	actionCommandMap.Add("👎", negativeFeedbackCmd)
+
+	return actionCommandMap, nil
+}
+
+func (b *IssueEnhancer) createOpenSnykLearnCodeAction(issue snyk.Issue) (ca *snyk.CodeAction) {
+	title := fmt.Sprintf("Learn more about %s (Snyk)", issueTitle(issue))
+	lesson, err := b.learnService.GetLesson(issue.Ecosystem, issue.ID, issue.CWEs, issue.CVEs, issue.IssueType)
+	if err != nil {
+		log.Err(err).Msg("failed to get lesson")
+		b.errorReporter.CaptureError(err)
+		return nil
+	}
+
+	if lesson != nil && lesson.Url != "" {
+		ca = &snyk.CodeAction{
+			Title: title,
+			Command: &snyk.CommandData{
+				Title:     title,
+				CommandId: snyk.OpenBrowserCommand,
+				Arguments: []any{lesson.Url},
+			},
+		}
+	}
+	return ca
+}
+
+func getShardKey(folderPath string, authToken string) string {
+	if len(folderPath) > 0 {
+		return util.Hash([]byte(folderPath))
+	}
+	if len(authToken) > 0 {
+		return util.Hash([]byte(authToken))
+	}
+
+	return ""
+}
+
+func issueTitle(issue snyk.Issue) string {
+	if issue.AdditionalData != nil && issue.AdditionalData.(snyk.CodeIssueData).Title != "" {
+		return issue.AdditionalData.(snyk.CodeIssueData).Title
+	}
+
+	return issue.ID
+}

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -1,0 +1,184 @@
+/*
+ * © 2022-2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sglsp "github.com/sourcegraph/go-lsp"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/domain/observability/performance"
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/internal/data_structure"
+	"github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/util"
+)
+
+func Test_getShardKey(t *testing.T) {
+	const testToken = "TEST"
+	t.Run("should return root path hash", func(t *testing.T) {
+		// Case 1: rootPath exists
+		sampleRootPath := "C:\\GIT\\root"
+		// deepcode ignore HardcodedPassword/test: false positive
+		token := testToken
+		assert.Equal(t, util.Hash([]byte(sampleRootPath)), getShardKey(sampleRootPath, token))
+	})
+
+	t.Run("should return token hash", func(t *testing.T) {
+		// Case 2: rootPath empty, token exists
+		sampleRootPath := ""
+		// deepcode ignore HardcodedPassword/test: false positive
+		token := testToken
+		assert.Equal(t, util.Hash([]byte(token)), getShardKey(sampleRootPath, token))
+	})
+
+	t.Run("should return empty shard key", func(t *testing.T) {
+		// Case 3: No token, no rootPath set
+		sampleRootPath := ""
+		// deepcode ignore HardcodedPassword/test: false positive
+		token := ""
+		assert.Equal(t, "", getShardKey(sampleRootPath, token))
+	})
+}
+
+func Test_autofixFunc(t *testing.T) {
+	fakeSnykCode := FakeSnykCodeClient{}
+	bundleHash := ""
+	mockNotifier := notification.NewMockNotifier()
+	issueEnhancer := IssueEnhancer{
+		SnykCode:     &fakeSnykCode,
+		notifier:     mockNotifier,
+		instrumentor: performance.NewInstrumentor(),
+	}
+
+	t.Run("Shows attempt message when fix requested", func(t *testing.T) {
+		fn := issueEnhancer.autofixFunc(context.Background(), FakeIssue, bundleHash)
+		fn()
+
+		assert.Contains(t, mockNotifier.SentMessages(), sglsp.ShowMessageParams{
+			Type:    sglsp.Info,
+			Message: "Attempting to fix SNYK-123 (Snyk)",
+		})
+	})
+
+	t.Run("Shows success message when fix provided", func(t *testing.T) {
+		fn := issueEnhancer.autofixFunc(context.Background(), FakeIssue, bundleHash)
+		fn()
+		var feedbackMessageReq snyk.ShowMessageRequest
+		assert.Eventually(t, func() bool {
+			messages := mockNotifier.SentMessages()
+			if messages == nil || len(messages) < 2 {
+				return false
+			}
+			for _, message := range messages {
+				if _, ok := message.(snyk.ShowMessageRequest); ok {
+					feedbackMessageReq = message.(snyk.ShowMessageRequest)
+					break
+				}
+			}
+			return snyk.Info == feedbackMessageReq.Type &&
+				"Congratulations! 🎉 You’ve just fixed this SNYK-123 issue. Was this fix helpful?" == feedbackMessageReq.Message
+		}, 10*time.Second, 1*time.Second)
+
+		// Compare button action commands
+		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
+		commandData1 := snyk.CommandData{
+			Title:     snyk.CodeSubmitFixFeedback,
+			CommandId: snyk.CodeSubmitFixFeedback,
+			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", true},
+		}
+		commandData2 := snyk.CommandData{
+			Title:     snyk.CodeSubmitFixFeedback,
+			CommandId: snyk.CodeSubmitFixFeedback,
+			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", false},
+		}
+		positiveFeedback := snyk.MessageAction("👍")
+		negativeFeedback := snyk.MessageAction("👎")
+		actionCommandMap.Add(positiveFeedback, commandData1)
+		actionCommandMap.Add(negativeFeedback, commandData2)
+
+		assert.Equal(t, actionCommandMap.Keys(), feedbackMessageReq.Actions.Keys())
+
+		buttonAction1, _ := feedbackMessageReq.Actions.Get(positiveFeedback)
+		buttonAction2, _ := feedbackMessageReq.Actions.Get(negativeFeedback)
+		assert.Equal(t, commandData1, buttonAction1)
+		assert.Equal(t, commandData2, buttonAction2)
+	})
+
+	t.Run("Shows success message when fix for test-issue provided", func(t *testing.T) {
+		// NOTE(alex.gronskiy): Code can return `<lang>/<ruleID>/test` ruleID
+		fakeTestIssue := FakeIssue
+		fakeTestIssue.ID = fakeTestIssue.ID + "/test"
+		fn := issueEnhancer.autofixFunc(context.Background(), fakeTestIssue, bundleHash)
+		fn()
+
+		var feedbackMessageReq snyk.ShowMessageRequest
+		assert.Eventually(t, func() bool {
+			messages := mockNotifier.SentMessages()
+			if messages == nil || len(messages) < 2 {
+				return false
+			}
+			for _, message := range messages {
+				if _, ok := message.(snyk.ShowMessageRequest); ok {
+					feedbackMessageReq = message.(snyk.ShowMessageRequest)
+					break
+				}
+			}
+			return snyk.Info == feedbackMessageReq.Type &&
+				"Congratulations! 🎉 You’ve just fixed this SNYK-123 issue. Was this fix helpful?" == feedbackMessageReq.Message
+		}, 10*time.Second, 1*time.Second)
+
+		// Compare button action commands
+		actionCommandMap := data_structure.NewOrderedMap[snyk.MessageAction, snyk.CommandData]()
+		commandData1 := snyk.CommandData{
+			Title:     snyk.CodeSubmitFixFeedback,
+			CommandId: snyk.CodeSubmitFixFeedback,
+			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", true},
+		}
+		commandData2 := snyk.CommandData{
+			Title:     snyk.CodeSubmitFixFeedback,
+			CommandId: snyk.CodeSubmitFixFeedback,
+			Arguments: []any{"123e4567-e89b-12d3-a456-426614174000/1", false},
+		}
+		positiveFeedback := snyk.MessageAction("👍")
+		negativeFeedback := snyk.MessageAction("👎")
+		actionCommandMap.Add(positiveFeedback, commandData1)
+		actionCommandMap.Add(negativeFeedback, commandData2)
+
+		assert.Equal(t, actionCommandMap.Keys(), feedbackMessageReq.Actions.Keys())
+
+		buttonAction1, _ := feedbackMessageReq.Actions.Get(positiveFeedback)
+		buttonAction2, _ := feedbackMessageReq.Actions.Get(negativeFeedback)
+		assert.Equal(t, commandData1, buttonAction1)
+		assert.Equal(t, commandData2, buttonAction2)
+	})
+
+	t.Run("Shows error message when no fix available", func(t *testing.T) {
+		fakeSnykCode.NoFixSuggestions = true
+
+		fn := issueEnhancer.autofixFunc(context.Background(), FakeIssue, bundleHash)
+		fn()
+
+		assert.Contains(t, mockNotifier.SentMessages(), sglsp.ShowMessageParams{
+			Type:    sglsp.MTError,
+			Message: "Oh snap! 😔 The fix did not remediate the issue and was not applied.",
+		})
+	})
+}


### PR DESCRIPTION
### Description

This part of the code will soon have some changes so that we can call off to the new Snyk Code scanning functionality in `code-client-go`. `code-client-go` will return SARIF and inside `snyk-ls` we are responsible for converting the SARIF to the `snyk.Issue` type used in the Language Server and enhance that issue with code actions etc. At the moment this functionality to enhance issues is done within the `Bundle` type, but it makes more sense to extract it into a new `IssueEnhancer` type (name is up for debate) and so then we can use this functionality both in the existing flow and then when we start using `code-client-go`. 

I've come to this conclusion by working on https://github.com/snyk/code-client-go/pull/2 and https://github.com/snyk/snyk-ls/pull/455 but these two PRs were getting too big to ask for reviews. Hopefully this PR makes sense but if not, we can chat about it.

I've tested it by running `make build-debug` and then running the `vscode-extension` by pointing at this binary. The UI still works as expected. 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs


<img width="1711" alt="Screenshot 2024-03-08 at 14 30 30" src="https://github.com/snyk/snyk-ls/assets/81559517/a6a7f384-09ab-4016-8f65-ca112eab7b89">

