### PR TITLE
feat: render Policy details for Open Source [IDE-454]

### DIFF
--- a/infrastructure/oss/issue_html.go
+++ b/infrastructure/oss/issue_html.go
@@ -83,6 +83,7 @@ func getDetailsHtml(issue snyk.Issue) string {
 		"FixedIn":            additionalData.FixedIn,
 		"DetailedPaths":      detailedPaths,
 		"MoreDetailedPaths":  len(detailedPaths) - 3,
+		"Policy":             buildPolicyMap(additionalData),
 	}
 
 	var html bytes.Buffer
@@ -92,6 +93,23 @@ func getDetailsHtml(issue snyk.Issue) string {
 	}
 
 	return html.String()
+}
+
+func buildPolicyMap(additionalData snyk.OssIssueData) map[string]interface{} {
+	policy := map[string]interface{}{}
+
+	if additionalData.AppliedPolicyRules.SeverityChange.OriginalSeverity != "" {
+		policy["OriginalSeverity"] = additionalData.AppliedPolicyRules.SeverityChange.OriginalSeverity
+		policy["NewSeverity"] = additionalData.AppliedPolicyRules.SeverityChange.NewSeverity
+		policy["Reason"] = additionalData.AppliedPolicyRules.SeverityChange.Reason
+	}
+
+	if additionalData.AppliedPolicyRules.Annotation.Value != "" {
+		policy["UserNote"] = additionalData.AppliedPolicyRules.Annotation.Value
+		policy["NoteReason"] = additionalData.AppliedPolicyRules.Annotation.Reason
+	}
+
+	return policy
 }
 
 func getIssueType(issue snyk.OssIssueData) string {

--- a/infrastructure/oss/issue_html_test.go
+++ b/infrastructure/oss/issue_html_test.go
@@ -199,3 +199,66 @@ func Test_OssDetailsPanel_html_moreDetailedPaths(t *testing.T) {
 	assert.False(t, strings.Contains(issueDetailsPanelHtml, "Learn about this vulnerability"))
 	assert.True(t, strings.Contains(issueDetailsPanelHtml, "...and"))
 }
+
+func Test_OssDetailsPanel_html_withAnnotationsPolicy(t *testing.T) {
+	_ = testutil.UnitTest(t)
+
+	// Arrange
+	issueAdditionalData := snyk.OssIssueData{
+		Title:       "myTitle",
+		Name:        "myIssue",
+		Description: "- list",
+		From:        []string{"1", "2", "3", "4"},
+		AppliedPolicyRules: snyk.AppliedPolicyRules{
+			Annotation: snyk.Annotation{
+				Value:  "This vulnerability was overridden to low severity due to our internal risk assessment that determined it poses minimal risk in our environment.",
+				Reason: "Our application does not use the affected functionality in a way that exposes it to the vulnerability. Therefore, it has a lower priority for fixing compared to other issues.",
+			},
+		},
+	}
+
+	issue := snyk.Issue{
+		ID:       "randomId",
+		Severity: snyk.Low,
+		// OriginalSeverity: snyk.Critical, // Mock original severity for testing
+		AdditionalData: issueAdditionalData,
+	}
+
+	// Act
+	issueDetailsPanelHtml := getDetailsHtml(issue)
+
+	// Assert
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, "User note"))
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, "Note reason"))
+}
+
+func Test_OssDetailsPanel_html_withSeverityChangePolicy(t *testing.T) {
+	_ = testutil.UnitTest(t)
+
+	// Arrange
+	issueAdditionalData := snyk.OssIssueData{
+		Title:       "myTitle",
+		Name:        "myIssue",
+		Description: "- list",
+		From:        []string{"1", "2", "3", "4"},
+		AppliedPolicyRules: snyk.AppliedPolicyRules{
+			SeverityChange: snyk.SeverityChange{
+				OriginalSeverity: snyk.Critical.String(),
+				NewSeverity:      snyk.Low.String(),
+				Reason:           "Changing severity to low due to internal risk assessment.",
+			},
+		},
+	}
+
+	issue := snyk.Issue{
+		ID:             "randomId",
+		Severity:       snyk.Low,
+		AdditionalData: issueAdditionalData,
+	}
+
+	// Act
+	issueDetailsPanelHtml := getDetailsHtml(issue)
+
+	// Assert
+	assert.True(t, strings.Contains(issueDetailsPanelHtml, "A policy has affected the severity of this issue. It was originally critical severity"))
+}

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -16,11 +16,12 @@
 
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self' ${cspSource}; style-src 'self' 'nonce-${nonce}' ${cspSource}; script-src 'nonce-${nonce}' ${cspSource};">
+    content="default-src 'self' ${cspSource}; style-src 'self' 'nonce-${nonce}' ${cspSource}; script-src 'nonce-${nonce}' ${cspSource};">
 
   <style nonce="${nonce}">
     :root {
@@ -154,9 +155,7 @@
       margin-left: 3px;
     }
 
-    .learn__code .learn--link {
-    }
-
+    .learn__code .learn--link {}
   </style>
 
   ${headerEnd}
