### PR TITLE
fix: use IDE-specific storage

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -19,11 +19,15 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/snyk/snyk-ls/domain/snyk/scanner"
 	"os"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/adrg/xdg"
+
+	"github.com/snyk/snyk-ls/domain/snyk/scanner"
+	storage2 "github.com/snyk/snyk-ls/internal/storage"
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/channel"
@@ -202,11 +206,24 @@ func initializeHandler(srv *jrpc2.Server) handler.Func {
 		logger := c.Logger().With().Str("method", method).Logger()
 		// we can only log, after we add the token to the list of forbidden outputs
 		defer logger.Info().Any("params", params).Msg("RECEIVING")
-		InitializeSettings(c, params.InitializationOptions)
 
 		c.SetClientCapabilities(params.Capabilities)
 		setClientInformation(params)
+		// update storage
+		file, err := xdg.ConfigFile("snyk/ls-config-" + c.IdeName())
+		if err != nil {
+			return nil, err
+		}
 
+		storage, err := storage2.NewStorageWithCallbacks(storage2.WithStorageFile(file))
+		if err != nil {
+			return nil, err
+		}
+
+		c.SetStorage(storage)
+		c.Engine().GetConfiguration().SetStorage(c.Storage())
+
+		InitializeSettings(c, params.InitializationOptions)
 		// async processing listener
 		go createProgressListener(progress.Channel, srv, c.Logger())
 		registerNotifier(c, srv)

--- a/infrastructure/authentication/auth_configuration_test.go
+++ b/infrastructure/authentication/auth_configuration_test.go
@@ -28,11 +28,15 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/snyk/go-application-framework/pkg/auth"
+	storage2 "github.com/snyk/snyk-ls/internal/storage"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
 func Test_NewOAuthProvider_registersStorageCallback(t *testing.T) {
 	c := testutil.UnitTest(t)
+	storageWithCallbacks, err2 := storage2.NewStorageWithCallbacks(storage2.WithStorageFile(t.TempDir() + "testStorage"))
+	assert.NoError(t, err2)
+	c.SetStorage(storageWithCallbacks)
 
 	// a token that's set into the configuration
 	token := oauth2.Token{

--- a/infrastructure/authentication/auth_configuration_test.go
+++ b/infrastructure/authentication/auth_configuration_test.go
@@ -63,6 +63,9 @@ func Test_NewOAuthProvider_registersStorageCallback(t *testing.T) {
 
 func Test_NewOauthProvider_oauthProvider_created_with_injected_refreshMethod(t *testing.T) {
 	c := testutil.UnitTest(t)
+	storageWithCallbacks, err2 := storage2.NewStorageWithCallbacks(storage2.WithStorageFile(t.TempDir() + "testStorage"))
+	assert.NoError(t, err2)
+	c.SetStorage(storageWithCallbacks)
 
 	// an expired token that's set into the configuration
 	token := oauth2.Token{


### PR DESCRIPTION
### Description

IDEs should not share credentials. Now the shared storage file is only shared by IDE name.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
