### PR TITLE
fix: autofix-function-location

### DIFF
--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -82,7 +82,7 @@ func (cmd *codeFixDiffs) Execute(ctx context.Context) (any, error) {
 		return nil, errors.New("failed to find issue")
 	}
 
-	suggestions, err := cmd.codeScanner.GetAutoFixDiffs(ctx, folderPath, relPath, issue)
+	suggestions, err := cmd.codeScanner.GetAutofixDiffs(ctx, folderPath, relPath, issue)
 	if err != nil {
 		// as long as the backend service doesn't support good error handling, we'll just log the error
 		logger.Err(err).Msgf("received an error from API: %s", err.Error())

--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -41,8 +41,8 @@ func (a AutofixUnifiedDiffSuggestion) GetUnifiedDiffForFile(filePath string) str
 	return a.UnifiedDiffsPerFile[filePath]
 }
 
-func (s *SnykCodeHTTPClient) GetAutoFixDiffs(ctx context.Context, baseDir string, options AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error) {
-	method := "GetAutoFixDiffs"
+func (s *SnykCodeHTTPClient) GetAutofixDiffs(ctx context.Context, baseDir string, options AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error) {
+	method := "GetAutofixDiffs"
 	logger := config.CurrentConfig().Logger().With().Str("method", method).Logger()
 	span := s.instrumentor.StartSpan(ctx, method)
 	defer s.instrumentor.Finish(span)
@@ -66,13 +66,13 @@ func (s *SnykCodeHTTPClient) GetAutoFixDiffs(ctx context.Context, baseDir string
 	return response.toUnifiedDiffSuggestions(baseDir, options.filePath), err
 }
 
-func (sc *Scanner) GetAutoFixDiffs(
+func (sc *Scanner) GetAutofixDiffs(
 	ctx context.Context,
 	baseDir string,
 	filePath string,
 	issue snyk.Issue,
 ) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error) {
-	method := "GetAutoFixDiffs"
+	method := "GetAutofixDiffs"
 	logger := config.CurrentConfig().Logger().With().Str("method", method).Logger()
 	span := sc.BundleUploader.instrumentor.StartSpan(ctx, method)
 	defer sc.BundleUploader.instrumentor.Finish(span)
@@ -109,7 +109,7 @@ func (sc *Scanner) GetAutoFixDiffs(
 			logger.Error().Msg(msg)
 			return nil, errors.New(msg)
 		case <-ticker.C:
-			suggestions, err := codeClient.GetAutoFixDiffs(span.Context(), baseDir, options)
+			suggestions, err := codeClient.GetAutofixDiffs(span.Context(), baseDir, options)
 			if err != nil {
 				logger.Err(err).Msg("Error getting autofix suggestions")
 				return nil, err

--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
-	performance2 "github.com/snyk/snyk-ls/internal/observability/performance"
 )
 
 // AutofixUnifiedDiffSuggestion represents the diff between the original and the fixed source code.
@@ -39,31 +38,6 @@ func (a AutofixUnifiedDiffSuggestion) String() string {
 
 func (a AutofixUnifiedDiffSuggestion) GetUnifiedDiffForFile(filePath string) string {
 	return a.UnifiedDiffsPerFile[filePath]
-}
-
-func (s *SnykCodeHTTPClient) GetAutofixDiffs(ctx context.Context, baseDir string, options AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error) {
-	method := "GetAutofixDiffs"
-	logger := config.CurrentConfig().Logger().With().Str("method", method).Logger()
-	span := s.instrumentor.StartSpan(ctx, method)
-	defer s.instrumentor.Finish(span)
-
-	var response AutofixResponse
-	requestId, err := performance2.GetTraceId(ctx)
-	if err != nil {
-		logger.Err(err).Msg(failedToObtainRequestIdString + err.Error())
-		return unifiedDiffSuggestions, err
-	}
-
-	logger.Info().Str("requestId", requestId).Msg("Started obtaining autofix diffs")
-	defer logger.Info().Str("requestId", requestId).Msg("Finished obtaining autofix diffs")
-
-	response, err = s.RunAutofix(span.Context(), options)
-	if err != nil || response.Status == failed.message {
-		logger.Err(err).Msg("error getting autofix suggestions")
-		return unifiedDiffSuggestions, err
-	}
-
-	return response.toUnifiedDiffSuggestions(baseDir, options.filePath), err
 }
 
 func (sc *Scanner) GetAutofixDiffs(

--- a/infrastructure/code/fake_snyk_code_api_service.go
+++ b/infrastructure/code/fake_snyk_code_api_service.go
@@ -141,7 +141,7 @@ type FakeSnykCodeClient struct {
 	C                      *config.Config
 }
 
-func (f *FakeSnykCodeClient) GetAutoFixDiffs(_ context.Context, _ string, _ AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error) {
+func (f *FakeSnykCodeClient) GetAutofixDiffs(_ context.Context, _ string, _ AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error) {
 	return f.UnifiedDiffSuggestions, nil
 }
 

--- a/infrastructure/code/snyk_code_http_client_interface.go
+++ b/infrastructure/code/snyk_code_http_client_interface.go
@@ -73,5 +73,5 @@ type SnykCodeClient interface {
 
 	SubmitAutofixFeedback(ctx context.Context, fixId string, result string) error
 
-	GetAutoFixDiffs(ctx context.Context, baseDir string, options AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error)
+	GetAutofixDiffs(ctx context.Context, baseDir string, options AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, err error)
 }


### PR DESCRIPTION
### Description

All the member functions of the interface SnykCodeHTTPClient are defined in its respective file `snyk_code_http_client.go` except the `GetAutofixDiffs` function which is defined in `autofix.go`. I do not see any reason to have this exception. Also, other autofix related functions are already in `snyk_code_http_client.go`, so moving `GetAutofixDiffs` there as well.

NOTE: Merge after #677 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced
