### PR TITLE
fix: add parsing edge case for submodule gemfiles [IDE-517]

### DIFF
--- a/infrastructure/oss/cli_package_scan_test.go
+++ b/infrastructure/oss/cli_package_scan_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/maps"
@@ -42,7 +43,7 @@ func TestCLIScanner_ScanPackages_WithoutContent(t *testing.T) {
 
 	scanner.ScanPackages(context.Background(), c, testFilePath, "")
 
-	assert.Len(t, scanner.inlineValues, 2)
+	assert.Eventuallyf(t, func() bool { return len(scanner.inlineValues[testFilePath]) == 2 }, time.Second*5, 10*time.Millisecond, "expected 2 values, got %d", len(scanner.inlineValues))
 	assert.Len(t, scanner.packageIssueCache, 2)
 	assert.NotContainsf(t, cliExecutor.GetCommand(), "--all-projects", "expected --all-projects NOT to be set")
 }
@@ -58,7 +59,7 @@ func TestCLIScanner_ScanPackages_WithContent(t *testing.T) {
 
 	scanner.ScanPackages(context.Background(), c, testFilePath, fileContent)
 
-	assert.Len(t, scanner.inlineValues, 2)
+	assert.Len(t, scanner.inlineValues[testFilePath], 2)
 	assert.Len(t, scanner.packageIssueCache, 2)
 }
 

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -132,7 +132,8 @@ func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 			}
 
 			base := t.TempDir()
