### PR TITLE
fix: data flow order for code [IDE-763]

### DIFF
--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -401,16 +401,10 @@ func getIgnoreReason(version string) string {
 }
 
 func Test_Prepare_DataFlowTable(t *testing.T) {
-
 	dataFlow := getDataFlowElements()
 	fixes := getFixes()
 	repoCount := 54387
 	issue := snyk.Issue{
-		Range:     getIssueRange(),
-		CWEs:      []string{"CWE-123", "CWE-456"},
-		ID:        "go/NoHardcodedCredentials/test",
-		Severity:  2,
-		LessonUrl: "https://learn.snyk.io/lesson/no-rate-limiting/?loc=ide",
 		AdditionalData: snyk.CodeIssueData{
 			Title:              "Allocation of Resources Without Limits or Throttling",
 			DataFlow:           dataFlow,

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -399,3 +399,42 @@ func getIgnoreReason(version string) string {
 	}
 	return `After a comprehensive review, our security team determined that the risk associated with this specific XSS vulnerability is mitigated by additional security measures implemented at the network and application layers.`
 }
+
+func Test_Prepare_DataFlowTable(t *testing.T) {
+
+	dataFlow := getDataFlowElements()
+	fixes := getFixes()
+	repoCount := 54387
+	issue := snyk.Issue{
+		Range:     getIssueRange(),
+		CWEs:      []string{"CWE-123", "CWE-456"},
+		ID:        "go/NoHardcodedCredentials/test",
+		Severity:  2,
+		LessonUrl: "https://learn.snyk.io/lesson/no-rate-limiting/?loc=ide",
+		AdditionalData: snyk.CodeIssueData{
+			Title:              "Allocation of Resources Without Limits or Throttling",
+			DataFlow:           dataFlow,
+			ExampleCommitFixes: fixes,
+			RepoDatasetSize:    repoCount,
+			IsSecurityType:     true,
+			Text:               getVulnerabilityOverviewText(),
+			PriorityScore:      890,
+			HasAIFix:           true,
+		},
+	}
+	codeIssueData := issue.AdditionalData.(snyk.CodeIssueData)
+	dataFlowKeys, dataFlowItems := prepareDataFlowTable(codeIssueData)
+
+	assert.Equal(t, len(dataFlowKeys), len(dataFlowItems))
+	assert.Contains(t, dataFlowItems, "main.ts")
+	assert.Equal(t, dataFlowKeys[1], "main.ts")
+}
+
+func Test_Prepare_DataFlowTable_Empty(t *testing.T) {
+	var codeIssueData snyk.CodeIssueData
+	dataFlowKeys, dataFlowItems := prepareDataFlowTable(codeIssueData)
+
+	assert.Equal(t, len(dataFlowKeys), len(dataFlowItems))
+	assert.Equal(t, len(dataFlowItems), 0)
+	assert.Equal(t, dataFlowKeys, []string(nil))
+}

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -234,14 +234,14 @@
                 Data Flow - {{len .DataFlow}} {{if gt (len .DataFlow) 1}}steps{{else}}step{{end}}
               </h2>
               <div class="data-flow-body">
-                {{range $fileName, $dataFlowItems := .DataFlowTable}}
+                {{range $fileName := .DataFlowKeys}}
                 <div class="data-flow-file">
                   {{$.FileIcon}}
                   <span class="data-flow-file-name">{{$fileName}}</span>
                 </div>
                 <table class="data-flow-table">
                   <tbody>
-                    {{range $dataFlowItems}}
+                    {{range index $.DataFlowTable $fileName}}
                     <tr class="data-flow-row">
                       <td class="data-flow-number">{{.Number}}</td>
                       <td class="data-flow-clickable-row" file-path="{{.FilePath}}" start-line="{{.StartLine}}"


### PR DESCRIPTION
### Description

This PR fixes DataFlowItems not being displayed in order, previously we used a map, which doesn't guarantee order, according to Go docs **_"The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next"_** 

To solve this while also being able to have a map and access the DataFlowItems by the `fileName` as key, a slice is created that uniquely holds the fileNames (keys) of the map.

In the HTML template we iterate over the keys slice ( which is indexed in order ), and access the map by the key from current iteration.
###  Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
