### PR TITLE
fix: parse gradle multiprojects correctly [IDA-39]

### DIFF
--- a/infrastructure/oss/cli_package_scan_test.go
+++ b/infrastructure/oss/cli_package_scan_test.go
@@ -42,7 +42,7 @@ func TestCLIScanner_ScanPackages_WithoutContent(t *testing.T) {
 
 	scanner.ScanPackages(context.Background(), c, testFilePath, "")
 
-	assert.Len(t, scanner.inlineValues, 1)
+	assert.Len(t, scanner.inlineValues, 2)
 	assert.Len(t, scanner.packageIssueCache, 2)
 	assert.NotContainsf(t, cliExecutor.GetCommand(), "--all-projects", "expected --all-projects NOT to be set")
 }
@@ -58,7 +58,7 @@ func TestCLIScanner_ScanPackages_WithContent(t *testing.T) {
 
 	scanner.ScanPackages(context.Background(), c, testFilePath, fileContent)
 
-	assert.Len(t, scanner.inlineValues, 1)
+	assert.Len(t, scanner.inlineValues, 2)
 	assert.Len(t, scanner.packageIssueCache, 2)
 }
 

--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -263,10 +263,15 @@ func (cliScanner *CLIScanner) unmarshallAndRetrieveAnalysis(ctx context.Context,
 	}
 
 	for _, scanResult := range scanResults {
-		targetFilePath := path
 		targetFile := cliScanner.determineTargetFile(scanResult.DisplayTargetFile)
-		if targetFile != "" {
-			targetFilePath = filepath.Join(workDir, targetFile)
+		targetFilePath := scanResult.Path
+		if targetFilePath == "" {
+			targetFilePath = workDir
+		}
+		if targetFilePath == "" {
+			targetFilePath = targetFile
+		} else {
+			targetFilePath = filepath.Join(targetFilePath, targetFile)
 		}
 		fileContent, err := os.ReadFile(targetFilePath)
 		if err != nil {
@@ -355,12 +360,12 @@ func (cliScanner *CLIScanner) determineTargetFile(displayTargetFile string) stri
 
 func (cliScanner *CLIScanner) retrieveIssues(
 	res *scanResult,
-	path string,
+	targetFilePath string,
 	fileContent []byte,
 ) []snyk.Issue {
 	issues := convertScanResultToIssues(
 		res,
-		path,
+		targetFilePath,
 		fileContent,
 		cliScanner.learnService,
 		cliScanner.errorReporter,

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -119,7 +119,7 @@ func toIssue(
 
 func convertScanResultToIssues(
 	res *scanResult,
-	path string,
+	targetFilePath string,
 	fileContent []byte,
 	ls learn.Service,
 	ep error_reporting.ErrorReporter,
@@ -131,12 +131,12 @@ func convertScanResultToIssues(
 
 	for _, issue := range res.Vulnerabilities {
 		packageKey := issue.PackageName + "@" + issue.Version
-		duplicateKey := issue.Id + "|" + issue.PackageName
+		duplicateKey := targetFilePath + "|" + issue.Id + "|" + issue.PackageName
 		if duplicateCheckMap[duplicateKey] {
 			continue
 		}
-		issueRange := findRange(issue, path, fileContent)
-		snykIssue := toIssue(path, issue, res, issueRange, ls, ep)
+		issueRange := findRange(issue, targetFilePath, fileContent)
+		snykIssue := toIssue(targetFilePath, issue, res, issueRange, ls, ep)
 		packageIssueCache[packageKey] = append(packageIssueCache[packageKey], snykIssue)
 		issues = append(issues, snykIssue)
 		duplicateCheckMap[duplicateKey] = true

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -19,6 +19,7 @@ package oss
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -107,7 +108,13 @@ type Annotation struct {
 
 func (i *ossIssue) toAdditionalData(scanResult *scanResult, matchingIssues []snyk.OssIssueData) snyk.OssIssueData {
 	var additionalData snyk.OssIssueData
-	additionalData.Key = util.GetIssueKey(i.Id, scanResult.DisplayTargetFile, i.LineNumber, i.LineNumber, 0, 0)
+
+	targetFilePath := filepath.Base(scanResult.DisplayTargetFile)
+	if scanResult.Path != "" {
+		targetFilePath = filepath.Join(scanResult.Path, targetFilePath)
+	}
+
+	additionalData.Key = util.GetIssueKey(i.Id, targetFilePath, i.LineNumber, i.LineNumber, 0, 0)
 	additionalData.Title = i.Title
 	additionalData.Name = i.Name
 	additionalData.Identifiers = snyk.Identifiers{
@@ -130,7 +137,7 @@ func (i *ossIssue) toAdditionalData(scanResult *scanResult, matchingIssues []sny
 	additionalData.Exploit = i.Exploit
 	additionalData.IsPatchable = i.IsPatchable
 	additionalData.ProjectName = scanResult.ProjectName
-	additionalData.DisplayTargetFile = scanResult.DisplayTargetFile
+	additionalData.DisplayTargetFile = targetFilePath
 	additionalData.Language = i.Language
 	additionalData.MatchingIssues = matchingIssues
 	if i.lesson != nil {

--- a/infrastructure/oss/types_test.go
+++ b/infrastructure/oss/types_test.go
@@ -105,7 +105,7 @@ func Test_unmarshalGradleMultiProject(t *testing.T) {
 	sampleApiCount := 0
 	sampleCommonCount := 0
 	for _, issue := range issues {
-		switch issue.AffectedFilePath {
+		switch filepath.ToSlash(issue.AffectedFilePath) {
 		case "/Users/bdoetsch/workspace/gradle-multi-module/build.gradle":
 			gradleRootCount++
 		case "/Users/bdoetsch/workspace/gradle-multi-module/sample-admin/build.gradle":

--- a/infrastructure/oss/types_test.go
+++ b/infrastructure/oss/types_test.go
@@ -17,14 +17,20 @@
 package oss
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/cli"
+	"github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
+	"github.com/snyk/snyk-ls/internal/observability/performance"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
@@ -67,21 +73,72 @@ func Test_ossIssue_toAdditionalData_ConvertsSeverityChange(t *testing.T) {
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.SeverityChange.Reason)
 }
 
+func Test_unmarshalGradleMultiProject(t *testing.T) {
+	c := testutil.UnitTest(t)
+	fileName := "gradle-multi-project.json"
+	testDir := "testdata"
+	file := filepath.Join(testDir, fileName)
+	inputJson, err := os.ReadFile(file)
+	require.NoError(t, err)
+
+	var sc []scanResult
+	err = json.Unmarshal(inputJson, &sc)
+	require.NoError(t, err)
+
+	assert.Len(t, sc, 4)
+
+	scanner := NewCLIScanner(
+		c,
+		performance.NewInstrumentor(),
+		error_reporting.NewTestErrorReporter(),
+		cli.NewTestExecutor(),
+		getLearnMock(t),
+		notification.NewNotifier(),
+	).(*CLIScanner)
+
+	issues := scanner.unmarshallAndRetrieveAnalysis(context.Background(), inputJson, testDir, file)
+
+	assert.Len(t, issues, 315)
+
+	gradleRootCount := 0
+	sampleAdminCount := 0
+	sampleApiCount := 0
+	sampleCommonCount := 0
+	for _, issue := range issues {
+		switch issue.AffectedFilePath {
+		case "/Users/bdoetsch/workspace/gradle-multi-module/build.gradle":
+			gradleRootCount++
+		case "/Users/bdoetsch/workspace/gradle-multi-module/sample-admin/build.gradle":
+			sampleAdminCount++
+		case "/Users/bdoetsch/workspace/gradle-multi-module/sample-api/build.gradle":
+			sampleApiCount++
+		case "/Users/bdoetsch/workspace/gradle-multi-module/sample-common/build.gradle":
+			sampleCommonCount++
+		default:
+			require.FailNow(t, "Unexpected file path", issue.AffectedFilePath)
+		}
+	}
+
+	assert.Equal(t, 135, sampleAdminCount)
+	assert.Equal(t, 135, sampleApiCount)
+	assert.Equal(t, 45, sampleCommonCount)
+}
+
 func setupOssIssueWithPolicyAnnotations(t *testing.T) ossIssue {
 	t.Helper()
 	name := filepath.Join("testdata", "policyAnnotationsInputData.json")
-	issue := unmarshalFromFile(t, name)
+	issue := unmarshalIssueFromFile(t, name)
 	return issue
 }
 
 func setupOssIssueWithSeverityChangePolicy(t *testing.T) ossIssue {
 	t.Helper()
 	name := filepath.Join("testdata", "policySeverityChangeInputData.json")
-	issue := unmarshalFromFile(t, name)
+	issue := unmarshalIssueFromFile(t, name)
 	return issue
 }
 
-func unmarshalFromFile(t *testing.T, name string) ossIssue {
+func unmarshalIssueFromFile(t *testing.T, name string) ossIssue {
 	t.Helper()
 	inputJson, err := os.ReadFile(name)
 	require.NoError(t, err)


### PR DESCRIPTION
### Description

Gradle multi module projects are reported differently in the JSON output. This PR adjusts parsing and issue key generation.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

![image](https://github.com/user-attachments/assets/a4486186-c3c2-408d-9a93-c26d515cbc8c)
