### PR TITLE
fix: escape nonce value with `template.HTML` [IDE-488]

### DIFF
--- a/domain/ide/workspace/ui/diagnostics_overview.go
+++ b/domain/ide/workspace/ui/diagnostics_overview.go
@@ -45,7 +45,7 @@ type TemplateData struct {
 	// File node with underlying slice of issue nodes
 	Issues               map[Node][]Node
 	Styles               template.CSS
-	Nonce                string
+	Nonce                template.HTML
 	DeltaFindingsEnabled bool
 }
 
@@ -82,7 +82,7 @@ func SendDiagnosticsOverview(c *config.Config, p product.Product, issuesByFile s
 		RootNodes:            rootNodes,
 		Issues:               fileNodes,
 		Styles:               template.CSS(diagnosticsOverviewTemplateCSS),
-		Nonce:                nonce,
+		Nonce:                template.HTML(nonce),
 		DeltaFindingsEnabled: c.IsDeltaFindingsEnabled(),
 	}
 

--- a/domain/ide/workspace/ui/template/diagnosticsOverview.css
+++ b/domain/ide/workspace/ui/template/diagnosticsOverview.css
@@ -1,6 +1,7 @@
-.issues-overview{}
+.issues-overview {}
 
-.main-tabs-nav, .tabs-nav {
+.main-tabs-nav,
+.tabs-nav {
   display: flex;
   list-style-type: none;
   overflow: hidden;
@@ -37,21 +38,29 @@
 }
 
 .sn-tree {}
-.sn-list {}
-.sn-list-item{}
 
-.is-clickable-true{
+.sn-list {}
+
+.sn-list-item {}
+
+.is-clickable-true {
   cursor: pointer;
 }
-.is-clickable-false{
+
+.is-clickable-false {
   cursor: not-allowed;
 }
-.sn-icon{}
-.sn-label{}
+
+.sn-icon {}
+
+.sn-label {}
+
 .sn-list-item.is-expandable {}
+
 .sn-list-item.is-expanded .sn-list {
   display: block;
 }
+
 .sn-list-item .sn-list {
   display: none;
 }

--- a/domain/ide/workspace/ui/template/diagnosticsOverview.html
+++ b/domain/ide/workspace/ui/template/diagnosticsOverview.html
@@ -18,112 +18,108 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy"
-          content="default-src 'none'; style-src 'self' 'nonce-{{.Nonce}}'; script-src 'nonce-{{.Nonce}}';">
-
-    <!-- see docs/ui-rendering.md  -->
-    <!--noformat-->
-    <!-- @formatter:off -->
-    <style nonce="{{.Nonce}}">
-        {{.Styles}}
-    </style>
-    <style nonce="ideNonce" data-ide-style></style>
-    <!-- @formatter:on -->
-    <!--noformat-->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src 'self' 'nonce-{{.Nonce}}' 'nonce-ideNonce'; script-src 'nonce-{{.Nonce}}';">
+  <!-- see docs/ui-rendering.md  -->
+  <!--noformat-->
+  <!-- @formatter:off -->
+  <style nonce="{{.Nonce}}">{{.Styles}}</style>
+  <style nonce="ideNonce" data-ide-style></style>
+  <!-- @formatter:on -->
+  <!--noformat-->
 </head>
 
 <body>
-
-<main class="issues-overview-container">
+  <main class="issues-overview-container">
     <!-- Tabs Issue Overview Container -->
     <article class="issues-overview">
-        <div class="main-tabs-nav">
-      <span data-tab="all-issues" id="all-issues-tab"
-            class="tab-item {{if not .DeltaFindingsEnabled}} is-selected {{end}} all-issues-tab">
+      <div class="main-tabs-nav">
+        <span data-tab="all-issues" id="all-issues-tab"
+          class="tab-item {{if not .DeltaFindingsEnabled}} is-selected {{end}} all-issues-tab">
           All Issues
-      </span>
-            <span data-tab="net-new-issues" id="net-new-issues-tab"
-                  class="tab-item {{if .DeltaFindingsEnabled}} is-selected {{end}} net-new-issues-tab">
+        </span>
+        <span data-tab="net-new-issues" id="net-new-issues-tab"
+          class="tab-item {{if .DeltaFindingsEnabled}} is-selected {{end}} net-new-issues-tab">
           Net new issues
-      </span>
-        </div>
+        </span>
+      </div>
 
-        <!-- Dynamic Content Sections -->
-        <div class="tab-container">
-            <!-- all-issues content -->
-            <div data-content="all-issues" id="all-issues-content"
-                 class="tab-content main-tab-content {{if not .DeltaFindingsEnabled}} is-selected {{end}}">
-                <section class="issue-overview delimiter-top">
-                    <div id="issueTree" class="sn-tree">
-                        <!--  root nodes-->
-                        <ul class="sn-list">
-                            {{range $index, $node := .RootNodes}}
-                            <li class="sn-list-item is-clickable-{{$node.ProductEnabled}}">
-                                <span class="sn-icon">{{$node.Icon}}</span><span class="sn-label">{{$node.Text}}</span>
-                            </li>
-                            {{ end }}
-                        </ul>
+      <!-- Dynamic Content Sections -->
+      <div class="tab-container">
+        <!-- all-issues content -->
+        <div data-content="all-issues" id="all-issues-content"
+          class="tab-content main-tab-content {{if not .DeltaFindingsEnabled}} is-selected {{end}}">
+          <section class="issue-overview delimiter-top">
+            <div id="issueTree" class="sn-tree">
+              <!--  root nodes-->
+              <ul class="sn-list">
+                {{range $index, $node := .RootNodes}}
+                <li class="sn-list-item is-clickable-{{$node.ProductEnabled}}">
+                  <span class="sn-icon">{{$node.Icon}}</span><span class="sn-label">{{$node.Text}}</span>
+                </li>
+                {{ end }}
+              </ul>
 
-                        <!--  file nodes -->
-                        <ul class="sn-list">
-                            {{range $node, $issueNodes := .Issues}}
-                            <li class="sn-list-item is-expandable is-clickable-{{$node.ProductEnabled}} is-expanded">
-                                <!-- file node-->
-                                <span class="sn-icon">{{$node.Icon}}</span><span class="sn-label">{{$node.Text}}</span>
-                                <!-- issue tree nodes -->
-                                <ul class="sn-list">
-                                    {{range $index, $issue := $issueNodes}}
-                                    <li class="sn-list-item is-clickable={{$node.ProductEnabled}}">
-                                        <span class="sn-icon">{{$issue.Icon}}</span><span class="sn-label">{{$issue.Text}}</span>
-                                    </li>
-                                    {{ end }}
-                                </ul>
-                            </li>
-                            {{ end }}
-                        </ul>
-                    </div>
-                </section>
-                <!-- Content for Vulnerability Overview -->
+              <!--  file nodes -->
+              <ul class="sn-list">
+                {{range $node, $issueNodes := .Issues}}
+                <li class="sn-list-item is-expandable is-clickable-{{$node.ProductEnabled}} is-expanded">
+                  <!-- file node-->
+                  <span class="sn-icon">{{$node.Icon}}</span><span class="sn-label">{{$node.Text}}</span>
+                  <!-- issue tree nodes -->
+                  <ul class="sn-list">
+                    {{range $index, $issue := $issueNodes}}
+                    <li class="sn-list-item is-clickable={{$node.ProductEnabled}}">
+                      <span class="sn-icon">{{$issue.Icon}}</span><span class="sn-label">{{$issue.Text}}</span>
+                    </li>
+                    {{ end }}
+                  </ul>
+                </li>
+                {{ end }}
+              </ul>
             </div>
-            <!-- End all-issues-content -->
-            <!-- net-new issues content -->
-            <div data-content="net-new-issues" id="net-new-issues-content"
-                 class="tab-content {{if .DeltaFindingsEnabled}} is-selected {{end}} main-tab-content">
-            </div>
-            <!-- End net-new-issues-content -->
+          </section>
+          <!-- Content for Vulnerability Overview -->
         </div>
+        <!-- End all-issues-content -->
+        <!-- net-new issues content -->
+        <div data-content="net-new-issues" id="net-new-issues-content"
+          class="tab-content {{if .DeltaFindingsEnabled}} is-selected {{end}} main-tab-content">
+        </div>
+        <!-- End net-new-issues-content -->
+      </div>
     </article>
-</main>
+  </main>
 
-<script nonce="{{.Nonce}}">
+  <script nonce="{{.Nonce}}">
     const allIssuesTab = document.getElementById("all-issues-tab");
     const netNewIssuesTab = document.getElementById("net-new-issues-tab");
     const deltaFindingsEnabled = Boolean("{{.DeltaFindingsEnabled}}");
 
     // event listeners for switching tabs
     netNewIssuesTab.addEventListener("click", () => {
-        retrieveIssues(true)
+      retrieveIssues(true)
     })
 
     allIssuesTab.addEventListener("click", () => {
-        retrieveIssues(false)
+      retrieveIssues(false)
     })
 
     function retrieveIssues(deltaFindingsEnabled) {
-        // retrieve issues, injected/overwritten by IDE
-        // this should force a reload & resending to the client.
-        // also the backend must update its config
-        console.log(`i should be retrieving values. delta: ${deltaFindingsEnabled}`)
+      // retrieve issues, injected/overwritten by IDE
+      // this should force a reload & resending to the client.
+      // also the backend must update its config
+      console.log(`i should be retrieving values. delta: ${deltaFindingsEnabled}`)
     }
 
     if (deltaFindingsEnabled) {
-        netNewIssuesTab.className.replace(" active", "")
+      netNewIssuesTab.className.replace(" active", "")
     } else {
-        allIssuesTab.className += " active"
+      allIssuesTab.className += " active"
     }
-</script>
+  </script>
 </body>
 
 </html>

--- a/infrastructure/iac/iac_html.go
+++ b/infrastructure/iac/iac_html.go
@@ -40,7 +40,7 @@ type TemplateData struct {
 	Description  template.HTML
 	Remediation  template.HTML
 	Path         template.HTML
-	Nonce        string
+	Nonce        template.HTML
 }
 
 //go:embed template/index.html
@@ -83,7 +83,7 @@ func (service *IacHtmlRender) getCustomUIContent(issue snyk.Issue) string {
 		Description:  html.MarkdownToHTML(issue.Message),
 		Remediation:  html.MarkdownToHTML(issue.AdditionalData.(snyk.IaCIssueData).Resolve),
 		Path:         formatPath(issue.AdditionalData.(snyk.IaCIssueData).Path),
-		Nonce:        nonce,
+		Nonce:        template.HTML(nonce),
 	}
 
 	err = service.GlobalTemplate.Execute(&htmlTemplate, data)

--- a/infrastructure/iac/template/index.html
+++ b/infrastructure/iac/template/index.html
@@ -23,9 +23,9 @@
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'none'; style-src 'self' 'nonce-{{.Nonce}}' 'nonce-ideNonce'; script-src 'nonce-{{.Nonce}}';">
   <!--noformat-->
-  <style nonce="{{.Nonce}}">
-    {{.Styles}}
-  </style>
+  <!-- @formatter:off -->
+  <style nonce="{{.Nonce}}">{{.Styles}}</style>
+  <!-- @formatter:on -->
   <!--noformat-->
   <!-- The following <style> tag is a placeholder that will be replaced by IDE-specific styles.
     IDEs can inject their own styles dynamically by replacing this tag using the data-ide-style attribute. -->


### PR DESCRIPTION
### Description

This PR fixes the value generated for the nonce value. Previously, the `nonce` was treated as a plain string, which led to improper escaping. By using `template.HTML`, we ensure that the `nonce` is inserted as **raw HTML**.

This change also adds at the The Content-Security-Policy header the missing `'nonce-ideNonce'` attribute, which is necessary for allowing IDEs to inject their specific styles. .

<img width="640" alt="nonce-needs-escaping" src="https://github.com/user-attachments/assets/df0233fe-bc86-4bb7-9c4a-fa8d3d116757">


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

