### PR TITLE
fix: remove target="_blank" from html sources [IDE-677]

### DIFF
--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -719,7 +719,7 @@
       {{if gt (len .CWEs) 0}}
       <span class="delimiter">|</span>
       {{range $index, $cwe := .CWEs}}
-      <a class="cwe styled-link" target="_blank" rel="noopener noreferrer"
+      <a class="cwe styled-link"  rel="noopener noreferrer"
         href="https://cwe.mitre.org/data/definitions/{{trimCWEPrefix $cwe}}.html">{{$cwe}}</a>
       {{if ne $index (idxMinusOne (len $.CWEs))}}<span class="delimiter"></span>{{end}}
       {{end}}
@@ -739,7 +739,7 @@
       <div class="lesson-icon">
         {{.LessonIcon}}
       </div>
-      <a class="lesson-link styled-link is-external" target="_blank" rel="noopener noreferrer" href="{{.LessonUrl}}">
+      <a class="lesson-link styled-link is-external"  rel="noopener noreferrer" href="{{.LessonUrl}}">
         Learn about this vulnerability
         {{.ExternalIcon}}
       </a>
@@ -782,7 +782,7 @@
             <div class="ignore-next-step-text">
               Ignores are currently managed in the Snyk web app.
               To edit or remove the ignore please go to:
-              <a class="styled-link" href="{{.SnykWebUrl}}" target="_blank"
+              <a class="styled-link" href="{{.SnykWebUrl}}"
                 rel="noopener noreferrer">{{.SnykWebUrl}}</a>.
             </div>
           </div>
@@ -938,7 +938,7 @@
                 <div id="current-example" class="repo clickable">
                   {{.GitHubIcon}}
                   <span id="example-link" class="example-repo-link">
-                    <a id="example-repo-anchor" href="{{(index .ExampleCommitFixes 0).RepoLink}}" target="_blank"
+                    <a id="example-repo-anchor" href="{{(index .ExampleCommitFixes 0).RepoLink}}"
                       rel="noopener noreferrer">
                       {{(index .ExampleCommitFixes 0).RepoName}}
                     </a>

--- a/infrastructure/iac/iac_html_test.go
+++ b/infrastructure/iac/iac_html_test.go
@@ -38,8 +38,8 @@ func Test_IaC_Html_getIacHtml(t *testing.T) {
 	assert.Contains(t, iacPanelHtml, `<div class="severity-container">`, "HTML should contain the severity icon container")
 
 	// Reference section
-	assert.Contains(t, iacPanelHtml, `<a class="styled-link" target="_blank" rel="noopener noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/">https://kubernetes.io/docs/reference/access-authn-authz/rbac/</a>`, "HTML should contain the first reference")
-	assert.Contains(t, iacPanelHtml, `<a class="styled-link" target="_blank" rel="noopener noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole">https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole</a>`, "HTML should contain the second reference")
+	assert.Contains(t, iacPanelHtml, `<a class="styled-link"  rel="noopener noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/">https://kubernetes.io/docs/reference/access-authn-authz/rbac/</a>`, "HTML should contain the first reference")
+	assert.Contains(t, iacPanelHtml, `<a class="styled-link"  rel="noopener noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole">https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole</a>`, "HTML should contain the second reference")
 }
 
 func createIacIssueSample() snyk.Issue {

--- a/infrastructure/iac/template/index.html
+++ b/infrastructure/iac/template/index.html
@@ -45,7 +45,7 @@
     <div class="severity-type-container">
       <div class="severity-type">Issue</div>
       <span class="delimiter"></span>
-      <a class="styled-link" target="_blank" rel="noopener noreferrer"
+      <a class="styled-link"  rel="noopener noreferrer"
          href="{{.Issue.AdditionalData.Documentation}}">{{.Issue.ID}}</a>
   </header>
   <section class="delimiter-top summary">
@@ -78,7 +78,7 @@
     <h2>References</h2>
     <div class="summary-items">
       {{range .Issue.AdditionalData.References}}
-      <a class="styled-link" target="_blank" rel="noopener noreferrer" href="{{.}}">{{.}}</a>
+      <a class="styled-link"  rel="noopener noreferrer" href="{{.}}">{{.}}</a>
       {{end}}
     </div>
   </section>

--- a/infrastructure/oss/template/details.html
+++ b/infrastructure/oss/template/details.html
@@ -175,7 +175,7 @@
         {{if gt (len .CVEs) 0}}
         <span class="delimiter"> </span>
         {{range $index, $cve := .CVEs}}
-        <a class="cve styled-link" target="_blank" rel="noopener noreferrer"
+        <a class="cve styled-link"  rel="noopener noreferrer"
           href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=$cve">{{$cve}}</a>
         {{if ne $index (idxMinusOne (len $.CVEs))}}<span class="delimiter"></span>{{end}}
         {{end}}
@@ -184,7 +184,7 @@
         {{if gt (len .CWEs) 0}}
         <span class="delimiter"> </span>
         {{range $index, $cwe := .CWEs}}
-        <a class="cwe styled-link" target="_blank" rel="noopener noreferrer"
+        <a class="cwe styled-link"  rel="noopener noreferrer"
           href="https://cwe.mitre.org/data/definitions/{{trimCWEPrefix $cwe}}.html">{{$cwe}}</a>
         {{if ne $index (idxMinusOne (len $.CWEs))}}<span class="delimiter"></span>{{end}}
         {{end}}
@@ -192,11 +192,11 @@
 
       {{if gt (len .CvssScore) 0}}
       <span class="delimiter"> </span>
-      <a class="cvssscore styled-link" target="_blank" rel="noopener noreferrer" href="https://www.first.org/cvss/calculator/3.1#{{.CVSSv3}}">CVSS {{.CvssScore}}</a>
+      <a class="cvssscore styled-link"  rel="noopener noreferrer" href="https://www.first.org/cvss/calculator/3.1#{{.CVSSv3}}">CVSS {{.CvssScore}}</a>
       {{end}}
 
         <span class="delimiter"> </span>
-        <a class="styled-link" target="_blank" rel="noopener noreferrer"
+        <a class="styled-link"  rel="noopener noreferrer"
           href="https://snyk.io/vuln/{{.IssueId}}">{{.IssueId}}</a>
       </div>
       {{ if .LessonUrl }}


### PR DESCRIPTION
### Description

If a target is set on a link, JCEF components cannot open the link in an external browser

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
