### PR TITLE
feat: share scm information between IDE and language server [IDE-451]

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,67 +321,47 @@ within `initializationOptions?: LSPAny;` we support the following settings:
 
 ```json5
 {
-  "activateSnykOpenSource": "true",
-  // Enables Snyk Open Source - defaults to true
-  "activateSnykCode": "false",
-  // Enables Snyk Code, if enabled for your organization - defaults to false, deprecated in favor of specific Snyk Code analysis types
-  "activateSnykIac": "true",
-  // Enables Infrastructure as Code - defaults to true
-  "insecure": "false",
-  // Allows custom CAs (Certification Authorities)
-  "endpoint": "https://example.com",
-  // Snyk API Endpoint required for non-default multi-tenant and single-tenant setups
-  "additionalParams": "--all-projects",
-  // Any extra params for Open Source scans using the Snyk CLI, separated by spaces
-  "additionalEnv": "MAVEN_OPTS=-Djava.awt.headless=true;FOO=BAR",
-  // Additional environment variables, separated by semicolons
-  "path": "/usr/local/bin",
-  // Adds to the system path used by the CLI
-  "sendErrorReports": "true",
-  // Whether to report errors to Snyk - defaults to true
-  "organization": "a string",
-  // The name of your organization, e.g. the output of: curl -H "Authorization: token $(snyk config get api)"  https://api.snyk.io/v1/cli-config/settings/sast | jq .org
-  "enableTelemetry": "true",
-  // Whether user analytics can be tracked
-  "manageBinariesAutomatically": "true",
-  // Whether CLI/LS binaries will be downloaded & updated automatically
-  "cliPath": "/a/patch/snyk-cli",
-  // The path where the CLI can be found, or where it should be downloaded to
-  "token": "secret-token",
-  // The Snyk token, e.g.: snyk config get api or a token from authentication flow
-  "automaticAuthentication": "true",
-  // Whether LS will automatically authenticate on scan start (default: true)
-  "enableTrustedFoldersFeature": "true",
-  // Whether LS will prompt to trust a folder (default: true)
-  "trustedFolders": [
-    "/a/trusted/path",
-    "/another/trusted/path"
-  ],
-  // An array of folder that should be trusted
-  "activateSnykCodeSecurity": "false",
-  // Enables Snyk Code Security reporting
-  "activateSnykCodeQuality": "false",
-  // Enable Snyk Code Quality issue reporting (Beta, only in IDEs and LS)
-  "deviceId": "a UUID",
-  // A unique ID from the running the LS, used for telemetry
-  "integrationName": "ECLIPSE",
-  // The name of the IDE or editor the LS is running in
-  "integrationVersion": "1.0.0",
-  // The version of the IDE or editor the LS is running in
-  "filterSeverity": {
-    // Filters to be applied for the determined issues
+  "activateSnykOpenSource": "true", // Enables Snyk Open Source - defaults to true
+  "activateSnykCode": "false", // Enables Snyk Code, if enabled for your organization - defaults to false, deprecated in favor of specific Snyk Code analysis types
+  "activateSnykIac": "true", // Enables Infrastructure as Code - defaults to true
+  "insecure": "false", // Allows custom CAs (Certification Authorities)
+  "endpoint": "https://api.eu.snyk.io", // Snyk API Endpoint required for non-default multi-tenant and single-tenant setups
+  "organization": "a string", // The name of your organization, e.g. the output of: curl -H "Authorization: token $(snyk config get api)"  https://api.snyk.io/v1/cli-config/settings/sast | jq .org
+  "path": "/usr/local/bin", // Adds to the system path used by the CLI
+  "cliPath": "/a/patch/snyk-cli", // The path where the CLI can be found, or where it should be downloaded to
+  "token": "secret-token", // The Snyk token, e.g.: snyk config get api or a token from authentication flow
+  "integrationName": "ECLIPSE", // The name of the IDE or editor the LS is running in
+  "integrationVersion": "1.0.0", // The version of the IDE or editor the LS is running in
+  "automaticAuthentication": "true", // Whether LS will automatically authenticate on scan start (default: true)
+  "deviceId": "a UUID", // A unique ID from the running the LS, used for telemetry
+  "filterSeverity": { // Filters to be applied for the determined issues
     "critical": true,
     "high": true,
     "medium": true,
     "low": true,
   },
-  "scanningMode": "auto",
-  // Specifies the mode for scans: "auto" for background scans or "manual" for scans on command
-  "authenticationMethod": "token",
-  // Specifies the authentication method to use: "token" for Snyk API token or "authentication" for Snyk OAuth flow. Default is token.
-  "snykCodeApi": "https://deeproxy.snyk.io",
-  // Specifies the Snyk Code API endpoint to use. Default is https://deeproxy.snyk.io
-  "requiredProtocolVersion": "11"
+  "sendErrorReports": "true", // Whether to report errors to Snyk - defaults to true
+  "manageBinariesAutomatically": "true", // Whether CLI/LS binaries will be downloaded & updated automatically
+  "enableTrustedFoldersFeature": "true", // Whether LS will prompt to trust a folder (default: true)
+  "activateSnykCodeSecurity": "false", // Enables Snyk Code Security reporting
+  "activateSnykCodeQuality": "false", // Enable Snyk Code Quality issue reporting (Beta, only in IDEs and LS)
+  "scanningMode": "auto", // Specifies the mode for scans: "auto" for background scans or "manual" for scans on command
+  "authenticationMethod": "oauth", // Specifies the authentication method to use: "token" for Snyk API token or "oauth" for Snyk OAuth flow. Default is token.
+  "snykCodeApi": "https://deeproxy.snyk.io", // Specifies the Snyk Code API endpoint to use. Default is https://deeproxy.snyk.io
+  "enableSnykLearnCodeActions": "true", // show snyk learns code actions
+  "enableSnykOSSQuickFixCodeActions": "true", // show quickfixes for supported OSS package manager issues
+  "enableDeltaFindings": "false", // only display issues that are not new and thus not on the base branch
+  "requiredProtocolVersion": "11",
+  "additionalParams": "--all-projects", // Any extra params for Open Source scans using the Snyk CLI, separated by spaces
+  "additionalEnv": "MAVEN_OPTS=-Djava.awt.headless=true;FOO=BAR", // Additional environment variables, separated by semicolons
+  "trustedFolders": [
+    "/a/trusted/path",
+    "/another/trusted/path"
+  ], // An array of folder that should be trusted
+  "folderConfig": [{
+    "baseBranch": "main",
+    "folderPath": "a/b/c",
+  }], // an array of folder configurations, defining the desired base branch of a workspaceFolder 
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ Right now the language server supports the following actions:
 - window/showMessage
 
 ### Custom additions to Language Server Protocol
-
+- Folder Config Notification
+  - method: `$/snyk.folderConfig`
+  - payload:
+  ```json5
+  {
+    "folderPath": "the/folder/path",
+    "baseBranch": "the-base-branch", // e.g. main
+    "localBranches": [ "branch1", "branch2" ] 
+  }
+  ```
 - Authentication Notification
   - method: `$/snyk.hasAuthenticated`
   - payload:

--- a/application/config/client_settings.go
+++ b/application/config/client_settings.go
@@ -29,7 +29,6 @@ const (
 	ActivateSnykAdvisorKey   = "ACTIVATE_SNYK_ADVISOR"
 	SendErrorReportsKey      = "SEND_ERROR_REPORTS"
 	Organization             = "SNYK_CFG_ORG"
-	EnableTelemetry          = "SNYK_CFG_DISABLE_ANALYTICS"
 )
 
 func (c *Config) clientSettingsFromEnv() {

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/ide/workspace"
+	gitconfig "github.com/snyk/snyk-ls/internal/git_config"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -127,6 +128,11 @@ func writeSettings(c *config.Config, settings types.Settings, initialize bool) {
 	updateSnykLearnCodeActions(c, settings)
 	updateSnykOSSQuickFixCodeActions(c, settings)
 	updateDeltaFindings(c, settings)
+	updateFolderConfig(settings)
+}
+
+func updateFolderConfig(settings types.Settings) {
+	gitconfig.SetBaseBranch(settings.FolderConfig)
 }
 
 func updateAuthenticationMethod(c *config.Config, settings types.Settings) {

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -117,7 +117,7 @@ func writeSettings(c *config.Config, settings types.Settings, initialize bool) {
 	updateToken(settings.Token)
 	updateEnvironment(c, settings)
 	updatePathFromSettings(c, settings)
-	updateTelemetry(c, settings)
+	updateErrorReporting(c, settings)
 	updateOrganization(c, settings)
 	manageBinariesAutomatically(c, settings)
 	updateTrustedFolders(c, settings)
@@ -246,7 +246,7 @@ func updateOrganization(c *config.Config, settings types.Settings) {
 	}
 }
 
-func updateTelemetry(c *config.Config, settings types.Settings) {
+func updateErrorReporting(c *config.Config, settings types.Settings) {
 	parseBool, err := strconv.ParseBool(settings.SendErrorReports)
 	if err != nil {
 		c.Logger().Debug().Msgf("couldn't read send error reports %s", settings.SendErrorReports)

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -181,7 +181,6 @@ func Test_UpdateSettings(t *testing.T) {
 			Path:                        "addPath",
 			SendErrorReports:            "true",
 			Organization:                expectedOrgId,
-			EnableTelemetry:             "false",
 			ManageBinariesAutomatically: "false",
 			CliPath:                     "C:\\Users\\CliPath\\snyk-ls.exe",
 			Token:                       "a fancy token",

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -20,17 +20,23 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/creachadair/jrpc2"
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
-
+	gitconfig "github.com/snyk/snyk-ls/internal/git_config"
 	"github.com/snyk/snyk-ls/internal/types"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -170,6 +176,8 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("All settings are updated", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
+		tempDir1 := filepath.Join(t.TempDir(), "tempDir1")
+		tempDir2 := filepath.Join(t.TempDir(), "tempDir2")
 		settings := types.Settings{
 			ActivateSnykOpenSource:      "false",
 			ActivateSnykCode:            "false",
@@ -193,6 +201,16 @@ func Test_UpdateSettings(t *testing.T) {
 			ScanningMode:                "manual",
 			AuthenticationMethod:        types.OAuthAuthentication,
 			SnykCodeApi:                 sampleSettings.SnykCodeApi,
+			FolderConfig: []types.FolderConfig{
+				{
+					FolderPath: tempDir1,
+					BaseBranch: "testBaseBranch1",
+				},
+				{
+					FolderPath: tempDir2,
+					BaseBranch: "testBaseBranch2",
+				},
+			},
 		}
 
 		UpdateSettings(c, settings)
@@ -219,6 +237,18 @@ func Test_UpdateSettings(t *testing.T) {
 		assert.Equal(t, settings.RuntimeVersion, c.RuntimeVersion())
 		assert.False(t, c.IsAutoScanEnabled())
 		assert.Equal(t, sampleSettings.SnykCodeApi, c.SnykCodeApi())
+
+		err := initTestRepo(t, tempDir1)
+		assert.NoError(t, err)
+		folderConfig1, err := gitconfig.GetOrCreateFolderConfig(tempDir1)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, folderConfig1.BaseBranch)
+
+		err = initTestRepo(t, tempDir2)
+		assert.NoError(t, err)
+		folderConfig2, err := gitconfig.GetOrCreateFolderConfig(tempDir2)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, folderConfig2.BaseBranch)
 	})
 
 	t.Run("empty snyk code api is ignored and default is used", func(t *testing.T) {
@@ -364,6 +394,25 @@ func Test_UpdateSettings(t *testing.T) {
 			assert.Equal(t, mixedSeverityFilter, c.FilterSeverity())
 		})
 	})
+}
+
+func initTestRepo(t *testing.T, tempDir string) error {
+	t.Helper()
+	fs := filesystem.NewStorage(osfs.New(tempDir), cache.NewObjectLRU(cache.FileSize(1024)))
+	repo1, err := git.Init(fs, fs.Filesystem())
+	assert.NoError(t, err)
+	absoluteFileName := filepath.Join(tempDir, "testFile")
+	err = os.WriteFile(absoluteFileName, []byte("testData"), 0600)
+	assert.NoError(t, err)
+	worktree, err := repo1.Worktree()
+	assert.NoError(t, err)
+	_, err = worktree.Add(filepath.Base(absoluteFileName))
+	assert.NoError(t, err)
+	_, err = worktree.Commit("testCommit", &git.CommitOptions{
+		Author: &object.Signature{Name: t.Name()},
+	})
+	assert.NoError(t, err)
+	return err
 }
 
 func Test_InitializeSettings(t *testing.T) {

--- a/application/server/notification.go
+++ b/application/server/notification.go
@@ -90,7 +90,7 @@ func registerNotifier(c *config.Config, srv types.Server) {
 	callbackFunction := func(params any) {
 		switch params := params.(type) {
 		case types.FolderConfig:
-			notifier(c, srv, "$/snyk.FolderConfig", params)
+			notifier(c, srv, "$/snyk.folderConfig", params)
 			logger.Info().Any("folderConfig", params).Msg("sending folderConfig to client")
 		case types.AuthenticationParams:
 			notifier(c, srv, "$/snyk.hasAuthenticated", params)

--- a/application/server/notification.go
+++ b/application/server/notification.go
@@ -89,6 +89,9 @@ func registerNotifier(c *config.Config, srv types.Server) {
 	logger := c.Logger().With().Str("method", "registerNotifier").Logger()
 	callbackFunction := func(params any) {
 		switch params := params.(type) {
+		case types.FolderConfig:
+			notifier(c, srv, "$/snyk.FolderConfig", params)
+			logger.Info().Any("folderConfig", params).Msg("sending folderConfig to client")
 		case types.AuthenticationParams:
 			notifier(c, srv, "$/snyk.hasAuthenticated", params)
 			logger.Info().Msg("sending token")

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -425,6 +425,15 @@ func runSmokeTest(t *testing.T, repo string, commit string, file1 string, file2 
 
 	waitForScan(t, cloneTargetDir)
 
+	notifications := jsonRPCRecorder.FindNotificationsByMethod("$/snyk.folderConfig")
+	assert.Len(t, notifications, 1)
+	var folderConfig types.FolderConfig
+	err := notifications[0].UnmarshalParams(&folderConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, cloneTargetDir, folderConfig.FolderPath)
+	assert.NotEmpty(t, folderConfig.BaseBranch)
+	assert.NotEmpty(t, folderConfig.LocalBranches)
+
 	jsonRPCRecorder.ClearNotifications()
 	var testPath string
 	if file1 != "" {

--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/ide/hover"
 	"github.com/snyk/snyk-ls/domain/snyk"
+	gitconfig "github.com/snyk/snyk-ls/internal/git_config"
 	noti "github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
 	"github.com/snyk/snyk-ls/internal/product"
@@ -122,6 +123,14 @@ func (w *Workspace) AddFolder(f *Folder) {
 		w.folders = map[string]*Folder{}
 	}
 	w.folders[f.Path()] = f
+	// get & send folder config to client
+	folderConfig, err := gitconfig.GetOrCreateFolderConfig(f.path)
+	if err != nil {
+		w.c.Logger().Warn().Err(err).Msg("error determining folder config")
+		return
+	}
+
+	w.notifier.Send(folderConfig)
 }
 
 func (w *Workspace) IssuesForFile(path string) []snyk.Issue {

--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -130,7 +130,7 @@ func (w *Workspace) AddFolder(f *Folder) {
 		return
 	}
 
-	w.notifier.Send(folderConfig)
+	w.notifier.Send(*folderConfig)
 }
 
 func (w *Workspace) IssuesForFile(path string) []snyk.Issue {

--- a/internal/git_config/git_config.go
+++ b/internal/git_config/git_config.go
@@ -1,0 +1,116 @@
+/*
+ * © 2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gitconfig
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	config2 "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/format/config"
+	"golang.org/x/exp/slices"
+
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+const (
+	mainSection   = "snyk"
+	baseBranchKey = "baseBranch"
+)
+
+// GetOrCreateFolderConfig queries git for the folder config of the given path
+func GetOrCreateFolderConfig(path string) (*types.FolderConfig, error) {
+	repository, repoConfig, _, folderSection, err := getConfigSection(path)
+	if err != nil {
+		return nil, err
+	}
+
+	localBranches, err := getLocalBranches(repository)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(localBranches) == 0 {
+		return nil, fmt.Errorf("no local branches found")
+	}
+
+	// base branch is either overwritten or we return the default branch
+	baseBranch := repoConfig.Init.DefaultBranch
+	if folderSection.HasOption(baseBranchKey) {
+		baseBranch = folderSection.Option(baseBranchKey)
+	}
+
+	if baseBranch == "" {
+		if slices.Contains(localBranches, "main") {
+			baseBranch = "main"
+		} else if slices.Contains(localBranches, "master") {
+			baseBranch = "master"
+		} else {
+			return nil, fmt.Errorf("could not determine base branch")
+		}
+	}
+
+	return &types.FolderConfig{
+		FolderPath:    path,
+		BaseBranch:    baseBranch,
+		LocalBranches: localBranches,
+	}, nil
+}
+
+func getConfigSection(path string) (*git.Repository, *config2.Config, *config.Config, *config.Subsection, error) {
+	repository, err := git.PlainOpen(path)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	repoConfig, err := repository.Config()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	raw := repoConfig.Raw
+	section := raw.Section(mainSection)
+	folderSection := section.Subsection(path)
+	return repository, repoConfig, raw, folderSection, nil
+}
+
+func getLocalBranches(repository *git.Repository) ([]string, error) {
+	localBranchRefs, err := repository.Branches()
+	if err != nil {
+		return nil, err
+	}
+	localBranches := []string{}
+	err = localBranchRefs.ForEach(func(reference *plumbing.Reference) error {
+		localBranches = append(localBranches, reference.Name().Short())
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return localBranches, nil
+}
+
+func SetBaseBranch(config []types.FolderConfig) {
+	for _, folderConfig := range config {
+		_, _, _, subsection, err := getConfigSection(folderConfig.FolderPath)
+		if err != nil {
+			continue
+		}
+		subsection.AddOption(baseBranchKey, folderConfig.BaseBranch)
+	}
+}

--- a/internal/types/lsp.go
+++ b/internal/types/lsp.go
@@ -560,11 +560,10 @@ type Settings struct {
 	RequiredProtocolVersion          string               `json:"requiredProtocolVersion,omitempty"`
 	// global settings end
 	// folder specific settings start
-	FolderConfig []FolderConfig `json:"folderConfig,omitempty"`
-
-	AdditionalParams string   `json:"additionalParams,omitempty"` // TODO make folder specific, move to folder config
-	AdditionalEnv    string   `json:"additionalEnv,omitempty"`    // TODO make folder specific, move to folder config
-	TrustedFolders   []string `json:"trustedFolders,omitempty"`   // TODO make folder specific, move to folder config
+	AdditionalParams string         `json:"additionalParams,omitempty"` // TODO make folder specific, move to folder config
+	AdditionalEnv    string         `json:"additionalEnv,omitempty"`    // TODO make folder specific, move to folder config
+	TrustedFolders   []string       `json:"trustedFolders,omitempty"`   // TODO make folder specific, move to folder config
+	FolderConfig     []FolderConfig `json:"folderConfig,omitempty"`
 	// folder specific settings end
 }
 

--- a/internal/types/lsp.go
+++ b/internal/types/lsp.go
@@ -516,20 +516,25 @@ type WorkspaceFoldersChangeEvent struct {
 	Removed []WorkspaceFolder `json:"Removed,omitempty"`
 }
 
+// FolderConfig is exchanged between IDE and LS
+// IDE sends this as part of the settings/initialization
+// LS sends this via the $/snyk.FolderConfig notification
+type FolderConfig struct {
+	FolderPath    string   `json:"folderPath"`
+	BaseBranch    string   `json:"baseBranch"`
+	LocalBranches []string `json:"localBranches,omitempty"`
+}
+
 // Settings is the struct that is parsed from the InitializationParams.InitializationOptions field
 type Settings struct {
+	// global settings start
 	ActivateSnykOpenSource           string               `json:"activateSnykOpenSource,omitempty"`
 	ActivateSnykCode                 string               `json:"activateSnykCode,omitempty"`
 	ActivateSnykIac                  string               `json:"activateSnykIac,omitempty"`
 	Insecure                         string               `json:"insecure,omitempty"`
 	Endpoint                         string               `json:"endpoint,omitempty"`
-	AdditionalParams                 string               `json:"additionalParams,omitempty"`
-	AdditionalEnv                    string               `json:"additionalEnv,omitempty"`
-	Path                             string               `json:"path,omitempty"`
-	SendErrorReports                 string               `json:"sendErrorReports,omitempty"`
 	Organization                     string               `json:"organization,omitempty"`
-	EnableTelemetry                  string               `json:"enableTelemetry,omitempty"`
-	ManageBinariesAutomatically      string               `json:"manageBinariesAutomatically,omitempty"`
+	Path                             string               `json:"path,omitempty"`
 	CliPath                          string               `json:"cliPath,omitempty"`
 	Token                            string               `json:"token,omitempty"`
 	IntegrationName                  string               `json:"integrationName,omitempty"`
@@ -537,8 +542,9 @@ type Settings struct {
 	AutomaticAuthentication          string               `json:"automaticAuthentication,omitempty"`
 	DeviceId                         string               `json:"deviceId,omitempty"`
 	FilterSeverity                   SeverityFilter       `json:"filterSeverity,omitempty"`
+	SendErrorReports                 string               `json:"sendErrorReports,omitempty"`
+	ManageBinariesAutomatically      string               `json:"manageBinariesAutomatically,omitempty"`
 	EnableTrustedFoldersFeature      string               `json:"enableTrustedFoldersFeature,omitempty"`
-	TrustedFolders                   []string             `json:"trustedFolders,omitempty"`
 	ActivateSnykCodeSecurity         string               `json:"activateSnykCodeSecurity,omitempty"`
 	ActivateSnykCodeQuality          string               `json:"activateSnykCodeQuality,omitempty"`
 	OsPlatform                       string               `json:"osPlatform,omitempty"`
@@ -550,8 +556,16 @@ type Settings struct {
 	SnykCodeApi                      string               `json:"snykCodeApi,omitempty"`
 	EnableSnykLearnCodeActions       string               `json:"enableSnykLearnCodeActions,omitempty"`
 	EnableSnykOSSQuickFixCodeActions string               `json:"enableSnykOSSQuickFixCodeActions,omitempty"`
-	EnableDeltaFindings              string               `json:"enableDeltaFindings,omitempty"`
+	EnableDeltaFindings              string               `json:"enableDeltaFindings,omitempty"` // should this be global?
 	RequiredProtocolVersion          string               `json:"requiredProtocolVersion,omitempty"`
+	// global settings end
+	// folder specific settings start
+	FolderConfig []FolderConfig `json:"folderConfig,omitempty"`
+
+	AdditionalParams string   `json:"additionalParams,omitempty"` // TODO make folder specific, move to folder config
+	AdditionalEnv    string   `json:"additionalEnv,omitempty"`    // TODO make folder specific, move to folder config
+	TrustedFolders   []string `json:"trustedFolders,omitempty"`   // TODO make folder specific, move to folder config
+	// folder specific settings end
 }
 
 type AuthenticationMethod string


### PR DESCRIPTION
### Description

This PR enables IDE/LS to communicate SCM data between IDE and LS.

IDEs can send a folderConfig JSON struct as part of the InitializationOptions / Settings that contains the chosen base branch. This selection is saved in gitconfig in our own subsection.

On adding a workspaceFolder to LS, LS queries the underlying git repository for all local branches and the currently configured base branch. in a subsection of the gitconfig. If none is configured it falls back to first use `gitconfig.init.DefaultBranch`, and if that's empty, main.

Gitconfig structure:
```
snyk
|-- folderPath 
      | baseBranch = main
```

Example of folderConfig:
```
{"baseBranch":"main","folderPath":"/var/folders/c_/lj9ppcwx2jnf8jhdhcqgz3940000gn/T/Test_SmokeWorkspaceScanOSS_and_Code2792167781/001/1","localBranches":["main"]}
```

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
