### PR TITLE
fix: severity filters when delta is enabled

### DIFF
--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"github.com/snyk/snyk-ls/internal/product"
 	"os"
 	"reflect"
 	"strconv"
@@ -395,8 +396,10 @@ func updateSeverityFilter(c *config.Config, s types.SeverityFilter) {
 		}
 
 		for _, folder := range ws.Folders() {
-			// Nil means send for all products found in reported issues.
-			folder.FilterAndPublishDiagnostics(nil)
+			folder.FilterAndPublishDiagnostics(product.ProductOpenSource)
+			folder.FilterAndPublishDiagnostics(product.ProductInfrastructureAsCode)
+			folder.FilterAndPublishDiagnostics(product.ProductCode)
+			folder.FilterAndPublishDiagnostics(product.ProductContainer)
 		}
 	}
 }

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -424,6 +424,7 @@ func (s *SarifConverter) toIssues(baseDir string) (issues []snyk.Issue, err erro
 				CWEs:                testRule.Properties.Cwe,
 			}
 			d.SetFingerPrint(result.Fingerprints.Num1)
+			d.SetGlobalIdentity(result.Fingerprints.Identity)
 			d.IsIgnored, d.IgnoreDetails = s.getIgnoreDetails(result)
 			d.AdditionalData = additionalData
 


### PR DESCRIPTION
### Description

* Severity filter when delta is enabled.
* Ensure Fingerprint.Identity is set.
* Added tests to ensure that Fingerprint.Identity won't be overwritten by delta finder if it exists.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