-			expected := filepath.Join(base, tc.expected)
+			after, _ := strings.CutPrefix(tc.expected, "C:")
+			expected := filepath.Join(base, after)
 			dir := filepath.Dir(expected)
 			require.NoError(t, os.MkdirAll(dir, 0770))
 			require.NoError(t, os.WriteFile(expected, []byte(expected), 0666))

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
-//nolint:dupl // not a real duplicate
 func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 	testutil.NotOnWindows(t, "filepaths are os dependent")
 	testCases := []struct {

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -125,22 +125,30 @@ func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			skipReason := "filepath is os dependent"
-			if strings.HasPrefix(tc.workDir, "C:") {
+			prefix := "C:"
+			if strings.HasPrefix(tc.workDir, prefix) {
 				testutil.OnlyOnWindows(t, skipReason)
 			} else {
 				testutil.NotOnWindows(t, skipReason)
 			}
 
 			base := t.TempDir()
-			after, _ := strings.CutPrefix(tc.expected, "C:")
-			expected := filepath.Join(base, after)
+			adjustedExpected, _ := strings.CutPrefix(tc.expected, prefix)
+			adjustedWorkDir, _ := strings.CutPrefix(tc.workDir, prefix)
+			adjustedPath, _ := strings.CutPrefix(tc.path, prefix)
+			expected := filepath.Join(base, adjustedExpected)
 			dir := filepath.Dir(expected)
 			require.NoError(t, os.MkdirAll(dir, 0770))
 			require.NoError(t, os.WriteFile(expected, []byte(expected), 0666))
-			actual := getAbsTargetFilePath(scanResult{
-				DisplayTargetFile: tc.displayTargetFile,
-				Path:              filepath.Join(base, tc.path),
-			}, filepath.Join(base, tc.workDir), "")
+
+			actual := getAbsTargetFilePath(
+				scanResult{
+					DisplayTargetFile: tc.displayTargetFile,
+					Path:              filepath.Join(base, adjustedPath),
+				},
+				filepath.Join(base, adjustedWorkDir),
+				filepath.Join(base, adjustedPath),
+			)
 			assert.Equal(t, expected, actual)
 		})
 	}

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
-	testutil.NotOnWindows(t, "filepaths are os dependent")
 	testCases := []struct {
 		name              string
 		displayTargetFile string
@@ -137,13 +136,10 @@ func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 			dir := filepath.Dir(expected)
 			require.NoError(t, os.MkdirAll(dir, 0770))
 			require.NoError(t, os.WriteFile(expected, []byte(expected), 0666))
-			actual := getAbsTargetFilePath(
-				scanResult{
-					DisplayTargetFile: tc.displayTargetFile,
-					Path:              filepath.Join(base, tc.path),
-				},
-				filepath.Join(base, tc.workDir),
-			)
+			actual := getAbsTargetFilePath(scanResult{
+				DisplayTargetFile: tc.displayTargetFile,
+				Path:              filepath.Join(base, tc.path),
+			}, filepath.Join(base, tc.workDir), "")
 			assert.Equal(t, expected, actual)
 		})
 	}

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -17,9 +17,13 @@
 package oss
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
@@ -69,73 +73,79 @@ func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 			path:              "/Users/cata/git/snyk/hammerhead/snyk-intellij-plugin",
 			expected:          "/Users/cata/git/snyk/hammerhead/snyk-intellij-plugin/src/test/resources/test-fixtures/oss/annotator/pom.xml",
 		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := getAbsTargetFilePath(
-				scanResult{DisplayTargetFile: tc.displayTargetFile, Path: tc.path},
-				tc.workDir,
-			)
-			assert.Equal(t, tc.expected, actual)
-		})
-	}
-}
-
-//nolint:dupl // not a real duplicate
-func TestCLIScanner_getAbsTargetFilePathForPackageManagers_Windows(t *testing.T) {
-	testutil.OnlyOnWindows(t, "filepaths are os dependent")
-	testCases := []struct {
-		name              string
-		displayTargetFile string
-		workDir           string
-		path              string
-		expected          string
-	}{
 		{
-			name:              "NPM root directory",
+			name:              "Gemfile deep below working dir",
+			displayTargetFile: ".bin/pact/lib/vendor/Gemfile.lock",
+			workDir:           "/Users/bdoetsch/workspace/snyk-ls",
+			path:              "/Users/bdoetsch/workspace/snyk-ls/.bin/pact/lib/vendor",
+			expected:          "/Users/bdoetsch/workspace/snyk-ls/.bin/pact/lib/vendor/Gemfile",
+		},
+		{
+			name:              "(win) NPM root directory",
 			displayTargetFile: "package-lock.json",
 			workDir:           "C:\\a\\cata\\git\\playground\\juice-shop",
 			path:              "C:\\a\\cata\\git\\playground\\juice-shop",
 			expected:          "C:\\a\\cata\\git\\playground\\juice-shop\\package.json",
 		},
 		{
-			name:              "Poetry Sub Project (below the working directory)",
+			name:              "(win) Poetry Sub Project (below the working directory)",
 			displayTargetFile: "poetry-sample\\pyproject.toml",
 			workDir:           "C:\\a\\cata\\git\\playground\\python-goof",
 			path:              "C:\\a\\cata\\git\\playground\\python-goof",
 			expected:          "C:\\a\\cata\\git\\playground\\python-goof\\poetry-sample\\pyproject.toml",
 		},
 		{
-			name:              "Gradle multi-module",
+			name:              "(win) Gradle multi-module",
 			displayTargetFile: "build.gradle",
 			workDir:           "C:\\a\\bdoetsch\\workspace\\gradle-multi-module",
 			path:              "C:\\a\\bdoetsch\\workspace\\gradle-multi-module\\sample-api",
 			expected:          "C:\\a\\bdoetsch\\workspace\\gradle-multi-module\\sample-api\\build.gradle",
 		},
 		{
-			name:              "Go Modules deeply nested",
+			name:              "(win) Go Modules deeply nested",
 			displayTargetFile: "build\\resources\\test\\test-fixtures\\oss\\annotator\\go.mod",
 			workDir:           "C:\\a\\cata\\git\\snyk\\hammerhead\\snyk-intellij-plugin",
 			path:              "C:\\a\\cata\\git\\snyk\\hammerhead\\snyk-intellij-plugin",
 			expected:          "C:\\a\\cata\\git\\snyk\\hammerhead\\snyk-intellij-plugin\\build\\resources\\test\\test-fixtures\\oss\\annotator\\go.mod",
 		},
 		{
-			name:              "Maven test fixtures",
+			name:              "(win) Maven test fixtures",
 			displayTargetFile: "src\\test\\resources\\test-fixtures\\oss\\annotator\\pom.xml",
 			workDir:           "C:\\a\\cata\\git\\snyk\\hammerhead\\snyk-intellij-plugin",
 			path:              "C:\\a\\cata\\git\\snyk\\hammerhead\\snyk-intellij-plugin",
 			expected:          "C:\\a\\cata\\git\\snyk\\hammerhead\\snyk-intellij-plugin\\src\\test\\resources\\test-fixtures\\oss\\annotator\\pom.xml",
 		},
+		{
+			name:              "(win) Gemfile deep below working dir",
+			displayTargetFile: ".bin\\pact\\lib\\vendor\\Gemfile.lock",
+			workDir:           "C:\\Users\\bdoetsch\\workspace\\snyk-ls",
+			path:              "C:\\Users\\bdoetsch\\workspace\\snyk-ls\\.bin\\pact\\lib\\vendor",
+			expected:          "C:\\Users\\bdoetsch\\workspace\\snyk-ls\\.bin\\pact\\lib\\vendor\\Gemfile",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			skipReason := "filepath is os dependent"
+			if strings.HasPrefix(tc.workDir, "C:") {
+				testutil.OnlyOnWindows(t, skipReason)
+			} else {
+				testutil.NotOnWindows(t, skipReason)
+			}
+
+			base := t.TempDir()
+			expected := filepath.Join(base, tc.expected)
+			dir := filepath.Dir(expected)
+			require.NoError(t, os.MkdirAll(dir, 0770))
+			require.NoError(t, os.WriteFile(expected, []byte(expected), 0666))
 			actual := getAbsTargetFilePath(
-				scanResult{DisplayTargetFile: tc.displayTargetFile, Path: tc.path},
-				tc.workDir,
+				scanResult{
+					DisplayTargetFile: tc.displayTargetFile,
+					Path:              filepath.Join(base, tc.path),
+				},
+				filepath.Join(base, tc.workDir),
 			)
-			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, expected, actual)
 		})
 	}
 }

