### PR TITLE
fix/autofix: fix html encoding and add test for toUnifiedDiffSuggestions

### DIFF
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -607,7 +607,10 @@ func (s *AutofixResponse) toUnifiedDiffSuggestions(baseDir string, filePath stri
 	logger := config.CurrentConfig().Logger().With().Str("method", "toUnifiedDiffSuggestions").Logger()
 	var fixSuggestions []AutofixUnifiedDiffSuggestion
 	for _, suggestion := range s.AutofixSuggestions {
-		path := ToAbsolutePath(baseDir, filePath)
+		path, err := DecodePath(ToAbsolutePath(baseDir, filePath))
+		if err != nil {
+			logger.Err(err).Msgf("cannot decode filePath %s", filePath)
+		}
 		fileContent, err := os.ReadFile(path)
 		if err != nil {
 			logger.Err(err).Msgf("cannot read fileContent %s", baseDir)


### PR DESCRIPTION
### Description

The file reading process for DeepCode AI Fix was wrong because it was not using the `DecodePath` function as it is done for other places in the codebase. This leads to AI Fix not working on files with spaces or other characters which are HTML encoded. 

There were also no tests for the conversion function `toUnifiedDiffSuggestions`. 

This PR:

- adds a test for `toUnifiedDiffSuggestions`.
- fixed the bug around HTML encoding in filepath by using `DecodePath`
- adds another test suit to test `toUnifiedDiffSuggestions` under HTML Encoding
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced

Before the fix

[ai_fix_space_bug.webm](https://github.com/user-attachments/assets/e104c8a0-5be6-494d-b443-38366de4786d)

After the fix


[ai_fix_spaces_fixed.webm](https://github.com/user-attachments/assets/6f64335a-7d2c-4195-a51f-3725ea0a0ec8)




https://snyksec.atlassian.net/browse/ML-888
