### PR TITLE
chore: move iac ignore scripts from intellij plugin to ls

### DIFF
--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -1203,8 +1203,8 @@
 
       showCurrentExample();
     });
-    ${ideScript}
   </script>
+  ${ideScript}
 </body>
 
 </html>

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -1203,8 +1203,8 @@
 
       showCurrentExample();
     });
+    ${ideScript}
   </script>
-  ${ideScript}
 </body>
 
 </html>

--- a/infrastructure/iac/iac_html.go
+++ b/infrastructure/iac/iac_html.go
@@ -35,6 +35,7 @@ type HtmlRenderer struct {
 
 type TemplateData struct {
 	Styles       template.CSS
+	Scripts      template.JS
 	Issue        snyk.Issue
 	SeverityIcon template.HTML
 	Description  template.HTML
@@ -49,6 +50,9 @@ var detailsHtmlTemplate string
 
 //go:embed template/styles.css
 var stylesCSS string
+
+//go:embed template/scripts.js
+var scripts string
 
 func NewHtmlRenderer(c *config.Config) (*HtmlRenderer, error) {
 	tmp, err := template.New(string(product.ProductInfrastructureAsCode)).Parse(detailsHtmlTemplate)
@@ -65,6 +69,10 @@ func NewHtmlRenderer(c *config.Config) (*HtmlRenderer, error) {
 
 func getStyles() template.CSS {
 	return template.CSS(stylesCSS)
+}
+
+func getScripts() template.JS {
+	return template.JS(scripts)
 }
 
 // Function to get the rendered HTML with issue details and CSS
@@ -85,6 +93,7 @@ func (service *HtmlRenderer) GetDetailsHtml(issue snyk.Issue) string {
 
 	data := TemplateData{
 		Styles:       getStyles(),
+		Scripts:      getScripts(),
 		Issue:        issue,
 		SeverityIcon: html.SeverityIcon(issue),
 		Description:  html.MarkdownToHTML(issue.Message),

--- a/infrastructure/iac/iac_html_test.go
+++ b/infrastructure/iac/iac_html_test.go
@@ -45,6 +45,9 @@ func Test_IaC_Html_getIacHtml(t *testing.T) {
 	// Reference section
 	assert.Contains(t, iacPanelHtml, `<a class="styled-link"  rel="noopener noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/">https://kubernetes.io/docs/reference/access-authn-authz/rbac/</a>`, "HTML should contain the first reference")
 	assert.Contains(t, iacPanelHtml, `<a class="styled-link"  rel="noopener noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole">https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole</a>`, "HTML should contain the second reference")
+
+	// Scripts are loaded
+	assert.Contains(t, iacPanelHtml, "function applyIgnoreInFile()", "Scripts should be injected in HTML template")
 }
 
 func createIacIssueSample() snyk.Issue {

--- a/infrastructure/iac/template/index.html
+++ b/infrastructure/iac/template/index.html
@@ -95,9 +95,9 @@
   {{end}}
 </div>
 </body>
-<script nonce="{{.Nonce}}">
+${ideScript}
+<script nonce="{{.Nonce}}" defer>
     {{.Scripts}}
-    ${ideScript}
-  </script>
+</script>
 
 </html>

--- a/infrastructure/iac/template/index.html
+++ b/infrastructure/iac/template/index.html
@@ -95,5 +95,10 @@
   {{end}}
 </div>
 </body>
-${ideScript}
+<script nonce="{{.Nonce}}">
+  (function(){
+    {{.Scripts}}
+    ${ideScript}
+  })()
+  </script>
 </html>

--- a/infrastructure/iac/template/index.html
+++ b/infrastructure/iac/template/index.html
@@ -96,9 +96,8 @@
 </div>
 </body>
 <script nonce="{{.Nonce}}">
-  (function(){
     {{.Scripts}}
     ${ideScript}
-  })()
   </script>
+
 </html>

--- a/infrastructure/iac/template/scripts.js
+++ b/infrastructure/iac/template/scripts.js
@@ -1,0 +1,55 @@
+/*
+ * © 2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  // Utility function to show/hide an element based on a toggle value
+  function toggleElement(element, action) {
+    if (!element) return;
+    element.classList.toggle("hidden", action === "hide");
+  }
+
+  function applyIgnoreInFile() {
+    console.log('Applying ignore', issue);
+    if (!issue) return;
+
+    window.applyIgnoreInFileQuery(issue + '|@' + filePath + ' > ' + resourcePath);
+    toggleElement(ignoreInFileBtn, "hide");
+    console.log('Applying ignore');
+  }
+
+  // DOM element references
+  const ignoreContainer = document.getElementById("ignore-container");
+  const ignoreInFileBtn = document.getElementById('ignore-file-issue')
+
+
+
+  let issue = ignoreInFileBtn.getAttribute('issue')
+  let resourcePath =  ignoreInFileBtn.getAttribute('resourcePath')
+  let filePath =  ignoreInFileBtn.getAttribute('filePath')
+
+  ignoreInFileBtn?.addEventListener("click", applyIgnoreInFile);
+  toggleElement(ignoreContainer, "show");
+
+  window.receiveIgnoreInFileResponse = function (success){
+    console.log('[[receiveIgnoreInFileResponse]]', success);
+    if(success){
+      ignoreInFileBtn.disabled = true;
+      console.log('Ignored in file', success);
+      document.getElementById('ignore-file-issue').disabled = true;
+    }else{
+      toggleElement(ignoreInFileBtn, "show");
+      console.error('Failed to apply fix', success);
+    }
+  }

--- a/infrastructure/iac/template/scripts.js
+++ b/infrastructure/iac/template/scripts.js
@@ -30,7 +30,6 @@
   }
 
   // DOM element references
-  const ignoreContainer = document.getElementById("ignore-container");
   const ignoreInFileBtn = document.getElementById('ignore-file-issue')
 
 
@@ -40,7 +39,6 @@
   let filePath =  ignoreInFileBtn.getAttribute('filePath')
 
   ignoreInFileBtn?.addEventListener("click", applyIgnoreInFile);
-  toggleElement(ignoreContainer, "show");
 
   window.receiveIgnoreInFileResponse = function (success){
     console.log('[[receiveIgnoreInFileResponse]]', success);


### PR DESCRIPTION
### Description

Moved the IaC ignore in file JS logic from the IntelliJ plugin to the `scripts.js` file in the IaC template

Added Scripts attribute in the template data from which we inject into the HTML and added it to the template.
### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
