### PR TITLE
refactor: oss issue data [IDE-283]

### DIFF
--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -117,6 +117,34 @@ func (n *scanNotifier) appendOssIssues(scanIssues []lsp.ScanIssue, folderPath st
 			continue // skip non-oss issues
 		}
 
+		matchingIssues := make([]lsp.OssIssueData, len(additionalData.MatchingIssues))
+		for i, matchingIssue := range additionalData.MatchingIssues {
+			matchingIssues[i] = lsp.OssIssueData{
+				License: matchingIssue.License,
+				Identifiers: lsp.OssIdentifiers{
+					CWE: issue.CWEs,
+					CVE: issue.CVEs,
+				},
+				Description:       matchingIssue.Description,
+				Language:          matchingIssue.Language,
+				PackageManager:    matchingIssue.PackageManager,
+				PackageName:       matchingIssue.PackageName,
+				Name:              matchingIssue.Name,
+				Version:           matchingIssue.Version,
+				Exploit:           matchingIssue.Exploit,
+				CVSSv3:            matchingIssue.CVSSv3,
+				CvssScore:         strconv.FormatFloat(matchingIssue.CvssScore, 'f', 2, 64), // convert float64 to string with 2 decimal places
+				FixedIn:           matchingIssue.FixedIn,
+				From:              matchingIssue.From,
+				UpgradePath:       matchingIssue.UpgradePath,
+				IsPatchable:       matchingIssue.IsPatchable,
+				IsUpgradable:      matchingIssue.IsUpgradable,
+				ProjectName:       matchingIssue.ProjectName,
+				DisplayTargetFile: matchingIssue.DisplayTargetFile,
+				Details:           matchingIssue.Details,
+			}
+		}
+
 		scanIssues = append(scanIssues, lsp.ScanIssue{
 			Id:       additionalData.Key,
 			Title:    additionalData.Title,
@@ -146,6 +174,8 @@ func (n *scanNotifier) appendOssIssues(scanIssues []lsp.ScanIssue, folderPath st
 				ProjectName:       additionalData.ProjectName,
 				DisplayTargetFile: additionalData.DisplayTargetFile,
 				Details:           additionalData.Details,
+				MatchingIssues:    matchingIssues,
+				Lesson:            additionalData.Lesson,
 			},
 		})
 	}

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -284,6 +284,8 @@ func Test_SendSuccess_SendsForOpenSource(t *testing.T) {
 				ProjectName:       "OSS ProjectName",
 				DisplayTargetFile: "OSS DisplayTargetFile",
 				Details:           "",
+				MatchingIssues:    []lsp2.OssIssueData{},
+				Lesson:            "test",
 			},
 		},
 	}
@@ -331,6 +333,7 @@ func Test_SendSuccess_SendsForOpenSource(t *testing.T) {
 				DisplayTargetFile: "OSS DisplayTargetFile",
 				Language:          "js",
 				Details:           "",
+				Lesson:            "test",
 			},
 		},
 	}

