### PR TITLE
feat: refactor the HTML to use html/template and to inject styling for other IDEs [IDE-326]

### DIFF
--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -27,10 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gomarkdown/markdown"
-
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/internal/html"
 	"github.com/snyk/snyk-ls/internal/product"
 )
 
@@ -66,8 +65,8 @@ var globalTemplate *template.Template
 func init() {
 	funcMap := template.FuncMap{
 		"repoName":      getRepoName,
-		"trimCWEPrefix": TrimCWEPrefix,
-		"idxMinusOne":   IdxMinusOne,
+		"trimCWEPrefix": html.TrimCWEPrefix,
+		"idxMinusOne":   html.IdxMinusOne,
 	}
 
 	var err error
@@ -92,9 +91,9 @@ func getCodeDetailsHtml(issue snyk.Issue) string {
 		"IssueTitle":         additionalData.Title,
 		"IssueMessage":       additionalData.Message,
 		"IssueType":          getIssueType(additionalData),
-		"SeverityIcon":       GetSeverityIconSvg(issue),
+		"SeverityIcon":       html.GetSeverityIconSvg(issue),
 		"CWEs":               issue.CWEs,
-		"IssueOverview":      markdownToHTML(additionalData.Text),
+		"IssueOverview":      html.MarkdownToHTML(additionalData.Text),
 		"IsIgnored":          issue.IsIgnored,
 		"DataFlow":           additionalData.DataFlow,
 		"DataFlowTable":      prepareDataFlowTable(additionalData),
@@ -105,7 +104,7 @@ func getCodeDetailsHtml(issue snyk.Issue) string {
 		"PriorityScore":      additionalData.PriorityScore,
 		"SnykWebUrl":         config.CurrentConfig().SnykUi(),
 		"LessonUrl":          issue.LessonUrl,
-		"LessonIcon":         GetLessonIconSvg(),
+		"LessonIcon":         html.GetLessonIconSvg(),
 		"IgnoreLineAction":   getLineToIgnoreAction(issue),
 		"HasAIFix":           additionalData.HasAIFix,
 		"ExternalIcon":       getExternalIconSvg(),
@@ -132,21 +131,8 @@ func getCodeDetailsHtml(issue snyk.Issue) string {
 	return html.String()
 }
 
-func markdownToHTML(md string) template.HTML {
-	html := markdown.ToHTML([]byte(md), nil, nil)
-	return template.HTML(html)
-}
-
 func getLineToIgnoreAction(issue snyk.Issue) int {
 	return issue.Range.Start.Line + 1
-}
-
-func IdxMinusOne(n int) int {
-	return n - 1
-}
-
-func TrimCWEPrefix(cwe string) string {
-	return strings.TrimPrefix(cwe, "CWE-")
 }
 
 func prepareIgnoreDetailsRow(ignoreDetails *snyk.IgnoreDetails) []IgnoreDetail {
@@ -279,33 +265,6 @@ func getExternalIconSvg() template.HTML {
 	</svg>`)
 }
 
-func GetSeverityIconSvg(issue snyk.Issue) template.HTML {
-	switch issue.Severity {
-	case snyk.Critical:
-		return template.HTML(`<svg id="critical" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
-			 <rect width="16" height="16" rx="2" fill="#AB1A1A"/>
-			 <path d="M9.975 9.64h2.011a3.603 3.603 0 0 1-.545 1.743 3.24 3.24 0 0 1-1.338 1.19c-.57.284-1.256.427-2.06.427-.627 0-1.19-.107-1.688-.32a3.594 3.594 0 0 1-1.278-.936 4.158 4.158 0 0 1-.801-1.47C4.092 9.7 4 9.057 4 8.345v-.675c0-.712.094-1.356.283-1.93a4.255 4.255 0 0 1 .82-1.476 3.657 3.657 0 0 1 1.286-.936A4.114 4.114 0 0 1 8.057 3c.817 0 1.505.147 2.066.44.565.295 1.002.7 1.312 1.217.314.516.502 1.104.565 1.763H9.982c-.023-.392-.101-.723-.236-.995a1.331 1.331 0 0 0-.612-.621c-.27-.143-.628-.214-1.077-.214-.336 0-.63.062-.881.187a1.632 1.632 0 0 0-.633.568c-.17.254-.298.574-.383.962a6.61 6.61 0 0 0-.121 1.349v.688c0 .503.038.946.114 1.33.076.378.193.699.35.961.161.259.368.454.619.588.256.13.563.194.922.194.421 0 .769-.067 1.043-.2a1.39 1.39 0 0 0 .625-.595c.148-.263.236-.59.263-.982Z" fill="#fff"/>
-		 </svg>`)
-	case snyk.High:
-		return template.HTML(`<svg id="high" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
-			 <rect width="16" height="16" rx="2" fill="#CE5019"/>
-			 <path d="M10.5 7v2h-5V7h5ZM6 3v10H4V3h2Zm6 0v10h-2V3h2Z" fill="#fff"/>
-		 </svg>`)
-	case snyk.Medium:
-		return template.HTML(`<svg id="medium" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
-			 <rect width="16" height="16" rx="2" fill="#D68000"/>
-			 <path d="M3 3h2l2.997 7.607L11 3h2L9 13H7L3 3Zm0 0h2v10l-2-.001V3.001Zm8 0h2V13h-2V3Z" fill="#fff"/>
-		 </svg>`)
-	case snyk.Low:
-		return template.HTML(`<svg id="low" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
-			 <rect width="16" height="16" rx="2" fill="#88879E"/>
-			 <path d="M11 11v2H6.705v-2H11ZM7 3v10H5V3h2Z" fill="#fff"/>
-		 </svg>`)
-	default:
-		return ``
-	}
-}
-
 func getGitHubIconSvg() template.HTML {
 	return template.HTML(`<svg class="tab-item-icon" width="18" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
 		<path
@@ -314,13 +273,6 @@ func getGitHubIconSvg() template.HTML {
 			d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
 		/>
 	</svg>`)
-}
-
-func GetLessonIconSvg() template.HTML {
-	return template.HTML(`<svg width="17" height="14" viewBox="0 0 17 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M8.25 0L0 4.5L3 6.135V10.635L8.25 13.5L13.5 10.635V6.135L15 5.3175V10.5H16.5V4.5L8.25 0ZM13.365 4.5L8.25 7.29L3.135 4.5L8.25 1.71L13.365 4.5ZM12 9.75L8.25 11.79L4.5 9.75V6.9525L8.25 9L12 6.9525V9.75Z" fill="#888"/>
-	</svg>
-	`)
 }
 
 func getScanAnimationSvg() template.HTML {

--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -66,8 +66,8 @@ var globalTemplate *template.Template
 func init() {
 	funcMap := template.FuncMap{
 		"repoName":      getRepoName,
-		"trimCWEPrefix": trimCWEPrefix,
-		"idxMinusOne":   idxMinusOne,
+		"trimCWEPrefix": TrimCWEPrefix,
+		"idxMinusOne":   IdxMinusOne,
 	}
 
 	var err error
@@ -92,7 +92,7 @@ func getCodeDetailsHtml(issue snyk.Issue) string {
 		"IssueTitle":         additionalData.Title,
 		"IssueMessage":       additionalData.Message,
 		"IssueType":          getIssueType(additionalData),
-		"SeverityIcon":       getSeverityIconSvg(issue),
+		"SeverityIcon":       GetSeverityIconSvg(issue),
 		"CWEs":               issue.CWEs,
 		"IssueOverview":      markdownToHTML(additionalData.Text),
 		"IsIgnored":          issue.IsIgnored,
@@ -105,7 +105,7 @@ func getCodeDetailsHtml(issue snyk.Issue) string {
 		"PriorityScore":      additionalData.PriorityScore,
 		"SnykWebUrl":         config.CurrentConfig().SnykUi(),
 		"LessonUrl":          issue.LessonUrl,
-		"LessonIcon":         getLessonIconSvg(),
+		"LessonIcon":         GetLessonIconSvg(),
 		"IgnoreLineAction":   getLineToIgnoreAction(issue),
 		"HasAIFix":           additionalData.HasAIFix,
 		"ExternalIcon":       getExternalIconSvg(),
@@ -141,11 +141,11 @@ func getLineToIgnoreAction(issue snyk.Issue) int {
 	return issue.Range.Start.Line + 1
 }
 
-func idxMinusOne(n int) int {
+func IdxMinusOne(n int) int {
 	return n - 1
 }
 
-func trimCWEPrefix(cwe string) string {
+func TrimCWEPrefix(cwe string) string {
 	return strings.TrimPrefix(cwe, "CWE-")
 }
 
@@ -279,25 +279,25 @@ func getExternalIconSvg() template.HTML {
 	</svg>`)
 }
 
-func getSeverityIconSvg(issue snyk.Issue) template.HTML {
+func GetSeverityIconSvg(issue snyk.Issue) template.HTML {
 	switch issue.Severity {
 	case snyk.Critical:
-		return template.HTML(`<svg fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="critical" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#AB1A1A"/>
 			 <path d="M9.975 9.64h2.011a3.603 3.603 0 0 1-.545 1.743 3.24 3.24 0 0 1-1.338 1.19c-.57.284-1.256.427-2.06.427-.627 0-1.19-.107-1.688-.32a3.594 3.594 0 0 1-1.278-.936 4.158 4.158 0 0 1-.801-1.47C4.092 9.7 4 9.057 4 8.345v-.675c0-.712.094-1.356.283-1.93a4.255 4.255 0 0 1 .82-1.476 3.657 3.657 0 0 1 1.286-.936A4.114 4.114 0 0 1 8.057 3c.817 0 1.505.147 2.066.44.565.295 1.002.7 1.312 1.217.314.516.502 1.104.565 1.763H9.982c-.023-.392-.101-.723-.236-.995a1.331 1.331 0 0 0-.612-.621c-.27-.143-.628-.214-1.077-.214-.336 0-.63.062-.881.187a1.632 1.632 0 0 0-.633.568c-.17.254-.298.574-.383.962a6.61 6.61 0 0 0-.121 1.349v.688c0 .503.038.946.114 1.33.076.378.193.699.35.961.161.259.368.454.619.588.256.13.563.194.922.194.421 0 .769-.067 1.043-.2a1.39 1.39 0 0 0 .625-.595c.148-.263.236-.59.263-.982Z" fill="#fff"/>
 		 </svg>`)
 	case snyk.High:
-		return template.HTML(`<svg fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="high" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#CE5019"/>
 			 <path d="M10.5 7v2h-5V7h5ZM6 3v10H4V3h2Zm6 0v10h-2V3h2Z" fill="#fff"/>
 		 </svg>`)
 	case snyk.Medium:
-		return template.HTML(`<svg fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="medium" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#D68000"/>
 			 <path d="M3 3h2l2.997 7.607L11 3h2L9 13H7L3 3Zm0 0h2v10l-2-.001V3.001Zm8 0h2V13h-2V3Z" fill="#fff"/>
 		 </svg>`)
 	case snyk.Low:
-		return template.HTML(`<svg fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="low" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#88879E"/>
 			 <path d="M11 11v2H6.705v-2H11ZM7 3v10H5V3h2Z" fill="#fff"/>
 		 </svg>`)
@@ -316,7 +316,7 @@ func getGitHubIconSvg() template.HTML {
 	</svg>`)
 }
 
-func getLessonIconSvg() template.HTML {
+func GetLessonIconSvg() template.HTML {
 	return template.HTML(`<svg width="17" height="14" viewBox="0 0 17 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<path d="M8.25 0L0 4.5L3 6.135V10.635L8.25 13.5L13.5 10.635V6.135L15 5.3175V10.5H16.5V4.5L8.25 0ZM13.365 4.5L8.25 7.29L3.135 4.5L8.25 1.71L13.365 4.5ZM12 9.75L8.25 11.79L4.5 9.75V6.9525L8.25 9L12 6.9525V9.75Z" fill="#888"/>
 	</svg>

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -17,124 +17,39 @@
 package oss
 
 import (
+	"bytes"
 	_ "embed"
 	"fmt"
-	"strings"
-
 	"github.com/gomarkdown/markdown"
-	"golang.org/x/exp/maps"
-
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/code"
+	"github.com/snyk/snyk-ls/internal/product"
+	"html/template"
+	"strings"
 )
 
 //go:embed template/details.html
 var detailsHtmlTemplate string
 
-func replaceVariableInHtml(html string, variableName string, variableValue string) string {
-	return strings.ReplaceAll(html, fmt.Sprintf("${%s}", variableName), variableValue)
-}
+var globalTemplate *template.Template
 
-func getIdentifiers(id string, issue snyk.OssIssueData) string {
-	identifierList := []string{""}
-
-	issueTypeString := "Vulnerability"
-	if len(issue.License) > 0 {
-		issueTypeString = "License"
+func init() {
+	funcMap := template.FuncMap{
+		"trimCWEPrefix": code.TrimCWEPrefix,
+		"idxMinusOne":   code.IdxMinusOne,
+		"join":          join,
 	}
 
-	for _, id := range issue.Identifiers.CVE {
-		url := "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + id
-		htmlAnchor := fmt.Sprintf("<a href='%s'>%s</a>", url, id)
-		identifierList = append(identifierList, htmlAnchor)
-	}
-
-	for _, id := range issue.Identifiers.CWE {
-		linkId := strings.ReplaceAll(strings.ToUpper(id), "CWE-", "")
-		htmlAnchor := fmt.Sprintf("<a href='https://cwe.mitre.org/data/definitions/%s.html'>%s</a>", linkId, id)
-		identifierList = append(identifierList, htmlAnchor)
-	}
-
-	if issue.CvssScore > 0 {
-		htmlAnchor := fmt.Sprintf("<span>CVSS %.1f</span>", issue.CvssScore)
-		identifierList = append(identifierList, htmlAnchor)
-	}
-
-	htmlAnchor := fmt.Sprintf("<a href='https://snyk.io/vuln/%s'>%s</a>", id, strings.ToUpper(id))
-	identifierList = append(identifierList, htmlAnchor)
-
-	return fmt.Sprintf("%s %s", issueTypeString, strings.Join(identifierList, "<span class='delimiter'> </span> "))
-}
-
-func getExploitMaturity(issue snyk.OssIssueData) string {
-	if len(issue.Exploit) > 0 {
-		return fmt.Sprintf("<div class='summary-item maturity'><div class='label font-light'>Exploit maturity</div>"+
-			"<div class='content'>%s</div></div>", issue.Exploit)
-	} else {
-		return ""
+	var err error
+	globalTemplate, err = template.New(string(product.ProductOpenSource)).Funcs(funcMap).Parse(detailsHtmlTemplate)
+	if err != nil {
+		config.CurrentConfig().Logger().Error().Msgf("Failed to parse details template: %s", err)
 	}
 }
 
-func getIntroducedBy(issue snyk.OssIssueData) string {
-	m := make(map[string]string)
-
-	if len(issue.From) > 0 {
-		for _, v := range issue.MatchingIssues {
-			if len(v.From) > 1 {
-				module := v.From[1]
-				htmlAnchor := getVulnHtmlAnchor(issue.PackageManager, module)
-				m[module] = htmlAnchor
-			}
-		}
-
-		return fmt.Sprintf("<div class='summary-item introduced-through'><div class='label font-light'>Introduced through</div>"+
-			"<div class='content'>%s</div></div>", strings.Join(maps.Values(m), ", "))
-	} else {
-		return ""
-	}
-}
-
-func getVulnHtmlAnchor(packageManager string, module string) string {
-	snykUi := config.CurrentConfig().SnykUi()
-	return fmt.Sprintf("<a href='%s/test/%s'>%s</a>", snykUi, packageManager, module)
-}
-
-func getLearnLink(issue snyk.OssIssueData) string {
-	if issue.Lesson == "" {
-		return ""
-	}
-
-	return fmt.Sprintf("<a class='learn--link' id='learn--link' href='%s'>Learn about this vulnerability</a>",
-		issue.Lesson)
-}
-
-func getFixedIn(issue snyk.OssIssueData) string {
-	if len(issue.FixedIn) == 0 {
-		return "Not fixed"
-	}
-
-	result := "%s@%v"
-	return fmt.Sprintf(result, issue.Name, strings.Join(issue.FixedIn, ", "))
-}
-
-func getDetailedPaths(issue snyk.OssIssueData) string {
-	detailedPathHtml := ""
-
-	for _, matchingIssue := range issue.MatchingIssues {
-		remediationAdvice := matchingIssue.Remediation
-		introducedThrough := strings.Join(matchingIssue.From, " > ")
-
-		detailedPathHtml += fmt.Sprintf(`<div class="summary-item path">
-						<div class="label font-light">Introduced through</div>
-						<div class="content">%s</div>
-					</div>
-					<div class="summary-item remediation">
-						<div class="label font-light">Remediation</div>
-						<div class="content">%s</div>
-					</div>`, introducedThrough, remediationAdvice)
-	}
-
-	return detailedPathHtml
+func join(sep string, s []string) string {
+	return strings.Join(s, sep)
 }
 
 func getDetailsHtml(issue snyk.Issue) string {
@@ -145,17 +60,132 @@ func getDetailsHtml(issue snyk.Issue) string {
 	}
 	overview := markdown.ToHTML([]byte(additionalData.Description), nil, nil)
 
-	html := replaceVariableInHtml(detailsHtmlTemplate, "issueId", issue.ID)
-	html = replaceVariableInHtml(html, "issueTitle", additionalData.Title)
-	html = replaceVariableInHtml(html, "severityText", issue.Severity.String())
-	html = replaceVariableInHtml(html, "vulnerableModule", additionalData.Name)
-	html = replaceVariableInHtml(html, "overview", string(overview))
-	html = replaceVariableInHtml(html, "identifiers", getIdentifiers(issue.ID, additionalData))
-	html = replaceVariableInHtml(html, "exploitMaturity", getExploitMaturity(additionalData))
-	html = replaceVariableInHtml(html, "introducedThrough", getIntroducedBy(additionalData))
-	html = replaceVariableInHtml(html, "learnLink", getLearnLink(additionalData))
-	html = replaceVariableInHtml(html, "fixedIn", getFixedIn(additionalData))
-	html = replaceVariableInHtml(html, "detailedPaths", getDetailedPaths(additionalData))
+	data := map[string]interface{}{
+		"IssueId":            issue.ID,
+		"IssueName":          additionalData.Name,
+		"IssueTitle":         additionalData.Title,
+		"IssueType":          getIssueType(additionalData),
+		"SeverityText":       issue.Severity.String(),
+		"SeverityIcon":       code.GetSeverityIconSvg(issue),
+		"VulnerableModule":   additionalData.Name,
+		"IssueOverview":      markdwonToHTML(string(overview)),
+		"CVEs":               additionalData.Identifiers.CVE,
+		"CWEs":               additionalData.Identifiers.CWE,
+		"CvssScore":          fmt.Sprintf("%.1f", additionalData.CvssScore),
+		"ExploitMaturity":    getExploitMaturity(additionalData),
+		"IntroducedThroughs": getIntroducedThroughs(additionalData),
+		"LessonUrl":          additionalData.Lesson,
+		"LessonIcon":         code.GetLessonIconSvg(),
+		"FixedIn":            additionalData.FixedIn,
+		"DetailedPaths":      getDetailedPaths(additionalData),
+	}
 
-	return html
+	var html bytes.Buffer
+	if err := globalTemplate.Execute(&html, data); err != nil {
+		config.CurrentConfig().Logger().Error().Msgf("Failed to execute main details template: %v", err)
+		return ""
+	}
+
+	return html.String()
+}
+
+func getIssueType(issue snyk.OssIssueData) string {
+	if len(issue.License) > 0 {
+		return "License"
+	}
+
+	return "Vulnerability"
+}
+
+func getExploitMaturity(issue snyk.OssIssueData) string {
+	if len(issue.Exploit) > 0 {
+		return issue.Exploit
+	} else {
+		return ""
+	}
+}
+
+// TODO: common
+func markdwonToHTML(md string) template.HTML {
+	html := markdown.ToHTML([]byte(md), nil, nil)
+	return template.HTML(html)
+}
+
+type IntroducedThrough struct {
+	SnykUI         string
+	PackageManager string
+	Module         string
+}
+
+func getIntroducedThroughs(issue snyk.OssIssueData) []IntroducedThrough {
+	introducedThroughs := []IntroducedThrough{}
+
+	snykUi := config.CurrentConfig().SnykUi()
+	if len(issue.From) > 0 {
+		for _, v := range issue.MatchingIssues {
+			if len(v.From) > 1 {
+				introducedThroughs = append(introducedThroughs, IntroducedThrough{
+					SnykUI:         snykUi,
+					PackageManager: issue.PackageManager,
+					Module:         v.From[1],
+				})
+			}
+		}
+	}
+	return introducedThroughs
+}
+
+type DetailedPath struct {
+	From        []string
+	Remediation string
+}
+
+func getDetailedPaths(issue snyk.OssIssueData) []DetailedPath {
+	var detailedPaths = make([]DetailedPath, len(issue.MatchingIssues))
+
+	for i, matchingIssue := range issue.MatchingIssues {
+		remediationAdvice := getRemediationAdvice(matchingIssue)
+
+		detailedPaths[i] = DetailedPath{
+			From:        matchingIssue.From,
+			Remediation: remediationAdvice,
+		}
+	}
+	return detailedPaths
+}
+
+func getRemediationAdvice(issue snyk.OssIssueData) string {
+	hasUpgradePath := len(issue.UpgradePath) > 1
+	isOutdated := hasUpgradePath && issue.UpgradePath[1] == issue.From[1]
+	remediationAdvice := "No remediation advice available"
+	upgradeMessage := ""
+	if issue.IsUpgradable || issue.IsPatchable {
+		if hasUpgradePath {
+			upgradeMessage = "Upgrade to " + issue.UpgradePath[1].(string)
+		}
+
+		if isOutdated {
+			if issue.IsPatchable {
+				remediationAdvice = upgradeMessage
+			} else {
+				remediationAdvice = getOutdatedDependencyMessage(issue)
+			}
+		} else {
+			remediationAdvice = upgradeMessage
+		}
+	}
+	return remediationAdvice
+}
+
+func getOutdatedDependencyMessage(issue snyk.OssIssueData) string {
+	remediationAdvice := fmt.Sprintf("Your dependencies are out of date, "+
+		"otherwise you would be using a newer %s than %s@%s. ", issue.Name, issue.Name, issue.Version)
+
+	if issue.PackageManager == "npm" || issue.PackageManager == "yarn" || issue.PackageManager == "yarn-workspace" {
+		remediationAdvice += "Try relocking your lockfile or deleting node_modules and reinstalling" +
+			" your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+	} else {
+		remediationAdvice += "Try reinstalling your dependencies. If the problem persists, one of your dependencies may be bundling outdated modules."
+	}
+	return remediationAdvice
 }

--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -20,13 +20,15 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"github.com/gomarkdown/markdown"
-	"github.com/snyk/snyk-ls/application/config"
-	"github.com/snyk/snyk-ls/domain/snyk"
-	"github.com/snyk/snyk-ls/infrastructure/code"
-	"github.com/snyk/snyk-ls/internal/product"
 	"html/template"
 	"strings"
+
+	"github.com/gomarkdown/markdown"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/internal/html"
+	"github.com/snyk/snyk-ls/internal/product"
 )
 
 //go:embed template/details.html
@@ -36,8 +38,8 @@ var globalTemplate *template.Template
 
 func init() {
 	funcMap := template.FuncMap{
-		"trimCWEPrefix": code.TrimCWEPrefix,
-		"idxMinusOne":   code.IdxMinusOne,
+		"trimCWEPrefix": html.TrimCWEPrefix,
+		"idxMinusOne":   html.IdxMinusOne,
 		"join":          join,
 	}
 
@@ -66,16 +68,16 @@ func getDetailsHtml(issue snyk.Issue) string {
 		"IssueTitle":         additionalData.Title,
 		"IssueType":          getIssueType(additionalData),
 		"SeverityText":       issue.Severity.String(),
-		"SeverityIcon":       code.GetSeverityIconSvg(issue),
+		"SeverityIcon":       html.GetSeverityIconSvg(issue),
 		"VulnerableModule":   additionalData.Name,
-		"IssueOverview":      markdwonToHTML(string(overview)),
+		"IssueOverview":      html.MarkdownToHTML(string(overview)),
 		"CVEs":               additionalData.Identifiers.CVE,
 		"CWEs":               additionalData.Identifiers.CWE,
 		"CvssScore":          fmt.Sprintf("%.1f", additionalData.CvssScore),
 		"ExploitMaturity":    getExploitMaturity(additionalData),
 		"IntroducedThroughs": getIntroducedThroughs(additionalData),
 		"LessonUrl":          additionalData.Lesson,
-		"LessonIcon":         code.GetLessonIconSvg(),
+		"LessonIcon":         html.GetLessonIconSvg(),
 		"FixedIn":            additionalData.FixedIn,
 		"DetailedPaths":      getDetailedPaths(additionalData),
 	}
@@ -103,12 +105,6 @@ func getExploitMaturity(issue snyk.OssIssueData) string {
 	} else {
 		return ""
 	}
-}
-
-// TODO: common
-func markdwonToHTML(md string) template.HTML {
-	html := markdown.ToHTML([]byte(md), nil, nil)
-	return template.HTML(html)
 }
 
 type IntroducedThrough struct {

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -31,7 +31,7 @@ import (
 
 func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	_ = testutil.UnitTest(t)
-	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
+	expectedVariables := []string{"${ideStyle}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
 	slices.Sort(expectedVariables)
 
 	issueAdditionalData := snyk.OssIssueData{

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -31,7 +31,7 @@ import (
 
 func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	_ = testutil.UnitTest(t)
-	expectedVariables := []string{"${ideStyle}", "${nonce}"}
+	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${ideStyle}", "${nonce}"}
 	slices.Sort(expectedVariables)
 
 	issueAdditionalData := snyk.OssIssueData{
@@ -131,6 +131,6 @@ func Test_OssDetailsPanel_html_withLearn_withCustomEndpoint(t *testing.T) {
 	issueAdditionalData.MatchingIssues = append(issueAdditionalData.MatchingIssues, issueAdditionalData)
 
 	issueDetailsPanelHtml := getDetailsHtml(issue)
-	
+
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, customEndpoint))
 }

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -31,7 +31,7 @@ import (
 
 func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	_ = testutil.UnitTest(t)
-	expectedVariables := []string{"${ideStyle}", "${cspSource}", "${nonce}", "${severityIcon}", "${learnIcon}"}
+	expectedVariables := []string{"${ideStyle}", "${nonce}"}
 	slices.Sort(expectedVariables)
 
 	issueAdditionalData := snyk.OssIssueData{
@@ -72,8 +72,8 @@ func Test_OssDetailsPanel_html_noLearn(t *testing.T) {
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.ID))
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, issueAdditionalData.Title))
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.Severity.String()))
-	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issueAdditionalData.From, " > ")))
-	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issue2.From, " > ")))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issueAdditionalData.From, " &gt; ")))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issue2.From, " &gt; ")))
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, "<li>list</li>"))
 	assert.False(t, strings.Contains(issueDetailsPanelHtml, "Learn about this vulnerability"))
 }
