### PR TITLE
fix: check if authenticated before executing commands

### DIFF
--- a/domain/ide/command/command_factory.go
+++ b/domain/ide/command/command_factory.go
@@ -58,14 +58,14 @@ func CreateFromCommandData(c *config.Config, commandData types.CommandData, srv 
 		return &openLearnLesson{command: commandData, srv: srv, learnService: learnService}, nil
 	case types.GetSettingsSastEnabled:
 		apiClient := snyk_api.NewSnykApiClient(c, httpClient)
-		return &sastEnabled{command: commandData, apiClient: apiClient, logger: c.Logger()}, nil
+		return &sastEnabled{command: commandData, apiClient: apiClient, logger: c.Logger(), authenticationService: authService}, nil
 	case types.GetFeatureFlagStatus:
 		apiClient := snyk_api.NewSnykApiClient(c, httpClient)
-		return &featureFlagStatus{command: commandData, apiClient: apiClient}, nil
+		return &featureFlagStatus{command: commandData, apiClient: apiClient, authenticationService: authService}, nil
 	case types.GetActiveUserCommand:
-		return &getActiveUser{command: commandData, authService: authService, notifier: notifier}, nil
+		return &getActiveUser{command: commandData, authenticationService: authService, notifier: notifier}, nil
 	case types.ReportAnalyticsCommand:
-		return &reportAnalyticsCommand{command: commandData}, nil
+		return &reportAnalyticsCommand{command: commandData, authenticationService: authService}, nil
 	case types.CodeFixCommand:
 		return &fixCodeIssue{command: commandData, issueProvider: issueProvider, notifier: notifier, logger: c.Logger()}, nil
 	case types.CodeSubmitFixFeedback:

--- a/domain/ide/command/get_active_user_test.go
+++ b/domain/ide/command/get_active_user_test.go
@@ -39,7 +39,7 @@ import (
 
 func Test_getActiveUser_Execute_User_found(t *testing.T) {
 	c := testutil.UnitTest(t)
-	cmd := setupCommandWithAuthService(c, t)
+	cmd := setupCommandWithAuthService(t, c)
 
 	expectedUser, expectedUserData := whoamiWorkflowResponse(t)
 
@@ -53,7 +53,7 @@ func Test_getActiveUser_Execute_User_found(t *testing.T) {
 	assert.Equal(t, expectedUser, actualUser)
 }
 
-func setupCommandWithAuthService(c *config.Config, t *testing.T) *getActiveUser {
+func setupCommandWithAuthService(t *testing.T, c *config.Config) *getActiveUser {
 	t.Helper()
 	provider := authentication.NewFakeCliAuthenticationProvider(c)
 	provider.IsAuthenticated = true
@@ -75,7 +75,7 @@ func setupCommandWithAuthService(c *config.Config, t *testing.T) *getActiveUser 
 
 func Test_getActiveUser_Execute_Result_Empty(t *testing.T) {
 	c := testutil.UnitTest(t)
-	cmd := setupCommandWithAuthService(c, t)
+	cmd := setupCommandWithAuthService(t, c)
 
 	mockEngine, engineConfig := setUpEngineMock(t, c)
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
@@ -89,7 +89,7 @@ func Test_getActiveUser_Execute_Result_Empty(t *testing.T) {
 
 func Test_getActiveUser_Execute_Error_Result(t *testing.T) {
 	c := testutil.UnitTest(t)
-	cmd := setupCommandWithAuthService(c, t)
+	cmd := setupCommandWithAuthService(t, c)
 
 	mockEngine, engineConfig := setUpEngineMock(t, c)
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()

--- a/domain/ide/command/get_active_user_test.go
+++ b/domain/ide/command/get_active_user_test.go
@@ -39,7 +39,7 @@ import (
 
 func Test_getActiveUser_Execute_User_found(t *testing.T) {
 	c := testutil.UnitTest(t)
-	cmd := setupCommandWithAuthService(c)
+	cmd := setupCommandWithAuthService(c, t)
 
 	expectedUser, expectedUserData := whoamiWorkflowResponse(t)
 
@@ -53,7 +53,8 @@ func Test_getActiveUser_Execute_User_found(t *testing.T) {
 	assert.Equal(t, expectedUser, actualUser)
 }
 
-func setupCommandWithAuthService(c *config.Config) *getActiveUser {
+func setupCommandWithAuthService(c *config.Config, t *testing.T) *getActiveUser {
+	t.Helper()
 	provider := authentication.NewFakeCliAuthenticationProvider(c)
 	provider.IsAuthenticated = true
 
@@ -74,7 +75,7 @@ func setupCommandWithAuthService(c *config.Config) *getActiveUser {
 
 func Test_getActiveUser_Execute_Result_Empty(t *testing.T) {
 	c := testutil.UnitTest(t)
-	cmd := setupCommandWithAuthService(c)
+	cmd := setupCommandWithAuthService(c, t)
 
 	mockEngine, engineConfig := setUpEngineMock(t, c)
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
@@ -88,7 +89,7 @@ func Test_getActiveUser_Execute_Result_Empty(t *testing.T) {
 
 func Test_getActiveUser_Execute_Error_Result(t *testing.T) {
 	c := testutil.UnitTest(t)
-	cmd := setupCommandWithAuthService(c)
+	cmd := setupCommandWithAuthService(c, t)
 
 	mockEngine, engineConfig := setUpEngineMock(t, c)
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()

--- a/domain/ide/command/get_active_user_test.go
+++ b/domain/ide/command/get_active_user_test.go
@@ -28,6 +28,9 @@ import (
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/snyk/snyk-ls/infrastructure/authentication"
+	"github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
+	"github.com/snyk/snyk-ls/internal/observability/ux"
 	"github.com/snyk/snyk-ls/internal/types"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -35,16 +38,25 @@ import (
 )
 
 func Test_getActiveUser_Execute_User_found(t *testing.T) {
-	testutil.UnitTest(t)
+	c := testutil.UnitTest(t)
+	provider := authentication.NewFakeCliAuthenticationProvider(c)
+	provider.IsAuthenticated = true
+
 	cmd := &getActiveUser{
 		command: types.CommandData{
 			CommandId: types.GetActiveUserCommand,
 		},
+		authenticationService: authentication.NewAuthenticationService(
+			c,
+			[]authentication.AuthenticationProvider{provider},
+			ux.NewTestAnalytics(c),
+			error_reporting.NewTestErrorReporter(),
+			notification.NewNotifier(),
+		),
 	}
 
 	expectedUser, expectedUserData := whoamiWorkflowResponse(t)
 
-	c := config.CurrentConfig()
 	mockEngine, engineConfig := setUpEngineMock(t, c)
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
 	mockEngine.EXPECT().InvokeWithConfig(localworkflows.WORKFLOWID_WHOAMI, gomock.Any()).Return(expectedUserData, nil)

--- a/domain/ide/command/get_active_user_test.go
+++ b/domain/ide/command/get_active_user_test.go
@@ -39,6 +39,21 @@ import (
 
 func Test_getActiveUser_Execute_User_found(t *testing.T) {
 	c := testutil.UnitTest(t)
+	cmd := setupCommandWithAuthService(c)
+
+	expectedUser, expectedUserData := whoamiWorkflowResponse(t)
+
+	mockEngine, engineConfig := setUpEngineMock(t, c)
+	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
+	mockEngine.EXPECT().InvokeWithConfig(localworkflows.WORKFLOWID_WHOAMI, gomock.Any()).Return(expectedUserData, nil)
+
+	actualUser, err := cmd.Execute(context.Background())
+
+	assert.NoErrorf(t, err, "cmd.Execute() error = %v", err)
+	assert.Equal(t, expectedUser, actualUser)
+}
+
+func setupCommandWithAuthService(c *config.Config) *getActiveUser {
 	provider := authentication.NewFakeCliAuthenticationProvider(c)
 	provider.IsAuthenticated = true
 
@@ -54,28 +69,13 @@ func Test_getActiveUser_Execute_User_found(t *testing.T) {
 			notification.NewNotifier(),
 		),
 	}
-
-	expectedUser, expectedUserData := whoamiWorkflowResponse(t)
-
-	mockEngine, engineConfig := setUpEngineMock(t, c)
-	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
-	mockEngine.EXPECT().InvokeWithConfig(localworkflows.WORKFLOWID_WHOAMI, gomock.Any()).Return(expectedUserData, nil)
-
-	actualUser, err := cmd.Execute(context.Background())
-
-	assert.NoErrorf(t, err, "cmd.Execute() error = %v", err)
-	assert.Equal(t, expectedUser, actualUser)
+	return cmd
 }
 
 func Test_getActiveUser_Execute_Result_Empty(t *testing.T) {
-	testutil.UnitTest(t)
-	cmd := &getActiveUser{
-		command: types.CommandData{
-			CommandId: types.GetActiveUserCommand,
-		},
-	}
+	c := testutil.UnitTest(t)
+	cmd := setupCommandWithAuthService(c)
 
-	c := config.CurrentConfig()
 	mockEngine, engineConfig := setUpEngineMock(t, c)
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
 	mockEngine.EXPECT().InvokeWithConfig(localworkflows.WORKFLOWID_WHOAMI, gomock.Any()).Return([]workflow.Data{}, nil)
@@ -87,14 +87,9 @@ func Test_getActiveUser_Execute_Result_Empty(t *testing.T) {
 }
 
 func Test_getActiveUser_Execute_Error_Result(t *testing.T) {
-	testutil.UnitTest(t)
-	cmd := &getActiveUser{
-		command: types.CommandData{
-			CommandId: types.GetActiveUserCommand,
-		},
-	}
+	c := testutil.UnitTest(t)
+	cmd := setupCommandWithAuthService(c)
 
-	c := config.CurrentConfig()
 	mockEngine, engineConfig := setUpEngineMock(t, c)
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
 	testError := errors.New("test error")

--- a/domain/ide/command/get_feature_flag_status_test.go
+++ b/domain/ide/command/get_feature_flag_status_test.go
@@ -41,7 +41,7 @@ func Test_ApiClient_FeatureFlagIsEnabled(t *testing.T) {
 	fakeApiClient := &snyk_api.FakeApiClient{}
 	fakeApiClient.SetResponse("FeatureFlagStatus", expectedResponse)
 
-	featureFlagStatusCmd := setupFeatureFlagCommand(c, fakeApiClient, t)
+	featureFlagStatusCmd := setupFeatureFlagCommand(t, c, fakeApiClient)
 
 	// Execute the command
 	result, err := featureFlagStatusCmd.Execute(context.Background())
@@ -53,7 +53,7 @@ func Test_ApiClient_FeatureFlagIsEnabled(t *testing.T) {
 	assert.True(t, ffResponse.Ok)
 }
 
-func setupFeatureFlagCommand(c *config.Config, fakeApiClient *snyk_api.FakeApiClient, t *testing.T) featureFlagStatus {
+func setupFeatureFlagCommand(t *testing.T, c *config.Config, fakeApiClient *snyk_api.FakeApiClient) featureFlagStatus {
 	t.Helper()
 	provider := authentication.NewFakeCliAuthenticationProvider(c)
 	provider.IsAuthenticated = true


### PR DESCRIPTION
### Description

Checks for authentication before executing commands that need it:

- reportAnalytics command
- getActiveUser command
- sastEnabled command
- getFeatureFlag command

Also, cache calls to the API for authentication. This should at least half the calls to registry / authentication services.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
