### PR TITLE
fix: handle 403 responses gracefully for feature flags checks [IDE-328]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,6 @@ jobs:
         shell: bash
         if: steps.cache-pact.outputs.cache-hit != 'true'
         run: |
-          cd ~
           make tools
 
       - name: Cache Go modules
@@ -118,7 +117,6 @@ jobs:
         shell: bash
         if: steps.cache-pact.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
         run: |
-          cd ~
           make tools
 
       - name: Run integration tests with Pact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,6 @@ jobs:
         shell: bash
         if: steps.cache-pact.outputs.cache-hit != 'true'
         run: |
-          cd ~
           make tools
 
       - name: Cache Go modules

--- a/domain/ide/command/get_feature_flag_status.go
+++ b/domain/ide/command/get_feature_flag_status.go
@@ -59,7 +59,7 @@ func (cmd *featureFlagStatus) Execute(ctx context.Context) (any, error) {
 	logger.Debug().Msg(message)
 
 	if err != nil {
-		logger.Err(err).Msg("Failed to get feature flag status for feature flag: " + ffStr)
+		logger.Err(err).Msg("Failed to get feature flag: " + ffStr)
 		return snyk_api.FFResponse{Ok: false, UserMessage: err.Error()}, nil
 	}
 

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -515,13 +515,14 @@ func (sc *Scanner) trackResult(success bool, scanMetrics *ScanMetrics) {
 }
 
 func (sc *Scanner) useIgnoresFlow() bool {
+	logger := config.CurrentConfig().Logger().With().Str("method", "code.useIgnoresFlow").Logger()
 	response, err := sc.SnykApiClient.FeatureFlagStatus(snyk_api.FeatureFlagSnykCodeConsistentIgnores)
 	if err != nil {
-		log.Debug().Err(err).Msg("Failed to check if the ignores experience is enabled")
+		logger.Debug().Msg("Failed to check if the ignores experience is enabled")
 		return false
 	}
 	if !response.Ok && response.UserMessage != "" {
-		log.Info().Msg(response.UserMessage)
+		logger.Info().Msg(response.UserMessage)
 	}
 	return response.Ok
 }


### PR DESCRIPTION
### Description

- Change log level from error to debug for 403 Forbidden responses in `FeatureFlagStatus`
- Provide clearer debug messages when the feature flag is disabled


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

New Messages:

```bash
// Startup:
// ======
DBG snyk_api.FeatureFlagStatus - Getting feature flag status path=/v1/cli-config/feature-flags/snykCodeConsistentIgnores?org=org_id

DBG snyk_api.FeatureFlagStatus - Feature flag 'snykCodeConsistentIgnores' is disabled

// When settings change
// =================
DBG snyk_api.FeatureFlagStatus - Getting feature flag status path=/v1/cli-config/feature-flags/snykCodeConsistentIgnores?org=org_id

DBG snyk_api.FeatureFlagStatus - Feature flag 'snykCodeConsistentIgnores' is disabled

DBG featureFlagStatus.Execute - Feature flag status for 'snykCodeConsistentIgnores': false
```