### PR TITLE
chore(autofix): more visible logging

### DIFF
--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
+	performance2 "github.com/snyk/snyk-ls/internal/observability/performance"
 )
 
 // AutofixUnifiedDiffSuggestion represents the diff between the original and the fixed source code.
@@ -46,6 +47,15 @@ func (s *SnykCodeHTTPClient) GetAutoFixDiffs(ctx context.Context, baseDir string
 	defer s.instrumentor.Finish(span)
 
 	var response AutofixResponse
+	requestId, err := performance2.GetTraceId(ctx)
+	if err != nil {
+		logger.Err(err).Msg(failedToObtainRequestIdString + err.Error())
+		return unifiedDiffSuggestions, err
+	}
+
+	logger.Info().Str("requestId", requestId).Msg("Started obtaining autofix diffs")
+	defer logger.Info().Str("requestId", requestId).Msg("Finished obtaining autofix diffs")
+
 	response, err = s.RunAutofix(span.Context(), options)
 	if err != nil || response.Status == failed.message {
 		logger.Err(err).Msg("error getting autofix suggestions")

--- a/infrastructure/code/snyk_code_http_client.go
+++ b/infrastructure/code/snyk_code_http_client.go
@@ -499,8 +499,8 @@ func (s *SnykCodeHTTPClient) RunAutofix(ctx context.Context, options AutofixOpti
 		logger.Err(err).Msg(failedToObtainRequestIdString + err.Error())
 		return AutofixResponse{}, err
 	}
-	logger.Debug().Msg("API: Retrieving autofix for bundle")
-	defer logger.Debug().Msg("API: Retrieving autofix done")
+	logger.Info().Msg("API: Retrieving autofix for bundle")
+	defer logger.Info().Msg("API: Retrieving autofix done")
 
 	requestBody, err := s.autofixRequestBody(&options)
 	if err != nil {

--- a/infrastructure/code/snyk_code_http_client.go
+++ b/infrastructure/code/snyk_code_http_client.go
@@ -499,8 +499,8 @@ func (s *SnykCodeHTTPClient) RunAutofix(ctx context.Context, options AutofixOpti
 		logger.Err(err).Msg(failedToObtainRequestIdString + err.Error())
 		return AutofixResponse{}, err
 	}
-	logger.Info().Msg("API: Retrieving autofix for bundle")
-	defer logger.Info().Msg("API: Retrieving autofix done")
+	logger.Debug().Msg("API: Retrieving autofix for bundle")
+	defer logger.Debug().Msg("API: Retrieving autofix done")
 
 	requestBody, err := s.autofixRequestBody(&options)
 	if err != nil {


### PR DESCRIPTION
### Description

We noticed, that while for Analysis, the `requestId` is visible at the `info` level, we don't have the same for autofix -- which would be useful when the users want to report the issues (without going through the complex procedure of switching the debug level on).

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] ~~README.md updated, if user-facing~~
- [ ] ~~License file updated, if new 3rd-party dependency is introduced~~
