### PR TITLE
chore: exclude notifications for `push` events

### DIFF
--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -83,7 +83,7 @@ jobs:
           make instance-standard-test
 
       - name: Slack Notification
-        if: ${{ github.event_name != 'push' && (failure() || cancelled()) }}
+        if: ${{ (github.event_name != 'push' || github.ref == 'refs/heads/main') && (failure() || cancelled()) }}
         with:
           payload: '{"text": "GitHub build result: ${{ job.status }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'
 

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -83,7 +83,7 @@ jobs:
           make instance-standard-test
 
       - name: Slack Notification
-        if: ${{ failure() || cancelled() }}
+        if: ${{ github.event_name != 'push' && (failure() || cancelled()) }}
         with:
           payload: '{"text": "GitHub build result: ${{ job.status }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'
 


### PR DESCRIPTION
### Description

- Previously, a Slack notification was sent whenever a build failed or was cancelled, regardless of the event type. This included push events to working branches
- This change will reduce the number of Slack notifications, particularly for ongoing work in development branches.
- Failures in more critical scenarios, like pull requests or main branch updates, will continue to trigger Slack notifications

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
