### PR TITLE
fix: store bundle hash for ai fix [IDE-380]

### DIFF
--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -409,6 +409,7 @@ func (sc *Scanner) UploadAndAnalyzeWithIgnores(ctx context.Context,
 	if err != nil {
 		return []snyk.Issue{}, err
 	}
+	sc.BundleHashes[path] = bundleHash
 
 	converter := SarifConverter{sarif: *sarif, c: sc.c}
 	issues, err = converter.toIssues(path)

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -400,6 +400,7 @@ func TestUploadAndAnalyzeWithIgnores(t *testing.T) {
 
 	scanner := New(
 		NewBundler(c, snykCodeMock, NewCodeInstrumentor()),
+
 		&snyk_api.FakeApiClient{CodeEnabled: true},
 		newTestCodeErrorReporter(),
 		ux2.NewTestAnalytics(c),
@@ -408,6 +409,7 @@ func TestUploadAndAnalyzeWithIgnores(t *testing.T) {
 		fakeCodeScanner,
 	)
 	issues, _ := scanner.UploadAndAnalyzeWithIgnores(context.Background(), "", sliceToChannel(files), map[string]bool{})
+
 	assert.True(t, fakeCodeScanner.UploadAndAnalyzeWasCalled)
 	assert.False(t, issues[0].IsIgnored)
 	assert.Nil(t, issues[0].IgnoreDetails)
@@ -417,6 +419,10 @@ func TestUploadAndAnalyzeWithIgnores(t *testing.T) {
 	assert.Equal(t, "13 days", issues[1].IgnoreDetails.Expiration)
 	assert.Equal(t, 2024, issues[1].IgnoreDetails.IgnoredOn.Year())
 	assert.Equal(t, "Neil M", issues[1].IgnoreDetails.IgnoredBy)
+
+	// verify that bundle hash has been saved
+	assert.Equal(t, 1, len(scanner.BundleHashes))
+	assert.Equal(t, snykCodeMock.Options.bundleHash, scanner.BundleHashes[path])
 }
 
 func Test_Scan(t *testing.T) {


### PR DESCRIPTION
### Description
The vulns get returned with AI fixes but the diffs that get generated from the UI when trying to generate an AI fix wouldn't work. This it because of this line of code: https://github.com/snyk/snyk-ls/blob/6de43f05fd81255636d2a70605719fb7b0907c5a/infrastructure/code/autofix.go#L72

Added a fix which can be found in the old flow too, where we set the bundle hash on the scanner. Added a test so that next time we change this code we don't forget to set the bundle hash.

To test manually, best to build this version of VSCode: https://github.com/snyk/vscode-extension/pull/467.
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

