### PR TITLE
fix: do not execute code action commands twice [IDE-506][HEAD-229] 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ LDFLAGS_DEV := "-X 'github.com/snyk/snyk-ls/application/config.Development=true'
 
 TOOLS_BIN := $(shell pwd)/.bin
 
-OVERRIDE_GOCI_LINT_V := v1.60.1
+OVERRIDE_GOCI_LINT_V := v1.60.2
 PACT_V := 2.4.2
 
 NOCACHE := "-count=1"

--- a/application/codeaction/codeaction.go
+++ b/application/codeaction/codeaction.go
@@ -1,7 +1,6 @@
 package codeaction
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -11,7 +10,6 @@ import (
 	sglsp "github.com/sourcegraph/go-lsp"
 
 	"github.com/snyk/snyk-ls/application/config"
-	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/ide/converter"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/code"
@@ -188,20 +186,6 @@ func (c *CodeActionsService) ResolveCodeAction(action types.CodeAction) (types.C
 
 	c.logger.Debug().Msg(fmt.Sprint("Resolved code action in ", elapsedSeconds, " seconds:\n", codeAction))
 	return codeAction, nil
-}
-
-func (c *CodeActionsService) handleCommand(action types.CodeAction, server types.Server) error {
-	c.logger.Debug().Str("method", "codeaction.handleCommand").Msgf("handling command %s", action.Command.Command)
-	cmd := types.CommandData{
-		Title:     action.Command.Title,
-		CommandId: action.Command.Command,
-		Arguments: action.Command.Arguments,
-	}
-	_, err := command.Service().ExecuteCommandData(context.Background(), cmd, server)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 type missingKeyError struct{}

--- a/application/codeaction/codeaction.go
+++ b/application/codeaction/codeaction.go
@@ -31,6 +31,7 @@ type CodeActionsService struct {
 	// actionsCache holds all the issues that were returns by the GetCodeActions method.
 	// This is used to resolve the code actions later on in ResolveCodeAction.
 	actionsCache  map[uuid.UUID]cachedAction
+	c             *config.Config
 	logger        zerolog.Logger
 	fileWatcher   dirtyFilesWatcher
 	notifier      noti.Notifier
@@ -46,6 +47,7 @@ func NewService(c *config.Config, provider snyk.IssueProvider, fileWatcher dirty
 	return &CodeActionsService{
 		IssuesProvider: provider,
 		actionsCache:   make(map[uuid.UUID]cachedAction),
+		c:              c,
 		logger:         c.Logger().With().Str("service", "CodeActionsService").Logger(),
 		fileWatcher:    fileWatcher,
 		notifier:       notifier,
@@ -154,27 +156,29 @@ func (c *CodeActionsService) cacheCodeAction(action snyk.CodeAction, issue snyk.
 	}
 }
 
-func (c *CodeActionsService) ResolveCodeAction(action types.CodeAction, server types.Server) (types.CodeAction, error) {
+func (c *CodeActionsService) ResolveCodeAction(action types.CodeAction) (types.CodeAction, error) {
 	c.logger.Debug().Msg("Received code action resolve request")
 	t := time.Now()
 
-	if action.Command != nil {
-		codeAction, err := c.handleCommand(action, server)
-		return codeAction, err
+	// If we don't have the data element, our resolution does not work. We then need to return
+	// the action we received, so that a potentially included command can be executed.
+	if action.Command != nil && action.Data == nil {
+		return action, nil
 	}
 
+	// we cannot proceed without action data, so now it would be an error
 	if action.Data == nil {
-		return types.CodeAction{}, missingKeyError{}
+		return action, missingKeyError{}
 	}
 
 	key := uuid.UUID(*action.Data)
 	cached, found := c.actionsCache[key]
-	// only delete cache entry after it's been resolved
-	defer delete(c.actionsCache, key)
 	if !found {
 		return types.CodeAction{}, errors.New(fmt.Sprint("could not find cached action for uuid ", key))
 	}
 
+	// only delete cache entry after it's been resolved
+	defer delete(c.actionsCache, key)
 	edit := (*cached.action.DeferredEdit)()
 	resolvedAction := cached.action
 	resolvedAction.Edit = edit
@@ -186,7 +190,7 @@ func (c *CodeActionsService) ResolveCodeAction(action types.CodeAction, server t
 	return codeAction, nil
 }
 
-func (c *CodeActionsService) handleCommand(action types.CodeAction, server types.Server) (types.CodeAction, error) {
+func (c *CodeActionsService) handleCommand(action types.CodeAction, server types.Server) error {
 	c.logger.Debug().Str("method", "codeaction.handleCommand").Msgf("handling command %s", action.Command.Command)
 	cmd := types.CommandData{
 		Title:     action.Command.Title,
@@ -195,9 +199,9 @@ func (c *CodeActionsService) handleCommand(action types.CodeAction, server types
 	}
 	_, err := command.Service().ExecuteCommandData(context.Background(), cmd, server)
 	if err != nil {
-		return types.CodeAction{}, err
+		return err
 	}
-	return types.CodeAction{}, nil
+	return nil
 }
 
 type missingKeyError struct{}

--- a/application/server/codeaction_handlers.go
+++ b/application/server/codeaction_handlers.go
@@ -37,7 +37,7 @@ func ResolveCodeActionHandler(c *config.Config, service *codeaction.CodeActionsS
 		logger = logger.With().Interface("request", params).Logger()
 		logger.Debug().Msg("RECEIVING")
 
-		action, err := service.ResolveCodeAction(params, server)
+		action, err := service.ResolveCodeAction(params)
 		if err != nil {
 			if codeaction.IsMissingKeyError(err) { // If the key is missing, it means that the code action is not a deferred code action
 				logger.Debug().Msg("Skipping code action - missing key")

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -19,13 +19,14 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/snyk/snyk-ls/domain/snyk/scanner"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/snyk/snyk-ls/domain/snyk/scanner"
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
@@ -40,7 +41,6 @@ import (
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
-	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/ide/converter"
 	"github.com/snyk/snyk-ls/domain/ide/hover"
 	"github.com/snyk/snyk-ls/domain/ide/workspace"
@@ -943,33 +943,6 @@ func Test_workspaceDidChangeWorkspaceFolders_shouldProcessChanges(t *testing.T) 
 	}
 
 	assert.Nil(t, w.GetFolderContaining(uri.PathFromUri(f.Uri)))
-}
-
-func Test_CodeActionResolve_ShouldExecuteCommands(t *testing.T) {
-	loc, _ := setupServer(t)
-	testutil.IntegTest(t)
-	_, err := loc.Client.Call(ctx, "initialize", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	config.CurrentConfig().SetAutomaticScanning(false)
-
-	expected := types.OpenBrowserCommand
-	serviceMock := types.NewCommandServiceMock()
-	command.SetService(serviceMock)
-
-	_, err = loc.Client.Call(ctx, "codeAction/resolve", types.CodeAction{
-		Title: "My super duper test action",
-		Command: &sglsp.Command{
-			Title:     expected,
-			Command:   expected,
-			Arguments: []any{"https://snyk.io"},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, expected, serviceMock.ExecutedCommands()[0].CommandId)
 }
 
 // Check if published diagnostics for given testPath match the expectedNumber.

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -571,10 +571,10 @@ func Test_initialize_shouldOfferAllCommands(t *testing.T) {
 	loc, _ := setupServer(t)
 	c := config.CurrentConfig()
 
-	scanner := &scanner.TestScanner{}
+	sc := &scanner.TestScanner{}
 	workspace.Get().AddFolder(workspace.NewFolder(c, "dummy",
 		"dummy",
-		scanner,
+		sc,
 		di.HoverService(),
 		di.ScanNotifier(),
 		di.Notifier(),


### PR DESCRIPTION
### Description

Eclipse and VSCode have slightly different behaviours. To cater for Eclipse's behaviour (HEAD-229) we added execution of commands during resolution of code actions. This is not correct and only worked, because we returned an empty code action afterwards to Eclipse which overwrote the command earlier contained.

In VSCode, the command of the code action is not overwritten by the resolved code action, thus `executeCommand` was called both in resolution and normal command execution.

This implementation difference abides by protocol, but our returning changed fields after executing the command does not. The PR fixes this incorrect behaviour.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
