### PR TITLE
chore: add repo link to repo tab name [IDE-381]

### DIFF
--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -55,6 +55,7 @@ type ExampleCommit struct {
 	CommitURL    string
 	IconSVG      template.HTML
 	RepoName     string
+	RepoLink     string
 	ExampleLines []ExampleLines
 }
 
@@ -191,6 +192,7 @@ func prepareExampleCommitFixes(fixes []snyk.ExampleCommitFix) []ExampleCommit {
 			IconSVG:      getVendorIconSvg(),
 			RepoName:     getRepoName(fix.CommitURL),
 			ExampleLines: prepareExampleLines(fix.Lines),
+			RepoLink:     fix.CommitURL,
 		})
 	}
 	return fixData

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -77,8 +77,9 @@ func Test_Code_Html_getCodeDetailsHtml(t *testing.T) {
 	expectedFixesDescription := fmt.Sprintf(`\s*This issue was fixed by %d projects. Here are %d example fixe.\s*`, repoCount, len(fixes))
 	assert.Regexp(t, regexp.MustCompile(expectedFixesDescription), codePanelHtml)
 	assert.Contains(t, codePanelHtml, `<span class="tab-item is-selected" id="tab-link-0">`, "Two tabs, first is selected")
-	assert.Contains(t, codePanelHtml, "</svg> apache/flink", "GitHub icon preceding the repo name is present")
-	assert.Contains(t, codePanelHtml, "</svg> apache/tomcat", "Second tab is present")
+	assert.Contains(t, codePanelHtml, `</svg> <a class="example-repo-link"`, "GitHub icon preceding the repo name is present")
+	assert.Contains(t, codePanelHtml, `apache/tomcat</a>`, "Second tab is present")
+	assert.Contains(t, codePanelHtml, `href="https://github.com/apache/tomcat/commit/0fa9d5547c5300cf8162b8f31a40aea6847a5c32?diff=split#diff-7e23eb1aa3b7b4d5db89bfd2860277e5L75"`, "Repo name has GitHub link")
 
 	// assert Footer
 	assert.Contains(t, codePanelHtml, `id="action-ignore-line">68</span>`)

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -238,6 +238,17 @@
       transition: background-color 0.3s, border-color 0.3s;
     }
 
+    .example-repo-link {
+      text-decoration: none;
+      color: inherit;
+      cursor: pointer;
+    }
+
+    .example-repo-link:hover {
+      text-decoration: none;
+      color: inherit;
+    }
+
     .example-line {
       display: block;
       padding: 2px 0 18px 0;
@@ -488,13 +499,16 @@
               <div class="example-fixes-tabs-nav example-fixes-tabs">
                 {{range $index, $fix := .ExampleCommitFixes}}
                 <span class="tab-item {{if eq $index 0}}is-selected{{end}}" id="tab-link-{{$index}}">
-                  {{$fix.IconSVG}} {{$fix.RepoName}}
+                  {{$fix.IconSVG}} <a class="example-repo-link" target="_blank" rel="noopener noreferrer"
+                    href="{{.RepoLink}}">
+                    {{$fix.RepoName}}</a>
                 </span>
                 {{end}}
               </div>
               <div class="tab-container">
                 {{range $index, $fix := .ExampleCommitFixes}}
-                <div id="tab-content-{{$index}}" class="tab-content example-fix-tab-content {{if eq $index 0}}is-selected{{end}}">
+                <div id="tab-content-{{$index}}"
+                  class="tab-content example-fix-tab-content {{if eq $index 0}}is-selected{{end}}">
                   {{range $fix.ExampleLines}}
                   <div class="example-line {{.LineChange}}">
                     <span class="example-line-number">{{.LineNumber}}</span>


### PR DESCRIPTION
### Description

This PR adds a link to the GitHub repo for **FIXED CODE EXAMPLES** tabs

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

https://github.com/snyk/snyk-ls/assets/1948377/fa1d5271-f6ea-4e54-9467-de68a1493121


