### PR TITLE
refactor: display detailed informantion in Slack alert [IDE-298]

### DIFF
--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -83,11 +83,43 @@ jobs:
         run: |
           make instance-standard-test
 
+  slackNotification:
+    needs: [instance-tests, instance-standard-test]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' && (needs.instance-tests.result != 'success' || needs.instance-standard-test.result != 'success') }}
+    steps:
       - name: Slack Notification
-        if: ${{ (github.event_name != 'push' || github.ref == 'refs/heads/main') && (failure() || cancelled()) }}
-        with:
-          payload: '{"text": "GitHub build result: ${{ job.status }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" }'
-
         uses: slackapi/slack-github-action@v1.24
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":WARNING: Language Server Instance Tests Failed\n*<https://github.com/snyk/snyk-ls/actions/workflows/instance-tests.yaml|GHA Workflow - Instance Tests>*"
+                  },
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<https://github.com/${{ github.repository }}|${{ github.repository }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.ref_name }}"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"


### PR DESCRIPTION
### Description

- Slack notification gets triggered by `instance-tests[MT1, MT3]` and `instance-standard-test`. Before it was only attached to `instance-standard-test`
- Display more detailed information in Slack alert
- Fixed conditional to only alert when the failure happens in the `main` branch

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

<img width="360" alt="image" src="https://github.com/snyk/snyk-ls/assets/1948377/5f614942-687b-46aa-9307-889a81d67ae7">

IDE-298