@@ -131,6 +131,6 @@ func Test_OssDetailsPanel_html_withLearn_withCustomEndpoint(t *testing.T) {
 	issueAdditionalData.MatchingIssues = append(issueAdditionalData.MatchingIssues, issueAdditionalData)
 
 	issueDetailsPanelHtml := getDetailsHtml(issue)
-
+	
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, customEndpoint))
 }

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -20,7 +20,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self' 'none'; style-src 'self' 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+        content="default-src 'self' ${cspSource}; style-src 'self' 'nonce-${nonce}' ${cspSource}; script-src 'nonce-${nonce}' ${cspSource};">
 
   <style nonce="${nonce}">
     .suggestion {
@@ -97,6 +97,8 @@
 
   </style>
 
+  ${headerEnd}
+
   ${ideStyle}
 </head>
 
@@ -110,7 +112,7 @@
     <div class="identifiers">
       {{.IssueType}}
       {{if gt (len .CVEs) 0}}
-      <span class="delimiter">|</span>
+      <span class="delimiter"> </span>
       {{range $index, $cve := .CVEs}}
       <a class="cve styled-link" target="_blank" rel="noopener noreferrer"
          href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=$cve">{{$cve}}</a>
@@ -119,7 +121,7 @@
       {{end}}
 
       {{if gt (len .CWEs) 0}}
-      <span class="delimiter">|</span>
+      <span class="delimiter"> </span>
       {{range $index, $cwe := .CWEs}}
       <a class="cwe styled-link" target="_blank" rel="noopener noreferrer"
          href="https://cwe.mitre.org/data/definitions/{{trimCWEPrefix $cwe}}.html">{{$cwe}}</a>
@@ -128,11 +130,11 @@
       {{end}}
 
       {{if gt (len .CvssScore) 0}}
-      <span class="delimiter">|</span>
-      <span>{{.CvssScore}}</span>
+      <span class="delimiter"> </span>
+      <span>CVSS {{.CvssScore}}</span>
       {{end}}
 
-      <span class="delimiter">|</span>
+      <span class="delimiter"> </span>
       <a class="styled-link" target="_blank" rel="noopener noreferrer"
          href="https://snyk.io/vuln/{{.IssueId}}">{{.IssueId}}</a>
     </div>

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -93,7 +93,7 @@
     }
 
   </style>