--- a/domain/snyk/issues.go
+++ b/domain/snyk/issues.go
@@ -136,28 +136,36 @@ type MarkerPosition struct {
 }
 
 type OssIssueData struct {
-	Key               string      `json:"key"`
-	Title             string      `json:"title"`
-	Name              string      `json:"name"`
-	LineNumber        int         `json:"lineNumber"`
-	Description       string      `json:"description"`
-	References        []Reference `json:"references,omitempty"`
-	Version           string      `json:"version"`
-	License           string      `json:"license,omitempty"`
-	PackageManager    string      `json:"packageManager"`
-	PackageName       string      `json:"packageName"`
-	From              []string    `json:"from"`
-	FixedIn           []string    `json:"fixedIn,omitempty"`
-	UpgradePath       []any       `json:"upgradePath,omitempty"`
-	IsUpgradable      bool        `json:"isUpgradable,omitempty"`
-	CVSSv3            string      `json:"CVSSv3,omitempty"`
-	CvssScore         float64     `json:"cvssScore,omitempty"`
-	Exploit           string      `json:"exploit,omitempty"`
-	IsPatchable       bool        `json:"isPatchable"`
-	ProjectName       string      `json:"projectName"`
-	DisplayTargetFile string      `json:"displayTargetFile"`
-	Language          string      `json:"language"`
-	Details           string      `json:"details"`
+	Key               string         `json:"key"`
+	Title             string         `json:"title"`
+	Name              string         `json:"name"`
+	LineNumber        int            `json:"lineNumber"`
+	Identifiers       Identifiers    `jsom:"identifiers"`
+	Description       string         `json:"description"`
+	References        []Reference    `json:"references,omitempty"`
+	Version           string         `json:"version"`
+	License           string         `json:"license,omitempty"`
+	PackageManager    string         `json:"packageManager"`
+	PackageName       string         `json:"packageName"`
+	From              []string       `json:"from"`
+	FixedIn           []string       `json:"fixedIn,omitempty"`
+	UpgradePath       []any          `json:"upgradePath,omitempty"`
+	IsUpgradable      bool           `json:"isUpgradable,omitempty"`
+	CVSSv3            string         `json:"CVSSv3,omitempty"`
+	CvssScore         float64        `json:"cvssScore,omitempty"`
+	Exploit           string         `json:"exploit,omitempty"`
+	IsPatchable       bool           `json:"isPatchable"`
+	ProjectName       string         `json:"projectName"`
+	DisplayTargetFile string         `json:"displayTargetFile"`
+	Language          string         `json:"language"`
+	Details           string         `json:"details"`
+	MatchingIssues    []OssIssueData `json:"matchingIssues"`
+	Lesson            string         `json:"lesson,omitempty"`
+}
+
+type Identifiers struct {
+	CWE []string `json:"CWE,omitempty"`
+	CVE []string `json:"CVE,omitempty"`
 }
 
 func (o OssIssueData) GetKey() string {

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -19,19 +19,14 @@ package oss
 import (
 	_ "embed"
 	"fmt"
-	"net/url"
-	"strings"
 
 	"github.com/gomarkdown/markdown"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/observability/error_reporting"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/learn"
 	"github.com/snyk/snyk-ls/internal/product"
-	"github.com/snyk/snyk-ls/internal/util"
 )
 
 var issuesSeverity = map[string]snyk.Severity{
@@ -39,127 +34,6 @@ var issuesSeverity = map[string]snyk.Severity{
 	"high":     snyk.High,
 	"low":      snyk.Low,
 	"medium":   snyk.Medium,
-}
-
-func (i *ossIssue) AddCodeActions(learnService learn.Service, ep error_reporting.ErrorReporter) (actions []snyk.
-	CodeAction) {
-	title := fmt.Sprintf("Open description of '%s affecting package %s' in browser (Snyk)", i.Title, i.PackageName)
-	command := &snyk.CommandData{
-		Title:     title,
-		CommandId: snyk.OpenBrowserCommand,
-		Arguments: []any{i.CreateIssueURL().String()},
-	}
-
-	action, _ := snyk.NewCodeAction(title, nil, command)
-	actions = append(actions, action)
-
-	codeAction := i.AddSnykLearnAction(learnService, ep)
-	if codeAction != nil {
-		actions = append(actions, *codeAction)
-	}
-	return actions
-}
-
-func (i *ossIssue) AddSnykLearnAction(learnService learn.Service, ep error_reporting.ErrorReporter) (action *snyk.
-	CodeAction) {
-	if config.CurrentConfig().IsSnykLearnCodeActionsEnabled() {
-		lesson, err := learnService.GetLesson(i.PackageManager, i.Id, i.Identifiers.CWE, i.Identifiers.CVE, snyk.DependencyVulnerability)
-		if err != nil {
-			msg := "failed to get lesson"
-			log.Err(err).Msg(msg)
-			ep.CaptureError(errors.WithMessage(err, msg))
-			return nil
-		}
-
-		if lesson != nil && lesson.Url != "" {
-			title := fmt.Sprintf("Learn more about %s (Snyk)", i.Title)
-			action = &snyk.CodeAction{
-				Title: title,
-				Command: &snyk.CommandData{
-					Title:     title,
-					CommandId: snyk.OpenBrowserCommand,
-					Arguments: []any{lesson.Url},
-				},
-			}
-			i.lesson = lesson
-			log.Debug().Str("method", "oss.issue.AddSnykLearnAction").Msgf("Learn action: %v", action)
-		}
-	}
-	return action
-}
-
-func (i *ossIssue) GetExtendedMessage(issue ossIssue) string {
-	title := issue.Title
-	description := issue.Description
-
-	if config.CurrentConfig().Format() == config.FormatHtml {
-		title = string(markdown.ToHTML([]byte(title), nil, nil))
-		description = string(markdown.ToHTML([]byte(description), nil, nil))
-	}
-	summary := fmt.Sprintf("### Vulnerability %s %s %s \n **Fixed in: %s | Exploit maturity: %s**",
-		issue.createCveLink(),
-		issue.createCweLink(),
-		issue.createIssueUrlMarkdown(),
-		issue.createFixedIn(),
-		strings.ToUpper(issue.Severity),
-	)
-
-	return fmt.Sprintf("\n### %s: %s affecting %s package \n%s \n%s",
-		issue.Id,
-		title,
-		issue.PackageName,
-		summary,
-		description)
-}
-
-func (i *ossIssue) createCveLink() string {
-	var formattedCve string
-	for _, c := range i.Identifiers.CVE {
-		formattedCve += fmt.Sprintf("| [%s](https://cve.mitre.org/cgi-bin/cvename.cgi?name=%s)", c, c)
-	}
-	return formattedCve
-}
-
-func (i *ossIssue) createIssueUrlMarkdown() string {
-	return fmt.Sprintf("| [%s](%s)", i.Id, i.CreateIssueURL().String())
-}
-
-func (i *ossIssue) CreateIssueURL() *url.URL {
-	parse, err := url.Parse("https://snyk.io/vuln/" + i.Id)
-	if err != nil {
-		log.Err(err).Msg("Unable to create issue link for issue:" + i.Id)
-	}
-	return parse
-}
-
-func (i *ossIssue) createFixedIn() string {
-	var f string
-	if len(i.FixedIn) < 1 {
-		f += "Not Fixed"
-	} else {
-		f += "@" + i.FixedIn[0]
-		for _, version := range i.FixedIn[1:] {
-			f += fmt.Sprintf(", %s", version)
-		}
-	}
-	return f
-}
-
-func (i *ossIssue) createCweLink() string {
-	var formattedCwe string
-	for _, c := range i.Identifiers.CWE {
-		id := strings.Replace(c, "CWE-", "", -1)
-		formattedCwe += fmt.Sprintf("| [%s](https://cwe.mitre.org/data/definitions/%s.html)", c, id)
-	}
-	return formattedCwe
-}
-
-func (i *ossIssue) ToIssueSeverity() snyk.Severity {
-	sev, ok := issuesSeverity[i.Severity]
-	if !ok {
-		return snyk.Low
-	}
-	return sev
 }
 
 func toIssue(
@@ -170,21 +44,22 @@ func toIssue(
 	learnService learn.Service,
 	ep error_reporting.ErrorReporter,
 ) snyk.Issue {
-	title := issue.Title
+	// find all issues with the same id
+	matchingIssues := []snyk.OssIssueData{}
+	for _, otherIssue := range scanResult.Vulnerabilities {
+		if otherIssue.Id == issue.Id {
+			matchingIssues = append(matchingIssues, otherIssue.toAdditionalData(scanResult,
+				[]snyk.OssIssueData{}))
+		}
+	}
 
+	additionalData := issue.toAdditionalData(scanResult, matchingIssues)
+
+	title := issue.Title
 	if config.CurrentConfig().Format() == config.FormatHtml {
 		title = string(markdown.ToHTML([]byte(title), nil, nil))
 	}
-	remediationAdvice := getRemediationAdvice(issue)
-
-	// find all issues with the same id
-	matchingIssues := []ossIssue{}
-	for _, otherIssue := range scanResult.Vulnerabilities {
-		if otherIssue.Id == issue.Id {
-			matchingIssues = append(matchingIssues, otherIssue)
-		}
-	}
-	issue.matchingIssues = matchingIssues
+	remediationAdvice := getRemediationAdvice(additionalData)
 
 	message := fmt.Sprintf(
 		"%s affecting package %s. %s",
@@ -197,8 +72,7 @@ func toIssue(
 	if len(message) > maxLength {
 		message = message[:maxLength] + "... (Snyk)"
 	}
-
-	return snyk.Issue{
+	d := snyk.Issue{
 		ID:                  issue.Id,
 		Message:             message,
 		FormattedMessage:    issue.GetExtendedMessage(issue),
@@ -212,55 +86,13 @@ func toIssue(
 		Ecosystem:           issue.PackageManager,
 		CWEs:                issue.Identifiers.CWE,
 		CVEs:                issue.Identifiers.CVE,
-		AdditionalData:      issue.toAdditionalData(scanResult),
+		AdditionalData:      additionalData,
 	}
-}
 
-func (i *ossIssue) toAdditionalData(scanResult *scanResult) snyk.OssIssueData {
-	var additionalData snyk.OssIssueData
-	additionalData.Key = util.GetIssueKey(i.Id, scanResult.DisplayTargetFile, i.LineNumber, i.LineNumber, 0, 0)
-	additionalData.Title = i.Title
-	additionalData.Name = i.Name
-	additionalData.LineNumber = i.LineNumber
-	additionalData.Description = i.Description
-	additionalData.References = i.toReferences()
-	additionalData.Version = i.Version
-	additionalData.License = i.License
-	additionalData.PackageManager = i.PackageManager
-	additionalData.PackageName = i.PackageName
-	additionalData.From = i.From
-	additionalData.FixedIn = i.FixedIn
-	additionalData.UpgradePath = i.UpgradePath
-	additionalData.IsUpgradable = i.IsUpgradable
-	additionalData.CVSSv3 = i.CVSSv3
-	additionalData.CvssScore = i.CvssScore
-	additionalData.Exploit = i.Exploit
-	additionalData.IsPatchable = i.IsPatchable
-	additionalData.ProjectName = scanResult.ProjectName
-	additionalData.DisplayTargetFile = scanResult.DisplayTargetFile
-	additionalData.Language = i.Language
-	additionalData.Details = getDetailsHtml(i)
+	additionalData.Details = getDetailsHtml(d)
+	d.AdditionalData = additionalData
 
-	return additionalData
-}
-
-func (i *ossIssue) toReferences() []snyk.Reference {
-	var references []snyk.Reference
-	for _, ref := range i.References {
-		references = append(references, ref.toReference())
-	}
-	return references
-}
-
-func (r reference) toReference() snyk.Reference {
-	u, err := url.Parse(string(r.Url))
-	if err != nil {
-		log.Err(err).Msg("Unable to parse reference url: " + string(r.Url))
-	}
-	return snyk.Reference{
-		Url:   u,
-		Title: r.Title,
-	}
+	return d
 }
 
 func convertScanResultToIssues(

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -44,6 +44,9 @@ func toIssue(
 	learnService learn.Service,
 	ep error_reporting.ErrorReporter,
 ) snyk.Issue {
+	// this needs to be first so that the lesson from Snyk Learn is added
+	codeActions := issue.AddCodeActions(learnService, ep)
+
 	// find all issues with the same id
 	matchingIssues := []snyk.OssIssueData{}
 	for _, otherIssue := range scanResult.Vulnerabilities {
@@ -82,7 +85,7 @@ func toIssue(
 		Product:             product.ProductOpenSource,
 		IssueDescriptionURL: issue.CreateIssueURL(),
 		IssueType:           snyk.DependencyVulnerability,
-		CodeActions:         issue.AddCodeActions(learnService, ep),
+		CodeActions:         codeActions,
 		Ecosystem:           issue.PackageManager,
 		CWEs:                issue.Identifiers.CWE,
 		CVEs:                issue.Identifiers.CVE,

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -141,6 +141,7 @@ func Test_toIssue_LearnParameterConversion(t *testing.T) {
 	assert.Equal(t, sampleOssIssue.Identifiers.CWE, issue.CWEs)
 	assert.Equal(t, sampleOssIssue.Identifiers.CVE, issue.CVEs)
 	assert.Equal(t, sampleOssIssue.PackageManager, issue.Ecosystem)
+	assert.Equal(t, "url", (issue.AdditionalData).(snyk.OssIssueData).Lesson)
 }
 
 func Test_introducingPackageAndVersionJava(t *testing.T) {
@@ -553,6 +554,6 @@ func getLearnMock(t *testing.T) learn.Service {
 	learnMock.
 		EXPECT().
 		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&learn.Lesson{}, nil).AnyTimes()
+		Return(&learn.Lesson{Url: "url"}, nil).AnyTimes()
 	return learnMock
 }

--- a/internal/lsp/message_types.go
+++ b/internal/lsp/message_types.go
@@ -1066,6 +1066,8 @@ type OssIssueData struct {
 	ProjectName       string         `json:"projectName"`
 	DisplayTargetFile string         `json:"displayTargetFile"`
 	Details           string         `json:"details,omitempty"`
+	MatchingIssues    []OssIssueData `json:"matchingIssues"`
+	Lesson            string         `json:"lessonUrl,omitempty"`
 }
 
 type OssIdentifiers struct {


### PR DESCRIPTION
### Description

Refactors the types used for OSS so that:
- they're used consistently and so the OSS scan deals with `oss.ossIssue`, the rendered HTML deals with `snyk.OssIssueData`, and the `snyk.scan` notification deals with `lsp.OssIssueData`, which is converted from `snyk.OssIssueData` (before this change the rendered HTML dealt with `oss.ossIssue` directly, and so the data given to `snyk.scan` and to the HTML logic differed)
- as a result, we are able to easily include new fields in the `snyk.scan` notification that can be used to build the UI (e.g. `MatchingIssues`, `Lesson`, `Identifiers`)

This will be the building block for rendering OSS vulnerabilities in IntelliJ via the LS, but not from HTML yet.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

Tested in the VSCode extension by running `make build-debug` in this repo and then changing the path to LS in VSCode to it.

Before:
![Screenshot 2024-05-09 at 11 23 22](https://github.com/snyk/snyk-ls/assets/81559517/dc007c9d-994e-4996-9f4d-66209be22681)

After:
![Screenshot 2024-05-09 at 11 23 57](https://github.com/snyk/snyk-ls/assets/81559517/231bde61-1517-4eee-9aa1-216722b15ad9)
![Screenshot 2024-05-09 at 11 24 34](https://github.com/snyk/snyk-ls/assets/81559517/c6be8648-2bfb-4bef-9f5c-1a00d19ca6bd)


Proof of using the new LS FROM LOGS:
```
[Info  - 11:24:16] 2024-05-09T11:24:16+01:00 INF - snyk-ls: v20240509.112159-SNAPSHOT-390c0ac (/Users/teodorasandu/Documents/repos/snyk-ls/build/snyk-ls)
```

