### PR TITLE
fix: hide ai fix code action if ignored [IDE-223]

### DIFF
--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -87,7 +87,7 @@ func (b *IssueEnhancer) addIssueActions(ctx context.Context, issues []snyk.Issue
 			continue
 		}
 
-		if autoFixEnabled && issueData.IsAutofixable {
+		if autoFixEnabled && issueData.IsAutofixable && !issues[i].IsIgnored {
 			codeAction := *b.createDeferredAutofixCodeAction(ctx, issues[i], bundleHash)
 			issues[i].CodeActions = append(issues[i].CodeActions, codeAction)
 


### PR DESCRIPTION
### Description

Removes the AI fix code action and code lens if the issue is ignored.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

To test it manually, apply this hack in `snyk-ls` until AI fixes work:
```
diff --git a/infrastructure/code/convert.go b/infrastructure/code/convert.go
index 94db11a..40459dc 100644
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -366,7 +366,7 @@ func (s *SarifConverter) toIssues(baseDir string) (issues []snyk.Issue, err erro
                                Cols:               [2]int{startCol, endCol},
                                Rows:               [2]int{startLine, endLine},
                                IsSecurityType:     isSecurityType,
-                               IsAutofixable:      result.Properties.IsAutofixable,
+                               IsAutofixable:      true,
                                PriorityScore:      result.Properties.PriorityScore,
                                DataFlow:           s.getCodeFlow(result, baseDir),
                        }
```

Non-ignored issue with an AI fix:
<img width="1313" alt="Screenshot 2024-06-06 at 16 03 07" src="https://github.com/snyk/snyk-ls/assets/81559517/ca678b49-330b-4f56-9476-5a395dfe8d8b">

Ignored issue with AI fix:
<img width="1330" alt="Screenshot 2024-06-06 at 16 03 16" src="https://github.com/snyk/snyk-ls/assets/81559517/8043d1c0-930b-4f02-ae9d-7937359e86a9">