-  ${headerEnd}
+  ${ideStyle}
 </head>
 <body>
 <div class="suggestion">

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -19,7 +19,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' ${cspSource}; style-src 'nonce-${nonce}' ${cspSource}; script-src 'nonce-${nonce}';">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self' 'none'; style-src 'self' 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+
   <style nonce="${nonce}">
     .suggestion {
       position: relative;
@@ -62,6 +64,7 @@
       line-height: 2rem;
     }
 
+    /*TODO: move to vscode*/
     .vscode-dark .light-only {
       display: none;
     }
@@ -93,39 +96,102 @@
     }
 
   </style>
+
   ${ideStyle}
 </head>
+
 <body>
 <div class="suggestion">
   <section class="suggestion--header">
     <div class="severity">
-      <img id="severity-icon" src="${severityIcon}" alt="${severityText}" class="icon"/>
+      {{.SeverityIcon}}
     </div>
-    <div class="suggestion-text">${issueTitle}</div>
-    <div class="identifiers">${identifiers}</div>
-    <div class="learn" id="learn">
-      <img class="icon" src="${learnIcon}" alt="learnIcon" />
-      ${learnLink}
+    <div class="suggestion-text">{{.IssueTitle}}</div>
+    <div class="identifiers">
+      {{.IssueType}}
+      {{if gt (len .CVEs) 0}}
+      <span class="delimiter">|</span>
+      {{range $index, $cve := .CVEs}}
+      <a class="cve styled-link" target="_blank" rel="noopener noreferrer"
+         href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=$cve">{{$cve}}</a>
+      {{if ne $index (idxMinusOne (len $.CVEs))}}<span class="delimiter"></span>{{end}}
+      {{end}}
+      {{end}}
+
+      {{if gt (len .CWEs) 0}}
+      <span class="delimiter">|</span>
+      {{range $index, $cwe := .CWEs}}
+      <a class="cwe styled-link" target="_blank" rel="noopener noreferrer"
+         href="https://cwe.mitre.org/data/definitions/{{trimCWEPrefix $cwe}}.html">{{$cwe}}</a>
+      {{if ne $index (idxMinusOne (len $.CWEs))}}<span class="delimiter"></span>{{end}}
+      {{end}}
+      {{end}}
+
+      {{if gt (len .CvssScore) 0}}
+      <span class="delimiter">|</span>
+      <span>{{.CvssScore}}</span>
+      {{end}}
+
+      <span class="delimiter">|</span>
+      <a class="styled-link" target="_blank" rel="noopener noreferrer"
+         href="https://snyk.io/vuln/{{.IssueId}}">{{.IssueId}}</a>
     </div>
