### PR TITLE
fix: panic because nil dep

### DIFF
--- a/infrastructure/oss/range_finder.go
+++ b/infrastructure/oss/range_finder.go
@@ -73,7 +73,7 @@ func getDependencyNode(c *config.Config, path string, issue ossIssue, fileConten
 	}
 
 	// recurse until a dependency with version was found
-	if currentDep.Value == "" && currentDep.Tree != nil && currentDep.Tree.ParentTree != nil {
+	if currentDep != nil && currentDep.Value == "" && currentDep.Tree != nil && currentDep.Tree.ParentTree != nil {
 		tree := currentDep.Tree.ParentTree
 		currentDep.LinkedParentDependencyNode = getDependencyNode(c, tree.Document, issue, []byte(tree.Root.Value))
 	}


### PR DESCRIPTION
### Description

```
goroutine 44 [running]:
github.com/snyk/snyk-ls/infrastructure/oss.getDependencyNode(_, {_, _}, {{0xc0001588d0, 0x25}, {0xc000179a40, 0x15}, {0xc0001799f8, 0x17}, {0xc0049006e8, ...}, ...}, ...)
    /mnt/c/users/shawky/work/snyk-ls/infrastructure/oss/range_finder.go:76 +0xa12
github.com/snyk/snyk-ls/infrastructure/oss.convertScanResultToIssues(0xc000d3dc08, 0xc004328a48, {0xc0001590e0, 0x1f}, {0xc007d37900, 0x116f, 0x1170}, {0x30a7bb0, 0xc0007ec640}, {0x30a3870, ...}, ...)
    /mnt/c/users/shawky/work/snyk-ls/infrastructure/oss/issue.go:140 +0x325
github.com/snyk/snyk-ls/infrastructure/oss.(*CLIScanner).retrieveIssues(0xc000229ce0, 0xc004328a48, {0xc0001590e0, 0x1f}, {0xc007d37900, 0x116f, 0x1170})
    /mnt/c/users/shawky/work/snyk-ls/infrastructure/oss/cli_scanner.go:493 +0x1eb
github.com/snyk/snyk-ls/infrastructure/oss.(*CLIScanner).unmarshallAndRetrieveAnalysis(0xc000229ce0, {0x30a6b50, 0xc004696230}, {0xc007f96000, 0x5ac2c, 0x80000}, {0xc000c60150, 0x18}, {0xc000c60150, 0x18})
    /mnt/c/users/shawky/work/snyk-ls/infrastructure/oss/cli_scanner.go:336 +0x85c
github.com/snyk/snyk-ls/infrastructure/oss.(*CLIScanner).scanInternal(0xc000229ce0, {0x30a6b50, 0xc004696230}, {0xc000c60150, 0x18}, 0xc0046b1830)
    /mnt/c/users/shawky/work/snyk-ls/infrastructure/oss/cli_scanner.go:233 +0x124a
github.com/snyk/snyk-ls/infrastructure/oss.(*CLIScanner).Scan(0xc000229ce0, {0x30a6b18, 0xc000cfe450}, {0xc0001783f0, 0x18}, {0xc0001783f0, 0x18})
    /mnt/c/users/shawky/work/snyk-ls/infrastructure/oss/cli_scanner.go:159 +0x295
github.com/snyk/snyk-ls/domain/snyk/scanner.(*DelegatingConcurrentScanner).internalScan(0xc0007ec8c0, {0x30a6b18, 0xc000cfe450}, {0x30a4c90, 0xc000229ce0}, {0xc0001783f0, 0x18}, {0xc0001783f0, 0x18})
    /mnt/c/users/shawky/work/snyk-ls/domain/snyk/scanner/scanner.go:359 +0xdd
github.com/snyk/snyk-ls/domain/snyk/scanner.(*DelegatingConcurrentScanner).Scan.func2({0x30a4c90, 0xc000229ce0})
    /mnt/c/users/shawky/work/snyk-ls/domain/snyk/scanner/scanner.go:286 +0x692
created by github.com/snyk/snyk-ls/domain/snyk/scanner.(*DelegatingConcurrentScanner).Scan in goroutine 105
    /mnt/c/users/shawky/work/snyk-ls/domain/snyk/scanner/scanner.go:276 +0xc7c
[Info  - 3:29:19 PM] Connection to server got closed. Server will restart.
```
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
