### PR TITLE
feat: read shell environment on startup

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -331,9 +331,7 @@ func (c *Config) SetTrustedFolderFeatureEnabled(enabled bool) {
 }
 
 func (c *Config) Load() {
-	c.m.Lock()
 	c.LoadShellEnvironment()
-	c.m.Unlock()
 
 	c.m.RLock()
 	files := c.configFiles()

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -349,7 +349,12 @@ func (c *Config) LoadShellEnvironment() {
 	if runtime.GOOS != "windows" {
 		parsedEnv := getParsedEnvFromShell("bash")
 		shell := parsedEnv["SHELL"]
-		c.setParsedVariablesToEnv(getParsedEnvFromShell(shell))
+		fromSpecificShell := getParsedEnvFromShell(shell)
+		if len(fromSpecificShell) > 0 {
+			c.setParsedVariablesToEnv(fromSpecificShell)
+		} else {
+			c.setParsedVariablesToEnv(parsedEnv)
+		}
 	}
 }
 

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -75,6 +75,7 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Equal(t, types.TokenAuthentication, c.authenticationMethod)
 }
 
+// this only tests that no error occurs on any os
 func TestConfig_LoadShellEnvironment(t *testing.T) {
 	c := New()
 	c.LoadShellEnvironment()

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -75,6 +75,11 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Equal(t, types.TokenAuthentication, c.authenticationMethod)
 }
 
+func TestConfig_LoadShellEnvironment(t *testing.T) {
+	c := New()
+	c.LoadShellEnvironment()
+}
+
 func Test_TokenChanged_ChannelsInformed(t *testing.T) {
 	// Arrange
 	c := New()


### PR DESCRIPTION
### Description

Load environment from shell environment. This reduces the number of errors caused by configuration mismatches.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
