### PR TITLE
fix: do not add `--all-projects` if `--file` is given [IDE-567]

### DIFF
--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -331,7 +331,7 @@ func Test_initialized_shouldRedactToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	os.Stderr = oldStdErr
+	defer func() { os.Stderr = oldStdErr }()
 	actual, err := os.ReadFile(file.Name())
 	require.NoError(t, err)
 	require.NotContainsf(t, string(actual), toBeRedacted, "token should be redacted")

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -362,6 +362,20 @@ func Test_prepareScanCommand(t *testing.T) {
 		assert.Contains(t, cmd, "-d")
 	})
 
+	t.Run("does not use --all-projects if --file is given", func(t *testing.T) {
+		settings := config.CliSettings{
+			AdditionalOssParameters: []string{"--file=asdf", "-d"},
+			C:                       c,
+		}
+		c.SetCliSettings(&settings)
+
+		cmd := scanner.prepareScanCommand([]string{"a"}, map[string]bool{})
+
+		assert.NotContains(t, cmd, "--all-projects")
+		assert.Contains(t, cmd, "-d")
+		assert.Contains(t, cmd, "--file=asdf")
+	})
+
 	t.Run("Uses --all-projects by default", func(t *testing.T) {
 		settings := config.CliSettings{
 			AdditionalOssParameters: []string{"-d"},


### PR DESCRIPTION
### Description

if --file is given, --all-projects cannot be used, as they are mutually exclusive. This commit introduces a blacklist that blocks automatic addition of `--all-projects`.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
