### PR TITLE
feat: Sending a user event when fixing inside the editor

### DIFF
--- a/infrastructure/code/constants.go
+++ b/infrastructure/code/constants.go
@@ -19,4 +19,5 @@ package code
 const (
 	FixPositiveFeedback string = "FIX_POSITIVE_FEEDBACK"
 	FixNegativeFeedback string = "FIX_NEGATIVE_FEEDBACK"
+	FixAppliedUserEvent string = "FIX_APPLIED"
 )

--- a/infrastructure/code/fake_snyk_code_api_service.go
+++ b/infrastructure/code/fake_snyk_code_api_service.go
@@ -140,6 +140,7 @@ type FakeSnykCodeClient struct {
 	AutofixStatus          AutofixStatus
 	Options                map[string]AnalysisOptions
 	C                      *config.Config
+	FeedbackSent           string
 }
 
 func (f *FakeSnykCodeClient) GetAutofixDiffs(_ context.Context, _ string, _ AutofixOptions) (unifiedDiffSuggestions []AutofixUnifiedDiffSuggestion, status AutofixStatus, err error) {
@@ -347,6 +348,9 @@ func (f *FakeSnykCodeClient) GetAutofixSuggestions(
 	return suggestions, AutofixStatus{message: "COMPLETE"}, nil
 }
 
-func (f *FakeSnykCodeClient) SubmitAutofixFeedback(_ context.Context, _ string, _ string) error {
+func (f *FakeSnykCodeClient) SubmitAutofixFeedback(_ context.Context, _ string, feedback string) error {
+	FakeSnykCodeApiServiceMutex.Lock()
+	f.FeedbackSent = feedback
+	FakeSnykCodeApiServiceMutex.Unlock()
 	return nil
 }

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -223,6 +223,8 @@ func (b *IssueEnhancer) autofixFunc(ctx context.Context, issue snyk.Issue,
 
 				// send feedback asynchronously, so people can actually see the changes done by the fix
 				go func() {
+					b.SnykCode.SubmitAutofixFeedback(ctx, fix.FixId, FixAppliedUserEvent)
+
 					actionCommandMap, err := b.autofixFeedbackActions(fix.FixId)
 					successMessage := "Congratulations! 🎉 You’ve just fixed this " + issueTitle(issue) + " issue."
 					if err != nil {

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -99,7 +99,10 @@ func Test_autofixFunc(t *testing.T) {
 					break
 				}
 			}
-			return types.Info == feedbackMessageReq.Type &&
+			FakeSnykCodeApiServiceMutex.Lock()
+			eventSent := fakeSnykCode.FeedbackSent == FixAppliedUserEvent
+			FakeSnykCodeApiServiceMutex.Unlock()
+			return eventSent && types.Info == feedbackMessageReq.Type &&
 				"Congratulations! 🎉 You’ve just fixed this SNYK-123 issue. Was this fix helpful?" == feedbackMessageReq.Message
 		}, 10*time.Second, 1*time.Second)
 
@@ -147,7 +150,10 @@ func Test_autofixFunc(t *testing.T) {
 					break
 				}
 			}
-			return types.Info == feedbackMessageReq.Type &&
+			FakeSnykCodeApiServiceMutex.Lock()
+			eventSent := fakeSnykCode.FeedbackSent == FixAppliedUserEvent
+			FakeSnykCodeApiServiceMutex.Unlock()
+			return eventSent && types.Info == feedbackMessageReq.Type &&
 				"Congratulations! 🎉 You’ve just fixed this SNYK-123 issue. Was this fix helpful?" == feedbackMessageReq.Message
 		}, 10*time.Second, 1*time.Second)
 


### PR DESCRIPTION
### Description

When the user triggers the issue action in code, no user event was sent for analytics. This addresses it by sending a FIX_APPLIED event.

EDIT: Using the existing event type FIX_APPLIED for simplicity.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
