### PR TITLE
fix: configure AI fix boolean even if issue is ignored [IDE-435]

### DIFF
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -414,10 +414,14 @@ func (s *SarifConverter) getIgnoreDetails(result codeClientSarif.Result) (bool, 
 		if suppression.Properties.Expiration != nil {
 			expiration = *suppression.Properties.Expiration
 		}
-
+		
+		reason := suppression.Justification
+		if reason == "" {
+			reason = "None given"
+		}
 		ignoreDetails = &snyk.IgnoreDetails{
 			Category:   string(suppression.Properties.Category),
-			Reason:     suppression.Justification,
+			Reason:     reason,
 			Expiration: expiration,
 			IgnoredOn:  parseDateFromString(suppression.Properties.IgnoredOn),
 			IgnoredBy:  suppression.Properties.IgnoredBy.Name,

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -961,6 +961,40 @@ func Test_Result_getIgnoreDetails(t *testing.T) {
 		assert.Equal(t, 2024, ignoreDetails.IgnoredOn.Year())
 		assert.Equal(t, "name", ignoreDetails.IgnoredBy)
 	})
+
+	t.Run("sets reason to a default value if justification not provided in suppression", func(t *testing.T) {
+		expiration := "expiration"
+		r := codeClientSarif.Result{
+			Message: codeClientSarif.ResultMessage{
+				Text:     "",
+				Markdown: "Printing the stack trace of {0}. Production code should not use {1}. {3}",
+				Arguments: []string{"[java.lang.InterruptedException](0)", "[printStackTrace](1)(2)", "",
+					"[This is a test argument](3)"},
+			},
+			Suppressions: []codeClientSarif.Suppression{
+				{
+					Properties: codeClientSarif.SuppressionProperties{
+						Category:   "category",
+						Expiration: &expiration,
+						IgnoredOn:  "2024-02-23T16:08:25Z",
+						IgnoredBy: codeClientSarif.IgnoredBy{
+							Name: "name",
+						},
+					},
+				},
+			},
+		}
+
+		sarifConverter := SarifConverter{sarif: codeClientSarif.SarifResponse{}}
+		isIgnored, ignoreDetails := sarifConverter.getIgnoreDetails(r)
+		assert.True(t, isIgnored)
+		assert.NotNil(t, ignoreDetails)
+		assert.Equal(t, "None given", ignoreDetails.Reason)
+		assert.Equal(t, "category", ignoreDetails.Category)
+		assert.Equal(t, "expiration", ignoreDetails.Expiration)
+		assert.Equal(t, 2024, ignoreDetails.IgnoredOn.Year())
+		assert.Equal(t, "name", ignoreDetails.IgnoredBy)
+	})
 }
 
 func Test_ParseDateFromString(t *testing.T) {

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -89,7 +89,9 @@ func (b *IssueEnhancer) addIssueActions(ctx context.Context, issues []snyk.Issue
 			continue
 		}
 
-		if autoFixEnabled && issueData.IsAutofixable && !issues[i].IsIgnored {
+		issueData.HasAIFix = autoFixEnabled && issueData.IsAutofixable
+
+		if issueData.HasAIFix && !issues[i].IsIgnored {
 			codeAction := *b.createDeferredAutofixCodeAction(ctx, issues[i], bundleHash)
 			issues[i].CodeActions = append(issues[i].CodeActions, codeAction)
 
@@ -103,9 +105,8 @@ func (b *IssueEnhancer) addIssueActions(ctx context.Context, issues []snyk.Issue
 					issues[i].Range,
 				},
 			})
-			issueData.HasAIFix = true
-			issues[i].AdditionalData = issueData
 		}
+		issues[i].AdditionalData = issueData
 
 		if learnEnabled {
 			action := b.createOpenSnykLearnCodeAction(issues[i])

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -241,7 +241,7 @@ func Test_addIssueActions(t *testing.T) {
 		assert.Len(t, fakeIssues[0].CodeActions, 2)
 	})
 
-	t.Run("Includes AI fixes if issue is not autofixable", func(t *testing.T) {
+	t.Run("Does not include AI fixes if issue is not autofixable", func(t *testing.T) {
 		setupCodeSettings()
 		defer t.Cleanup(resetCodeSettings)
 		fakeIssues := setupFakeIssues(false, false)
@@ -255,7 +255,7 @@ func Test_addIssueActions(t *testing.T) {
 		assert.Len(t, fakeIssues[0].CodeActions, 1)
 	})
 
-	t.Run("Does not include AI fixes if issue is ignored", func(t *testing.T) {
+	t.Run("Does not include AI fixes even if it is autofixable if issue is ignored", func(t *testing.T) {
 		setupCodeSettings()
 		defer t.Cleanup(resetCodeSettings)
 		fakeIssues := setupFakeIssues(true, true)

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -264,7 +264,7 @@ func Test_addIssueActions(t *testing.T) {
 
 		issueData, ok := fakeIssues[0].AdditionalData.(snyk.CodeIssueData)
 		require.True(t, ok)
-		assert.False(t, issueData.HasAIFix)
+		assert.True(t, issueData.HasAIFix)
 		assert.Len(t, fakeIssues[0].CodelensCommands, 1)
 		assert.Len(t, fakeIssues[0].CodeActions, 1)
 	})


### PR DESCRIPTION
### Description

We want to continue hiding the code actions and code lenses for ignored findings that have AI fixes. But we want the Fix Analysis tab to show AI fixes, so that issues that are temporarily ignored because of noise can be fixed if the developer chooses to. So the `HasAIFix` boolean needs to be configured.

Also sets the reason for an ignore to a default `None given` which matches what the UI shows.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.