### PR TITLE
feat: add `--all-projects` flag to open source scans by default [IDE-318]

### DIFF
--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -242,9 +242,9 @@ func (cliScanner *CLIScanner) prepareScanCommand(args []string, parameterBlackli
 		}
 		cmd = append(cmd, parameter)
 	}
-
-	if !slices.Contains(cmd, "--all-projects") {
-		cmd = append(cmd, "--all-projects")
+	allProjectsParam := "--all-projects"
+	if !slices.Contains(cmd, allProjectsParam) && !parameterBlacklist[allProjectsParam] {
+		cmd = append(cmd, allProjectsParam)
 	}
 
 	return cmd

--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"golang.org/x/exp/slices"
 
 	"github.com/snyk/snyk-ls/application/config"
 	noti "github.com/snyk/snyk-ls/domain/ide/notification"
@@ -241,6 +242,11 @@ func (cliScanner *CLIScanner) prepareScanCommand(args []string, parameterBlackli
 		}
 		cmd = append(cmd, parameter)
 	}
+
+	if !slices.Contains(cmd, "--all-projects") {
+		cmd = append(cmd, "--all-projects")
+	}
+
 	return cmd
 }
 

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -340,7 +340,7 @@ func sampleIssue() ossIssue {
 	}
 }
 
-func Test_prepareScanCommand_ExpandsAdditionalParameters(t *testing.T) {
+func Test_prepareScanCommand(t *testing.T) {
 	c := testutil.UnitTest(t)
 	scanner := NewCLIScanner(performance.NewInstrumentor(),
 		error_reporting.NewTestErrorReporter(),
@@ -350,15 +350,30 @@ func Test_prepareScanCommand_ExpandsAdditionalParameters(t *testing.T) {
 		notification.NewNotifier(),
 		c).(*CLIScanner)
 
-	settings := config.CliSettings{
-		AdditionalOssParameters: []string{"--all-projects", "-d"},
-	}
-	c.SetCliSettings(&settings)
+	t.Run("Expands parameters", func(t *testing.T) {
+		settings := config.CliSettings{
+			AdditionalOssParameters: []string{"--all-projects", "-d"},
+		}
+		c.SetCliSettings(&settings)
 
-	cmd := scanner.prepareScanCommand([]string{"a"}, map[string]bool{})
+		cmd := scanner.prepareScanCommand([]string{"a"}, map[string]bool{})
 
-	assert.Contains(t, cmd, "--all-projects")
-	assert.Contains(t, cmd, "-d")
+		assert.Contains(t, cmd, "--all-projects")
+		assert.Contains(t, cmd, "-d")
+	})
+
+	t.Run("Uses --all-projects by default", func(t *testing.T) {
+		settings := config.CliSettings{
+			AdditionalOssParameters: []string{"-d"},
+		}
+		c.SetCliSettings(&settings)
+
+		cmd := scanner.prepareScanCommand([]string{"a"}, map[string]bool{})
+
+		assert.Contains(t, cmd, "--all-projects")
+		assert.Len(t, cmd, 4)
+	})
+
 }
 
 func Test_Scan_SchedulesNewScan(t *testing.T) {

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -373,7 +373,6 @@ func Test_prepareScanCommand(t *testing.T) {
 		assert.Contains(t, cmd, "--all-projects")
 		assert.Len(t, cmd, 4)
 	})
-
 }
 
 func Test_Scan_SchedulesNewScan(t *testing.T) {


### PR DESCRIPTION
### Description

Add `--all-projects` flag to scans by default

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
