### PR TITLE
feat: start branching off to new flow for snyk code ignores [IDE-172]

### DIFF
--- a/domain/ide/command/get_feature_flag_status.go
+++ b/domain/ide/command/get_feature_flag_status.go
@@ -44,6 +44,6 @@ func (cmd *featureFlagStatus) Execute(ctx context.Context) (any, error) {
 	}
 
 	ff := args[0].(snyk_api.FeatureFlagType)
-	featureFlagResponse, err := cmd.apiClient.FeatureFlagSettings(ff)
+	featureFlagResponse, err := cmd.apiClient.FeatureFlagStatus(ff)
 	return featureFlagResponse, err
 }

--- a/domain/ide/command/get_feature_flag_status_test.go
+++ b/domain/ide/command/get_feature_flag_status_test.go
@@ -35,7 +35,7 @@ func Test_ApiClient_FeatureFlagIsEnabled(t *testing.T) {
 	expectedResponse := snyk_api.FFResponse{Ok: true}
 
 	fakeApiClient := &snyk_api.FakeApiClient{}
-	fakeApiClient.SetResponse("FeatureFlagSettings", expectedResponse)
+	fakeApiClient.SetResponse("FeatureFlagStatus", expectedResponse)
 
 	// Pass the featureFlagType to the command
 	featureFlagStatusCmd := featureFlagStatus{

--- a/domain/snyk/issues.go
+++ b/domain/snyk/issues.go
@@ -19,6 +19,7 @@ package snyk
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -36,6 +37,9 @@ type Issue struct {
 	ID        string
 	Severity  Severity
 	IssueType Type
+	IsIgnored bool // If not explicitly it will default to false so it doesn't break backwards
+	// compatibility
+	IgnoreDetails *IgnoreDetails // It defaults to nil so it doesn't break backwards compatibility
 	// Range identifies the location of this issue in its source of origin (e.g. line & character start & end)
 	Range Range
 	// Message is a human-readable description of the issue
@@ -62,6 +66,14 @@ type Issue struct {
 	CVEs []string
 	// AdditionalData contains data that can be passed by the product (e.g. for presentation)
 	AdditionalData any
+}
+
+type IgnoreDetails struct {
+	Category   string
+	Reason     string
+	Expiration time.Time
+	IgnoredOn  time.Time
+	IgnoredBy  string
 }
 
 type CodeIssueData struct {

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -509,7 +509,7 @@ func (sc *Scanner) trackResult(success bool, scanMetrics *ScanMetrics) {
 }
 
 func (sc *Scanner) useIgnoresFlow() bool {
-	response, err := sc.SnykApiClient.FeatureFlagSettings(snyk_api.FeatureFlagSnykCodeConsistentIgnores)
+	response, err := sc.SnykApiClient.FeatureFlagStatus(snyk_api.FeatureFlagSnykCodeConsistentIgnores)
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to check if the ignores experience is enabled")
 		return false

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -18,10 +18,12 @@ package code
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/puzpuzpuz/xsync"
 	"github.com/rs/zerolog/log"
@@ -306,7 +308,84 @@ func (sc *Scanner) UploadAndAnalyze(ctx context.Context,
 }
 
 func (sc *Scanner) UploadAndAnalyzeWithIgnores() (issues []snyk.Issue, err error) {
-	return []snyk.Issue{}, nil
+	return []snyk.Issue{
+		{
+			ID:        uuid.New().String(),
+			Severity:  snyk.High,
+			IssueType: snyk.CodeSecurityVulnerability,
+			Range: snyk.Range{
+				Start: snyk.Position{
+					Line:      1,
+					Character: 1,
+				},
+				End: snyk.Position{
+					Line:      1,
+					Character: 10,
+				},
+			},
+			Message:             "You silly goose",
+			FormattedMessage:    "",
+			AffectedFilePath:    "test/util/postgresql.ts",
+			Product:             product.ProductCode,
+			References:          []snyk.Reference{},
+			IssueDescriptionURL: &url.URL{Path: "https://security.snyk.io/vuln/SNYK-JS-LODASHSET-1320032"},
+			CodeActions:         []snyk.CodeAction{},
+			CodelensCommands:    []snyk.CommandData{},
+			Ecosystem:           "npm",
+			CWEs:                []string{},
+			CVEs:                []string{},
+			AdditionalData: snyk.CodeIssueData{
+				Key:                "key1",
+				Title:              "Another title",
+				Message:            "You silly goose",
+				Rule:               "rule",
+				RuleId:             "ruleId",
+				RepoDatasetSize:    0,
+				ExampleCommitFixes: []snyk.ExampleCommitFix{},
+				CWE:                []string{},
+				Text:               "",
+				Markers:            []snyk.Marker{},
+				Cols:               snyk.CodePoint{},
+				Rows:               snyk.CodePoint{},
+				IsSecurityType:     true,
+				IsAutofixable:      false,
+				PriorityScore:      1,
+				HasAIFix:           false,
+			},
+		},
+		{
+			ID:        uuid.New().String(),
+			Severity:  snyk.High,
+			IssueType: snyk.CodeSecurityVulnerability,
+			IsIgnored: true,
+			IgnoreDetails: &snyk.IgnoreDetails{
+				Category:   "Won't fix",
+				Reason:     "False positive",
+				Expiration: time.Now().Add(3 * 24 * time.Hour),
+				IgnoredOn:  time.Now().Add(-3 * 24 * time.Hour),
+				IgnoredBy:  "Neil M",
+			},
+			Range: snyk.Range{
+				Start: snyk.Position{
+					Line:      2,
+					Character: 1,
+				},
+				End: snyk.Position{
+					Line:      2,
+					Character: 10,
+				},
+			},
+			Message:             "This is a false positive",
+			FormattedMessage:    "",
+			AffectedFilePath:    "test/util/postgresql.ts",
+			Product:             product.ProductCode,
+			References:          []snyk.Reference{},
+			IssueDescriptionURL: &url.URL{Path: "https://security.snyk.io/vuln/SNYK-JS-LODASHSET-1320032"},
+			Ecosystem:           "npm",
+			CWEs:                []string{},
+			CVEs:                []string{},
+		},
+	}, nil
 }
 
 func (sc *Scanner) handleCreationAndUploadError(path string, err error, msg string, scanMetrics *ScanMetrics) {

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -564,7 +564,7 @@ func Test_Scan(t *testing.T) {
 		testutil.UnitTest(t)
 		snykCodeMock := &FakeSnykCodeClient{}
 		snykApiMock := &snyk_api.FakeApiClient{CodeEnabled: true}
-		snykApiMock.SetResponse("FeatureFlagSettings", snyk_api.FFResponse{Ok: false})
+		snykApiMock.SetResponse("FeatureFlagStatus", snyk_api.FFResponse{Ok: false})
 		learnMock := mock_learn.NewMockService(gomock.NewController(t))
 		learnMock.
 			EXPECT().
@@ -592,7 +592,7 @@ func Test_Scan(t *testing.T) {
 		testutil.UnitTest(t)
 		snykCodeMock := &FakeSnykCodeClient{}
 		snykApiMock := &snyk_api.FakeApiClient{CodeEnabled: true}
-		snykApiMock.SetResponse("FeatureFlagSettings", snyk_api.FFResponse{Ok: true})
+		snykApiMock.SetResponse("FeatureFlagStatus", snyk_api.FFResponse{Ok: true})
 		learnMock := mock_learn.NewMockService(gomock.NewController(t))
 		learnMock.
 			EXPECT().

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -377,6 +377,30 @@ func TestUploadAndAnalyze(t *testing.T) {
 	)
 }
 
+func TestUploadAndAnalyzeWithIgnores(t *testing.T) {
+	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	learnMock.
+		EXPECT().
+		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&learn.Lesson{}, nil).AnyTimes()
+	testutil.UnitTest(t)
+	snykCodeMock := &FakeSnykCodeClient{}
+	c := New(
+		NewBundler(snykCodeMock, performance.NewInstrumentor()),
+		&snyk_api.FakeApiClient{CodeEnabled: true},
+		error_reporting.NewTestErrorReporter(),
+		ux2.NewTestAnalytics(),
+		learnMock,
+		notification.NewNotifier(),
+	)
+
+	issues, _ := c.UploadAndAnalyzeWithIgnores()
+	assert.Equal(t, false, issues[0].IsIgnored)
+	assert.Nil(t, issues[0].IgnoreDetails)
+	assert.Equal(t, true, issues[1].IsIgnored)
+	assert.Equal(t, "False positive", issues[1].IgnoreDetails.Reason)
+}
+
 func Test_Scan(t *testing.T) {
 	t.Run("Should update changed files", func(t *testing.T) {
 		testutil.UnitTest(t)
@@ -525,6 +549,62 @@ func Test_Scan(t *testing.T) {
 			error_reporting.NewTestErrorReporter(),
 			ux2.NewTestAnalytics(),
 			nil,
+			notification.NewNotifier(),
+		)
+		tempDir, _, _ := setupIgnoreWorkspace(t)
+
+		_, _ = c.Scan(context.Background(), "", tempDir)
+
+		params := snykCodeMock.GetCallParams(0, CreateBundleOperation)
+		assert.Nil(t, params)
+	})
+
+	//nolint:dupl // test cases differ by a boolean
+	t.Run("Should run existing flow if feature flag is disabled", func(t *testing.T) {
+		testutil.UnitTest(t)
+		snykCodeMock := &FakeSnykCodeClient{}
+		snykApiMock := &snyk_api.FakeApiClient{CodeEnabled: true}
+		snykApiMock.SetResponse("FeatureFlagSettings", snyk_api.FFResponse{Ok: false})
+		learnMock := mock_learn.NewMockService(gomock.NewController(t))
+		learnMock.
+			EXPECT().
+			GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&learn.Lesson{}, nil).AnyTimes()
+
+		c := New(
+			NewBundler(snykCodeMock, performance.NewInstrumentor()),
+			snykApiMock,
+			error_reporting.NewTestErrorReporter(),
+			ux2.NewTestAnalytics(),
+			learnMock,
+			notification.NewNotifier(),
+		)
+		tempDir, _, _ := setupIgnoreWorkspace(t)
+
+		_, _ = c.Scan(context.Background(), "", tempDir)
+
+		params := snykCodeMock.GetCallParams(0, CreateBundleOperation)
+		assert.NotNil(t, params)
+	})
+
+	//nolint:dupl // test cases differ by a boolean
+	t.Run("Should run new flow if feature flag is enabled", func(t *testing.T) {
+		testutil.UnitTest(t)
+		snykCodeMock := &FakeSnykCodeClient{}
+		snykApiMock := &snyk_api.FakeApiClient{CodeEnabled: true}
+		snykApiMock.SetResponse("FeatureFlagSettings", snyk_api.FFResponse{Ok: true})
+		learnMock := mock_learn.NewMockService(gomock.NewController(t))
+		learnMock.
+			EXPECT().
+			GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&learn.Lesson{}, nil).AnyTimes()
+
+		c := New(
+			NewBundler(snykCodeMock, performance.NewInstrumentor()),
+			snykApiMock,
+			error_reporting.NewTestErrorReporter(),
+			ux2.NewTestAnalytics(),
+			learnMock,
 			notification.NewNotifier(),
 		)
 		tempDir, _, _ := setupIgnoreWorkspace(t)

--- a/infrastructure/snyk_api/fake_api_client.go
+++ b/infrastructure/snyk_api/fake_api_client.go
@@ -114,10 +114,10 @@ func (f *FakeApiClient) SastSettings() (SastResponse, error) {
 	}, nil
 }
 
-func (f *FakeApiClient) FeatureFlagSettings(featureFlagType FeatureFlagType) (FFResponse, error) {
-	f.addCallForMethod("FeatureFlagSettings", []any{featureFlagType})
+func (f *FakeApiClient) FeatureFlagStatus(featureFlagType FeatureFlagType) (FFResponse, error) {
+	f.addCallForMethod("FeatureFlagStatus", []any{featureFlagType})
 
-	if resp, ok := f.Responses["FeatureFlagSettings"]; ok {
+	if resp, ok := f.Responses["FeatureFlagStatus"]; ok {
 		if ffResp, ok := resp.(FFResponse); ok {
 			return ffResp, nil
 		}

--- a/infrastructure/snyk_api/fake_api_client.go
+++ b/infrastructure/snyk_api/fake_api_client.go
@@ -16,7 +16,9 @@
 
 package snyk_api
 
-import "sync"
+import (
+	"sync"
+)
 
 const (
 	SastEnabledOperation = "sastEnabled"

--- a/infrastructure/snyk_api/snyk_api.go
+++ b/infrastructure/snyk_api/snyk_api.go
@@ -62,7 +62,7 @@ type FFResponse struct {
 
 type SnykApiClient interface {
 	SastSettings() (SastResponse, error)
-	FeatureFlagSettings(featureFlagType FeatureFlagType) (FFResponse, error)
+	FeatureFlagStatus(featureFlagType FeatureFlagType) (FFResponse, error)
 }
 
 type SnykApiError struct {
@@ -107,8 +107,8 @@ func (s *SnykApiClientImpl) SastSettings() (SastResponse, error) {
 	return response, err
 }
 
-func (s *SnykApiClientImpl) FeatureFlagSettings(featureFlagType FeatureFlagType) (FFResponse, error) {
-	method := "FeatureFlagSettings"
+func (s *SnykApiClientImpl) FeatureFlagStatus(featureFlagType FeatureFlagType) (FFResponse, error) {
+	method := "FeatureFlagStatus"
 	var response FFResponse
 	log.Debug().Str("method", method).Msgf("API: Getting %s", featureFlagType)
 	path := path.Join("/cli-config/feature-flag/", string(featureFlagType))

--- a/infrastructure/snyk_api/snyk_api_pact_test.go
+++ b/infrastructure/snyk_api/snyk_api_pact_test.go
@@ -184,7 +184,7 @@ func TestSnykApiPact(t *testing.T) {
 		interaction.Description = "feature flag with org as query param"
 
 		test := func() error {
-			_, err := client.FeatureFlagSettings("snykCodeConsistentIgnores")
+			_, err := client.FeatureFlagStatus("snykCodeConsistentIgnores")
 			if err != nil {
 				return err
 			}
@@ -229,7 +229,7 @@ func TestSnykApiPact(t *testing.T) {
 		interaction.Description = fmt.Sprintf("feature flag '%s' disabled for org", featureFlagType)
 
 		test := func() error {
-			_, err := client.FeatureFlagSettings(featureFlagType)
+			_, err := client.FeatureFlagStatus(featureFlagType)
 			t.Logf("err: %+v\n", err)
 			return err
 		}


### PR DESCRIPTION
### Description

In https://snyksec.atlassian.net/browse/IDE-172 we want to start using `code-client-go` behind the feature flag to branch off to the new flow and be able to manipulate ignored findings in our IDEs. `code-client-go` is currently not open sourced yet and we don't have a defined contract yet for what the data we return will look like, so for now this PR adds a separate flow for the Snyk Code scanning capabilities with ignores, which returns fake issues with fake ignore metadata. 

This PR will then unblock us working on the UI while the backend is sorted out.

Therefore, in this PR we are defining where the ignore information gets stored in the `snyk.Issue` type used by the Language Server.

I've run `make build-debug` and tested VSCode by changing the location of the LS binary.

I haven't tested it with IntelliJ because of problems with building the CLI.
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.