@@ -165,83 +164,83 @@
 </head>
 
 <body>
-<div class="suggestion">
-  <section class="suggestion--header">
-    <div class="severity">
-      {{.SeverityIcon}}
-    </div>
-    <div class="suggestion-text">{{.IssueTitle}}</div>
-    <div class="identifiers">
-      {{.IssueType}}
-      {{if gt (len .CVEs) 0}}
-      <span class="delimiter"> </span>
-      {{range $index, $cve := .CVEs}}
-      <a class="cve styled-link" target="_blank" rel="noopener noreferrer"
-         href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=$cve">{{$cve}}</a>
-      {{if ne $index (idxMinusOne (len $.CVEs))}}<span class="delimiter"></span>{{end}}
-      {{end}}
-      {{end}}
+  <div class="suggestion">
+    <section class="suggestion--header">
+      <div class="severity">
+        {{.SeverityIcon}}
+      </div>
+      <div class="suggestion-text">{{.IssueTitle}}</div>
+      <div class="identifiers">
+        {{.IssueType}}
+        {{if gt (len .CVEs) 0}}
+        <span class="delimiter"> </span>
+        {{range $index, $cve := .CVEs}}
+        <a class="cve styled-link" target="_blank" rel="noopener noreferrer"
+          href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=$cve">{{$cve}}</a>
+        {{if ne $index (idxMinusOne (len $.CVEs))}}<span class="delimiter"></span>{{end}}
+        {{end}}
+        {{end}}
 
-      {{if gt (len .CWEs) 0}}
-      <span class="delimiter"> </span>
-      {{range $index, $cwe := .CWEs}}
-      <a class="cwe styled-link" target="_blank" rel="noopener noreferrer"
-         href="https://cwe.mitre.org/data/definitions/{{trimCWEPrefix $cwe}}.html">{{$cwe}}</a>
-      {{if ne $index (idxMinusOne (len $.CWEs))}}<span class="delimiter"></span>{{end}}
-      {{end}}
-      {{end}}
+        {{if gt (len .CWEs) 0}}
+        <span class="delimiter"> </span>
+        {{range $index, $cwe := .CWEs}}
+        <a class="cwe styled-link" target="_blank" rel="noopener noreferrer"
+          href="https://cwe.mitre.org/data/definitions/{{trimCWEPrefix $cwe}}.html">{{$cwe}}</a>
+        {{if ne $index (idxMinusOne (len $.CWEs))}}<span class="delimiter"></span>{{end}}
+        {{end}}
+        {{end}}
 
-      {{if gt (len .CvssScore) 0}}
-      <span class="delimiter"> </span>
-      <span>CVSS {{.CvssScore}}</span>
-      {{end}}
+        {{if gt (len .CvssScore) 0}}
+        <span class="delimiter"> </span>
+        <span>CVSS {{.CvssScore}}</span>
+        {{end}}
 
-      <span class="delimiter"> </span>
-      <a class="styled-link" target="_blank" rel="noopener noreferrer"
-         href="https://snyk.io/vuln/{{.IssueId}}">{{.IssueId}}</a>
-    </div>
-    {{ if .LessonUrl }}
+        <span class="delimiter"> </span>
+        <a class="styled-link" target="_blank" rel="noopener noreferrer"
+          href="https://snyk.io/vuln/{{.IssueId}}">{{.IssueId}}</a>
+      </div>
+      {{ if .LessonUrl }}
       <div class="learn" id="learn">
         {{.LessonIcon}}
         <a class="learn--link" id="learn--link" href="{{.LessonUrl}}">Learn about this vulnerability</a>
       </div>
-    {{end}}
-  </section>
-  <section class="delimiter-top summary">
-    <div class="summary-item module">
-      <div class="label font-light">Vulnerable module</div>
-      <div class="content">{{.VulnerableModule}}</div>
-    </div>
-    <div class="summary-item introduced-through">
-      <div class="label font-light">Introduced through</div>
-      <div class="content">
-        {{range $i, $element := .IntroducedThroughs}}
+      {{end}}
+    </section>
+    <section class="delimiter-top summary">
+      <div class="summary-item module">
+        <div class="label font-light">Vulnerable module</div>
+        <div class="content">{{.VulnerableModule}}</div>
+      </div>
+      <div class="summary-item introduced-through">
+        <div class="label font-light">Introduced through</div>
+        <div class="content">
+          {{range $i, $element := .IntroducedThroughs}}
           <a href="{{$element.SnykUI}}/test/{{$element.PackageManager}}">{{$element.Module}}</a>
           {{ if lt $i (idxMinusOne (len $.IntroducedThroughs)) }}, {{end}}
-        {{end}}
+          {{end}}
+        </div>
       </div>
-    </div>
-    <div class="summary-item fixed-in">
-      <div class="label font-light">Fixed in</div>
-      <div class="content">
-        {{ if eq (len .FixedIn) 0 }}
-        Not fixed
-        {{else}}
-        {{.IssueName}}@{{ join ", " .FixedIn }}
-        {{end}}
+      <div class="summary-item fixed-in">
+        <div class="label font-light">Fixed in</div>
+        <div class="content">
+          {{ if eq (len .FixedIn) 0 }}
+          Not fixed
+          {{else}}
+          {{.IssueName}}@{{ join ", " .FixedIn }}
+          {{end}}
+        </div>
       </div>
