### PR TITLE
feat: Sending IDE+extension versions to autofix

### DIFF
--- a/infrastructure/code/snyk_code_http_client.go
+++ b/infrastructure/code/snyk_code_http_client.go
@@ -539,6 +539,12 @@ func (s *SnykCodeHTTPClient) autofixRequestBody(options *AutofixOptions) ([]byte
 			LineNum:  options.issue.Range.Start.Line + 1,
 		},
 		AnalysisContext: newCodeRequestContext(),
+		IdeExtensionDetails: AutofixIdeExtensionDetails{
+			IdeName:          s.c.IdeName(),
+			IdeVersion:       s.c.IdeVersion(),
+			ExtensionName:    s.c.IntegrationName(),
+			ExtensionVersion: s.c.IntegrationVersion(),
+		},
 	}
 	if len(options.shardKey) > 0 {
 		request.Key.Shard = options.shardKey
@@ -562,13 +568,17 @@ func (s *SnykCodeHTTPClient) SubmitAutofixFeedback(ctx context.Context, fixId st
 	s.c.Logger().Debug().Str("method", method).Str("requestId", requestId).Msg("API: Submitting Autofix feedback")
 	defer s.c.Logger().Debug().Str("method", method).Str("requestId", requestId).Msg("API: Submitting Autofix feedback done")
 
-	request := map[string]interface{}{
-		"channel":   "IDE",
-		"eventType": feedback,
-		"eventDetails": map[string]string{
-			"fixId": fixId,
+	request := AutofixUserEvent{
+		Channel:         "IDE",
+		EventType:       feedback,
+		EventDetails:    AutofixEventDetails{FixId: fixId},
+		AnalysisContext: newCodeRequestContext(),
+		IdeExtensionDetails: AutofixIdeExtensionDetails{
+			IdeName:          s.c.IdeName(),
+			IdeVersion:       s.c.IdeVersion(),
+			ExtensionName:    s.c.IntegrationName(),
+			ExtensionVersion: s.c.IntegrationVersion(),
 		},
-		"analysisContext": newCodeRequestContext(),
 	}
 
 	requestBody, err := json.Marshal(request)

--- a/infrastructure/code/types.go
+++ b/infrastructure/code/types.go
@@ -77,9 +77,17 @@ type AutofixRequestKey struct {
 	LineNum int `json:"lineNum"`
 }
 
+type AutofixIdeExtensionDetails struct {
+	IdeName          string `json:"ideName"`
+	IdeVersion       string `json:"ideVersion"`
+	ExtensionName    string `json:"extensionName"`
+	ExtensionVersion string `json:"extensionVersion"`
+}
+
 type AutofixRequest struct {
-	Key             AutofixRequestKey  `json:"key"`
-	AnalysisContext codeRequestContext `json:"analysisContext"`
+	Key                 AutofixRequestKey          `json:"key"`
+	AnalysisContext     codeRequestContext         `json:"analysisContext"`
+	IdeExtensionDetails AutofixIdeExtensionDetails `json:"ideExtensionDetails"`
 }
 
 // Should implement `error` interface
@@ -95,8 +103,14 @@ type AutofixSuggestion struct {
 	AutofixEdit snyk.WorkspaceEdit
 }
 
-type AutofixFeedback struct {
-	FixId           string             `json:"fixId"`
-	Feedback        string             `json:"feedback"`
-	AnalysisContext codeRequestContext `json:"analysisContext"`
+type AutofixEventDetails struct {
+	FixId string `json:"fixId"`
+}
+
+type AutofixUserEvent struct {
+	AnalysisContext     codeRequestContext         `json:"analysisContext"`
+	Channel             string                     `json:"channel"`
+	EventType           string                     `json:"eventType"`
+	EventDetails        AutofixEventDetails        `json:"eventDetails"`
+	IdeExtensionDetails AutofixIdeExtensionDetails `json:"ideExtensionDetails"`
 }


### PR DESCRIPTION
### Description

This is sending the IDE name and version and the extension name and version to autofix requests and feedback events.
This is for analytics purposes. IDE extensions might support different features at a given point in time and knowing the extension used helps knowing what features are available to the end user.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
