### PR TITLE
fix: trigger folder scan when `.snyk` file changes [IDE-253]

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -554,13 +554,13 @@ func textDocumentDidSaveHandler() jrpc2.Handler {
 		di.FileWatcher().SetFileAsSaved(params.TextDocument.URI)
 		filePath := uri.PathFromUri(params.TextDocument.URI)
 
-		ws := workspace.Get()
-		if ws != nil && autoScanEnabled && uri.IsDotSnykFile(params.TextDocument.URI) {
-			go ws.ScanWorkspace(bgCtx)
+		f := workspace.Get().GetFolderContaining(filePath)
+
+		if f != nil && autoScanEnabled && uri.IsDotSnykFile(params.TextDocument.URI) {
+			go f.ScanFolder(bgCtx)
 			return nil, nil
 		}
 
-		f := ws.GetFolderContaining(filePath)
 		if f != nil {
 			if autoScanEnabled {
 				go f.ScanFile(bgCtx, filePath)

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
+
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/ide/command"
@@ -772,7 +773,7 @@ func Test_initialize_doesnotHandleUntrustedFolders(t *testing.T) {
 		t.Fatal(err, "couldn't send initialized")
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Eventually(t, func() bool { return checkTrustMessageRequest(jsonRPCRecorder) }, time.Second, time.Millisecond)
 }
 
@@ -820,7 +821,7 @@ ignore:
 patch: {}
 `
 	err = os.WriteFile(snykFilePath, []byte(yamlContent), 0600)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return snykFilePath, temp
 }
 

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -820,9 +820,7 @@ ignore:
 patch: {}
 `
 	err = os.WriteFile(snykFilePath, []byte(yamlContent), 0600)
-	if err != nil {
-		t.Fatalf("couldn't create temp .snyk file: %v", err)
-	}
+	assert.Nil(t, err)
 	return snykFilePath, temp
 }
 

--- a/internal/uri/uri_util.go
+++ b/internal/uri/uri_util.go
@@ -72,6 +72,10 @@ func IsDirectory(path string) bool {
 	return stat.IsDir()
 }
 
+func IsDotSnykFile(uri sglsp.DocumentURI) bool {
+	return strings.HasSuffix(string(uri), ".snyk")
+}
+
 // Range gives a position in a document. All attributes are 0-based
 type Range struct {
 	StartLine int

--- a/internal/uri/uri_util_test.go
+++ b/internal/uri/uri_util_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/go-lsp"
+	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -112,6 +113,65 @@ func TestUri_AddRangeToUri(t *testing.T) {
 		actual := string(AddRangeToUri("file://asdf#L1,1-L1,1", r))
 		assert.Equal(t, "file://asdf#L1,1-L1,1", actual)
 	})
+}
+
+func TestUri_IsDotSnykFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      sglsp.DocumentURI
+		expected bool
+	}{
+		// POSIX paths
+		{
+			name:     "POSIX: file with .snyk extension",
+			uri:      sglsp.DocumentURI("file:///path/to/file.snyk"),
+			expected: true,
+		},
+		{
+			name:     "POSIX: file without .snyk extension",
+			uri:      sglsp.DocumentURI("file:///path/to/file.txt"),
+			expected: false,
+		},
+		// Windows URIs
+		{
+			name:     "Windows URI: file with .snyk extension",
+			uri:      sglsp.DocumentURI("file:///C:/path/to/file.snyk"),
+			expected: true,
+		},
+		{
+			name:     "Windows URI: URI with encoded colon and file with .snyk extension",
+			uri:      sglsp.DocumentURI("file:///c%3A/Users/git/node-restify/examples/todoapp/lib/file.snyk"),
+			expected: true,
+		},
+		{
+			name:     "Windows URI: URI with encoded colon and file without .snyk extension",
+			uri:      sglsp.DocumentURI("file:///c%3A/Users/git/node-restify/examples/todoapp/lib/file.txt"),
+			expected: false,
+		},
+		// Windows paths with backslashes
+		{
+			name:     "Windows Path: file with .snyk extension",
+			uri:      sglsp.DocumentURI("C:\\path\\to\\file.snyk"),
+			expected: true,
+		},
+		{
+			name:     "Windows URI: file without .snyk extension",
+			uri:      sglsp.DocumentURI("file:///C:/path/to/file.txt"),
+			expected: false,
+		},
+		{
+			name:     "Windows Path: file without .snyk extension",
+			uri:      sglsp.DocumentURI("C:\\path\\to\\file.txt"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDotSnykFile(tt.uri)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func getTestRange() Range {


### PR DESCRIPTION
### Description

This PR triggers a workspace scan when the `.snyk` file was saved.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs


https://github.com/snyk/snyk-ls/assets/1948377/d9f761f9-d692-4c48-b77e-15bc5181896a


