### PR TITLE
feat: add code template [IDE-180]

### DIFF
--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -256,6 +256,7 @@ func (n *scanNotifier) appendCodeIssues(scanIssues []lsp.ScanIssue, folderPath s
 				LeadURL:            "",
 				HasAIFix:           additionalData.HasAIFix,
 				DataFlow:           dataFlow,
+				Details:            additionalData.Details,
 			},
 		}
 		if scanIssue.IsIgnored {

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -488,6 +488,7 @@ func Test_SendSuccess_SendsForSnykCode_WithIgnores(t *testing.T) {
 				DataFlow: []lsp2.DataflowElement{
 					{FilePath: "testFile", FlowRange: converter.ToRange(r), Content: "testContent"},
 				},
+				Details: "<!-- Data Flow -->\n <span class=\"data-flow-filepath\">testFile/data-subject.service.ts:27</span>\n\t\t",
 			},
 		},
 	}
@@ -530,6 +531,7 @@ func Test_SendSuccess_SendsForSnykCode_WithIgnores(t *testing.T) {
 				DataFlow: []snyk.DataFlowElement{
 					{FilePath: "testFile", FlowRange: r, Content: "testContent"},
 				},
+				Details: "<!-- Data Flow -->\n <span class=\"data-flow-filepath\">testFile/data-subject.service.ts:27</span>\n\t\t",
 			},
 		},
 	}

