### PR TITLE
fix: encode paths correctly for autofix in windows

### DIFF
--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -72,10 +72,14 @@ func (sc *Scanner) GetAutoFixDiffs(
 		return unifiedDiffSuggestions, fmt.Errorf("bundle hash not found for baseDir: %s", baseDir)
 	}
 
+	encodedNormalizedPath, err := ToEncodedNormalizedPath(baseDir, filePath)
+	if err != nil {
+		return unifiedDiffSuggestions, err
+	}
 	options := AutofixOptions{
 		bundleHash: bundleHash,
 		shardKey:   getShardKey(baseDir, config.CurrentConfig().Token()),
-		filePath:   filePath,
+		filePath:   encodedNormalizedPath,
 		issue:      issue,
 	}
 


### PR DESCRIPTION
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

![image](https://github.com/snyk/snyk-ls/assets/20150761/fccd583e-6822-41f3-b1fa-e2a427f29b2f)
