### PR TITLE
fix: associate learn lessons with all ecosystems [IDE-203]

### DIFF
--- a/infrastructure/learn/service.go
+++ b/infrastructure/learn/service.go
@@ -51,7 +51,7 @@ type Lesson struct {
 	Cves          []string `json:"cves"`
 	Cwes          []string `json:"cwes"`
 	Description   string   `json:"description"`
-	Ecosystem     string   `json:"ecosystem"`
+	Ecosystems    []string `json:"ecosystems"`
 	Rules         []string `json:"rules"`
 	Slug          string   `json:"slug"`
 	Published     bool     `json:"published"`
@@ -204,13 +204,14 @@ func (s *serviceImpl) updateCaches(lessons []Lesson) {
 			lessonsForRule = append(lessonsForRule, lesson)
 			s.lessonsByRuleCache.Set(lesson.Slug, lessonsForRule, expiration)
 		}
-
-		lessonsForEcosystem, exists := s.lessonsByEcosystemCache.Get(lesson.Ecosystem)
-		if !exists {
-			lessonsForEcosystem = []Lesson{}
+		for _, ecosystem := range lesson.Ecosystems {
+			lessonsForEcosystem, exists := s.lessonsByEcosystemCache.Get(ecosystem)
+			if !exists {
+				lessonsForEcosystem = []Lesson{}
+			}
+			lessonsForEcosystem = append(lessonsForEcosystem, lesson)
+			s.lessonsByEcosystemCache.Set(ecosystem, lessonsForEcosystem, expiration)
 		}
-		lessonsForEcosystem = append(lessonsForEcosystem, lesson)
-		s.lessonsByEcosystemCache.Set(lesson.Ecosystem, lessonsForEcosystem, expiration)
 	}
 }
 

--- a/infrastructure/learn/service_test.go
+++ b/infrastructure/learn/service_test.go
@@ -81,16 +81,19 @@ func Test_GetLesson(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, lesson)
 	})
-	t.Run("Code security - lesson returned", func(t *testing.T) {
+	t.Run("Code security - lesson returned - javascript", func(t *testing.T) {
 		params := getRealCodeLookupParams()
 
-		lesson, err := cut.GetLesson(params.Ecosystem, params.Rule, params.CWEs, params.CVEs, snyk.CodeSecurityVulnerability)
-
-		assert.NoError(t, err)
-		assert.NotEmpty(t, lesson)
-		assert.Contains(t, lesson.Cwes, params.CWEs[0])
-		assert.Equal(t, lesson.Ecosystem, params.Ecosystem)
+		checkLesson(t, cut, params)
 	})
+
+	t.Run("Code security - lesson returned - java", func(t *testing.T) {
+		params := getRealCodeLookupParams()
+		params.Ecosystem = "java"
+
+		checkLesson(t, cut, params)
+	})
+
 	t.Run("Code quality - no lessons returned", func(t *testing.T) {
 		params := getRealCodeLookupParams()
 
@@ -99,4 +102,14 @@ func Test_GetLesson(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, lesson)
 	})
+}
+
+func checkLesson(t *testing.T, cut Service, params LessonLookupParams) {
+	t.Helper()
+	lesson, err := cut.GetLesson(params.Ecosystem, params.Rule, params.CWEs, params.CVEs, snyk.CodeSecurityVulnerability)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, lesson)
+	assert.Contains(t, lesson.Cwes, params.CWEs[0])
+	assert.Contains(t, lesson.Ecosystems, params.Ecosystem)
 }


### PR DESCRIPTION
### Description

Previously, a lesson was only associated with one ecosystem. Now it is associated with all ecosystems.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
