### PR TITLE
fix: normalize line endings before computing diff

### DIFF
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -414,7 +414,7 @@ func (s *SarifConverter) getIgnoreDetails(result codeClientSarif.Result) (bool, 
 		if suppression.Properties.Expiration != nil {
 			expiration = *suppression.Properties.Expiration
 		}
-		
+
 		reason := suppression.Justification
 		if reason == "" {
 			reason = "None given"
@@ -567,6 +567,8 @@ func (s *AutofixResponse) toUnifiedDiffSuggestions(baseDir string, filePath stri
 			return fixSuggestions
 		}
 		contentBefore := string(fileContent)
+		// Workaround: AI Suggestion API only returns \n new lines. It doesn't consider carriage returns.
+		contentBefore = strings.Replace(contentBefore, "\r\n", "\n", -1)
 		edits := myers.ComputeEdits(span.URIFromPath(baseDir), contentBefore, suggestion.Value)
 		unifiedDiff := fmt.Sprint(gotextdiff.ToUnified(baseDir, baseDir+"-fixed", contentBefore, edits))
 


### PR DESCRIPTION
### Description

Currently AI Suggestion API returns line endings only as "\n". Which makes it detect all the lines as a change in Windows.
![image](https://github.com/snyk/snyk-ls/assets/6913627/15043f81-6aa3-45e2-9753-9f7d919a32bc)


This change normalizes the line endings before computing the diff.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
