### PR TITLE
fix: fix issue metadata used for hashing [IDE-816]

### DIFF
--- a/infrastructure/utils/fingerprint.go
+++ b/infrastructure/utils/fingerprint.go
@@ -27,9 +27,16 @@ import (
 
 func CalculateFingerprintFromAdditionalData(issue snyk.Issue) string {
 	var preHash string
+	var dependencyChainHash string
 	switch additionalData := issue.AdditionalData.(type) {
 	case snyk.OssIssueData:
-		dependencyChainHash := normalizeArray(additionalData.From)
+		if additionalData.PackageManager == "pip" {
+			// Pip has base directory name in from data-flow at index 0, this should not be considered for the fingerprint
+			dependencyChainHash = normalizeArray(additionalData.From[1:])
+		} else {
+			dependencyChainHash = normalizeArray(additionalData.From)
+		}
+		dependencyChainHash = normalizeArray(additionalData.From)
 		// Fingerprint for OSS Issues is: name@version@fromArrayHash
 		preHash = fmt.Sprintf("%s|%s|%s", additionalData.PackageName, additionalData.Version, dependencyChainHash)
 	case snyk.IaCIssueData:

--- a/infrastructure/utils/fingerprint.go
+++ b/infrastructure/utils/fingerprint.go
@@ -30,7 +30,7 @@ func CalculateFingerprintFromAdditionalData(issue snyk.Issue) string {
 	var dependencyChainHash string
 	switch additionalData := issue.AdditionalData.(type) {
 	case snyk.OssIssueData:
-		if additionalData.PackageManager == "pip" {
+		if additionalData.PackageManager == "pip" && len(additionalData.From) > 0 {
 			// Pip has base directory name in from data-flow at index 0, this should not be considered for the fingerprint
 			dependencyChainHash = normalizeArray(additionalData.From[1:])
 		} else {

--- a/infrastructure/utils/fingerprint.go
+++ b/infrastructure/utils/fingerprint.go
@@ -36,7 +36,6 @@ func CalculateFingerprintFromAdditionalData(issue snyk.Issue) string {
 		} else {
 			dependencyChainHash = normalizeArray(additionalData.From)
 		}
-		dependencyChainHash = normalizeArray(additionalData.From)
 		// Fingerprint for OSS Issues is: name@version@fromArrayHash
 		preHash = fmt.Sprintf("%s|%s|%s", additionalData.PackageName, additionalData.Version, dependencyChainHash)
 	case snyk.IaCIssueData:

--- a/infrastructure/utils/fingerprint.go
+++ b/infrastructure/utils/fingerprint.go
@@ -30,7 +30,7 @@ func CalculateFingerprintFromAdditionalData(issue snyk.Issue) string {
 	var dependencyChainHash string
 	switch additionalData := issue.AdditionalData.(type) {
 	case snyk.OssIssueData:
-		if additionalData.PackageManager == "pip" && len(additionalData.From) > 0 {
+		if additionalData.PackageManager == "pip" && len(additionalData.From) > 1 {
 			// Pip has base directory name in from data-flow at index 0, this should not be considered for the fingerprint
 			dependencyChainHash = normalizeArray(additionalData.From[1:])
 		} else {


### PR DESCRIPTION
### Description

OSS Issues reported for "pip" package manager have base directory in the data-flow, this interferes with the logic making hashing inconsistent and relative to the directory which is not relevant in this case.

Example data flow: `pip-goof@0.0.0 > flask@1.0.2 > werkzeug@2.1.2`

In this case, **pip-goof** should not be included as part of the **string** to be **hashed** because the same issue coming from a different directory will have a different hash 

(eg: when we do delta scanning, the base branch will be cloned in a `tmp` directory and scanned, this will result in the hash to always be different for all OSS "pip" issues.
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