-    </div>
-    {{ if .ExploitMaturity }}
-    <div class="summary-item maturity">
-      <div class="label font-light">Exploit maturity</div>
-      <div class="content">{{.ExploitMaturity}}</div>
-    </div>
-    {{end}}
-  </section>
-  <section class="delimiter-top summary">
-    <h2>Detailed paths</h2>
-    <div class="detailed-paths">
-      {{range $i, $element := .DetailedPaths}}
+      {{ if .ExploitMaturity }}
+      <div class="summary-item maturity">
+        <div class="label font-light">Exploit maturity</div>
+        <div class="content">{{.ExploitMaturity}}</div>
+      </div>
+      {{end}}
+    </section>
+    <section class="delimiter-top summary">
+      <h2>Detailed paths</h2>
+      <div class="detailed-paths">
+        {{range $i, $element := .DetailedPaths}}
         <div class="summary-item path {{ if gt $i 3 }}hidden{{end}}">
           <div class="label font-light">Introduced through</div>
           <div class="content">{{join " > " $element.From}}</div>
@@ -250,35 +249,56 @@
           <div class="label font-light">Remediation</div>
           <div class="content">{{$element.Remediation}}</div>
         </div>
+        {{end}}
+        {{ if gt .MoreDetailedPaths 0 }}
+        <a id="more-detailed-paths--link">...and {{ .MoreDetailedPaths}} more</a>
+        {{end}}
+      </div>
+    </section>
+    <section class="delimiter-top">
+      <div id="overview" class="vulnerability-overview">
+        {{.IssueOverview}}
+      </div>
+    </section>
+    {{ if .Policy }}
+    <section class="delimiter-top summary">
+      <h2>Policy Applied</h2>
+      {{ if .Policy.OriginalSeverity }}
+      <p>A policy has affected the severity of this issue. It was originally {{.Policy.OriginalSeverity}} severity.</p>
       {{end}}
-      {{ if gt .MoreDetailedPaths 0 }}
-      <a id="more-detailed-paths--link">...and {{ .MoreDetailedPaths}} more</a>
+      {{ if .Policy.UserNote }}
+      <div class="detailed-paths">
+        <div class="summary-item path">
+          <div class="label font-light">User note</div>
+          <div class="content">{{.Policy.UserNote}}</div>
+        </div>
+        <div class="summary-item remediation">
+          <div class="label font-light">Note reason</div>
+          <div class="content">{{.Policy.NoteReason}}</div>
+        </div>
+      </div>
       {{end}}
-    </div>
-  </section>
-  <section class="delimiter-top">
-    <div id="overview" class="vulnerability-overview">
-      {{.IssueOverview}}
-    </div>
-  </section>
-</div>
-<script nonce="${nonce}">
-  if (document.getElementById("learn--link")) {
-    document.getElementById("learn").className = "learn show"
-  }
-  if (document.getElementById("more-detailed-paths--link")) {
-    document.getElementById("more-detailed-paths--link").addEventListener('click', () => {
-      const paths = document.getElementsByClassName("path");
-      for(const path of paths) {
-        path.classList.remove("hidden");
-      }
-      const remediations = document.getElementsByClassName("remediation")
-      for(const remediation of remediations) {
-        remediation.classList.remove("hidden");
-      }
-      document.getElementById("more-detailed-paths--link").classList.add("hidden");
-    })
-  }
-</script>
+    </section>
+    {{end}}
+  </div>
+  <script nonce="${nonce}">
+    if (document.getElementById("learn--link")) {
+      document.getElementById("learn").className = "learn show"
+    }
+    if (document.getElementById("more-detailed-paths--link")) {
+      document.getElementById("more-detailed-paths--link").addEventListener('click', () => {
+        const paths = document.getElementsByClassName("path");
+        for (const path of paths) {
+          path.classList.remove("hidden");
+        }
+        const remediations = document.getElementsByClassName("remediation")
+        for (const remediation of remediations) {
+          remediation.classList.remove("hidden");
+        }
+        document.getElementById("more-detailed-paths--link").classList.add("hidden");
+      })
+    }
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
### Description

This PR surfaces the Policy notes when a user applies Severity change rules or add Annotations to a policy

- Added support for displaying policy data in OSS issue details.
- Updated the `details.html` template to conditionally render policy information if present.
- Updated unit tests to cover policy data rendering

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

|Policy With Annotations|With Severity Change|
|-|-|
|<img width="2056" alt="image" src="https://github.com/snyk/snyk-ls/assets/1948377/f03e85e8-1184-4b2e-b671-37cbe7a25096">|<img width="2056" alt="image" src="https://github.com/snyk/snyk-ls/assets/1948377/f636a43f-e077-4eb3-884e-5c7bbb85068f">|
