### PR TITLE
chore: explicitly set token authentication when using the CLI

### DIFF
--- a/infrastructure/cli/auth/provider.go
+++ b/infrastructure/cli/auth/provider.go
@@ -172,7 +172,7 @@ func (a *CliAuthenticationProvider) getToken(ctx context.Context) (string, error
 
 func (a *CliAuthenticationProvider) authCmd(ctx context.Context) (*exec.Cmd, error) {
 	log.Info().Msg("authenticate Snyk CLI with a Snyk account")
-	args := []string{"auth"}
+	args := []string{"auth", "--auth-type=token"}
 	return a.buildCLICmd(ctx, args...), nil
 }
 

--- a/infrastructure/cli/auth/provider_test.go
+++ b/infrastructure/cli/auth/provider_test.go
@@ -36,7 +36,7 @@ func TestAuth_authCmd(t *testing.T) {
 	authCmd, err := provider.authCmd(ctx)
 
 	assert.NoError(t, err)
-	assertCmd(t, []string{"auth"}, authCmd)
+	assertCmd(t, []string{"auth", "--auth-type=token"}, authCmd)
 }
 
 func TestConfig_configGetAPICmd(t *testing.T) {


### PR DESCRIPTION
### Description

The CLI default authentication will be switching to OAuth, since snyk-ls uses the CLI for token based authentication, it is necessary to explicitly state the `auth-type` to be token.

This can be tested with the `preview` version of the CLI, which already uses OAuth as default.
The expected behaviour is that snyk-ls still uses token based authentication unless it is connecting to fedramp instances or the authentication type is changed.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
