### PR TITLE
fix: autofix html decoding

### DIFF
--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -592,10 +592,16 @@ func createAutofixWorkspaceEdit(absoluteFilePath string, fixedSourceCode string)
 
 // toAutofixSuggestionsIssues converts the HTTP json-first payload to the domain type
 func (s *AutofixResponse) toAutofixSuggestions(baseDir string, filePath string) (fixSuggestions []AutofixSuggestion) {
+	logger := config.CurrentConfig().Logger().With().Str("method", "toAutofixSuggestions").Logger()
 	for _, suggestion := range s.AutofixSuggestions {
+		decodedPath, err := DecodePath(ToAbsolutePath(baseDir, filePath))
+		if err != nil {
+			logger.Err(err).Msgf("cannot decode filePath %s", filePath)
+			continue
+		}
 		d := AutofixSuggestion{
 			FixId:       suggestion.Id,
-			AutofixEdit: createAutofixWorkspaceEdit(ToAbsolutePath(baseDir, filePath), suggestion.Value),
+			AutofixEdit: createAutofixWorkspaceEdit(decodedPath, suggestion.Value),
 		}
 		fixSuggestions = append(fixSuggestions, d)
 	}

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -607,7 +607,10 @@ func (s *AutofixResponse) toUnifiedDiffSuggestions(baseDir string, filePath stri
 	logger := config.CurrentConfig().Logger().With().Str("method", "toUnifiedDiffSuggestions").Logger()
 	var fixSuggestions []AutofixUnifiedDiffSuggestion
 	for _, suggestion := range s.AutofixSuggestions {
-		path := ToAbsolutePath(baseDir, filePath)
+		path, err := DecodePath(ToAbsolutePath(baseDir, filePath))
+		if err != nil {
+			logger.Err(err).Msgf("cannot decode filePath %s", filePath)
+		}
 		fileContent, err := os.ReadFile(path)
 		if err != nil {
 			logger.Err(err).Msgf("cannot read fileContent %s", baseDir)

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -934,7 +934,7 @@ func Test_AutofixResponse_toAutofixSuggestion_HtmlEncodedFilePath(t *testing.T) 
 
 	assert.Contains(t, editValues, "test1", "test2")
 	for _, filePath := range editFilePaths {
-		assert.Contains(t, editFilePaths, "file_with space.js")
+		assert.Contains(t, filePath, "file_with space.js")
 	}
 }
 

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -903,6 +903,39 @@ func Test_AutofixResponse_toAutofixSuggestion(t *testing.T) {
 	assert.Contains(t, editValues, "test1", "test2")
 }
 
+func Test_AutofixResponse_toAutofixSuggestion_HtmlEncodedFilePath(t *testing.T) {
+	response := AutofixResponse{
+		Status: "COMPLETE",
+	}
+	fixes := []autofixResponseSingleFix{{
+		Id:    "123e4567-e89b-12d3-a456-426614174000/1",
+		Value: "test1",
+	}, {
+		Id:    "123e4567-e89b-12d3-a456-426614174000/2",
+		Value: "test2",
+	}}
+	response.AutofixSuggestions = append(response.AutofixSuggestions, fixes...)
+	filePath := "file_with space.js"
+	baseDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(baseDir, filePath), []byte("test test test"), 0666)
+	require.NoError(t, err)
+	// Here, we provide the HTML encoded path and expect toAutofixSuggestions to decode it.
+	edits := response.toAutofixSuggestions(baseDir, "file_with%20space.js")
+	editValues := make([]string, 0)
+	for _, edit := range edits {
+		change := edit.AutofixEdit.Changes[ToAbsolutePath(baseDir, filePath)][0]
+		editValues = append(editValues, change.NewText)
+	}
+
+	editFilePaths := make([]string, 0)
+	for key := range edit.AutofixEdit.Changes {
+		editFilePaths = append(editFilePaths, key)
+	}
+
+	assert.Contains(t, editValues, "test1", "test2")
+	assert.Equal(t, editFilePaths, []string{"file_with space.js", "file_with space.js"})
+}
+
 func Test_AutofixResponse_toUnifiedDiffSuggestions(t *testing.T) {
 	response := AutofixResponse{
 		Status: "COMPLETE",

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -922,14 +922,14 @@ func Test_AutofixResponse_toAutofixSuggestion_HtmlEncodedFilePath(t *testing.T) 
 	// Here, we provide the HTML encoded path and expect toAutofixSuggestions to decode it.
 	edits := response.toAutofixSuggestions(baseDir, "file_with%20space.js")
 	editValues := make([]string, 0)
+	editFilePaths := make([]string, 0)
 	for _, edit := range edits {
 		change := edit.AutofixEdit.Changes[ToAbsolutePath(baseDir, filePath)][0]
 		editValues = append(editValues, change.NewText)
-	}
 
-	editFilePaths := make([]string, 0)
-	for key := range edit.AutofixEdit.Changes {
-		editFilePaths = append(editFilePaths, key)
+		for key := range edit.AutofixEdit.Changes {
+			editFilePaths = append(editFilePaths, key)
+		}
 	}
 
 	assert.Contains(t, editValues, "test1", "test2")

--- a/infrastructure/code/convert_test.go
+++ b/infrastructure/code/convert_test.go
@@ -933,7 +933,9 @@ func Test_AutofixResponse_toAutofixSuggestion_HtmlEncodedFilePath(t *testing.T) 
 	}
 
 	assert.Contains(t, editValues, "test1", "test2")
-	assert.Equal(t, editFilePaths, []string{"file_with space.js", "file_with space.js"})
+	for _, filePath := range editFilePaths {
+		assert.Contains(t, editFilePaths, "file_with space.js")
+	}
 }
 
 func Test_AutofixResponse_toUnifiedDiffSuggestions(t *testing.T) {


### PR DESCRIPTION
### Description

Autofix Code action flow does not work on file names with HTML encoded characters. We show the user that everything went correctly and show the popup with the Congratualitons message but we fail to modify the file. The file content stays the same.

This PR fixes this issue.
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced


Before

[code_action_bug.webm](https://github.com/user-attachments/assets/e1256c97-42e2-4460-a177-451601cf9ba2)


After

[code_action_fix.webm](https://github.com/user-attachments/assets/59162aad-d559-447a-b378-ceef58ad59da)


