### PR TITLE
fix: remove open browser action by default, make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ within `initializationOptions?: LSPAny;` we support the following settings:
   "snykCodeApi": "https://deeproxy.snyk.io", // Specifies the Snyk Code API endpoint to use. Default is https://deeproxy.snyk.io
   "enableSnykLearnCodeActions": "true", // show snyk learns code actions
   "enableSnykOSSQuickFixCodeActions": "true", // show quickfixes for supported OSS package manager issues
+  "enableSnykOpenBrowserActions": "false", // show code actions to open issue descriptions
   "enableDeltaFindings": "false", // only display issues that are not new and thus not on the base branch
   "requiredProtocolVersion": "11",
   "additionalParams": "--all-projects", // Any extra params for Open Source scans using the Snyk CLI, separated by spaces

--- a/application/codeaction/codeaction.go
+++ b/application/codeaction/codeaction.go
@@ -82,6 +82,8 @@ func (c *CodeActionsService) GetCodeActions(params types.CodeActionParams) []typ
 func (c *CodeActionsService) updateIssuesWithQuickFix(quickFixGroupables []types.Groupable, issues []snyk.Issue) []snyk.Issue {
 	// we only allow one quickfix, so it needs to be grouped
 	quickFix := c.getQuickFixAction(quickFixGroupables)
+	// update title with number of issues
+	quickFix.Title = fmt.Sprintf("%s and fix %d issues", quickFix.Title, len(quickFixGroupables))
 
 	var updatedIssues []snyk.Issue
 	for _, issue := range issues {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -193,6 +193,7 @@ type Config struct {
 	storage                          storage.StorageWithCallbacks
 	m                                sync.Mutex
 	clientProtocolVersion            string
+	isOpenBrowserActionEnabled       bool
 }
 
 func CurrentConfig() *Config {
@@ -849,7 +850,7 @@ func (c *Config) SetSnykLearnCodeActionsEnabled(enabled bool) {
 	c.enableSnykLearnCodeActions = enabled
 }
 
-func (c *Config) IsSnyOSSQuickFixCodeActionsEnabled() bool {
+func (c *Config) IsSnykOSSQuickFixCodeActionsEnabled() bool {
 	return c.enableSnykOSSQuickFixCodeActions
 }
 
@@ -941,4 +942,12 @@ func (c *Config) AuthenticationMethod() types.AuthenticationMethod {
 
 func (c *Config) SetAuthenticationMethod(authMethod types.AuthenticationMethod) {
 	c.authenticationMethod = authMethod
+}
+
+func (c *Config) IsSnykOpenBrowserActionEnabled() bool {
+	return c.isOpenBrowserActionEnabled
+}
+
+func (c *Config) SetSnykOpenBrowserActionsEnabled(enable bool) {
+	c.isOpenBrowserActionEnabled = enable
 }

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -127,8 +127,18 @@ func writeSettings(c *config.Config, settings types.Settings, initialize bool) {
 	updateAutoScan(c, settings)
 	updateSnykLearnCodeActions(c, settings)
 	updateSnykOSSQuickFixCodeActions(c, settings)
+	updateSnykOpenBrowserCodeActions(c, settings)
 	updateDeltaFindings(c, settings)
 	updateFolderConfig(settings)
+}
+
+func updateSnykOpenBrowserCodeActions(c *config.Config, settings types.Settings) {
+	enable := false
+	if settings.EnableSnykOpenBrowserActions == "true" {
+		enable = true
+	}
+
+	c.SetSnykOpenBrowserActionsEnabled(enable)
 }
 
 func updateFolderConfig(settings types.Settings) {

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -176,28 +176,29 @@ func Test_UpdateSettings(t *testing.T) {
 		tempDir1 := filepath.Join(t.TempDir(), "tempDir1")
 		tempDir2 := filepath.Join(t.TempDir(), "tempDir2")
 		settings := types.Settings{
-			ActivateSnykOpenSource:      "false",
-			ActivateSnykCode:            "false",
-			ActivateSnykIac:             "false",
-			Insecure:                    "true",
-			Endpoint:                    "https://api.snyk.io",
-			AdditionalParams:            "--all-projects -d",
-			AdditionalEnv:               "a=b;c=d",
-			Path:                        "addPath",
-			SendErrorReports:            "true",
-			Organization:                expectedOrgId,
-			ManageBinariesAutomatically: "false",
-			CliPath:                     "C:\\Users\\CliPath\\snyk-ls.exe",
-			Token:                       "a fancy token",
-			FilterSeverity:              types.DefaultSeverityFilter(),
-			TrustedFolders:              []string{"trustedPath1", "trustedPath2"},
-			OsPlatform:                  "windows",
-			OsArch:                      "amd64",
-			RuntimeName:                 "java",
-			RuntimeVersion:              "1.8.0_275",
-			ScanningMode:                "manual",
-			AuthenticationMethod:        types.OAuthAuthentication,
-			SnykCodeApi:                 sampleSettings.SnykCodeApi,
+			ActivateSnykOpenSource:       "false",
+			ActivateSnykCode:             "false",
+			ActivateSnykIac:              "false",
+			Insecure:                     "true",
+			Endpoint:                     "https://api.snyk.io",
+			AdditionalParams:             "--all-projects -d",
+			AdditionalEnv:                "a=b;c=d",
+			Path:                         "addPath",
+			SendErrorReports:             "true",
+			Organization:                 expectedOrgId,
+			ManageBinariesAutomatically:  "false",
+			CliPath:                      "C:\\Users\\CliPath\\snyk-ls.exe",
+			Token:                        "a fancy token",
+			FilterSeverity:               types.DefaultSeverityFilter(),
+			TrustedFolders:               []string{"trustedPath1", "trustedPath2"},
+			OsPlatform:                   "windows",
+			OsArch:                       "amd64",
+			RuntimeName:                  "java",
+			RuntimeVersion:               "1.8.0_275",
+			ScanningMode:                 "manual",
+			AuthenticationMethod:         types.OAuthAuthentication,
+			SnykCodeApi:                  sampleSettings.SnykCodeApi,
+			EnableSnykOpenBrowserActions: "true",
 			FolderConfig: []types.FolderConfig{
 				{
 					FolderPath: tempDir1,
@@ -234,6 +235,7 @@ func Test_UpdateSettings(t *testing.T) {
 		assert.Equal(t, settings.RuntimeVersion, c.RuntimeVersion())
 		assert.False(t, c.IsAutoScanEnabled())
 		assert.Equal(t, sampleSettings.SnykCodeApi, c.SnykCodeApi())
+		assert.Equal(t, true, c.IsSnykOpenBrowserActionEnabled())
 
 		err := initTestRepo(t, tempDir1)
 		assert.NoError(t, err)

--- a/infrastructure/oss/code_actions.go
+++ b/infrastructure/oss/code_actions.go
@@ -32,9 +32,10 @@ import (
 )
 
 func (i *ossIssue) AddCodeActions(learnService learn.Service, ep error_reporting.ErrorReporter, affectedFilePath string, issueRange snyk.Range) (actions []snyk.CodeAction) {
+	c := config.CurrentConfig()
 	if reflect.DeepEqual(issueRange, snyk.Range{}) {
-		config.CurrentConfig().Logger().Debug().Str("issue", i.Id).Msg("skipping adding code action, as issueRange is empty")
-		return
+		c.Logger().Debug().Str("issue", i.Id).Msg("skipping adding code action, as issueRange is empty")
+		return actions
 	}
 
 	quickFixAction := i.AddQuickFixAction(affectedFilePath, issueRange)
@@ -42,15 +43,21 @@ func (i *ossIssue) AddCodeActions(learnService learn.Service, ep error_reporting
 		actions = append(actions, *quickFixAction)
 	}
 
-	title := fmt.Sprintf("Open description of '%s affecting package %s' in browser (Snyk)", i.Title, i.PackageName)
-	command := &types.CommandData{
-		Title:     title,
-		CommandId: types.OpenBrowserCommand,
-		Arguments: []any{i.CreateIssueURL().String()},
-	}
+	if c.IsSnykOpenBrowserActionEnabled() {
+		title := fmt.Sprintf("Open description of '%s affecting package %s' in browser (Snyk)", i.Title, i.PackageName)
+		command := &types.CommandData{
+			Title:     title,
+			CommandId: types.OpenBrowserCommand,
+			Arguments: []any{i.CreateIssueURL().String()},
+		}
 
-	action, _ := snyk.NewCodeAction(title, nil, command)
-	actions = append(actions, action)
+		action, err := snyk.NewCodeAction(title, nil, command)
+		if err != nil {
+			c.Logger().Err(err).Msgf("could not create code action %s", title)
+		} else {
+			actions = append(actions, action)
+		}
+	}
 
 	codeAction := i.AddSnykLearnAction(learnService, ep)
 	if codeAction != nil {
@@ -90,7 +97,7 @@ func (i *ossIssue) AddSnykLearnAction(learnService learn.Service, ep error_repor
 
 func (i *ossIssue) AddQuickFixAction(affectedFilePath string, issueRange snyk.Range) *snyk.CodeAction {
 	logger := config.CurrentConfig().Logger().With().Str("method", "oss.AddQuickFixAction").Logger()
-	if !config.CurrentConfig().IsSnyOSSQuickFixCodeActionsEnabled() {
+	if !config.CurrentConfig().IsSnykOSSQuickFixCodeActionsEnabled() {
 		return nil
 	}
 	logger.Debug().Msg("create deferred quickfix code action")

--- a/infrastructure/oss/code_actions.go
+++ b/infrastructure/oss/code_actions.go
@@ -105,7 +105,7 @@ func (i *ossIssue) AddQuickFixAction(affectedFilePath string, issueRange snyk.Ra
 	if quickfixEdit == "" {
 		return nil
 	}
-	upgradeMessage := "Upgrade to " + quickfixEdit + " (Snyk)"
+	upgradeMessage := "⚡️ Upgrade to " + quickfixEdit
 	autofixEditCallback := func() *snyk.WorkspaceEdit {
 		edit := &snyk.WorkspaceEdit{}
 		singleTextEdit := snyk.TextEdit{

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -53,7 +53,7 @@ func toIssue(
 	for _, codeAction := range codeActions {
 		if strings.Contains(codeAction.Title, "Upgrade to") {
 			codelensCommands = append(codelensCommands, types.CommandData{
-				Title:     "⚡ Fix this issue: " + codeAction.Title,
+				Title:     codeAction.Title,
 				CommandId: types.CodeFixCommand,
 				Arguments: []any{
 					codeAction.Uuid,

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -117,6 +117,7 @@ func nonEmptyRange() snyk.Range {
 }
 
 func Test_toIssue_CodeActions(t *testing.T) {
+	const flashy = "⚡️ "
 	tests := []struct {
 		name               string
 		packageName        string
@@ -124,12 +125,12 @@ func Test_toIssue_CodeActions(t *testing.T) {
 		expectedUpgrade    string
 		openBrowserEnabled bool
 	}{
-		{"WithNPMFix", "pkg@v2", "npm", "Upgrade to \"pkg\": \"v2\" (Snyk)", false},
-		{"WithScopedNPMFix", "@org/pkg@v2", "npm", "Upgrade to \"@org/pkg\": \"v2\" (Snyk)", true},
-		{"WithGomodFix", "pkg@v2", "gomodules", "Upgrade to vv2 (Snyk)", true},
-		{"WithMavenFix", "pkg@v2", "maven", "Upgrade to v2 (Snyk)", true},
-		{"WithMavenFixForBuildGradle", "a:pkg@v2", "maven", "Upgrade to v2 (Snyk)", true},
-		{"WithGradleFix", "a:pkg@v2", "gradle", "Upgrade to pkg:v2 (Snyk)", true},
+		{"WithNPMFix", "pkg@v2", "npm", "Upgrade to \"pkg\": \"v2\"", false},
+		{"WithScopedNPMFix", "@org/pkg@v2", "npm", "Upgrade to \"@org/pkg\": \"v2\"", true},
+		{"WithGomodFix", "pkg@v2", "gomodules", "Upgrade to vv2", true},
+		{"WithMavenFix", "pkg@v2", "maven", "Upgrade to v2", true},
+		{"WithMavenFixForBuildGradle", "a:pkg@v2", "maven", "Upgrade to v2", true},
+		{"WithGradleFix", "a:pkg@v2", "gradle", "Upgrade to pkg:v2", true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -146,9 +147,9 @@ func Test_toIssue_CodeActions(t *testing.T) {
 			issue := toIssue("testPath", sampleOssIssue, &scanResult{}, snyk.Range{Start: snyk.Position{Line: 1}}, scanner.learnService, scanner.errorReporter)
 
 			assert.Equal(t, sampleOssIssue.Id, issue.ID)
-			assert.Equal(t, test.expectedUpgrade, issue.CodeActions[0].Title)
+			assert.Equal(t, flashy+test.expectedUpgrade, issue.CodeActions[0].Title)
 			assert.Equal(t, 1, len(issue.CodelensCommands))
-			assert.Equal(t, "⚡ Fix this issue: "+test.expectedUpgrade, issue.CodelensCommands[0].Title)
+			assert.Equal(t, flashy+test.expectedUpgrade, issue.CodelensCommands[0].Title)
 
 			if test.openBrowserEnabled {
 				assert.Equal(t, 3, len(issue.CodeActions))

--- a/internal/types/lsp.go
+++ b/internal/types/lsp.go
@@ -556,6 +556,7 @@ type Settings struct {
 	SnykCodeApi                      string               `json:"snykCodeApi,omitempty"`
 	EnableSnykLearnCodeActions       string               `json:"enableSnykLearnCodeActions,omitempty"`
 	EnableSnykOSSQuickFixCodeActions string               `json:"enableSnykOSSQuickFixCodeActions,omitempty"`
+	EnableSnykOpenBrowserActions     string               `json:"enableSnykOpenBrowserActions,omitempty"`
 	EnableDeltaFindings              string               `json:"enableDeltaFindings,omitempty"` // should this be global?
 	RequiredProtocolVersion          string               `json:"requiredProtocolVersion,omitempty"`
 	// global settings end


### PR DESCRIPTION
### Description
Before, open description in browser was added as a code action by default
![image](https://github.com/user-attachments/assets/a88a7efb-4749-4ff3-8fec-93fa59b7f578)

Now, the open action is gone, and the fix description has been updated
![image](https://github.com/user-attachments/assets/fb40820e-6209-4195-b311-31ebf84d4c46)

A configuration setting has been added, to be able to enable it via settings/initializationOptions.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
