### PR TITLE
fix: autofix: enable code fix diff test on windows

### DIFF
--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -74,14 +74,13 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 		notifier:    notification.NewMockNotifier(),
 		codeScanner: codeScanner,
 	}
-
+	if runtime.GOOS == "windows" {
+		codeScanner.AddBundleHash("\\folderPath", "bundleHash")
+	} else {
+		codeScanner.AddBundleHash("/folderPath", "bundleHash")
+	}
 	t.Run("happy path", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		if runtime.GOOS == "windows" {
-			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
-		} else {
-			codeScanner.AddBundleHash("/folderPath", "bundleHash")
-		}
 
 		cut.command = types.CommandData{
 			Arguments: []any{"file:///folderPath", "file:///folderPath/issuePath", "issueId"},
@@ -95,11 +94,6 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 	t.Run("unhappy - file not beneath folder", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		if runtime.GOOS == "windows" {
-			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
-		} else {
-			codeScanner.AddBundleHash("/folderPath", "bundleHash")
-		}
 		cut.command = types.CommandData{
 			Arguments: []any{"file:///folderPath", "file:///anotherFolder/issuePath", "issueId"},
 		}
@@ -112,11 +106,6 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 	t.Run("unhappy - folder empty", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		if runtime.GOOS == "windows" {
-			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
-		} else {
-			codeScanner.AddBundleHash("/folderPath", "bundleHash")
-		}
 		cut.command = types.CommandData{
 			Arguments: []any{"", "file:///anotherFolder/issuePath", "issueId"},
 		}
@@ -129,11 +118,6 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 	t.Run("unhappy - file empty", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		if runtime.GOOS == "windows" {
-			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
-		} else {
-			codeScanner.AddBundleHash("/folderPath", "bundleHash")
-		}
 		cut.command = types.CommandData{
 			Arguments: []any{"file://folder", "", "issueId"},
 		}

--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -55,10 +55,6 @@ func (m mockIssueProvider) Issue(key string) snyk.Issue {
 }
 
 func Test_codeFixDiffs_Execute(t *testing.T) {
-	if //goland:noinspection GoBoolExpressions
-	runtime.GOOS == "windows" {
-		t.Skip("Skipping test on windows")
-	}
 	c := testutil.UnitTest(t)
 	instrumentor := code.NewCodeInstrumentor()
 	snykCodeClient := &code.FakeSnykCodeClient{

--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -82,15 +82,9 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 		} else {
 			codeScanner.AddBundleHash("/folderPath", "bundleHash")
 		}
-		// codeScanner.AddBundleHash("\\folderPath", "bundleHashWindows")
-		if runtime.GOOS == "windows" {
-			cut.command = types.CommandData{
-				Arguments: []any{"file:///folderPath", "file:///folderPath/issuePath", "issueId"},
-			}
-		} else {
-			cut.command = types.CommandData{
-				Arguments: []any{"file:///folderPath", "file:///folderPath/issuePath", "issueId"},
-			}
+
+		cut.command = types.CommandData{
+			Arguments: []any{"file:///folderPath", "file:///folderPath/issuePath", "issueId"},
 		}
 
 		suggestions, err := cut.Execute(context.Background())
@@ -101,7 +95,11 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 	t.Run("unhappy - file not beneath folder", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		codeScanner.AddBundleHash("/folderPath", "bundleHash")
+		if runtime.GOOS == "windows" {
+			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
+		} else {
+			codeScanner.AddBundleHash("/folderPath", "bundleHash")
+		}
 		cut.command = types.CommandData{
 			Arguments: []any{"file:///folderPath", "file:///anotherFolder/issuePath", "issueId"},
 		}
@@ -114,7 +112,11 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 	t.Run("unhappy - folder empty", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		codeScanner.AddBundleHash("/folderPath", "bundleHash")
+		if runtime.GOOS == "windows" {
+			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
+		} else {
+			codeScanner.AddBundleHash("/folderPath", "bundleHash")
+		}
 		cut.command = types.CommandData{
 			Arguments: []any{"", "file:///anotherFolder/issuePath", "issueId"},
 		}
@@ -127,7 +129,11 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 	t.Run("unhappy - file empty", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		codeScanner.AddBundleHash("/folderPath", "bundleHash")
+		if runtime.GOOS == "windows" {
+			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
+		} else {
+			codeScanner.AddBundleHash("/folderPath", "bundleHash")
+		}
 		cut.command = types.CommandData{
 			Arguments: []any{"file://folder", "", "issueId"},
 		}

--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/google/uuid"

--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -85,7 +85,7 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 		// codeScanner.AddBundleHash("\\folderPath", "bundleHashWindows")
 		if runtime.GOOS == "windows" {
 			cut.command = types.CommandData{
-				Arguments: []any{"file://\\folderPath", "file://\\folderPath\\issuePath", "issueId"},
+				Arguments: []any{"file:///folderPath", "file:///folderPath/issuePath", "issueId"},
 			}
 		} else {
 			cut.command = types.CommandData{

--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/google/uuid"
@@ -76,9 +77,20 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		cut.issueProvider = mockIssueProvider{}
-		codeScanner.AddBundleHash("/folderPath", "bundleHash")
-		cut.command = types.CommandData{
-			Arguments: []any{"file:///folderPath", "file:///folderPath/issuePath", "issueId"},
+		if runtime.GOOS == "windows" {
+			codeScanner.AddBundleHash("\\folderPath", "bundleHash")
+		} else {
+			codeScanner.AddBundleHash("/folderPath", "bundleHash")
+		}
+		// codeScanner.AddBundleHash("\\folderPath", "bundleHashWindows")
+		if runtime.GOOS == "windows" {
+			cut.command = types.CommandData{
+				Arguments: []any{"file://\\folderPath", "file://\\folderPath\\issuePath", "issueId"},
+			}
+		} else {
+			cut.command = types.CommandData{
+				Arguments: []any{"file:///folderPath", "file:///folderPath/issuePath", "issueId"},
+			}
 		}
 
 		suggestions, err := cut.Execute(context.Background())


### PR DESCRIPTION
### Description

Enables the fix code diffs test for Windows. It seems adapting the bundle hash is enough.


In Windows, a directory path can sometimes start with a backslash (\), and this usually happens in specific contexts or for certain reasons:

1. Relative Path to the Root of the Current Drive
When a directory path starts with a backslash (e.g., \folderPath), it refers to an absolute path relative to the root of the current drive. In this case, Windows assumes the drive you're currently on and applies the path starting from the root of that drive.

Example:
If you're on drive C:, the path \folderPath refers to C:\folderPath.
When is this used?

It's common in scripts or command-line usage where the drive context is known and fixed (like C:). This allows the user to quickly reference a folder from the root without specifying the drive letter.
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced
