### PR TITLE
fix: improve resiliency of CLI download [IDE-90]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -104,7 +104,7 @@ func (c *CliSettings) Installed() bool {
 }
 
 func (c *CliSettings) CliPathFileInfo() (os.FileInfo, error) {
-	stat, err := os.Lstat(c.cliPath)
+	stat, err := os.Stat(c.cliPath)
 	if err == nil {
 		log.Debug().Str("method", "config.cliSettings.Installed").Msgf("CLI path: %s, Size: %d, Perm: %s",
 			c.cliPath,

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -109,15 +109,8 @@ func (i *Initializer) installCli() {
 		cliPath = cliPathInConfig()
 		log.Info().Str("method", "installCli").Str("cliPath", cliPath).Msg("Using configured CLI path")
 	} else {
-		cliPath, err = i.installer.Find()
-		if err != nil {
-			log.Info().Str("method", "installCli").Msg("could not find Snyk CLI in user directories and PATH.")
-			cliFileName := (&install.Discovery{}).ExecutableName(false)
-			cliPath = filepath.Join(currentConfig.CliSettings().DefaultBinaryInstallPath(), cliFileName)
-		} else {
-			log.Info().Str("method", "installCli").Str("cliPath", cliPath).Msgf("found CLI at %s", cliPath)
-		}
-
+		cliFileName := (&install.Discovery{}).ExecutableName(false)
+		cliPath = filepath.Join(currentConfig.CliSettings().DefaultBinaryInstallPath(), cliFileName)
 		currentConfig.CliSettings().SetPath(cliPath)
 	}
 
@@ -175,7 +168,7 @@ func (i *Initializer) updateCli() {
 func (i *Initializer) isOutdatedCli() bool {
 	cliPath := cliPathInConfig()
 
-	fileInfo, err := os.Stat(cliPath) // todo: we can save stat calls by caching mod time
+	fileInfo, err := os.Lstat(cliPath)
 	if err != nil {
 		log.Err(err).Str("method", "isOutdatedCli").Msg("Failed to stat CLI file.")
 		return false

--- a/infrastructure/cli/initializer.go
+++ b/infrastructure/cli/initializer.go
@@ -168,7 +168,7 @@ func (i *Initializer) updateCli() {
 func (i *Initializer) isOutdatedCli() bool {
 	cliPath := cliPathInConfig()
 
-	fileInfo, err := os.Lstat(cliPath)
+	fileInfo, err := os.Stat(cliPath)
 	if err != nil {
 		log.Err(err).Str("method", "isOutdatedCli").Msg("Failed to stat CLI file.")
 		return false

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/adrg/xdg"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
@@ -139,12 +138,12 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	// pipe stream
 	cliReader := io.TeeReader(resp.Body, newWriter(resp.ContentLength, d.progressTracker, onProgress))
 
-	err = os.MkdirAll(xdg.DataHome, 0755)
+	cliDirectory := filepath.Dir(config.CurrentConfig().CliSettings().Path())
+	err = os.MkdirAll(cliDirectory, 0755)
 	if err != nil {
-		logger.Err(err).Msg("couldn't create xdg.DataHome directory")
+		logger.Err(err).Msg("couldn't create directory for Snyk CLI")
 		return err
 	}
-	cliDirectory := filepath.Dir(config.CurrentConfig().CliSettings().Path())
 	tmpDirPath, err := os.MkdirTemp(cliDirectory, "downloads")
 	if err != nil {
 		logger.Err(err).Msg("couldn't create tmpdir")

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -144,7 +144,8 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 		logger.Err(err).Msg("couldn't create xdg.DataHome directory")
 		return err
 	}
-	tmpDirPath, err := os.MkdirTemp(xdg.DataHome, "downloads")
+	cliDirectory := filepath.Dir(config.CurrentConfig().CliSettings().Path())
+	tmpDirPath, err := os.MkdirTemp(cliDirectory, "downloads")
 	if err != nil {
 		logger.Err(err).Msg("couldn't create tmpdir")
 		return err

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/adrg/xdg"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -77,6 +78,7 @@ func (d *Downloader) lockFileName() string {
 }
 
 func (d *Downloader) Download(r *Release, isUpdate bool) error {
+	logger := log.With().Str("method", "Download").Logger()
 	if r == nil {
 		return fmt.Errorf("release cannot be nil")
 	}
@@ -84,7 +86,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	if isUpdate {
 		kindStr = "update"
 	}
-	log.Debug().Str("method", "Download").Str("release", r.Version).Msgf("attempting %s", kindStr)
+	logger.Debug().Str("release", r.Version).Msgf("attempting %s", kindStr)
 
 	cliDiscovery := Discovery{}
 
@@ -97,7 +99,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 		return fmt.Errorf("no builds found for current OS")
 	}
 
-	log.Info().Str("download_url", downloadURL).Msgf("Snyk CLI %s in progress...", kindStr)
+	logger.Info().Str("download_url", downloadURL).Msgf("Snyk CLI %s in progress...", kindStr)
 
 	if isUpdate {
 		d.progressTracker.BeginWithMessage("Updating Snyk CLI...", "")
@@ -110,7 +112,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	var resp *http.Response
 
 	resp, err = d.httpClient().Get(downloadURL) //nolint:bodyclose // body is closed in a longer-lived goroutine
-	log.Debug().Any("response-headers", resp.Header).Msg("headers")
+	logger.Debug().Any("response-headers", resp.Header).Msg("headers")
 	if err != nil {
 		return err
 	}
@@ -119,7 +121,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 		d.progressTracker.CancelOrDone(func() {
 			_ = body.Close()
 
-			log.Info().Str("method", "Download").Msgf("Cancellation received. Aborting %s.", kindStr)
+			logger.Info().Msgf("Cancellation received. Aborting %s.", kindStr)
 		}, doneCh)
 	}(resp.Body)
 
@@ -131,16 +133,20 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 		doneCh <- true
-		log.Info().Str("method", "Download").Msgf("finished Snyk CLI %s", kindStr)
+		logger.Info().Msgf("finished Snyk CLI %s", kindStr)
 	}(resp.Body)
 
 	// pipe stream
 	cliReader := io.TeeReader(resp.Body, newWriter(resp.ContentLength, d.progressTracker, onProgress))
 
-	_ = os.MkdirAll(xdg.DataHome, 0755)
+	err = os.MkdirAll(xdg.DataHome, 0755)
+	if err != nil {
+		logger.Err(err).Msg("couldn't create xdg.DataHome directory")
+		return err
+	}
 	tmpDirPath, err := os.MkdirTemp(xdg.DataHome, "downloads")
 	if err != nil {
-		log.Err(err).Str("method", "Download").Msg("couldn't create tmpdir")
+		logger.Err(err).Msg("couldn't create tmpdir")
 		return err
 	}
 
@@ -158,7 +164,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	if err != nil {
 		return err
 	}
-	log.Info().Int64("bytes_copied", bytesCopied).Msgf("copied to %s", cliTmpFile.Name())
+	logger.Info().Int64("bytes_copied", bytesCopied).Msgf("copied to %s", cliTmpFile.Name())
 
 	expectedChecksum, err := expectedChecksum(r, &cliDiscovery)
 	if err != nil {
@@ -195,28 +201,52 @@ func (d *Downloader) createLockFile() error {
 }
 
 func (d *Downloader) moveToDestination(destinationFileName string, sourceFilePath string) error {
-	cliDirectory := filepath.Dir(config.CurrentConfig().CliSettings().Path())
+	c := config.CurrentConfig()
+	logger := c.Logger().With().Str("method", "moveToDestination").Logger()
+	cliDirectory := filepath.Dir(c.CliSettings().Path())
+	err := os.MkdirAll(cliDirectory, 0755)
+	if err != nil {
+		msg := fmt.Sprintf("couldn't create directory for Snyk CLI at %s. "+
+			"Please change permissions or configured CLI path.", cliDirectory)
+		err = errors.Wrap(err, msg)
+		logger.Err(err).Send()
+		return err
+	}
 	destinationFilePath := filepath.Join(cliDirectory, destinationFileName) // snyk-win.exe.latest
-	log.Info().Str("method", "moveToDestination").Str("path", destinationFilePath).Msg("copying Snyk CLI to user directory")
+	logger.Info().Str("path", destinationFilePath).Msg("copying Snyk CLI to user directory")
 
 	// for Windows, we have to remove original file first before move/rename
-	if _, err := os.Stat(destinationFilePath); err == nil {
-		err = os.Remove(destinationFilePath)
-		if err != nil {
+	if fileInfo, statErr := os.Stat(destinationFilePath); statErr == nil {
+		removeErr := os.Remove(destinationFilePath)
+		if removeErr != nil {
+			returnErr := errors.Wrap(
+				removeErr,
+				fmt.Sprintf("couldn't remove old CLI at %s. FileInfo: %v", destinationFilePath, fileInfo),
+			)
+			logger.Err(returnErr).Send()
 			return err
 		}
 	}
 
-	log.Info().Str("method", "moveToDestination").Str("tempFilePath", sourceFilePath).Msg("tempfile path")
-	err := os.Rename(sourceFilePath, destinationFilePath)
+	logger.Info().Str("tempFilePath", sourceFilePath).Msg("tempfile path")
+	err = os.Rename(sourceFilePath, destinationFilePath)
 	if err != nil {
-		return err
+		returnErr :=
+			errors.Wrap(
+				err,
+				fmt.Sprintf("couldn't rename Snyk CLI from %s to %s", sourceFilePath, destinationFilePath),
+			)
+		logger.Err(returnErr).Send()
+		return returnErr
 	}
 
-	log.Info().Str("method", "moveToDestination").Str("path", destinationFilePath).Msg("setting executable bit for Snyk CLI")
+	logger.Info().Str("path", destinationFilePath).Msg("setting executable bit for Snyk CLI")
 	err = os.Chmod(destinationFilePath, 0755)
 	if err != nil {
-		return err
+		returnErr :=
+			errors.Wrap(err, fmt.Sprintf("couldn't set executable bit for Snyk CLI at %s", destinationFilePath))
+		logger.Err(returnErr).Send()
+		return returnErr
 	}
 	return nil
 }

--- a/infrastructure/cli/install/installer.go
+++ b/infrastructure/cli/install/installer.go
@@ -152,7 +152,7 @@ func replaceOutdatedCli(cliDiscovery Discovery) error {
 
 		// Cleanup an old executable, if left after previous update.
 		// There should be no chance that this is still running due to 4-day update cycle. Any CLI run should be guaranteed to terminate within 4 days.
-		if _, err := os.Stat(tildeExecutableName); err == nil {
+		if _, err := os.Lstat(tildeExecutableName); err == nil {
 			err = os.Remove(tildeExecutableName)
 			if err != nil {
 				log.Warn().Err(err).Str("method", "replaceOutdatedCli").Msg("couldn't remove old CLI on Windows")

--- a/infrastructure/cli/install/installer.go
+++ b/infrastructure/cli/install/installer.go
@@ -152,7 +152,7 @@ func replaceOutdatedCli(cliDiscovery Discovery) error {
 
 		// Cleanup an old executable, if left after previous update.
 		// There should be no chance that this is still running due to 4-day update cycle. Any CLI run should be guaranteed to terminate within 4 days.
-		if _, err := os.Lstat(tildeExecutableName); err == nil {
+		if _, err := os.Stat(tildeExecutableName); err == nil {
 			err = os.Remove(tildeExecutableName)
 			if err != nil {
 				log.Warn().Err(err).Str("method", "replaceOutdatedCli").Msg("couldn't remove old CLI on Windows")


### PR DESCRIPTION
### Description

This changes the download of the CLI in a minor way:
- it does not search for a CLI in the system path anymore and chooses an arbitrary file that is called snyk
- it downloads the CLI in a directory below the actual destination directory, so chances are high, it can finish once it's begun
- it creates the necessary directory tree before trying to move

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
