### PR TITLE
refactor: set default api url to api.nyk.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ within `initializationOptions?: LSPAny;` we support the following settings:
   "sendErrorReports": "true",
   // Whether to report errors to Snyk - defaults to true
   "organization": "a string",
-  // The name of your organization, e.g. the output of: curl -H "Authorization: token $(snyk config get api)"  https://snyk.io/api/cli-config/settings/sast | jq .org
+  // The name of your organization, e.g. the output of: curl -H "Authorization: token $(snyk config get api)"  https://api.snyk.io/v1/cli-config/settings/sast | jq .org
   "enableTelemetry": "true",
   // Whether user analytics can be tracked
   "manageBinariesAutomatically": "true",

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -30,12 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
-	"github.com/snyk/snyk-ls/infrastructure/cli/cli_constants"
-	"github.com/snyk/snyk-ls/internal/logging"
-	storage2 "github.com/snyk/snyk-ls/internal/storage"
-	"github.com/snyk/snyk-ls/internal/types"
-
 	"github.com/adrg/xdg"
 	"github.com/denisbrodbeck/machineid"
 	"github.com/rs/zerolog"
@@ -48,11 +42,16 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	frameworkLogging "github.com/snyk/go-application-framework/pkg/logging"
+	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
+	"github.com/snyk/snyk-ls/infrastructure/cli/cli_constants"
 	"github.com/snyk/snyk-ls/infrastructure/cli/filename"
 	"github.com/snyk/snyk-ls/internal/concurrency"
+	"github.com/snyk/snyk-ls/internal/logging"
 	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/storage"
+	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/util"
 )
 
