### PR TITLE
chore: correction on diagnostic example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,23 +74,21 @@ Right now the language server supports the following actions:
         "message": "Message",
         "tags": ["security"],
         "data": {
-          "scanIssue": {
-            "id": "123",
-            "issueType": "vulnerability",
-            "packageName": "packageName",
-            "packageVersion": "packageVersion",
-            "issue": "issue",
-            "additionalData": {
-              "ruleId": "ruleId",
-              "identifiers": {
-                "cwe": ["cwe"],
-                "cve": ["cve"]
-              },
-              "description": "description",
-              "language": "language",
-              "packageManager": "packageManager",
-              "packageName": "packageName"
-            }
+          "id": "123",
+          "issueType": "vulnerability",
+          "packageName": "packageName",
+          "packageVersion": "packageVersion",
+          "issue": "issue",
+          "additionalData": {
+            "ruleId": "ruleId",
+            "identifiers": {
+              "cwe": ["cwe"],
+              "cve": ["cve"]
+            },
+            "description": "description",
+            "language": "language",
+            "packageManager": "packageManager",
+            "packageName": "packageName"
           }
         }
       }
@@ -113,35 +111,33 @@ Right now the language server supports the following actions:
         "message": "Message",
         "tags": ["security"],
         "data": {
-          "scanIssue": {
-            "id": "123",
-            "filePath": "filePath",
-            "range": {
-              "start": { "line": 1, "character": 0 },
-              "end": { "line": 2, "character": 0 },
-            },
-            "additionalData": {
-              "message": "message",
-              "rule": "rule",
-              "ruleId": "ruleId",
-              "dataFlow": [
-                {
-                  "filePath": "filePath",
-                  "range": {
-                    "start": { "line": 1, "character": 0 },
-                    "end": { "line": 2, "character": 0 },
-                  },
-                }
-              ],
-              "exampleCommitFixes": [
-                {
-                  "commit": "commit",
-                  "diff": "diff"
-                }
-              ],
-              "cwe": "cwe",
-              "isSecurityType": true
-            }
+          "id": "123",
+          "filePath": "filePath",
+          "range": {
+            "start": { "line": 1, "character": 0 },
+            "end": { "line": 2, "character": 0 },
+          },
+          "additionalData": {
+            "message": "message",
+            "rule": "rule",
+            "ruleId": "ruleId",
+            "dataFlow": [
+              {
+                "filePath": "filePath",
+                "range": {
+                  "start": { "line": 1, "character": 0 },
+                  "end": { "line": 2, "character": 0 },
+                },
+              }
+            ],
+            "exampleCommitFixes": [
+              {
+                "commit": "commit",
+                "diff": "diff"
+              }
+            ],
+            "cwe": "cwe",
+            "isSecurityType": true
           }
         }
       }

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -680,7 +680,7 @@ func Test_initialize_handlesUntrustedFoldersWhenAuthenticated(t *testing.T) {
 	}
 
 	assert.Nil(t, err)
-	assert.Eventually(t, func() bool { return checkTrustMessageRequest(jsonRPCRecorder) }, time.Second, time.Millisecond)
+	assert.Eventually(t, func() bool { return checkTrustMessageRequest(jsonRPCRecorder) }, time.Second*5, time.Millisecond)
 }
 
 func Test_initialize_doesnotHandleUntrustedFolders(t *testing.T) {


### PR DESCRIPTION
### Description

Removing a phantom attribute that doesn't actually exist in the Diagnostic type, from README examples.

### Checklist

- [ ] Tests added and all succeed
- [X] Linted
- [X] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
