### PR TITLE
fix: go releaser argument for skip publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -235,7 +235,7 @@ jobs:
         env:
           LICENSES: ${{ steps.create_license_report.outputs.LICENSES }}
         with:
-          args: release --clean --snapshot --skip-publish
+          args: release --clean --snapshot --skip=publish
 
       - name: Output compiled licenses
         run: |


### PR DESCRIPTION
### Description
- Use the new argument for skip from goreleaser

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