@@ -61,7 +60,7 @@ const (
 	FormatHtml            = "html"
 	FormatMd              = "md"
 	snykCodeTimeoutKey    = "SNYK_CODE_TIMEOUT" // timeout as duration (number + unit), e.g. 10m
-	DefaultSnykApiUrl     = "https://snyk.io/api"
+	DefaultSnykApiUrl     = "https://api.snyk.io"
 	DefaultSnykUiUrl      = "https://app.snyk.io"
 	DefaultDeeproxyApiUrl = "https://deeproxy.snyk.io"
 	pathListSeparator     = string(os.PathListSeparator)
@@ -191,7 +190,7 @@ type Config struct {
 	enableSnykOSSQuickFixCodeActions bool
 	enableDeltaFindings              bool
 	logger                           *zerolog.Logger
-	storage                          storage2.StorageWithCallbacks
+	storage                          storage.StorageWithCallbacks
 	m                                sync.Mutex
 	clientProtocolVersion            string
 }
@@ -250,7 +249,7 @@ func New() *Config {
 func initWorkFlowEngine(c *Config) {
 	conf := configuration.NewInMemory()
 	c.engine = app.CreateAppEngineWithOptions(app.WithConfiguration(conf), app.WithZeroLogger(c.logger))
-	c.storage = storage2.NewStorage()
+	c.storage = storage.NewStorage()
 	conf.SetStorage(c.storage)
 	conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 	conf.Set(cli_constants.EXECUTION_MODE_KEY, cli_constants.EXECUTION_MODE_VALUE_STANDALONE)
@@ -900,7 +899,7 @@ func (c *Config) TokenAsOAuthToken() (oauth2.Token, error) {
 	return oauthToken, nil
 }
 
-func (c *Config) Storage() storage2.StorageWithCallbacks {
+func (c *Config) Storage() storage.StorageWithCallbacks {
 	return c.storage
 }
 

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
+
 	"github.com/snyk/snyk-ls/internal/types"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -174,7 +175,7 @@ func Test_UpdateSettings(t *testing.T) {
 			ActivateSnykCode:            "false",
 			ActivateSnykIac:             "false",
 			Insecure:                    "true",
-			Endpoint:                    "https://snyk.io/api",
+			Endpoint:                    "https://api.snyk.io",
 			AdditionalParams:            "--all-projects -d",
 			AdditionalEnv:               "a=b;c=d",
 			Path:                        "addPath",
@@ -202,7 +203,7 @@ func Test_UpdateSettings(t *testing.T) {
 		assert.Equal(t, false, c.IsSnykIacEnabled())
 		assert.Equal(t, true, c.CliSettings().Insecure)
 		assert.Equal(t, []string{"--all-projects", "-d"}, c.CliSettings().AdditionalOssParameters)
-		assert.Equal(t, "https://snyk.io/api", c.SnykApi())
+		assert.Equal(t, "https://api.snyk.io", c.SnykApi())
 		assert.Equal(t, "b", os.Getenv("a"))
 		assert.Equal(t, "d", os.Getenv("c"))
 		assert.True(t, strings.HasPrefix(os.Getenv("PATH"), "addPath"+string(os.PathListSeparator)))

--- a/infrastructure/authentication/cli_provider_test.go
+++ b/infrastructure/authentication/cli_provider_test.go
@@ -123,10 +123,10 @@ func TestBuildCLICmd(t *testing.T) {
 		c := testutil.UnitTest(t)
 		ctx := context.Background()
 		provider := &CliAuthenticationProvider{c: c}
-		config.CurrentConfig().UpdateApiEndpoints("https://app.snyk.io/api")
+		config.CurrentConfig().UpdateApiEndpoints("https://api.eu.snyk.io")
 
 		cmd := provider.buildCLICmd(ctx, "auth")
 
-		assert.Contains(t, cmd.Env, "SNYK_API=https://app.snyk.io/api")
+		assert.Contains(t, cmd.Env, "SNYK_API=https://api.eu.snyk.io")
 	})
 }

--- a/infrastructure/cli/environment_test.go
+++ b/infrastructure/cli/environment_test.go
@@ -51,7 +51,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		testutil.UnitTest(t)
 		c := config.CurrentConfig()
 		c.SetOrganization("testOrg")
-		c.UpdateApiEndpoints("https://app.snyk.io/api")
+		c.UpdateApiEndpoints("https://api.eu.snyk.io")
 		c.SetIntegrationName(expectedIntegrationName)
 		c.SetIntegrationVersion(expectedIntegrationVersion)
 		c.SetIdeVersion(expectedIdeVersion)
@@ -68,7 +68,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 
 		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
 
-		assert.Contains(t, updatedEnv, ApiEnvVar+"=https://app.snyk.io/api")
+		assert.Contains(t, updatedEnv, ApiEnvVar+"=https://api.eu.snyk.io")
 		token, err := c.TokenAsOAuthToken()
 		require.NoError(t, err)
 		assert.Contains(t, updatedEnv, SnykOauthTokenEnvVar+"="+token.AccessToken)

--- a/infrastructure/learn/service_test.go
+++ b/infrastructure/learn/service_test.go
@@ -31,7 +31,7 @@ import (
 func Test_GetLearnEndpoint(t *testing.T) {
 	testutil.UnitTest(t)
 	c := config.CurrentConfig()
-	c.UpdateApiEndpoints("https://snyk.io/api")
+	c.UpdateApiEndpoints("https://api.snyk.io")
 	cut := New(c, c.Engine().GetNetworkAccess().GetUnauthorizedHttpClient, errorreporting.NewTestErrorReporter())
 
 	endpoint, err := cut.LearnEndpoint(c)
@@ -60,7 +60,7 @@ func getRealCodeLookupParams() LessonLookupParams {
 
 func Test_GetLesson(t *testing.T) {
 	c := testutil.SmokeTest(t, false)
-	c.UpdateApiEndpoints("https://snyk.io/api")
+	c.UpdateApiEndpoints("https://api.snyk.io")
 	cut := New(c, c.Engine().GetNetworkAccess().GetUnauthorizedHttpClient, errorreporting.NewTestErrorReporter())
 	t.Run("OSS vulnerability - lesson returned", func(t *testing.T) {
 		params := getRealOSSLookupParams()


### PR DESCRIPTION
### Description

snyk.io/api is the legacy and deprecated API url.
Let's favour api.snyk.io instead.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.