### PR TITLE
fix: send empty vulns diagnostics [IDE-305]

### DIFF
--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -426,7 +426,7 @@ func updateSeverityFilter(s lsp.SeverityFilter) {
 		}
 
 		for _, folder := range ws.Folders() {
-			folder.FilterAndPublishDiagnostics(folder.Issues())
+			folder.FilterAndPublishDiagnostics(nil)
 		}
 	}
 }

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -125,16 +125,18 @@ func (f *Folder) Issues() snyk.IssuesByFile {
 }
 
 func (f *Folder) IssuesByProduct() snyk.ProductIssuesByFile {
-	issuesForProduct := snyk.ProductIssuesByFile{}
+	issuesForProduct := snyk.ProductIssuesByFile{
+		product.ProductOpenSource:           snyk.IssuesByFile{},
+		product.ProductCode:                 snyk.IssuesByFile{},
+		product.ProductInfrastructureAsCode: snyk.IssuesByFile{},
+		product.ProductContainer:            snyk.IssuesByFile{},
+	}
 	for path, issues := range f.Issues() {
 		if !f.Contains(path) {
 			panic("issue found in cache that does not pertain to folder")
 		}
 		for _, issue := range issues {
 			p := issue.Product
-			if issuesForProduct[p] == nil {
-				issuesForProduct[p] = snyk.IssuesByFile{}
-			}
 			issuesForProduct[p][path] = append(issuesForProduct[p][path], issue)
 		}
 	}
@@ -469,7 +471,7 @@ func (f *Folder) filterDiagnostics(issues snyk.IssuesByFile) snyk.IssuesByFile {
 }
 
 func (f *Folder) FilterIssues(issues snyk.IssuesByFile, supportedIssueTypes map[product.FilterableIssueType]bool) snyk.
-	IssuesByFile {
+IssuesByFile {
 	logger := log.With().Str("method", "FilterIssues").Logger()
 
 	filteredIssues := snyk.IssuesByFile{}


### PR DESCRIPTION
### Description

This fixes a bug where if we scan a workspace that doesn't have Code/IaC vulnerabilities we don't notify the IDEs that the scan has ended and so they seem to be stuck `Scanning...`. This is because while re-implementing the cache we forgot that we need to publish diagnostics even for scans that have no vulns.

This PR is in 3 commits:
- adding a smoke test that never finishes, which replicates the scenario (**Note** Checkout this commit only to run it and see it fail)
- refactoring the code because it was a bit difficult to understand
- adding the fix

There's a repo provided in https://snyksec.atlassian.net/browse/IDE-305 to replicate this with. Try it out before and after the fix in VSCode. Also make sure to run the following manual tests:
- scan a repo with vulns (e.g. https://github.com/snyk/target-service/tree/main)
- fix one of the vulns and re-trigger a scan to see that everything gets returned okay (one less vuln than before)
- undo the fix and re-trigger a scan to see that everything gets returned okay (one extra vuln)

### Checklist

- [X] Tests added and all succeed
- [X] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

In `snyk-ls`, run `make build-debug`.

Run VSCode and in the Snyk extension configure the Language Server Path to `snyk-ls/build/snyk-ls`.

Before:
![Screenshot 2024-05-02 at 17 03 56](https://github.com/snyk/snyk-ls/assets/81559517/4667b068-5c03-4399-a264-e908031cc705)

After:
![Screenshot 2024-05-02 at 16 41 59](https://github.com/snyk/snyk-ls/assets/81559517/4ba31dec-3b65-464b-955b-7d7aed8a928c)



