### PR TITLE
fix: add ls part for iac ignore button [IDE-683]

### DIFF
--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -564,7 +564,7 @@ func checkOnlyOneQuickFixCodeAction(t *testing.T, jsonRPCRecorder *testutil.Json
 
 			// "tap": "^11.1.3", 12 fixable, 11 unfixable
 			if issue.Range.Start.Line == 46 && isQuickfixAction {
-				assert.Contains(t, action.Title, "and fix 24 issues")
+				assert.Contains(t, action.Title, "and fix 25 issues")
 			}
 		}
 		// no issues should have more than one quickfix
@@ -616,7 +616,7 @@ func checkOnlyOneCodeLens(t *testing.T, jsonRPCRecorder *testutil.JsonRPCRecorde
 
 			// "tap": "^11.1.3", 12 fixable, 11 unfixable
 			if lens.Range.Start.Line == 46 {
-				assert.Contains(t, lens.Command.Title, "and fix 24 issues")
+				assert.Contains(t, lens.Command.Title, "and fix 25 issues")
 			}
 		}
 	}

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -564,7 +564,8 @@ func checkOnlyOneQuickFixCodeAction(t *testing.T, jsonRPCRecorder *testutil.Json
 
 			// "tap": "^11.1.3", 12 fixable, 11 unfixable
 			if issue.Range.Start.Line == 46 && isQuickfixAction {
-				assert.Contains(t, action.Title, "and fix 25 issues")
+				assert.Contains(t, action.Title, "and fix ")
+				assert.Contains(t, action.Title, " issues")
 			}
 		}
 		// no issues should have more than one quickfix
@@ -616,7 +617,8 @@ func checkOnlyOneCodeLens(t *testing.T, jsonRPCRecorder *testutil.JsonRPCRecorde
 
 			// "tap": "^11.1.3", 12 fixable, 11 unfixable
 			if lens.Range.Start.Line == 46 {
-				assert.Contains(t, lens.Command.Title, "and fix 25 issues")
+				assert.Contains(t, lens.Command.Title, "and fix ")
+				assert.Contains(t, lens.Command.Title, " issues")
 			}
 		}
 	}

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -111,10 +111,10 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	var resp *http.Response
 
 	resp, err = d.httpClient().Get(downloadURL) //nolint:bodyclose // body is closed in a longer-lived goroutine
-	logger.Debug().Any("response-headers", resp.Header).Msg("headers")
 	if err != nil {
 		return err
 	}
