### PR TITLE
feat: update code-client-go to v1.8.0 [IDE-399]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,8 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/code-client-go v1.7.3
-	github.com/snyk/go-application-framework v0.0.0-20240606122504-961e838cb356
+	github.com/snyk/code-client-go v1.8.0
+	github.com/snyk/go-application-framework v0.0.0-20240614132431-77ccf7f7ec6b
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/stretchr/testify v1.9.0
 	github.com/subosito/gotenv v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/code-client-go v1.7.1
+	github.com/snyk/code-client-go v1.7.3
 	github.com/snyk/go-application-framework v0.0.0-20240606122504-961e838cb356
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -409,12 +409,12 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/code-client-go v1.7.3 h1:EbMyXoxf3KkF7FqBq+XsAFFxhGtLM/xBmhhjXlcFkxQ=
-github.com/snyk/code-client-go v1.7.3/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
+github.com/snyk/code-client-go v1.8.0 h1:6H883KAn7ybiSIxhvL2QR9yEyHgAwA2+9WVHMDNEKa8=
+github.com/snyk/code-client-go v1.8.0/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240605115201-8461850930e6 h1:0t2lDRZY9zn/zgmY9sbRZ4WZFFR+7lIV/4+CMPUhJOs=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240605115201-8461850930e6/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20240606122504-961e838cb356 h1:1o4uMyLtiE6wibY8G57DQcsUDlMolyu1WP9eauJX2QQ=
-github.com/snyk/go-application-framework v0.0.0-20240606122504-961e838cb356/go.mod h1:1T6hnPUgT0lJPO0g3VjwvW0fCKDcgst8bgXs+wCfmW8=
+github.com/snyk/go-application-framework v0.0.0-20240614132431-77ccf7f7ec6b h1:dnbbyMpHnd6cAOYfZ2jM5LZ1LU8g8LdQ+6GajWXqWpg=
+github.com/snyk/go-application-framework v0.0.0-20240614132431-77ccf7f7ec6b/go.mod h1:v76hiANT35FweRFQEosU5KQ8q27BviioeJkWOh00ghY=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/go.sum
+++ b/go.sum
@@ -409,12 +409,10 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snyk/code-client-go v1.7.1 h1:YvnLUPmMRdSHw8spiTQed6z+f4IXQytMwP6mN5HC4qQ=
-github.com/snyk/code-client-go v1.7.1/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
+github.com/snyk/code-client-go v1.7.3 h1:EbMyXoxf3KkF7FqBq+XsAFFxhGtLM/xBmhhjXlcFkxQ=
+github.com/snyk/code-client-go v1.7.3/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240605115201-8461850930e6 h1:0t2lDRZY9zn/zgmY9sbRZ4WZFFR+7lIV/4+CMPUhJOs=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240605115201-8461850930e6/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20240605102342-67b064c1e417 h1:piXelZOB/V+kfUGouG/nm6F2YKNCXH993bC0YqtW+gc=
-github.com/snyk/go-application-framework v0.0.0-20240605102342-67b064c1e417/go.mod h1:1T6hnPUgT0lJPO0g3VjwvW0fCKDcgst8bgXs+wCfmW8=
 github.com/snyk/go-application-framework v0.0.0-20240606122504-961e838cb356 h1:1o4uMyLtiE6wibY8G57DQcsUDlMolyu1WP9eauJX2QQ=
 github.com/snyk/go-application-framework v0.0.0-20240606122504-961e838cb356/go.mod h1:1T6hnPUgT0lJPO0g3VjwvW0fCKDcgst8bgXs+wCfmW8=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=


### PR DESCRIPTION
### Description

Includes the following changes:
- https://github.com/snyk/code-client-go/releases/tag/v1.7.2
- https://github.com/snyk/code-client-go/releases/tag/v1.7.3
- https://github.com/snyk/code-client-go/releases/tag/v1.8.0 - where `SnykCodeAnalysisTimeout` becomes necessary, but it's already defined in `snyk-ls`