### PR TITLE
feat: include ruleId in LS response for OSS [IDE-238] 

### DIFF
--- a/application/server/notification/scan_notifier.go
+++ b/application/server/notification/scan_notifier.go
@@ -152,6 +152,7 @@ func (n *scanNotifier) appendOssIssues(scanIssues []lsp.ScanIssue, folderPath st
 			FilePath: issue.AffectedFilePath,
 			Range:    converter.ToRange(issue.Range),
 			AdditionalData: lsp.OssIssueData{
+				RuleId:  issue.ID,
 				License: additionalData.License,
 				Identifiers: lsp.OssIdentifiers{
 					CWE: issue.CWEs,

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -259,6 +259,7 @@ func Test_SendSuccess_SendsForOpenSource(t *testing.T) {
 			FilePath: "ossAffectedFilePath",
 			Range:    lspTestRange,
 			AdditionalData: lsp2.OssIssueData{
+				RuleId:  "SNYK-JS-BABELTRAVERSE-5962463",
 				License: "OSS License",
 				Identifiers: lsp2.OssIdentifiers{
 					CWE: []string{"CWE-184"},

--- a/internal/lsp/message_types.go
+++ b/internal/lsp/message_types.go
@@ -1047,6 +1047,7 @@ type IgnoreDetails struct {
 
 // Snyk Open Source
 type OssIssueData struct {
+	RuleId            string         `json:"ruleId"`
 	License           string         `json:"license,omitempty"`
 	Identifiers       OssIdentifiers `json:"identifiers,omitempty"`
 	Description       string         `json:"description"`


### PR DESCRIPTION
### Description

Adds a `ruleId` field to the LS message so that in IntelliJ we can include it in the rendered UI.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
