### PR TITLE
fix: append v1 to sast settings URL [IDE-126]

### DIFF
--- a/infrastructure/snyk_api/snyk_api.go
+++ b/infrastructure/snyk_api/snyk_api.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -92,7 +93,12 @@ func (s *SnykApiClientImpl) SastSettings() (SastResponse, error) {
 	method := "SastSettings"
 	var response SastResponse
 	log.Debug().Str("method", method).Msg("API: Getting SastEnabled")
+
 	p := "/cli-config/settings/sast"
+	host := config.CurrentConfig().SnykApi()
+	if !strings.HasSuffix(host, "/v1") {
+		p = "/v1" + p
+	}
 	organization := config.CurrentConfig().Organization()
 	if organization != "" {
 		p += "?org=" + url.QueryEscape(organization)
@@ -113,6 +119,10 @@ func (s *SnykApiClientImpl) FeatureFlagStatus(featureFlagType FeatureFlagType) (
 	var response FFResponse
 	logger.Debug().Msgf("API: Getting %s", featureFlagType)
 	path := fmt.Sprintf("/cli-config/feature-flags/%s", string(featureFlagType))
+	host := config.CurrentConfig().SnykApi()
+	if !strings.HasSuffix(host, "/v1") {
+		path = "/v1" + path
+	}
 	organization := config.CurrentConfig().Organization()
 	if organization != "" {
 		path += "?org=" + url.QueryEscape(organization)

--- a/infrastructure/snyk_api/snyk_api_pact_test.go
+++ b/infrastructure/snyk_api/snyk_api_pact_test.go
@@ -80,7 +80,7 @@ func TestSnykApiPact(t *testing.T) {
 
 		interactionConfigSettings := pact.AddInteraction().WithRequest(dsl.Request{
 			Method: "GET",
-			Path:   dsl.String("/cli-config/settings/sast"),
+			Path:   dsl.String("/v1/cli-config/settings/sast"),
 			Headers: dsl.MapMatcher{
 				"Content-Type":  dsl.String("application/json"),
 				"Authorization": dsl.Regex("token fc763eba-0905-41c5-a27f-3934ab26786c", `^token [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`),
@@ -124,7 +124,7 @@ func TestSnykApiPact(t *testing.T) {
 		interaction := pact.AddInteraction().
 			WithRequest(dsl.Request{
 				Method: "GET",
-				Path:   dsl.String("/cli-config/settings/sast"),
+				Path:   dsl.String("/v1/cli-config/settings/sast"),
 				Query:  matcher,
 				Headers: dsl.MapMatcher{
 					"Content-Type":  dsl.String("application/json"),
@@ -167,7 +167,7 @@ func TestSnykApiPact(t *testing.T) {
 		interaction := pact.AddInteraction().
 			WithRequest(dsl.Request{
 				Method: "GET",
-				Path:   dsl.String("/cli-config/feature-flags/" + featureFlagType),
+				Path:   dsl.String("/v1/cli-config/feature-flags/" + featureFlagType),
 				Query:  matcher,
 				Headers: dsl.MapMatcher{
 					"Content-Type":  dsl.String("application/json"),
@@ -212,7 +212,7 @@ func TestSnykApiPact(t *testing.T) {
 		interaction := pact.AddInteraction().
 			WithRequest(dsl.Request{
 				Method: "GET",
-				Path:   dsl.String("/cli-config/feature-flags/" + featureFlagType),
+				Path:   dsl.String("/v1/cli-config/feature-flags/" + featureFlagType),
 				Query:  matcher,
 				Headers: dsl.MapMatcher{
 					"Content-Type":  dsl.String("application/json"),


### PR DESCRIPTION
### Description

We are changing the `customEndpoint` to be `api.snyk.io`. It seems that when it's `app.snyk.io/api` this API does not require the `v1` but when it's `api.snyk.io` it does, otherwise it returns a 404. We don't want to break backwards compatibility so this change optionally adds `/v1` so that we can change the default `customEndpoint` correctly.

We tried to do this in IntelliJ but it causes a bug instead where this `/v1` is added to all APIs and not all of them requite it: https://github.com/snyk/snyk-intellij-plugin/blob/227befec201d4b47ad05a263c9625bb97c07bb33/src/main/kotlin/snyk/common/CustomEndpoints.kt#L76. We are fixing this in https://github.com/snyk/snyk-intellij-plugin/pull/523 and instead doing it in the LS, so that it applies to all IDEs.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

```
❯ curl -X GET https://api.snyk.io/cli-config/settings/sast\?org\=f3042861-6a41-4d31-a1bb-d92b3aebd62a -v
404
❯ curl -X GET https://app.snyk.io/api/cli-config/settings/sast\?org\=f3042861-6a41-4d31-a1bb-d92b3aebd62a -v
{"code":"401","status":"Unauthorized"}%
❯ curl -X GET https://api.snyk.io/v1/cli-config/settings/sast\?org\=f3042861-6a41-4d31-a1bb-d92b3aebd62a -v
{"code":"401","status":"Unauthorized"}%
❯ curl -X GET https://app.snyk.io/api/v1/cli-config/settings/sast\?org\=f3042861-6a41-4d31-a1bb-d92b3aebd62a -v
{"code":"401","status":"Unauthorized"}%
```
