### PR TITLE
fix: check if path is a sub directory correctly

### DIFF
--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -275,7 +275,7 @@ func Test_SmokeIssueCaching(t *testing.T) {
 
 func addJuiceShopAsWorkspaceFolder(t *testing.T, loc server.Local, c *config.Config) *workspace.Folder {
 	t.Helper()
-	var cloneTargetDirJuice, err = setupCustomTestRepo(t, "https://github.com/juice-shop/juice-shop", "bc9cef127", c.Logger())
+	var cloneTargetDirJuice, err = testutil.SetupCustomTestRepo(t, t.TempDir(), "https://github.com/juice-shop/juice-shop", "bc9cef127", c.Logger())
 	require.NoError(t, err)
 
 	juiceLspWorkspaceFolder := types.WorkspaceFolder{Uri: uri.PathToUri(cloneTargetDirJuice), Name: "juicy-mac-juice-face"}
@@ -597,7 +597,7 @@ func isNotStandardRegion(c *config.Config) bool {
 
 func setupRepoAndInitialize(t *testing.T, repo string, commit string, loc server.Local, c *config.Config) string {
 	t.Helper()
-	var cloneTargetDir, err = setupCustomTestRepo(t, repo, commit, c.Logger())
+	var cloneTargetDir, err = testutil.SetupCustomTestRepo(t, t.TempDir(), repo, commit, c.Logger())
 	if err != nil {
 		t.Fatal(err, "Couldn't setup test repo")
 	}
@@ -664,7 +664,7 @@ func Test_SmokeSnykCodeFileScan(t *testing.T) {
 	cleanupChannels()
 	di.Init()
 
-	var cloneTargetDir, err = setupCustomTestRepo(t, "https://github.com/snyk-labs/nodejs-goof", "0336589", c.Logger())
+	var cloneTargetDir, err = testutil.SetupCustomTestRepo(t, t.TempDir(), "https://github.com/snyk-labs/nodejs-goof", "0336589", c.Logger())
 	defer func(path string) { _ = os.RemoveAll(path) }(cloneTargetDir)
 	if err != nil {
 		t.Fatal(err, "Couldn't setup test repo")

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -1011,7 +1011,7 @@ func Test_IntegrationHoverResults(t *testing.T) {
 	fakeAuthenticationProvider := di.AuthenticationService().Providers()[0].(*authentication.FakeAuthenticationProvider)
 	fakeAuthenticationProvider.IsAuthenticated = true
 
-	var cloneTargetDir, err = setupCustomTestRepo(t, "https://github.com/snyk-labs/nodejs-goof", "0336589", c.Logger())
+	var cloneTargetDir, err = testutil.SetupCustomTestRepo(t, t.TempDir(), "https://github.com/snyk-labs/nodejs-goof", "0336589", c.Logger())
 	defer func(path string) { _ = os.RemoveAll(path) }(cloneTargetDir)
 	if err != nil {
 		t.Fatal(err, "Couldn't setup test repo")
@@ -1065,36 +1065,6 @@ func Test_IntegrationHoverResults(t *testing.T) {
 		hoverResult.Contents.Value,
 		di.HoverService().GetHover(testPath, converter.FromPosition(testPosition)).Contents.Value)
 	assert.Equal(t, hoverResult.Contents.Kind, "markdown")
-}
-
-func setupCustomTestRepo(t *testing.T, url string, targetCommit string, logger *zerolog.Logger) (string, error) {
-	t.Helper()
-	tempDir := t.TempDir()
-	repoDir := "1"
-	absoluteCloneRepoDir := filepath.Join(tempDir, repoDir)
-	cmd := []string{"clone", url, repoDir}
-	logger.Debug().Interface("cmd", cmd).Msg("clone command")
-	clone := exec.Command("git", cmd...)
-	clone.Dir = tempDir
-	reset := exec.Command("git", "reset", "--hard", targetCommit)
-	reset.Dir = absoluteCloneRepoDir
-
-	clean := exec.Command("git", "clean", "--force")
-	clean.Dir = absoluteCloneRepoDir
-
-	output, err := clone.CombinedOutput()
-	if err != nil {
-		t.Fatal(err, "clone didn't work")
-	}
-
-	logger.Debug().Msg(string(output))
-	output, _ = reset.CombinedOutput()
-
-	logger.Debug().Msg(string(output))
-	output, err = clean.CombinedOutput()
-
-	logger.Debug().Msg(string(output))
-	return absoluteCloneRepoDir, err
 }
 
 //goland:noinspection ALL

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -21,10 +21,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/snyk/snyk-ls/domain/snyk/persistence"
-	"github.com/snyk/snyk-ls/internal/delta"
 	"strings"
 	"sync"
+
+	"github.com/snyk/snyk-ls/domain/snyk/persistence"
+	"github.com/snyk/snyk-ls/internal/delta"
 
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/util"
@@ -669,9 +670,8 @@ func (f *Folder) IsTrusted() bool {
 	if !config.CurrentConfig().IsTrustedFolderFeatureEnabled() {
 		return true
 	}
-
 	for _, path := range config.CurrentConfig().TrustedFolders() {
-		if strings.HasPrefix(f.path, path) {
+		if uri.FolderContains(path, f.path) {
 			return true
 		}
 	}

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/progress"
@@ -153,6 +154,7 @@ func OnlyEnableCode() {
 func SetupCustomTestRepo(t *testing.T, rootDir string, url string, targetCommit string, logger *zerolog.Logger) (string, error) {
 	t.Helper()
 	tempDir := filepath.Join(rootDir, util.Murmur(t.Name()))
+	assert.NoError(t, os.MkdirAll(tempDir, 0755))
 	repoDir := "1"
 	absoluteCloneRepoDir := filepath.Join(tempDir, repoDir)
 	cmd := []string{"clone", url, repoDir}

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -18,11 +18,16 @@ package testutil
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/rs/zerolog"
+
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/progress"
+	"github.com/snyk/snyk-ls/internal/util"
 )
 
 const (
@@ -143,4 +148,34 @@ func OnlyEnableCode() {
 	config.CurrentConfig().SetSnykIacEnabled(false)
 	config.CurrentConfig().SetSnykOssEnabled(false)
 	config.CurrentConfig().SetSnykCodeEnabled(true)
+}
+
+func SetupCustomTestRepo(t *testing.T, rootDir string, url string, targetCommit string, logger *zerolog.Logger) (string, error) {
+	t.Helper()
+	tempDir := filepath.Join(rootDir, util.Murmur(t.Name()))
+	repoDir := "1"
+	absoluteCloneRepoDir := filepath.Join(tempDir, repoDir)
+	cmd := []string{"clone", url, repoDir}
+	logger.Debug().Interface("cmd", cmd).Msg("clone command")
+	clone := exec.Command("git", cmd...)
+	clone.Dir = tempDir
+	reset := exec.Command("git", "reset", "--hard", targetCommit)
+	reset.Dir = absoluteCloneRepoDir
+
+	clean := exec.Command("git", "clean", "--force")
+	clean.Dir = absoluteCloneRepoDir
+
+	output, err := clone.CombinedOutput()
+	if err != nil {
+		t.Fatal(err, "clone didn't work")
+	}
+
+	logger.Debug().Msg(string(output))
+	output, _ = reset.CombinedOutput()
+
+	logger.Debug().Msg(string(output))
+	output, err = clean.CombinedOutput()
+
+	logger.Debug().Msg(string(output))
+	return absoluteCloneRepoDir, err
 }


### PR DESCRIPTION
### Description

Previously, the sub directory check for trust was just checking if the trusted directory had the same prefix. Now it's checking the relative path.

Example:
Trusted: /a
Untrusted: /a-123

Previously, /a-123 would be trusted. This PR fixes that.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

🚨After having merged, please update the CLI go.mod to pull in latest language server.

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
