### PR TITLE
fix: downgrade to go1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/snyk/snyk-ls
 
-go 1.23
+go 1.22
 
-toolchain go1.23.0
+toolchain go1.22.6
 
 require (
 	github.com/adrg/strutil v0.3.1


### PR DESCRIPTION
### Description

CLI will only support go 1.23 in the next cycle, not this cycle.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
