### PR TITLE
chore: parse ignore category value to copy

### DIFF
--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -139,12 +139,25 @@ func trimCWEPrefix(cwe string) string {
 
 func prepareIgnoreDetailsRow(ignoreDetails *snyk.IgnoreDetails) []IgnoreDetail {
 	return []IgnoreDetail{
-		{"Category", ignoreDetails.Category},
+		{"Category", parseCategory(ignoreDetails.Category)},
 		{"Expiration", ignoreDetails.Expiration},
 		{"Ignored On", formatDate(ignoreDetails.IgnoredOn)},
 		{"Ignored By", ignoreDetails.IgnoredBy},
 		{"Reason", ignoreDetails.Reason},
 	}
+}
+
+func parseCategory(category string) string {
+	categoryMap := map[string]string{
+		"not-vulnerable":   "Not vulnerable",
+		"temporary-ignore": "Ignored temporarily",
+		"wont-fix":         "Ignored permanently",
+	}
+
+	if result, ok := categoryMap[category]; ok {
+		return result
+	}
+	return category
 }
 
 func prepareDataFlowTable(issue snyk.CodeIssueData) []DataFlowItem {

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -129,6 +129,7 @@ func Test_Code_Html_getCodeDetailsHtml_ignored(t *testing.T) {
 	assert.Contains(t, codePanelHtml, `class="ignore-warning-wrapper"`)
 	assert.Contains(t, codePanelHtml, `class="ignore-badge"`)
 	assert.Contains(t, codePanelHtml, `data-content="ignore-details"`)
+	assert.Contains(t, codePanelHtml, `class="ignore-details-value">Ignored permanently</div>`)
 
 	// assert Footer buttons are not present when issue is ignored
 	assert.NotContains(t, codePanelHtml, `id="ignore-actions"`)


### PR DESCRIPTION
### Description

This PR maps the `reasonType` defined by the [Policy](https://github.com/snyk/policy/blob/39a6316bfa435a7dbd68295d065c6789b7bd331c/lib/add.ts#L7C1-L10) lib to the copy shown in the Web UI

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

|Web UI|Before|After|
|-|-|-|
|![image](https://github.com/snyk/snyk-ls/assets/1948377/37326ae4-6351-42f0-8654-7751b4b8abd2)|<img width="768" alt="image" src="https://github.com/snyk/snyk-ls/assets/1948377/8d9c0ae3-3f19-4a7a-b44d-52d4aa5b7c6d">|<img width="767" alt="image" src="https://github.com/snyk/snyk-ls/assets/1948377/6b3b7073-3249-44d8-ac45-e88c355ce2de">|