--- a/domain/snyk/issues.go
+++ b/domain/snyk/issues.go
@@ -95,6 +95,7 @@ type CodeIssueData struct {
 	PriorityScore      int                `json:"priorityScore"`
 	HasAIFix           bool               `json:"hasAIFix"`
 	DataFlow           []DataFlowElement  `json:"dataFlow,omitempty"`
+	Details            string             `json:"details"`
 }
 
 type ExampleCommitFix struct {

--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -31,15 +31,6 @@ func replaceVariableInHtml(html string, variableName string, variableValue strin
 	return strings.ReplaceAll(html, fmt.Sprintf("${%s}", variableName), variableValue)
 }
 
-// func getLearnLink(issue *snyk.CodeIssueData) string {
-// 	if issue.lesson == nil {
-// 		return ""
-// 	}
-
-// 	return fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>",
-// 		issue.lesson.Url)
-// }
-
 func getDataFlowHtml(issue snyk.CodeIssueData) string {
 	dataFlowHtml := ""
 	for i, flow := range issue.DataFlow {
@@ -61,7 +52,6 @@ func getDetailsHtml(issue snyk.Issue) string {
 	html := replaceVariableInHtml(detailsHtmlTemplate, "issueId", issue.ID)
 	html = replaceVariableInHtml(html, "issueTitle", issue.AdditionalData.(snyk.CodeIssueData).Title)
 	html = replaceVariableInHtml(html, "severityText", issue.Severity.String())
-	// html = replaceVariableInHtml(html, "learnLink", getLearnLink(issue))
 	html = replaceVariableInHtml(html, "dataFlow", dataFlowHtml)
 	html = replaceVariableInHtml(html, "dataFlowCount", fmt.Sprintf("%d", len(issue.AdditionalData.(snyk.CodeIssueData).DataFlow)))
 

--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -38,12 +38,31 @@ func getLearnLink(issue *codeIssue) string {
 		issue.lesson.Url)
 }
 
+func getDataFlowHtml(issue *codeIssue) string {
+	dataFlowHtml := ""
+	for i, flow := range issue.DataFlow {
+		dataFlowHtml += fmt.Sprintf(`
+		<div class="data-flow-row">
+		  <span class="data-flow-number">%d</span>
+		  <span class="data-flow-blank"> </span>
+		  <span class="data-flow-filepath">%s:%d</span>
+		  <span class="data-flow-delimiter">|</span>
+		  <span class="data-flow-text">%s</span>
+		</div>`, i+1, flow.FilePath, flow.Position, flow.Content)
+	}
+	return dataFlowHtml
+}
+
 func getDetailsHtml(issue *codeIssue) string {
+	dataFlowHtml := getDataFlowHtml(issue)
+
 	html := replaceVariableInHtml(detailsHtmlTemplate, "issueId", issue.Id)
 	html = replaceVariableInHtml(html, "issueTitle", issue.Title)
 	html = replaceVariableInHtml(html, "severityText", issue.Severity)
 	html = replaceVariableInHtml(html, "vulnerableModule", issue.Name)
 	html = replaceVariableInHtml(html, "learnLink", getLearnLink(issue))
+	html = replaceVariableInHtml(html, "dataFlow", dataFlowHtml)
+	html = replaceVariableInHtml(html, "dataFlowCount", fmt.Sprintf("%d", len(issue.DataFlow)))
 
 	return html
 }

--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -1,0 +1,49 @@
+/*
+ * © 2023-2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+)
+
+//go:embed template/details.html
+var detailsHtmlTemplate string
+
+func replaceVariableInHtml(html string, variableName string, variableValue string) string {
+	return strings.ReplaceAll(html, fmt.Sprintf("${%s}", variableName), variableValue)
+}
+
+func getLearnLink(issue *codeIssue) string {
+	if issue.lesson == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>",
+		issue.lesson.Url)
+}
+
+func getDetailsHtml(issue *codeIssue) string {
+	html := replaceVariableInHtml(detailsHtmlTemplate, "issueId", issue.Id)
+	html = replaceVariableInHtml(html, "issueTitle", issue.Title)
+	html = replaceVariableInHtml(html, "severityText", issue.Severity)
+	html = replaceVariableInHtml(html, "vulnerableModule", issue.Name)
+	html = replaceVariableInHtml(html, "learnLink", getLearnLink(issue))
+
+	return html
+}

--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/snyk/snyk-ls/domain/snyk"
 )
 
@@ -47,13 +49,19 @@ func getDataFlowHtml(issue snyk.CodeIssueData) string {
 }
 
 func getDetailsHtml(issue snyk.Issue) string {
-	dataFlowHtml := getDataFlowHtml(issue.AdditionalData.(snyk.CodeIssueData))
+	additionalData, ok := issue.AdditionalData.(snyk.CodeIssueData)
+	if !ok {
+		log.Error().Msg("Failed to cast additional data to CodeIssueData")
+		return ""
+	}
+
+	dataFlowHtml := getDataFlowHtml(additionalData)
 
 	html := replaceVariableInHtml(detailsHtmlTemplate, "issueId", issue.ID)
-	html = replaceVariableInHtml(html, "issueTitle", issue.AdditionalData.(snyk.CodeIssueData).Title)
+	html = replaceVariableInHtml(html, "issueTitle", additionalData.Title)
 	html = replaceVariableInHtml(html, "severityText", issue.Severity.String())
 	html = replaceVariableInHtml(html, "dataFlow", dataFlowHtml)
-	html = replaceVariableInHtml(html, "dataFlowCount", fmt.Sprintf("%d", len(issue.AdditionalData.(snyk.CodeIssueData).DataFlow)))
+	html = replaceVariableInHtml(html, "dataFlowCount", fmt.Sprintf("%d", len(additionalData.DataFlow)))
 
 	return html
 }

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -17,97 +17,58 @@
 package code
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
-	"github.com/snyk/snyk-ls/infrastructure/learn"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
-func Test_CodeDetailsPanel_html_noLearn(t *testing.T) {
-	// arrange
+func Test_CodeDetailsPanel_html_withDataFlow(t *testing.T) {
 	_ = testutil.UnitTest(t)
 	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
 
-	issue := codeIssue{
-		Title:    "Path Traversal",
-		Name:     "Path Traversal",
-		Severity: "High",
-		Id:       "randomId",
-		lesson:   nil,
-	}
-
-	// invoke method under test
-	issueDetailsPanelHtml := getDetailsHtml(&issue)
-
-	// assert
-	assert.NotContains(t, issueDetailsPanelHtml, "id='learn--link'")
-
-	for _, expectedVariable := range expectedVariables {
-		assert.Contains(t, issueDetailsPanelHtml, expectedVariable)
-	}
-}
-
-func Test_CodeDetailsPanel_html_withLearn(t *testing.T) {
-	_ = testutil.UnitTest(t)
-
-	issue := codeIssue{
-		Title:    "Path Traversal",
-		Name:     "Path Traversal",
-		Severity: "High",
-		Id:       "randomId",
-		lesson: &learn.Lesson{
-			Url: "https://learn.snyk.io/lesson/directory-traversal/?loc=ide",
-		},
-	}
-
-	// invoke method under test
-	issueDetailsPanelHtml := getDetailsHtml(&issue)
-
-	// assert
-	learnLink := fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>", issue.lesson.Url)
-	assert.Contains(t, issueDetailsPanelHtml, learnLink)
-	assert.NotContains(t, issueDetailsPanelHtml, "${learnLink}")
-
-}
-
-func Test_CodeDetailsPanel_html_withDataFlow(t *testing.T) {
-	_ = testutil.UnitTest(t)
-
-	issue := codeIssue{
-		Title:    "Path Traversal",
-		Name:     "Path Traversal",
-		Severity: "High",
-		Id:       "randomId",
-		lesson: &learn.Lesson{
-			Url: "https://learn.snyk.io/lesson/directory-traversal/?loc=ide",
-		},
-		// TODO: add more data flow elements to check the line count - Fix Range
-		DataFlow: []*snyk.DataFlowElement{
-			{
-				Position: 10,
-				FilePath: "/Users/cata/git/juice-shop/routes/vulnCodeSnippet.ts",
-				Content:  "if (!vulnLines.every(e => selectedLines.includes(e))) return false",
+	issue := snyk.Issue{
+		ID:       "java/DontUsePrintStackTrace",
+		Severity: 3,
+		AdditionalData: snyk.CodeIssueData{
+			DataFlow: []snyk.DataFlowElement{
+				{
+					Content:  "if (!vulnLines.every(e => selectedLines.includes(e))) return false",
+					FilePath: "/Users/cata/git/juice-shop/routes/vulnCodeSnippet.ts",
+					FlowRange: snyk.Range{
+						End: snyk.Position{
+							Character: 42,
+							Line:      67,
+						},
+						Start: snyk.Position{
+							Character: 28,
+							Line:      67,
+						},
+					},
+					Position: 0,
+				},
 			},
 		},
 	}
 
 	// invoke method under test
-	issueDetailsPanelHtml := getDetailsHtml(&issue)
+	issueDetailsPanelHtml := getDetailsHtml(issue)
 
 	// assert
 	dataFlowHtml := `
 		<div class="data-flow-row">
 		  <span class="data-flow-number">1</span>
 		  <span class="data-flow-blank"> </span>
-		  <span class="data-flow-filepath">/Users/cata/git/juice-shop/routes/vulnCodeSnippet.ts:10</span>
+		  <span class="data-flow-filepath">/Users/cata/git/juice-shop/routes/vulnCodeSnippet.ts:68</span>
 		  <span class="data-flow-delimiter">|</span>
 		  <span class="data-flow-text">if (!vulnLines.every(e => selectedLines.includes(e))) return false</span>
 		</div>`
 	assert.Contains(t, issueDetailsPanelHtml, dataFlowHtml)
 	assert.NotContains(t, issueDetailsPanelHtml, "${dataFlow}")
 
+	for _, expectedVariable := range expectedVariables {
+		assert.Contains(t, issueDetailsPanelHtml, expectedVariable)
+	}
 }

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -1,0 +1,78 @@
+/*
+ * © 2023-2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/internal/testutil"
+)
+
+func Test_CodeDetailsPanel_html_noLearn(t *testing.T) {
+	// arrange
+	_ = testutil.UnitTest(t)
+	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
+
+	issue := codeIssue{
+		Title:    "Path Traversal",
+		Name:     "Path Traversal",
+		Severity: "High",
+		Id:       "randomId",
+		lesson:   nil,
+	}
+
+	// invoke method under test
+	issueDetailsPanelHtml := getDetailsHtml(&issue)
+
+	// assert
+	assert.NotContains(t, issueDetailsPanelHtml, "id='learn--link'")
+
+	for _, expectedVariable := range expectedVariables {
+		assert.Contains(t, issueDetailsPanelHtml, expectedVariable)
+	}
+}
+
+func Test_CodeDetailsPanel_html_withLearn(t *testing.T) {
+	_ = testutil.UnitTest(t)
+	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
+
+	issue := codeIssue{
+		Title:    "Path Traversal",
+		Name:     "Path Traversal",
+		Severity: "High",
+		Id:       "randomId",
+		lesson: &learn.Lesson{
+			Url: "https://learn.snyk.io/lesson/directory-traversal/?loc=ide",
+		},
+	}
+
+	// invoke method under test
+	issueDetailsPanelHtml := getDetailsHtml(&issue)
+
+	// assert
+	learnLink := fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>", issue.lesson.Url)
+	assert.Contains(t, issueDetailsPanelHtml, learnLink)
+	assert.NotContains(t, issueDetailsPanelHtml, "${learnLink}")
+
+	for _, expectedVariable := range expectedVariables {
+		assert.Contains(t, issueDetailsPanelHtml, expectedVariable)
+	}
+}

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -27,7 +27,7 @@ import (
 
 func Test_CodeDetailsPanel_html_withDataFlow(t *testing.T) {
 	_ = testutil.UnitTest(t)
-	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
+	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}"}
 
 	issue := snyk.Issue{
 		ID:       "java/DontUsePrintStackTrace",

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -394,6 +394,16 @@ func (s *SarifConverter) toIssues(baseDir string) (issues []snyk.Issue, err erro
 			}
 
 			d.IsIgnored, d.IgnoreDetails = s.getIgnoreDetails(result)
+			additionalDataDetails := getDetailsHtml(d)
+
+			codeIssueData, ok := d.AdditionalData.(snyk.CodeIssueData)
+			if !ok {
+				log.Error().Msg("Failed to cast additional data to CodeIssueData")
+				return issues, errors.New("failed to cast additional data to CodeIssueData")
+			}
+			codeIssueData.Details = additionalDataDetails
+			d.AdditionalData = codeIssueData
+
 			issues = append(issues, d)
 		}
 	}

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -394,15 +394,8 @@ func (s *SarifConverter) toIssues(baseDir string) (issues []snyk.Issue, err erro
 			}
 
 			d.IsIgnored, d.IgnoreDetails = s.getIgnoreDetails(result)
-			additionalDataDetails := getDetailsHtml(d)
-
-			codeIssueData, ok := d.AdditionalData.(snyk.CodeIssueData)
-			if !ok {
-				log.Error().Msg("Failed to cast additional data to CodeIssueData")
-				return issues, errors.New("failed to cast additional data to CodeIssueData")
-			}
-			codeIssueData.Details = additionalDataDetails
-			d.AdditionalData = codeIssueData
+			additionalData.Details = getDetailsHtml(d)
+			d.AdditionalData = additionalData
 
 			issues = append(issues, d)
 		}

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -643,6 +643,9 @@ func TestSnykCodeBackendService_convert_shouldConvertIssues(t *testing.T) {
 	assert.Equal(t, markersForSampleSarifResponse(path), issue.AdditionalData.(snyk.CodeIssueData).Markers)
 	assert.Equal(t, 550, issue.AdditionalData.(snyk.CodeIssueData).PriorityScore)
 	assert.Equal(t, resp.Sarif.Runs[0].Tool.Driver.Rules[0].Properties.Cwe, issue.CWEs)
+	assert.Nil(t, issues[0].IgnoreDetails)
+	assert.False(t, issues[0].IsIgnored)
+	assert.Contains(t, (issues[0].AdditionalData).(snyk.CodeIssueData).Details, "<h2>Data Flow - 4 steps</h2>")
 }
 
 func referencesForSampleSarifResponse() []snyk.Reference {

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -67,27 +67,6 @@
     .vscode-light .dark-only {
       display: none;
     }
-
-    .learn {
-      opacity: 0;
-      height: 0;
-      margin-top: 0;
-      font-size: 1.3rem;
-    }
-
-    .learn.show {
-      margin-top: 6px;
-      opacity: 1;
-      height: auto;
-      transition-duration: 500ms;
-      transition-property: height, opacity, margin-top;
-    }
-
-    .learn--link {
-      margin-left: 3px;
-    }
-
-    .learn__code .learn--link {}
   </style>
   ${headerEnd}
 </head>
@@ -100,10 +79,6 @@
       </div>
       <div class="suggestion-text">${issueTitle}</div>
       <div id="meta" class="suggestion-metas">${meta}</div>
-      <div class="learn" id="learn">
-        <img class="icon" src="${learnIcon}" alt="learnIcon" />
-        ${learnLink}
-      </div>
     </section>
     <section id="suggestion-info" class="delimiter-top">
       <div id="description" class="suggestion-text"></div>
@@ -119,11 +94,6 @@
 
     <!-- TODO: External example fixes -->
   </div>
-  <script nonce="${nonce}">
-    if (document.getElementById("learn--link")) {
-      document.getElementById("learn").className = "learn show"
-    }
-  </script>
 </body>
 
 </html>

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -1,0 +1,127 @@
+<!--
+  ~ © 2024 Snyk Limited
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self' ${cspSource}; style-src 'nonce-${nonce}' ${cspSource}; script-src 'nonce-${nonce}';">
+  <style nonce="${nonce}">
+    .suggestion {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+    }
+
+    .suggestion .suggestion-text {
+      padding: 0.4rem 0;
+      margin-bottom: 0.8rem;
+      font-size: 1.8rem;
+      font-weight: 500;
+      line-height: 2.4rem;
+    }
+
+    .severity {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 0;
+      float: left;
+      margin: 0 1rem 0 0;
+      text-align: center;
+    }
+
+    .severity .icon {
+      width: 32px;
+      height: 32px;
+    }
+
+    .icon {
+      vertical-align: middle;
+      width: 16px;
+      height: 16px;
+    }
+
+    .vscode-dark .light-only {
+      display: none;
+    }
+
+    .vscode-light .dark-only {
+      display: none;
+    }
+
+    .learn {
+      opacity: 0;
+      height: 0;
+      margin-top: 0;
+      font-size: 1.3rem;
+    }
+
+    .learn.show {
+      margin-top: 6px;
+      opacity: 1;
+      height: auto;
+      transition-duration: 500ms;
+      transition-property: height, opacity, margin-top;
+    }
+
+    .learn--link {
+      margin-left: 3px;
+    }
+
+    .learn__code .learn--link {}
+  </style>
+  ${headerEnd}
+</head>
+
+<body>
+  <div class="suggestion">
+    <section class="suggestion--header">
+      <div class="severity">
+        <img id="severity-icon" src="${severityIcon}" alt="${severityText}" class="icon" />
+      </div>
+      <div class="suggestion-text">${issueTitle}</div>
+      <div id="meta" class="suggestion-metas">${meta}</div>
+      <div class="learn" id="learn">
+        <img class="icon" src="${learnIcon}" alt="learnIcon" />
+        ${learnLink}
+      </div>
+    </section>
+    <section id="suggestion-info" class="delimiter-top">
+      <div id="description" class="suggestion-text"></div>
+      <div class="suggestion-links">
+        <div id="lead-url" class="clickable hidden">
+          <img class="icon" src="${images['icon-external']}" /> More info
+        </div>
+      </div>
+    </section>
+    <section class="delimiter-top suggestion-details-content">
+      <div id="suggestion-details" class="suggestion-details"></div>
+    </section>
+  </div>
+  <script nonce="${nonce}">
+    if (document.getElementById("learn--link")) {
+      document.getElementById("learn").className = "learn show"
+    }
+  </script>
+</body>
+
+</html>

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -107,15 +107,17 @@
     </section>
     <section id="suggestion-info" class="delimiter-top">
       <div id="description" class="suggestion-text"></div>
-      <div class="suggestion-links">
-        <div id="lead-url" class="clickable hidden">
-          <img class="icon" src="${images['icon-external']}" /> More info
-        </div>
+    </section>
+
+    <!-- Data Flow -->
+    <section class="data-flow">
+      <h2>Data Flow - ${dataFlowCount} steps</h2>
+      <div class="data-flow-body">
+        ${dataFlow}
       </div>
     </section>
-    <section class="delimiter-top suggestion-details-content">
-      <div id="suggestion-details" class="suggestion-details"></div>
-    </section>
+
+    <!-- TODO: External example fixes -->
   </div>
   <script nonce="${nonce}">
     if (document.getElementById("learn--link")) {

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -28,20 +28,21 @@ type identifiers struct {
 }
 
 type codeIssue struct {
-	Id             string        `json:"id"`
-	Name           string        `json:"name"`
-	Title          string        `json:"title"`
-	Severity       string        `json:"severity"`
-	Description    string        `json:"description"`
-	Version        string        `json:"version"`
-	PackageManager string        `json:"packageManager"`
-	From           []string      `json:"from"`
-	Identifiers    identifiers   `json:"identifiers,omitempty"`
-	FixedIn        []string      `json:"fixedIn,omitempty"`
-	CvssScore      float64       `json:"cvssScore,omitempty"`
-	Exploit        string        `json:"exploit,omitempty"`
-	License        string        `json:"license,omitempty"`
-	lesson         *learn.Lesson `json:"-"`
+	Id             string                  `json:"id"`
+	Name           string                  `json:"name"`
+	Title          string                  `json:"title"`
+	Severity       string                  `json:"severity"`
+	Description    string                  `json:"description"`
+	Version        string                  `json:"version"`
+	PackageManager string                  `json:"packageManager"`
+	From           []string                `json:"from"`
+	Identifiers    identifiers             `json:"identifiers,omitempty"`
+	FixedIn        []string                `json:"fixedIn,omitempty"`
+	CvssScore      float64                 `json:"cvssScore,omitempty"`
+	Exploit        string                  `json:"exploit,omitempty"`
+	License        string                  `json:"license,omitempty"`
+	lesson         *learn.Lesson           `json:"-"`
+	DataFlow       []*snyk.DataFlowElement `json:"dataFlow,omitempty"`
 }
 
 type SnykAnalysisFailedError struct {

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -18,7 +18,31 @@ package code
 
 import (
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/learn"
 )
+
+type identifiers struct {
+	CWE  []string `json:"CWE,omitempty"`
+	GHSA []string `json:"GHSA,omitempty"`
+	CVE  []string `json:"CVE,omitempty"`
+}
+
+type codeIssue struct {
+	Id             string        `json:"id"`
+	Name           string        `json:"name"`
+	Title          string        `json:"title"`
+	Severity       string        `json:"severity"`
+	Description    string        `json:"description"`
+	Version        string        `json:"version"`
+	PackageManager string        `json:"packageManager"`
+	From           []string      `json:"from"`
+	Identifiers    identifiers   `json:"identifiers,omitempty"`
+	FixedIn        []string      `json:"fixedIn,omitempty"`
+	CvssScore      float64       `json:"cvssScore,omitempty"`
+	Exploit        string        `json:"exploit,omitempty"`
+	License        string        `json:"license,omitempty"`
+	lesson         *learn.Lesson `json:"-"`
+}
 
 type SnykAnalysisFailedError struct {
 	Msg string

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -20,12 +20,6 @@ import (
 	"github.com/snyk/snyk-ls/domain/snyk"
 )
 
-type identifiers struct {
-	CWE  []string `json:"CWE,omitempty"`
-	GHSA []string `json:"GHSA,omitempty"`
-	CVE  []string `json:"CVE,omitempty"`
-}
-
 type SnykAnalysisFailedError struct {
 	Msg string
 }

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -18,31 +18,12 @@ package code
 
 import (
 	"github.com/snyk/snyk-ls/domain/snyk"
-	"github.com/snyk/snyk-ls/infrastructure/learn"
 )
 
 type identifiers struct {
 	CWE  []string `json:"CWE,omitempty"`
 	GHSA []string `json:"GHSA,omitempty"`
 	CVE  []string `json:"CVE,omitempty"`
-}
-
-type codeIssue struct {
-	Id             string                  `json:"id"`
-	Name           string                  `json:"name"`
-	Title          string                  `json:"title"`
-	Severity       string                  `json:"severity"`
-	Description    string                  `json:"description"`
-	Version        string                  `json:"version"`
-	PackageManager string                  `json:"packageManager"`
-	From           []string                `json:"from"`
-	Identifiers    identifiers             `json:"identifiers,omitempty"`
-	FixedIn        []string                `json:"fixedIn,omitempty"`
-	CvssScore      float64                 `json:"cvssScore,omitempty"`
-	Exploit        string                  `json:"exploit,omitempty"`
-	License        string                  `json:"license,omitempty"`
-	lesson         *learn.Lesson           `json:"-"`
-	DataFlow       []*snyk.DataFlowElement `json:"dataFlow,omitempty"`
 }
 
 type SnykAnalysisFailedError struct {

--- a/internal/lsp/message_types.go
+++ b/internal/lsp/message_types.go
@@ -1096,6 +1096,7 @@ type CodeIssueData struct {
 	PriorityScore      int                `json:"priorityScore"`
 	HasAIFix           bool               `json:"hasAIFix"`
 	DataFlow           []DataflowElement  `json:"dataFlow,omitempty"`
+	Details            string             `json:"details,omitempty"`
 }
 
 type Point = [2]int


### PR DESCRIPTION
### Description

This is the first PR of many related to the migration of the Code Issue panel to Language Server. This PR adds the initial HTML template for the Code Issue panel serving parts of the **Heading** and **Data Flow.**

How to test it:
- Use IntelliJ to trigger a Code Scan (FF required)
- Inspect the Language Server logs and look for the generated HTML (`additionalDataDetails := getDetailsHtml(d)`) with all the placeholders populated.

👀 Important note: **styling** and **actions** will be addressed in future PRs.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

|IntelliJ UI and generated HTML|
|-|
|![IntelliJ2LS](https://github.com/snyk/snyk-ls/assets/1948377/fb6a3b74-babb-416a-88ee-71976437d4ba)|




