### PR TITLE
fix: introduce throughs and detailed paths in html of oss

### DIFF
--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -62,6 +62,8 @@ func getDetailsHtml(issue snyk.Issue) string {
 	}
 	overview := markdown.ToHTML([]byte(additionalData.Description), nil, nil)
 
+	detailedPaths := getDetailedPaths(additionalData)
+
 	data := map[string]interface{}{
 		"IssueId":            issue.ID,
 		"IssueName":          additionalData.Name,
@@ -79,7 +81,8 @@ func getDetailsHtml(issue snyk.Issue) string {
 		"LessonUrl":          additionalData.Lesson,
 		"LessonIcon":         html.GetLessonIconSvg(),
 		"FixedIn":            additionalData.FixedIn,
-		"DetailedPaths":      getDetailedPaths(additionalData),
+		"DetailedPaths":      detailedPaths,
+		"MoreDetailedPaths":  len(detailedPaths) - 3,
 	}
 
 	var html bytes.Buffer
@@ -114,7 +117,7 @@ type IntroducedThrough struct {
 }
 
 func getIntroducedThroughs(issue snyk.OssIssueData) []IntroducedThrough {
-	introducedThroughs := []IntroducedThrough{}
+	var introducedThroughs []IntroducedThrough
 
 	snykUi := config.CurrentConfig().SnykUi()
 	if len(issue.From) > 0 {

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -134,3 +134,68 @@ func Test_OssDetailsPanel_html_withLearn_withCustomEndpoint(t *testing.T) {
 
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, customEndpoint))
 }
+
+func Test_OssDetailsPanel_html_moreDetailedPaths(t *testing.T) {
+	_ = testutil.UnitTest(t)
+	expectedVariables := []string{"${headerEnd}", "${cspSource}", "${ideStyle}", "${nonce}"}
+	slices.Sort(expectedVariables)
+
+	issueAdditionalData := snyk.OssIssueData{
+		Title:       "myTitle",
+		Name:        "myIssue",
+		Description: "- list",
+		From:        []string{"1", "2", "3", "4"},
+	}
+
+	issue2 := snyk.OssIssueData{
+		Title:       "myTitle2",
+		Name:        "myIssue2",
+		Description: "- list2",
+		From:        []string{"5", "6", "7", "8"},
+	}
+
+	issue3 := snyk.OssIssueData{
+		Title:       "myTitle3",
+		Name:        "myIssue3",
+		Description: "- list3",
+		From:        []string{"9", "10"},
+	}
+
+	issue4 := snyk.OssIssueData{
+		Title:       "myTitle4",
+		Name:        "myIssue4",
+		Description: "- list4",
+		From:        []string{"11"},
+	}
+	issueAdditionalData.MatchingIssues = append(issueAdditionalData.MatchingIssues, issueAdditionalData)
+	issueAdditionalData.MatchingIssues = append(issueAdditionalData.MatchingIssues, issue2)
+	issueAdditionalData.MatchingIssues = append(issueAdditionalData.MatchingIssues, issue3)
+	issueAdditionalData.MatchingIssues = append(issueAdditionalData.MatchingIssues, issue4)
+
+	issue := snyk.Issue{
+		ID:             "randomId",
+		Severity:       snyk.Critical,
+		AdditionalData: issueAdditionalData,
+	}
+
+	// invoke methode under test
+	issueDetailsPanelHtml := getDetailsHtml(issue)
+
+	// compare
+	reg := regexp.MustCompile(`\$\{\w+\}`)
+	actualVariables := reg.FindAllString(issueDetailsPanelHtml, -1)
+	slices.Sort(actualVariables)
+	actualVariables = slices.Compact(actualVariables)
+
+	assert.Equal(t, expectedVariables, actualVariables)
+
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issueAdditionalData.Name))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.ID))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issueAdditionalData.Title))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, issue.Severity.String()))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issueAdditionalData.From, " &gt; ")))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, strings.Join(issue2.From, " &gt; ")))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, "<li>list</li>"))
+	assert.False(t, strings.Contains(issueDetailsPanelHtml, "Learn about this vulnerability"))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, "...and"))
+}

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -150,14 +150,15 @@
       <div class="label font-light">Vulnerable module</div>
       <div class="content">{{.VulnerableModule}}</div>
     </div>
-    {{range .IntroducedThroughs}}
     <div class="summary-item introduced-through">
       <div class="label font-light">Introduced through</div>
       <div class="content">
-        <a href="{{.SnykUI}}/test/{{.PackageManager}}">{{.Module}}</a>
+        {{range $i, $element := .IntroducedThroughs}}
+          <a href="{{$element.SnykUI}}/test/{{$element.PackageManager}}">{{$element.Module}}</a>
+          {{ if lt $i (idxMinusOne (len $.IntroducedThroughs)) }}, {{end}}
+        {{end}}
       </div>
     </div>
-    {{end}}
     <div class="summary-item fixed-in">
       <div class="label font-light">Fixed in</div>
       <div class="content">
@@ -178,15 +179,18 @@
   <section class="delimiter-top summary">
     <h2>Detailed paths</h2>
     <div class="detailed-paths">
-      {{range .DetailedPaths}}
-        <div class="summary-item path">
+      {{range $i, $element := .DetailedPaths}}
+        <div class="summary-item path {{ if gt $i 3 }}hidden{{end}}">
           <div class="label font-light">Introduced through</div>
-          <div class="content">{{join " > " .From}}</div>
+          <div class="content">{{join " > " $element.From}}</div>
         </div>
-        <div class="summary-item remediation">
+        <div class="summary-item remediation {{ if gt $i 3 }}hidden{{end}}">
           <div class="label font-light">Remediation</div>
-          <div class="content">{{.Remediation}}</div>
+          <div class="content">{{$element.Remediation}}</div>
         </div>
+      {{end}}
+      {{ if gt .MoreDetailedPaths 0 }}
+      <a id="more-detailed-paths--link">...and {{ .MoreDetailedPaths}} more</a>
       {{end}}
     </div>
   </section>
@@ -199,6 +203,19 @@
 <script nonce="${nonce}">
   if (document.getElementById("learn--link")) {
     document.getElementById("learn").className = "learn show"
+  }
+  if (document.getElementById("more-detailed-paths--link")) {
+    document.getElementById("more-detailed-paths--link").addEventListener('click', () => {
+      const paths = document.getElementsByClassName("path");
+      for(const path of paths) {
+        path.classList.remove("hidden");
+      }
+      const remediations = document.getElementsByClassName("remediation")
+      for(const remediation of remediations) {
+        remediation.classList.remove("hidden");
+      }
+      document.getElementById("more-detailed-paths--link").classList.add("hidden");
+    })
   }
 </script>
 </body>


### PR DESCRIPTION
### Description

Fixes some small UI problems in the OSS suggestion panel:
- the `Introduced Through` overview section should have the packages separated by comma and not as separate components on individual lines
- the `Detailed Paths` section in IntelliJ needs to render only the top 3 elements. It doesn't seem like VSCode deals with that today but it would be a good thing to have.

Have tested it with `target-service`.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs
Before:
<img width="678" alt="Screenshot 2024-07-08 at 15 59 49" src="https://github.com/snyk/snyk-ls/assets/81559517/4bd90155-6804-433f-954a-44563dc677e6">

After:
<img width="690" alt="Screenshot 2024-07-08 at 15 45 58" src="https://github.com/snyk/snyk-ls/assets/81559517/3a69fd53-42a0-4a80-99bf-348e19d02870">