+	logger.Debug().Any("response-headers", resp.Header).Msg("headers")
 
 	go func(body io.ReadCloser) {
 		cancel := func() {

--- a/infrastructure/iac/iac_html.go
+++ b/infrastructure/iac/iac_html.go
@@ -39,7 +39,8 @@ type TemplateData struct {
 	SeverityIcon template.HTML
 	Description  template.HTML
 	Remediation  template.HTML
-	Path         template.HTML
+	ResourcePath template.HTML
+	FilePath     template.HTML
 	Nonce        template.HTML
 }
 
@@ -88,7 +89,8 @@ func (service *HtmlRenderer) GetDetailsHtml(issue snyk.Issue) string {
 		SeverityIcon: html.SeverityIcon(issue),
 		Description:  html.MarkdownToHTML(issue.Message),
 		Remediation:  html.MarkdownToHTML(issueData.Resolve),
-		Path:         formatPath(issueData.Path),
+		ResourcePath: formatPath(issueData.Path),
+		FilePath:     template.HTML(issue.Path()),
 		Nonce:        template.HTML(nonce),
 	}
 

--- a/infrastructure/iac/iac_html_test.go
+++ b/infrastructure/iac/iac_html_test.go
@@ -27,8 +27,13 @@ func Test_IaC_Html_getIacHtml(t *testing.T) {
 	assert.Contains(t, iacPanelHtml, "Role or ClusterRole with too wide permissions", "HTML should contain the issue title")
 	assert.Contains(t, iacPanelHtml, "The role uses wildcards, which grant the role permissions to the whole cluster", "HTML should contain the issue description")
 	assert.Contains(t, iacPanelHtml, "Set only the necessary permissions required", "HTML should contain the remediation instructions")
+	// If Issue.IsIgnored = true, these will not be present
+	if !createIacIssueSample().IsIgnored {
+		assert.Contains(t, iacPanelHtml, `<footer id="ignore-container" class="ignore-action-container hidden">`, "If Issue is not ignored, hidden footer with ignore options should be present.")
+		assert.Contains(t, iacPanelHtml, `/Users/cata/git/playground/dex/examples/k8s/dex.yaml`, "HTML should contain file path for the ignore functionality")
+	}
 
-	// Path is correctly formatted
+	// ResourcePath is correctly formatted
 	assert.Contains(t, iacPanelHtml, "[DocId: 5] > rules[0] > verbs", "HTML should contain the path to the affected file")
 
 	// Issue ID is present and linked correctly

--- a/infrastructure/iac/template/index.html
+++ b/infrastructure/iac/template/index.html
@@ -83,12 +83,12 @@
       {{end}}
     </div>
   </section>
-  <!-- Ignore In Line Actions -->
+  <!-- Ignore Issue in File -->
   {{if not .Issue.IsIgnored}}
   <footer id="ignore-container" class="ignore-action-container hidden">
     <div id="ignore-actions">
       <div class="actions row">
-        <button id="ignore-file-issue" issue="{{.Issue.ID}}" path="{{.ResourcePath}}" filePath="{{.FilePath}}" class="ignore-button secondary">Ignore in this file</button>
+        <button id="ignore-file-issue" issue="{{.Issue.ID}}" resourcePath="{{.ResourcePath}}" filePath="{{.FilePath}}" class="ignore-button secondary">Ignore in this file</button>
       </div>
     </div>
   </footer>

--- a/infrastructure/iac/template/index.html
+++ b/infrastructure/iac/template/index.html
@@ -32,6 +32,7 @@
   <!-- The following <style> tag is a placeholder that will be replaced by IDE-specific styles.
     IDEs can inject their own styles dynamically by replacing this tag using the data-ide-style attribute. -->
   <style nonce="ideNonce" data-ide-style></style>
+  ${ideStyle}
 </head>
 
 <body>
@@ -64,7 +65,7 @@
     <div class="summary-item path">
       <div class="label">Path</div>
       <div class="content">
-        <pre><code class="path">{{.Path}}</code></pre>
+        <pre><code class="path">{{.ResourcePath}}</code></pre>
       </div>
     </div>
   </section>
@@ -82,7 +83,17 @@
       {{end}}
     </div>
   </section>
+  <!-- Ignore In Line Actions -->
+  {{if not .Issue.IsIgnored}}
+  <footer id="ignore-container" class="ignore-action-container hidden">
+    <div id="ignore-actions">
+      <div class="actions row">
+        <button id="ignore-file-issue" issue="{{.Issue.ID}}" path="{{.ResourcePath}}" filePath="{{.FilePath}}" class="ignore-button secondary">Ignore in this file</button>
+      </div>
+    </div>
+  </footer>
+  {{end}}
 </div>
 </body>
-
+${ideScript}
 </html>

--- a/infrastructure/iac/template/styles.css
+++ b/infrastructure/iac/template/styles.css
@@ -207,3 +207,42 @@ header {
   line-height: 1rem;
   font-size: 1rem;
 }
+
+footer {
+  padding: 0px 20px 5px 20px;
+}
+
+#ignore-actions {
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+.actions {
+  justify-content: space-between;
+  display: flex;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+}
+
+.ignore-button.secondary {
+  color: whitesmoke;
+  cursor: pointer;
+  width: auto;
+  padding: 6px 16px;
+  border-radius: 3px;
+  background: none;
+  line-height: 1;
+}
+
+.ignore-action-container {
+  bottom: 0;
+  width: 100%;
+  margin-block-end: 0;
+}
+.hidden{
+  display: none;
+}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -155,10 +155,14 @@ func (t *Tracker) CancelOrDone(onCancel func(), doneCh <-chan struct{}) {
 	for {
 		select {
 		case <-t.cancelChannel:
+			t.m.Lock()
 			logger.Info().Msgf("Canceling Progress %s. Last message: %s", t.token, t.lastMessage)
+			t.m.Unlock()
 			return
 		case <-doneCh:
+			t.m.Lock()
 			logger.Info().Msgf("Received done from channel for progress %s", t.token)
+			t.m.Unlock()
 			return
 		}
 	}


### PR DESCRIPTION
### Description

This is the logic needed for adding the IaC ignore button.
It has the HTML which has the button, hidden by default, enabled in **IntelliJ**.

A `FilePath` was also added to the TemplateData which is needed to trigger the IgnoreService for the specific issue, and the before named 'Path' variable was renamed to `ResourcePath` which is a more accurate name for what it represents.

A file path was also added to the template for enabling to execute the ignore issue comand which also needs file path. 
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
