### PR TITLE
fix: data flow html to aid with interactions [IDE-216]

### DIFF
--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -19,6 +19,7 @@ package code
 import (
 	_ "embed"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -36,14 +37,24 @@ func replaceVariableInHtml(html string, variableName string, variableValue strin
 func getDataFlowHtml(issue snyk.CodeIssueData) string {
 	dataFlowHtml := ""
 	for i, flow := range issue.DataFlow {
+		fileName := filepath.Base(flow.FilePath)
 		dataFlowHtml += fmt.Sprintf(`
 		<div class="data-flow-row">
 		  <span class="data-flow-number">%d</span>
 		  <span class="data-flow-blank"> </span>
-		  <span class="data-flow-filepath">%s:%d</span>
+		  <span class="data-flow-filepath" file-path="%s" start-line="%d" end-line="%d" start-character="%d" end-character="%d">%s:%d</span>
 		  <span class="data-flow-delimiter">|</span>
 		  <span class="data-flow-text">%s</span>
-		</div>`, i+1, flow.FilePath, flow.FlowRange.Start.Line+1, flow.Content)
+		</div>`,
+			i+1,
+			flow.FilePath,
+			flow.FlowRange.Start.Line,
+			flow.FlowRange.End.Line,
+			flow.FlowRange.Start.Character,
+			flow.FlowRange.End.Character,
+			fileName,
+			flow.FlowRange.Start.Line+1,
+			flow.Content)
 	}
 	return dataFlowHtml
 }

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -61,7 +61,7 @@ func Test_CodeDetailsPanel_html_withDataFlow(t *testing.T) {
 		<div class="data-flow-row">
 		  <span class="data-flow-number">1</span>
 		  <span class="data-flow-blank"> </span>
-		  <span class="data-flow-filepath">/Users/cata/git/juice-shop/routes/vulnCodeSnippet.ts:68</span>
+		  <span class="data-flow-filepath" file-path="/Users/cata/git/juice-shop/routes/vulnCodeSnippet.ts" start-line="67" end-line="67" start-character="28" end-character="42">vulnCodeSnippet.ts:68</span>
 		  <span class="data-flow-delimiter">|</span>
 		  <span class="data-flow-text">if (!vulnLines.every(e => selectedLines.includes(e))) return false</span>
 		</div>`


### PR DESCRIPTION
### Description

If we want to be able to navigate to the right line in the file we need to provide some extra values for the IntelliJ plugin. This PR adds them as attributes on the `span` which contains the file path. Then in IntelliJ we can add a listener for that `span` and use the attributes to navigate tot he line.

This can be tested with IntelliJ by running https://github.com/snyk/snyk-intellij-plugin/pull/497.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots / GIFs
![Demo dataflow interaction](https://github.com/snyk/snyk-ls/assets/81559517/0d6c524e-62e5-45b3-82ac-6b48b4e03971)

