### PR TITLE
feat: return token in login command [IDE-458]

### DIFF
--- a/application/server/execute_command_test.go
+++ b/application/server/execute_command_test.go
@@ -143,12 +143,13 @@ func Test_loginCommand_StartsAuthentication(t *testing.T) {
 	params := lsp.ExecuteCommandParams{Command: types.LoginCommand}
 
 	// Act
-	_, err = loc.Client.Call(ctx, "workspace/executeCommand", params)
+	tokenResponse, err := loc.Client.Call(ctx, "workspace/executeCommand", params)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Assert
+	assert.NotEmpty(t, tokenResponse.ResultString())
 	assert.True(t, fakeAuthenticationProvider.IsAuthenticated)
 	assert.Eventually(t, func() bool { return len(jsonRPCRecorder.Notifications()) > 0 }, 5*time.Second, 50*time.Millisecond)
 	assert.Equal(t, 1, len(jsonRPCRecorder.FindNotificationsByMethod("$/snyk.hasAuthenticated")))

--- a/domain/ide/command/login.go
+++ b/domain/ide/command/login.go
@@ -49,6 +49,7 @@ func (cmd *loginCommand) Execute(ctx context.Context) (any, error) {
 		cmd.logger.Debug().Str("method", "loginCommand.Execute").
 			Str("hashed token", util.Hash([]byte(token))[0:16]).
 			Msgf("authentication successful, received token")
+		return token, nil
 	}
 	return nil, err
 }

--- a/infrastructure/authentication/auth_configuration.go
+++ b/infrastructure/authentication/auth_configuration.go
@@ -18,8 +18,6 @@ package authentication
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"golang.org/x/oauth2"
 
@@ -47,12 +45,8 @@ func Default(c *config.Config, errorReporter error_reporting.ErrorReporter, auth
 	conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 	conf.Unset(configuration.AUTHENTICATION_TOKEN)
 	credentialsUpdateCallback := func(_ string, value any) {
-		newToken, ok := value.(string)
-		if !ok {
-			msg := fmt.Sprintf("Failed to cast creds of type %T to string", value)
-			errorReporter.CaptureError(errors.New(msg))
-			return
-		}
+		// an empty struct marks an empty token, so we stay with empty string if the cast fails
+		newToken, _ := value.(string)
 		go authenticationService.UpdateCredentials(newToken, true)
 	}
 

--- a/infrastructure/authentication/auth_configuration.go
+++ b/infrastructure/authentication/auth_configuration.go
@@ -40,7 +40,7 @@ func Token(c *config.Config, errorReporter error_reporting.ErrorReporter) Authen
 
 // Default authentication configures an OAuth2 authenticator,
 // the auth service parameter is needed, as the oauth2 provider needs a callback function
-func Default(c *config.Config, errorReporter error_reporting.ErrorReporter, authenticationService AuthenticationService) AuthenticationProvider {
+func Default(c *config.Config, authenticationService AuthenticationService) AuthenticationProvider {
 	conf := c.Engine().GetConfiguration()
 	conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 	conf.Unset(configuration.AUTHENTICATION_TOKEN)

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -184,7 +184,7 @@ func (a *AuthenticationServiceImpl) ConfigureProviders(c *config.Config) {
 			authProviderChange = true
 		}
 
-		p = Default(c, a.errorReporter, a)
+		p = Default(c, a)
 		a.SetProvider(p)
 	case types.TokenAuthentication:
 		// if err == nil, previous token was oauth2. So we had a provider change


### PR DESCRIPTION
### Description

Facilitate client handling by returning the authentication token after successful login. Also parallelize cloning in parallel test to speed it up (now it's 3x faster on my local machine).

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] License file updated, if new 3rd-party dependency is introduced
- [ ] README.md updated, if user-facing