+    {{ if .LessonUrl }}
+      <div class="learn" id="learn">
+        {{.LessonIcon}}
+        <a class="learn--link" id="learn--link" href="{{.LessonUrl}}">Learn about this vulnerability</a>
+      </div>
+    {{end}}
   </section>
   <section class="delimiter-top summary">
     <div class="summary-item module">
       <div class="label font-light">Vulnerable module</div>
-      <div class="content">${vulnerableModule}</div>
+      <div class="content">{{.VulnerableModule}}</div>
     </div>
-    ${introducedThrough}
+    {{range .IntroducedThroughs}}
+    <div class="summary-item introduced-through">
+      <div class="label font-light">Introduced through</div>
+      <div class="content">
+        <a href="{{.SnykUI}}/test/{{.PackageManager}}">{{.Module}}</a>
+      </div>
+    </div>
+    {{end}}
     <div class="summary-item fixed-in">
       <div class="label font-light">Fixed in</div>
-      <div class="content">${fixedIn}</div>
+      <div class="content">
+        {{ if eq (len .FixedIn) 0 }}
+        Not fixed
+        {{else}}
+        {{.IssueName}}@{{ join ", " .FixedIn }}
+        {{end}}
+      </div>
     </div>
-    ${exploitMaturity}
+    {{ if .ExploitMaturity }}
+    <div class="summary-item maturity">
+      <div class="label font-light">Exploit maturity</div>
+      <div class="content">{{.ExploitMaturity}}</div>
+    </div>
+    {{end}}
   </section>
   <section class="delimiter-top summary">
     <h2>Detailed paths</h2>
