### PR TITLE
fix: move learn service cache init to after ls startup & init

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "./go.mod"
+          cache: "true"
 
       - name: Set up Snyk CLI
         uses: snyk/actions/setup@master
@@ -47,15 +48,6 @@ jobs:
         if: steps.cache-pact.outputs.cache-hit != 'true'
         run: |
           make tools
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - name: Lint source code
         run: |

--- a/.github/workflows/create-cli-pr.yaml
+++ b/.github/workflows/create-cli-pr.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: "true"
 
       - uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "./go.mod"
+          cache: "true"
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: "true"
 
       - name: Cache Pact CLI tools
         id: cache-pact

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ OVERRIDE_GOCI_LINT_V := v1.60.2
 PACT_V := 2.4.2
 
 NOCACHE := "-count=1"
-TIMEOUT := "-timeout=45m"
+TIMEOUT := "-timeout=15m"
 
 
 ## tools: Install required tooling.

--- a/application/di/test_init.go
+++ b/application/di/test_init.go
@@ -17,9 +17,10 @@
 package di
 
 import (
+	"testing"
+
 	"github.com/snyk/snyk-ls/domain/snyk/persistence"
 	scanner2 "github.com/snyk/snyk-ls/domain/snyk/scanner"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 
@@ -75,6 +76,8 @@ func TestInit(t *testing.T) {
 	scanNotifier, _ = appNotification.NewScanNotifier(c, notifier)
 	// mock Learn Service
 	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	learnMock.EXPECT().GetAllLessons().Return([]learn.Lesson{learn.Lesson{}}, nil).AnyTimes()
+	learnMock.EXPECT().MaintainCache().AnyTimes()
 	learnMock.
 		EXPECT().
 		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -390,18 +390,19 @@ func initializedHandler(srv *jrpc2.Server) handler.Func {
 
 		handleProtocolVersion(c, di.Notifier(), config.LsProtocolVersion, c.ClientProtocolVersion())
 
-		// initialize cache
-		learnService := di.LearnService()
-		_, err := learnService.GetAllLessons()
-		if err != nil {
-			logger.Err(err).Msg("Error initializing lessons cache")
-		}
-
-		// start goroutine that keeps the cache filled
-		go learnService.MaintainCache()
+		// initialize learn cache
+		go func() {
+			learnService := di.LearnService()
+			_, err := learnService.GetAllLessons()
+			if err != nil {
+				logger.Err(err).Msg("Error initializing lessons cache")
+			}
+			// start goroutine that keeps the cache filled
+			go learnService.MaintainCache()
+		}()
 
 		// CLI & Authentication initialization - returns error if not authenticated
-		err = di.Scanner().Init()
+		err := di.Scanner().Init()
 		if err != nil {
 			logger.Error().Err(err).Msg("Scan initialization error, canceling scan")
 			return nil, nil

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -382,6 +382,9 @@ func initializedHandler(srv *jrpc2.Server) handler.Func {
 		initialLogger.Info().Msg("no_proxy: " + os.Getenv("NO_PROXY"))
 		initialLogger.Info().Msg("IDE: " + c.IdeName() + "/" + c.IdeVersion())
 		initialLogger.Info().Msg("snyk-plugin: " + c.IntegrationName() + "/" + c.IntegrationVersion())
+		if token, err := c.TokenAsOAuthToken(); err == nil {
+			initialLogger.Info().Msgf("Truncated token: %s", token.RefreshToken[len(token.RefreshToken)-8:])
+		}
 
 		logger := c.Logger().With().Str("method", "initializedHandler").Logger()
 

--- a/infrastructure/authentication/auth_configuration.go
+++ b/infrastructure/authentication/auth_configuration.go
@@ -58,6 +58,7 @@ func Default(c *config.Config, authenticationService AuthenticationService) Auth
 	refresherFunc := func(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 		logger := c.Logger().With().Str("method", "oauth.refresherFunc").Logger()
 		logger.Info().Msg("refreshing oauth2 token")
+		logger.Info().Msgf("used truncated refresh token: %s", token.RefreshToken[len(token.RefreshToken)-8:])
 		refreshToken, err := auth.RefreshToken(ctx, oauthConfig, token)
 		if err != nil {
 			logger.Err(err).Msg("failed to refresh oauth2 token")

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -18,11 +18,20 @@ package authentication
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
 	"reflect"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/erni27/imcache"
+	"github.com/rs/zerolog"
+	"golang.org/x/oauth2"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/data_structure"
@@ -135,30 +144,97 @@ func (a *AuthenticationServiceImpl) IsAuthenticated() bool {
 
 		invalidToken, isLegacyTokenErr := a.c.TokenAsOAuthToken()
 
-		// we always log out
-		logger.Debug().Msg("logging out")
-		a.Logout(context.Background())
-
-		// determine the right error message
-		if isLegacyTokenErr == nil {
-			// it is an oauth token
-			if invalidToken.Expiry.Before(time.Now()) {
-				a.handleFailedRefresh()
-			} else {
-				// access token not expired, but creds still not work
-				a.HandleInvalidCredentials()
-			}
+		if logoutCausingError(err) {
+			a.handleLogoutCausingError(logger, isLegacyTokenErr, invalidToken)
+			return false
 		} else {
-			// legacy token does not work
-			a.HandleInvalidCredentials()
+			// try again
+			time.Sleep(2 * time.Second)
+			retryUser, retryError := a.provider.GetCheckAuthenticationFunction()()
+			if retryUser == "" || retryError != nil {
+				// retry failed again, we gotta logout after all
+				a.handleLogoutCausingError(logger, isLegacyTokenErr, invalidToken)
+				return false
+			}
 		}
-		return false
 	}
-
 	// we cache the API auth ok for up to 1 minutes after last access. Afterwards, a new check is performed.
 	a.authCache.Set(a.c.Token(), true, imcache.WithSlidingExpiration(time.Minute))
 	a.c.Logger().Debug().Msg("IsAuthenticated: " + user + ", adding to cache.")
 	return true
+}
+
+func (a *AuthenticationServiceImpl) handleLogoutCausingError(logger zerolog.Logger, isLegacyTokenErr error, invalidToken oauth2.Token) {
+	logger.Debug().Msg("logging out")
+	a.Logout(context.Background())
+
+	// determine the right error message
+	if isLegacyTokenErr == nil {
+		// it is an oauth token
+		if invalidToken.Expiry.Before(time.Now()) {
+			a.handleFailedRefresh()
+		} else {
+			// access token not expired, but creds still not work
+			a.HandleInvalidCredentials()
+		}
+	} else {
+		// legacy token does not work
+		a.HandleInvalidCredentials()
+	}
+}
+
+func logoutCausingError(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	// Check for context cancellation
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	// Check for timeout errors
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Check for URL errors
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return false
+	}
+
+	// Check for network operation errors
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return false
+	}
+
+	// Check for DNS errors
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return false
+	}
+
+	// Check for system call errors
+	var sysCallErr *os.SyscallError
+	if errors.As(err, &sysCallErr) {
+		return false
+	}
+
+	// Check for connection reset error
+	if errors.Is(err, syscall.ECONNRESET) {
+		return false
+	}
+
+	// Check for EOF error
+	if errors.Is(err, io.EOF) {
+		return false
+	}
+
+	// as we can't enforce correct error reporting, let's do a final check on the internet connection, whether it's there
+	_, err = http.Get("https://www.google.com")
+	return err == nil
 }
 
 func (a *AuthenticationServiceImpl) handleFailedRefresh() {

--- a/infrastructure/learn/mock_learn/service_mock.go
+++ b/infrastructure/learn/mock_learn/service_mock.go
@@ -81,3 +81,17 @@ func (mr *MockServiceMockRecorder) LearnEndpoint(arg0 interface{}) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LearnEndpoint", reflect.TypeOf((*MockService)(nil).LearnEndpoint), arg0)
 }
+
+// MaintainCache mocks base method.
+func (m *MockService) MaintainCache() func() {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaintainCache")
+	ret0, _ := ret[0].(func())
+	return ret0
+}
+
+// MaintainCache indicates an expected call of LearnEndpoint.
+func (mr *MockServiceMockRecorder) MaintainCache() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainCache", reflect.TypeOf((*MockService)(nil).MaintainCache))
+}

--- a/infrastructure/learn/service_test.go
+++ b/infrastructure/learn/service_test.go
@@ -62,6 +62,8 @@ func Test_GetLesson(t *testing.T) {
 	c := testutil.SmokeTest(t, false)
 	c.UpdateApiEndpoints("https://api.snyk.io")
 	cut := New(c, c.Engine().GetNetworkAccess().GetUnauthorizedHttpClient, errorreporting.NewTestErrorReporter())
+	_, err := cut.GetAllLessons()
+	assert.NoError(t, err)
 	t.Run("OSS issue - lesson returned", func(t *testing.T) {
 		params := getRealOSSLookupParams()
 

--- a/internal/vcs/checkout_handler.go
+++ b/internal/vcs/checkout_handler.go
@@ -18,10 +18,11 @@ package vcs
 
 import (
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	"github.com/rs/zerolog"
 	"os"
 	"sync"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/rs/zerolog"
 )
 
 type CheckoutHandler struct {

--- a/internal/vcs/checkout_handler_test.go
+++ b/internal/vcs/checkout_handler_test.go
@@ -17,9 +17,11 @@
 package vcs
 
 import (
-	"github.com/snyk/snyk-ls/internal/testutil"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
 func TestCheckoutHandler_ShouldCheckout(t *testing.T) {


### PR DESCRIPTION
### Description

Moves the learn service initialization to after language server is initialized. Logs truncated refresh tokens for error debugging.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
