### PR TITLE
fix: only log msg when not succeeding to send event to endpoint [IDE-418]

### DIFF
--- a/infrastructure/analytics/analytics.go
+++ b/infrastructure/analytics/analytics.go
@@ -46,7 +46,6 @@ func SendAnalyticsToAPI(c *config.Config, payload []byte) error {
 
 	if err != nil {
 		logger.Err(err).Msg("error invoking workflow")
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

LS should not return an error to the IDEs if the analytics service isn't available or the call returns an error. Instead, it should just log.

### Checklist

- [x] Tests added and all succeed
- [x] Linted

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