-    <div class="detailed-paths">${detailedPaths}</div>
+    <div class="detailed-paths">
+      {{range .DetailedPaths}}
+        <div class="summary-item path">
+          <div class="label font-light">Introduced through</div>
+          <div class="content">{{join " > " .From}}</div>
+        </div>
+        <div class="summary-item remediation">
+          <div class="label font-light">Remediation</div>
+          <div class="content">{{.Remediation}}</div>
+        </div>
+      {{end}}
+    </div>
   </section>
   <section class="delimiter-top">
-    <div id="overview" class="vulnerability-overview">${overview}</div>
+    <div id="overview" class="vulnerability-overview">
+      {{.IssueOverview}}
+    </div>
   </section>
 </div>
 <script nonce="${nonce}">

--- a/internal/html/html.go
+++ b/internal/html/html.go
@@ -37,7 +37,7 @@ func TrimCWEPrefix(cwe string) string {
 }
 
 func GetLessonIconSvg() template.HTML {
-	return template.HTML(`<svg width="17" height="14" viewBox="0 0 17 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+	return template.HTML(`<svg class="icon" width="17" height="14" viewBox="0 0 17 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<path d="M8.25 0L0 4.5L3 6.135V10.635L8.25 13.5L13.5 10.635V6.135L15 5.3175V10.5H16.5V4.5L8.25 0ZM13.365 4.5L8.25 7.29L3.135 4.5L8.25 1.71L13.365 4.5ZM12 9.75L8.25 11.79L4.5 9.75V6.9525L8.25 9L12 6.9525V9.75Z" fill="#888"/>
 	</svg>
 	`)
@@ -46,22 +46,22 @@ func GetLessonIconSvg() template.HTML {
 func GetSeverityIconSvg(issue snyk.Issue) template.HTML {
 	switch issue.Severity {
 	case snyk.Critical:
-		return template.HTML(`<svg id="critical" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="severity-icon" class="icon critical" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#AB1A1A"/>
 			 <path d="M9.975 9.64h2.011a3.603 3.603 0 0 1-.545 1.743 3.24 3.24 0 0 1-1.338 1.19c-.57.284-1.256.427-2.06.427-.627 0-1.19-.107-1.688-.32a3.594 3.594 0 0 1-1.278-.936 4.158 4.158 0 0 1-.801-1.47C4.092 9.7 4 9.057 4 8.345v-.675c0-.712.094-1.356.283-1.93a4.255 4.255 0 0 1 .82-1.476 3.657 3.657 0 0 1 1.286-.936A4.114 4.114 0 0 1 8.057 3c.817 0 1.505.147 2.066.44.565.295 1.002.7 1.312 1.217.314.516.502 1.104.565 1.763H9.982c-.023-.392-.101-.723-.236-.995a1.331 1.331 0 0 0-.612-.621c-.27-.143-.628-.214-1.077-.214-.336 0-.63.062-.881.187a1.632 1.632 0 0 0-.633.568c-.17.254-.298.574-.383.962a6.61 6.61 0 0 0-.121 1.349v.688c0 .503.038.946.114 1.33.076.378.193.699.35.961.161.259.368.454.619.588.256.13.563.194.922.194.421 0 .769-.067 1.043-.2a1.39 1.39 0 0 0 .625-.595c.148-.263.236-.59.263-.982Z" fill="#fff"/>
 		 </svg>`)
 	case snyk.High:
-		return template.HTML(`<svg id="high" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="severity-icon" class="icon high" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#CE5019"/>
 			 <path d="M10.5 7v2h-5V7h5ZM6 3v10H4V3h2Zm6 0v10h-2V3h2Z" fill="#fff"/>
 		 </svg>`)
 	case snyk.Medium:
-		return template.HTML(`<svg id="medium" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="severity-icon" class="icon medium" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#D68000"/>
 			 <path d="M3 3h2l2.997 7.607L11 3h2L9 13H7L3 3Zm0 0h2v10l-2-.001V3.001Zm8 0h2V13h-2V3Z" fill="#fff"/>
 		 </svg>`)
 	case snyk.Low:
-		return template.HTML(`<svg id="low" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+		return template.HTML(`<svg id="severity-icon" class="icon low" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
 			 <rect width="16" height="16" rx="2" fill="#88879E"/>
 			 <path d="M11 11v2H6.705v-2H11ZM7 3v10H5V3h2Z" fill="#fff"/>
 		 </svg>`)

--- a/internal/html/html.go
+++ b/internal/html/html.go
@@ -1,0 +1,71 @@
+/*
+ * © 2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package html
+
+import (
+	"github.com/gomarkdown/markdown"
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"html/template"
+	"strings"
+)
+
+func MarkdownToHTML(md string) template.HTML {
+	html := markdown.ToHTML([]byte(md), nil, nil)
+	return template.HTML(html)
+}
+
+func IdxMinusOne(n int) int {
+	return n - 1
+}
+
+func TrimCWEPrefix(cwe string) string {
+	return strings.TrimPrefix(cwe, "CWE-")
+}
+
+func GetLessonIconSvg() template.HTML {
+	return template.HTML(`<svg width="17" height="14" viewBox="0 0 17 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M8.25 0L0 4.5L3 6.135V10.635L8.25 13.5L13.5 10.635V6.135L15 5.3175V10.5H16.5V4.5L8.25 0ZM13.365 4.5L8.25 7.29L3.135 4.5L8.25 1.71L13.365 4.5ZM12 9.75L8.25 11.79L4.5 9.75V6.9525L8.25 9L12 6.9525V9.75Z" fill="#888"/>
+	</svg>
+	`)
+}
+
+func GetSeverityIconSvg(issue snyk.Issue) template.HTML {
+	switch issue.Severity {
+	case snyk.Critical:
+		return template.HTML(`<svg id="critical" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+			 <rect width="16" height="16" rx="2" fill="#AB1A1A"/>
+			 <path d="M9.975 9.64h2.011a3.603 3.603 0 0 1-.545 1.743 3.24 3.24 0 0 1-1.338 1.19c-.57.284-1.256.427-2.06.427-.627 0-1.19-.107-1.688-.32a3.594 3.594 0 0 1-1.278-.936 4.158 4.158 0 0 1-.801-1.47C4.092 9.7 4 9.057 4 8.345v-.675c0-.712.094-1.356.283-1.93a4.255 4.255 0 0 1 .82-1.476 3.657 3.657 0 0 1 1.286-.936A4.114 4.114 0 0 1 8.057 3c.817 0 1.505.147 2.066.44.565.295 1.002.7 1.312 1.217.314.516.502 1.104.565 1.763H9.982c-.023-.392-.101-.723-.236-.995a1.331 1.331 0 0 0-.612-.621c-.27-.143-.628-.214-1.077-.214-.336 0-.63.062-.881.187a1.632 1.632 0 0 0-.633.568c-.17.254-.298.574-.383.962a6.61 6.61 0 0 0-.121 1.349v.688c0 .503.038.946.114 1.33.076.378.193.699.35.961.161.259.368.454.619.588.256.13.563.194.922.194.421 0 .769-.067 1.043-.2a1.39 1.39 0 0 0 .625-.595c.148-.263.236-.59.263-.982Z" fill="#fff"/>
+		 </svg>`)
+	case snyk.High:
+		return template.HTML(`<svg id="high" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+			 <rect width="16" height="16" rx="2" fill="#CE5019"/>
+			 <path d="M10.5 7v2h-5V7h5ZM6 3v10H4V3h2Zm6 0v10h-2V3h2Z" fill="#fff"/>
+		 </svg>`)
+	case snyk.Medium:
+		return template.HTML(`<svg id="medium" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+			 <rect width="16" height="16" rx="2" fill="#D68000"/>
+			 <path d="M3 3h2l2.997 7.607L11 3h2L9 13H7L3 3Zm0 0h2v10l-2-.001V3.001Zm8 0h2V13h-2V3Z" fill="#fff"/>
+		 </svg>`)
+	case snyk.Low:
+		return template.HTML(`<svg id="low" fill="none" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 16 16">
+			 <rect width="16" height="16" rx="2" fill="#88879E"/>
+			 <path d="M11 11v2H6.705v-2H11ZM7 3v10H5V3h2Z" fill="#fff"/>
+		 </svg>`)
+	default:
+		return ``
+	}
+}


### PR DESCRIPTION
### Description

This PR refactors the HTML template used for the OSS Sugestion Panel so that it's more secure and uses the `html/template` library. This also refactors the template so that it injects icons directly in LS and so other IDEs don't need to know what icons to inject. It adds a `${ideStyle}` variable so that in both VSCode and IntelliJ we can inject the IDE specific styling, like we do for Snyk Code.

To test this, need to use https://github.com/snyk/vscode-extension/pull/482.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.
