### PR TITLE
fix: also display files for sub modules in npm [IDE-573]

### DIFF
--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -317,15 +317,15 @@ func getAbsTargetFilePath(c *config.Config, scanResult scanResult, workDir strin
 		// if displayTargetFile is not relative, let's try to join path with basename
 		basePath := filepath.Base(displayTargetFile)
 		scanResultPath := scanResult.Path
-		tryOutPath := filepath.Join(scanResultPath, basePath)
+		tryOutPath := filepath.Join(scanResultPath, displayTargetFile)
 		_, tryOutErr := os.Stat(tryOutPath)
 		if tryOutErr != nil {
-			logger.Trace().Err(err).Msgf("joining basePath: %s to path: %s failed", basePath, scanResultPath)
-			// if that doesn't work, let's try full path and full display target file
-			tryOutPath = filepath.Join(scanResultPath, displayTargetFile)
-			_, tryOutErr = os.Stat(tryOutPath)
+			logger.Trace().Err(err).Msgf("joining displayTargetFile: %s to path: %s failed", displayTargetFile, scanResultPath)
+			tryOutPath = filepath.Join(scanResultPath, basePath)
+			_, tryOutErr := os.Stat(tryOutPath)
 			if tryOutErr != nil {
-				logger.Trace().Err(err).Msgf("joining displayTargetFile: %s to path: %s failed", displayTargetFile, scanResultPath)
+				logger.Trace().Err(err).Msgf("joining basePath: %s to path: %s failed", basePath, scanResultPath)
+				// if that doesn't work, let's try full path and full display target file
 				tryOutPath = filepath.Join(workDir, displayTargetFile)
 				_, tryOutErr = os.Stat(tryOutPath)
 				if tryOutErr != nil {

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -30,11 +30,12 @@ import (
 
 func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 	testCases := []struct {
-		name              string
-		displayTargetFile string
-		workDir           string
-		path              string
-		expected          string
+		name                       string
+		displayTargetFile          string
+		workDir                    string
+		displayTargetFileInWorkDir string
+		path                       string
+		expected                   string
 	}{
 		{
 			name:              "NPM root directory",
@@ -42,6 +43,14 @@ func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 			workDir:           "/Users/cata/git/playground/juice-shop", // if we mock the workDir
 			path:              "/Users/cata/git/playground/juice-shop",
 			expected:          "/Users/cata/git/playground/juice-shop/package.json",
+		},
+		{
+			name:                       "NPM sub directory",
+			displayTargetFile:          "frontend/package.json",
+			displayTargetFileInWorkDir: "package.json",
+			workDir:                    "/Users/cata/git/playground/juice-shop", // if we mock the workDir
+			path:                       "/Users/cata/git/playground/juice-shop",
+			expected:                   "/Users/cata/git/playground/juice-shop/frontend/package.json",
 		},
 		{
 			name:              "Poetry Sub Project (below the working directory)",
@@ -141,6 +150,10 @@ func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 			dir := filepath.Dir(expected)
 			require.NoError(t, os.MkdirAll(dir, 0770))
 			require.NoError(t, os.WriteFile(expected, []byte(expected), 0666))
+			if tc.displayTargetFileInWorkDir != "" {
+				absFile := filepath.Join(base, adjustedWorkDir, tc.displayTargetFileInWorkDir)
+				require.NoError(t, os.WriteFile(absFile, []byte(tc.displayTargetFileInWorkDir), 0666))
+			}
 
 			actual := getAbsTargetFilePath(c, scanResult{
 				DisplayTargetFile: tc.displayTargetFile,

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -60,11 +60,12 @@ func TestCLIScanner_getAbsTargetFilePathForPackageManagers(t *testing.T) {
 			expected:          "/Users/cata/git/playground/python-goof/poetry-sample/pyproject.toml",
 		},
 		{
-			name:              "Gradle multi-module",
-			displayTargetFile: "build.gradle",
-			workDir:           "/Users/bdoetsch/workspace/gradle-multi-module",
-			path:              "/Users/bdoetsch/workspace/gradle-multi-module/sample-api",
-			expected:          "/Users/bdoetsch/workspace/gradle-multi-module/sample-api/build.gradle",
+			name:                       "Gradle multi-module",
+			displayTargetFile:          "build.gradle",
+			displayTargetFileInWorkDir: "build.gradle",
+			workDir:                    "/Users/bdoetsch/workspace/gradle-multi-module",
+			path:                       "/Users/bdoetsch/workspace/gradle-multi-module/sample-api",
+			expected:                   "/Users/bdoetsch/workspace/gradle-multi-module/sample-api/build.gradle",
 		},
 		{
 			name:              "Go Modules deeply nested",


### PR DESCRIPTION
### Description

Previously, a file tree as the following was causing problems in NPM SCA scans:

```
project
|-package.json
|-frontend
|--package.json
```
The JSON result parser would not identify the right package.json (unfortunately, the CLI does not report the absolute path of the package manager file).

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

![image](https://github.com/user-attachments/assets/9b319a74-23dd-4a9f-8316-4f4bf12640ed)

