### PR TITLE
test: fix pact learn tests

### DIFF
--- a/infrastructure/learn/pacts/snykls-snyklearn.json
+++ b/infrastructure/learn/pacts/snykls-snyklearn.json
@@ -49,7 +49,9 @@
             ],
             "datePublished": "string",
             "description": "string",
-            "ecosystem": "string",
+            "ecosystems": [
+              "string"
+            ],
             "img": "string",
             "lessonId": "string",
             "published": true,
@@ -101,7 +103,13 @@
           "$.body[*].description": {
             "match": "type"
           },
-          "$.body[*].ecosystem": {
+          "$.body[*].ecosystems": {
+            "min": 1
+          },
+          "$.body[*].ecosystems[*].*": {
+            "match": "type"
+          },
+          "$.body[*].ecosystems[*]": {
             "match": "type"
           },
           "$.body[*].img": {


### PR DESCRIPTION
### Description

The `snyk-ls` binary hasn't released in a while because the integration tests have failed. The integration tests fail because of a broken `pact` contract. They don't run in the CI/CD in PRs, only in `main`, so we didn't realise code changes broke them.

The code changes are in https://github.com/snyk/snyk-ls/pull/466.