--- a/infrastructure/oss/types_test.go
+++ b/infrastructure/oss/types_test.go
@@ -17,20 +17,14 @@
 package oss
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
-	"github.com/snyk/snyk-ls/infrastructure/cli"
-	"github.com/snyk/snyk-ls/internal/notification"
-	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
-	"github.com/snyk/snyk-ls/internal/observability/performance"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
@@ -71,57 +65,6 @@ func Test_ossIssue_toAdditionalData_ConvertsSeverityChange(t *testing.T) {
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.SeverityChange.OriginalSeverity)
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.SeverityChange.NewSeverity)
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.SeverityChange.Reason)
-}
-
-func Test_unmarshalGradleMultiProject(t *testing.T) {
-	c := testutil.UnitTest(t)
-	fileName := "gradle-multi-project.json"
-	testDir := "testdata"
-	file := filepath.Join(testDir, fileName)
-	inputJson, err := os.ReadFile(file)
-	require.NoError(t, err)
-
-	var sc []scanResult
-	err = json.Unmarshal(inputJson, &sc)
-	require.NoError(t, err)
-
-	assert.Len(t, sc, 4)
-
-	scanner := NewCLIScanner(
-		c,
-		performance.NewInstrumentor(),
-		error_reporting.NewTestErrorReporter(),
-		cli.NewTestExecutor(),
-		getLearnMock(t),
-		notification.NewNotifier(),
-	).(*CLIScanner)
-
-	issues := scanner.unmarshallAndRetrieveAnalysis(context.Background(), inputJson, testDir, file)
-
-	assert.Len(t, issues, 315)
-
-	gradleRootCount := 0
-	sampleAdminCount := 0
-	sampleApiCount := 0
-	sampleCommonCount := 0
-	for _, issue := range issues {
-		switch filepath.ToSlash(issue.AffectedFilePath) {
-		case "/Users/bdoetsch/workspace/gradle-multi-module/build.gradle":
-			gradleRootCount++
-		case "/Users/bdoetsch/workspace/gradle-multi-module/sample-admin/build.gradle":
-			sampleAdminCount++
-		case "/Users/bdoetsch/workspace/gradle-multi-module/sample-api/build.gradle":
-			sampleApiCount++
-		case "/Users/bdoetsch/workspace/gradle-multi-module/sample-common/build.gradle":
-			sampleCommonCount++
-		default:
-			require.FailNow(t, "Unexpected file path", issue.AffectedFilePath)
-		}
-	}
-
-	assert.Equal(t, 135, sampleAdminCount)
-	assert.Equal(t, 135, sampleApiCount)
-	assert.Equal(t, 45, sampleCommonCount)
 }
 
 func setupOssIssueWithPolicyAnnotations(t *testing.T) ossIssue {


### PR DESCRIPTION
### Description

Gemfile package manager locations were reported differently. The parsing now has a "panic" mode to try out different combinations if the standard doesn't work and uses stat to verify.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
