### PR TITLE
fix: concurrent processing in server, switch CLI download URL

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -67,8 +67,9 @@ func Start(c *config.Config) {
 		Logger: func(text string) {
 			c.Logger().Trace().Str("method", "jrpc-server").Msg(text)
 		},
-		RPCLog:    RPCLogger{c},
-		AllowPush: true,
+		RPCLog:      RPCLogger{c},
+		AllowPush:   true,
+		Concurrency: 0, // set concurrency to < 1 causes initialization with number of cores
 	})
 
 	c.ConfigureLogging(srv)

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -136,7 +136,12 @@ func startServer(callBackFn onCallbackFn, jsonRPCRecorder *testutil.JsonRPCRecor
 			},
 		},
 		Server: &jrpc2.ServerOptions{
-			AllowPush: true,
+			AllowPush:   true,
+			Concurrency: 0, // set concurrency to < 1 causes initialization with number of cores
+			Logger: func(text string) {
+				config.CurrentConfig().Logger().Debug().Str("method", "json-rpc").Msg(text)
+			},
+			RPCLog: RPCLogger{c: config.CurrentConfig()},
 		},
 	}
 

--- a/infrastructure/cli/install/downloader_test.go
+++ b/infrastructure/cli/install/downloader_test.go
@@ -88,23 +88,23 @@ func getTestAsset() *Release {
 	r := &Release{
 		Assets: &ReleaseAssets{
 			MacOS: &ReleaseAsset{
-				URL:          "https://static.snyk.io/cli/v1.1276.0/snyk-macos",
+				URL:          "https://downloads.snyk.io/cli/v1.1276.0/snyk-macos",
 				ChecksumInfo: "00c7f96ce389cff3f79e920ba345efef2ab78f80ffebd8922082dfca07ed3af0  snyk-macos",
 			},
 			MacOSARM64: &ReleaseAsset{
-				URL:          "https://static.snyk.io/cli/v1.1276.0/snyk-macos-arm64",
+				URL:          "https://downloads.snyk.io/cli/v1.1276.0/snyk-macos-arm64",
 				ChecksumInfo: "691b455a8fdcfb31089ca460658d060b51c58b2e37dc757e8b5434ca0a9b80cf  snyk-macos-arm64",
 			},
 			Linux: &ReleaseAsset{
-				URL:          "https://static.snyk.io/cli/v1.1276.0/snyk-linux",
+				URL:          "https://downloads.snyk.io/cli/v1.1276.0/snyk-linux",
 				ChecksumInfo: "4ade26062f3631bf04ca6a75a7c560752585d2aed025a6a4be97517dbb4701ce  snyk-linux",
 			},
 			LinuxARM64: &ReleaseAsset{
-				URL:          "https://static.snyk.io/cli/v1.1276.0/snyk-linux-arm64",
+				URL:          "https://downloads.snyk.io/cli/v1.1276.0/snyk-linux-arm64",
 				ChecksumInfo: "c26cc7e49354c24d4eeaec41445c612f3b93ad782482fbf9f7d38947815f01a8  snyk-linux-arm64",
 			},
 			Windows: &ReleaseAsset{
-				URL:          "https://static.snyk.io/cli/v1.1276.0/snyk-win.exe",
+				URL:          "https://downloads.snyk.io/cli/v1.1276.0/snyk-win.exe",
 				ChecksumInfo: "76f38b24fe996dcdcb6750f005f2f07044c7a01b7f355d59f88104611a2c9d65  snyk-win.exe",
 			},
 		},

--- a/infrastructure/cli/install/releases.go
+++ b/infrastructure/cli/install/releases.go
@@ -34,7 +34,7 @@ import (
 	"github.com/snyk/snyk-ls/application/config"
 )
 
-const DefaultBaseURL = "https://static.snyk.io"
+const DefaultBaseURL = "https://downloads.snyk.io"
 
 // Release represents a Snyk CLI release with assets.
 type Release struct {

--- a/infrastructure/cli/install/releases_test.go
+++ b/infrastructure/cli/install/releases_test.go
@@ -154,7 +154,7 @@ func Test_GetCLIDownloadURL(t *testing.T) {
 
 		actual := GetCLIDownloadURL(c, DefaultBaseURL, httpClient)
 
-		assert.Equal(t, "https://static.snyk.io/cli/v1.234/"+name, actual)
+		assert.Equal(t, "https://downloads.snyk.io/cli/v1.234/"+name, actual)
 	})
 	t.Run("CLI, preview, non fips", func(t *testing.T) {
 		c := testutil.UnitTest(t)
@@ -164,7 +164,7 @@ func Test_GetCLIDownloadURL(t *testing.T) {
 
 		actual := GetCLIDownloadURL(c, DefaultBaseURL, httpClient)
 
-		assert.Equal(t, "https://static.snyk.io/cli/v1.234-preview./"+name, actual)
+		assert.Equal(t, "https://downloads.snyk.io/cli/v1.234-preview./"+name, actual)
 	})
 }
 
@@ -176,7 +176,7 @@ func setupCLIDownloadURLTest(t *testing.T, releaseChannel, version string, c *co
 	httpClient := mocks.NewMockHTTPClient(ctrl)
 	httpClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
 		req := i.(*http.Request)
-		return req.URL.String() == fmt.Sprintf("https://static.snyk.io/cli/%s/ls-protocol-version-%s", releaseChannel, config.LsProtocolVersion) &&
+		return req.URL.String() == fmt.Sprintf("https://downloads.snyk.io/cli/%s/ls-protocol-version-%s", releaseChannel, config.LsProtocolVersion) &&
 			req.Method == http.MethodGet
 	})).Return(&http.Response{
 		StatusCode: http.StatusOK,


### PR DESCRIPTION
### Description

- enable concurrent processing
- change CLI download URL

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
