### PR TITLE
docs: UI rendering with Language Server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,18 @@ Server: [Snyk LSP Contribution Example](./docs/example.md).
 Error reporting and performance monitoring is done via [Sentry](https://sentry.io/). Analytics are captured
 via [Segment](https://segment.com/) and further propagated to [Amplitude Analytics](https://amplitude.com/).
 
+## UI Rendering with LSP
+
+To learn more about the architecture and interaction between the Language Server and IDEs for UI rendering, please refer to our detailed documentation: [UI Rendering with LSP](./docs/ui_rendering.md).
+
+This document covers:
+- The process of generating HTML templates using the Go `html/template` library.
+- How the LSP includes scaffolding CSS and how IDEs inject their own theming.
+- Step-by-step guidance on adding and modifying UI components.
+
+This guide is intended to help contributors add or modify UI components in the IDEs that support Language Server.
+
+
 ### Error reporting
 
 `error_reporting.ErrorReporter` can be injected via the new scanner's constructor. It is used to report errors to Sentry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,11 +54,11 @@ via [Segment](https://segment.com/) and further propagated to [Amplitude Analyti
 
 ## UI Rendering with LSP
 
-To learn more about the architecture and interaction between the Language Server and IDEs for UI rendering, please refer to our detailed documentation: [UI Rendering with LSP](./docs/ui_rendering.md).
+To learn more about the architecture and interaction between the Language Server and IDEs for UI rendering, please refer to our detailed documentation: [UI Rendering with LSP](./docs/ui-rendering.md).
 
 This document covers:
 - The process of generating HTML templates using the Go `html/template` library.
-- How the LSP includes scaffolding CSS and how IDEs inject their own theming.
+- How the LS includes scaffolding CSS and how IDEs inject their own theming.
 - Step-by-step guidance on adding and modifying UI components.
 
 This guide is intended to help contributors add or modify UI components in the IDEs that support Language Server.

--- a/docs/ui-rendering.md
+++ b/docs/ui-rendering.md
@@ -1,0 +1,90 @@
+## UI Rendering with Language Server
+
+This document explains the architecture and interaction between the Language Server and IDEs for rendering the UI components. It aims to guide contributors in adding or modifying UI components.
+
+
+### Architecture Overview
+
+Our approach unifies the user interface for Snyk Code Ignores across multiple IDEs by leveraging the Language Server Protocol. This ensures consistency, reduces redundancy, and simplifies future enhancements.
+
+
+```mermaid
+sequenceDiagram
+    participant LSP
+    participant Template
+    participant IDE
+    LSP->>Template: Generate HTML Template
+    Template->>IDE: Send HTML Template
+    IDE->>Template: Inject IDE-specific CSS
+    IDE->>User: Rendered Content
+```
+
+### Workflow Description
+
+1. **Generate HTML Template**: The Language Server generates an HTML template using the Go `html/template` library. The template includes placeholders for dynamic content.
+2. **Send HTML Template**: The generated HTML template is sent to the IDEs. This template includes the structure of the UI components but lacks specific styling.
+3. **Injected IDE-specific CSS**: Each IDE injects its own CSS to style the HTML template according to its theming and design guidelines. This allows the same HTML structure to be visually consistent with the rest of the IDE.
+
+### Adding or Modifying UI Components
+
+To add or modify UI components in the IDEs that support the Language Server, follow these steps:
+
+1. Process the dynamic data to be rendered in the in the HTML template in `infrastructure/code/code_html.go`. For example, to display the issue ecosystem in the UI:
+
+```go
+func getCodeDetailsHtml(issue snyk.Issue) string {
+	c := config.CurrentConfig()
+
+	data := map[string]interface{}{
+		"Ecosystem":          issue.Ecosystem,
+		"IssueTitle":         additionalData.Title,
+    // more data
+	}
+
+	var html bytes.Buffer
+	if err := globalTemplate.Execute(&html, data); err != nil {
+		c.Logger().Error().Msgf("Failed to execute main details template: %v", err)
+		return ""
+	}
+
+	return html.String()
+}
+```
+
+2. Update the HTML template in `infrastructure/code/template/details.html` to include the placeholders for the dynamic data. Include CSS in the template itself if the styles are the same across all IDEs, otherwise use IDE-specific files.
+
+```html
+<head>
+  <style>
+    .ecosystem-badge {
+      padding: 0.35em 0.35em;
+      border-radius: 0.25em;
+      margin-left: 1em;
+      background: #FFF4ED;
+      color: #B6540B;
+      border: 1px solid #E27122;
+    }
+  </style>
+</head>
+<body>
+  <h2 class="severity-title">{{.IssueTitle}}</h2>
+  <span class="delimiter"></span>
+  <div>Priority score: {{.PriorityScore}}</div>
+  <span class="delimiter"></span>
+  <div class="ecosystem-badge">{{.Ecosystem}}</div>
+  <!-- more HTML -->
+</body>
+```
+
+1. If necessary, add IDE-specific CSS:
+
+**VSCode**
+- CSS: [suggestionLS.scss](https://github.com/snyk/vscode-extension/blob/main/media/views/snykCode/suggestion/suggestionLS.scss)
+- HTML Rendering: [showPanel](https://github.com/snyk/vscode-extension/blob/main/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts#L92)
+- Script Injection: [codeSuggestionWebviewScriptLS.ts](https://github.com/snyk/vscode-extension/blob/main/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts)
+
+**IntelliJ**
+- CSS: [snyk_code_suggestion.scss](https://github.com/snyk/snyk-intellij-plugin/blob/master/src/main/resources/stylesheets/snyk_code_suggestion.scss)
+- HTML Rendering: [OpenFileLoadHandlerGenerator](https://github.com/snyk/snyk-intellij-plugin/blob/master/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt)
+
+<img src="https://github.com/snyk/snyk-ls/assets/1948377/01644706-f884-48cd-b98d-24868030677c" width="640">

--- a/docs/ui-rendering.md
+++ b/docs/ui-rendering.md
@@ -27,9 +27,10 @@ sequenceDiagram
 
 ### Adding or Modifying UI Components
 
+#### Snyk Code Suggestion Panel
 To add or modify UI components in the IDEs that support the Language Server, follow these steps:
 
-1. Process the dynamic data to be rendered in the in the HTML template in `infrastructure/code/code_html.go`. For example, to display the issue ecosystem in the UI:
+1. Process the dynamic data to be rendered in the HTML template in `infrastructure/code/code_html.go`. For example, to display the issue ecosystem in the UI:
 
 ```go
 func getCodeDetailsHtml(issue snyk.Issue) string {
@@ -76,15 +77,15 @@ func getCodeDetailsHtml(issue snyk.Issue) string {
 </body>
 ```
 
-1. If necessary, add IDE-specific CSS:
+3. If necessary, add IDE-specific CSS:
 
 **VSCode**
-- CSS: [suggestionLS.scss](https://github.com/snyk/vscode-extension/blob/main/media/views/snykCode/suggestion/suggestionLS.scss)
-- HTML Rendering: [showPanel](https://github.com/snyk/vscode-extension/blob/main/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts#L92)
-- Script Injection: [codeSuggestionWebviewScriptLS.ts](https://github.com/snyk/vscode-extension/blob/main/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts)
+- CSS: [suggestionLS.scss](https://github.com/snyk/vscode-extension/blob/ae111dd5aa7a1e1eaa33bef33b2af7c15ef558d2/media/views/snykCode/suggestion/suggestionLS.scss)
+- HTML Rendering: [codeSuggestionWebviewProvider.ts](https://github.com/snyk/vscode-extension/blob/ae111dd5aa7a1e1eaa33bef33b2af7c15ef558d2/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts#L92)
+- Script Injection: [codeSuggestionWebviewScriptLS.ts](https://github.com/snyk/vscode-extension/blob/ae111dd5aa7a1e1eaa33bef33b2af7c15ef558d2/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts)
 
 **IntelliJ**
-- CSS: [snyk_code_suggestion.scss](https://github.com/snyk/snyk-intellij-plugin/blob/master/src/main/resources/stylesheets/snyk_code_suggestion.scss)
-- HTML Rendering: [OpenFileLoadHandlerGenerator](https://github.com/snyk/snyk-intellij-plugin/blob/master/src/main/kotlin/io/snyk/plugin/ui/jcef/OpenFileLoadHandlerGenerator.kt)
+- CSS: [snyk_code_suggestion.scss](https://github.com/snyk/snyk-intellij-plugin/blob/2581e2dc2e8722a960d0f0095377b7912a3789fe/src/main/resources/stylesheets/snyk_code_suggestion.scss)
+- HTML Rendering: [JCEFDescriptionPanel.kt](https://github.com/snyk/snyk-intellij-plugin/blob/2581e2dc2e8722a960d0f0095377b7912a3789fe/src/main/kotlin/io/snyk/plugin/ui/toolwindow/panels/JCEFDescriptionPanel.kt)
 
-<img src="https://github.com/snyk/snyk-ls/assets/1948377/01644706-f884-48cd-b98d-24868030677c" width="640">
+  <img src="https://github.com/snyk/snyk-ls/assets/1948377/01644706-f884-48cd-b98d-24868030677c" width="640">


### PR DESCRIPTION
### Description

This PR adds a guide on how to render UI components using the Language Server for the Snyk Code Issues across different IDEs, specifically focusing on VSCode and IntelliJ.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

This screenshot is for the example added in the `ui-rendering.md` so I can add this link in the MD.

<img src="https://github.com/snyk/snyk-ls/assets/1948377/01644706-f884-48cd-b98d-24868030677c" width="240">

