### PR TITLE
hotfix: fix fileFilter and reduce memory usage [IDE-926] [IDE-662]

### DIFF
--- a/domain/snyk/issues.go
+++ b/domain/snyk/issues.go
@@ -74,7 +74,6 @@ type Issue struct {
 	LessonUrl      string `json:"url"`
 	Fingerprint    string
 	GlobalIdentity string
-	FileContent    []byte
 }
 
 var _ delta.Identifiable = (*Issue)(nil)

--- a/infrastructure/code/bundle_uploader_test.go
+++ b/infrastructure/code/bundle_uploader_test.go
@@ -89,7 +89,7 @@ func Test_Bundler_Upload(t *testing.T) {
 func createTempFileInDir(t *testing.T, name string, size int, temporaryDir string) (string, BundleFile) {
 	t.Helper()
 	documentURI, fileContent := createFileOfSize(t, name, size, temporaryDir)
-	return documentURI, BundleFile{Hash: util.Hash(fileContent), Content: string(fileContent)}
+	return documentURI, BundleFile{Hash: util.Hash(fileContent), Content: string(fileContent), Size: size}
 }
 
 func Test_IsSupportedLanguage(t *testing.T) {

--- a/infrastructure/code/bundle_uploader_test.go
+++ b/infrastructure/code/bundle_uploader_test.go
@@ -48,7 +48,7 @@ func Test_Bundler_Upload(t *testing.T) {
 		bundleFileMap[documentURI] = bundleFile
 
 		testTracker := progress.NewTestTracker(make(chan types.ProgressParams, 100000), make(chan bool, 1))
-		_, err := bundleUploader.Upload(context.Background(), Bundle{SnykCode: snykCodeService, missingFiles: []string{documentURI}, logger: c.Logger()}, bundleFileMap, testTracker)
+		_, err := bundleUploader.Upload(context.Background(), Bundle{SnykCode: snykCodeService, missingFiles: []string{documentURI}, logger: c.Logger(), Files: bundleFileMap}, testTracker)
 
 		assert.Equal(t, 1, snykCodeService.TotalBundleCount)
 		assert.NoError(t, err)
@@ -77,7 +77,7 @@ func Test_Bundler_Upload(t *testing.T) {
 		missingFiles = append(missingFiles, path)
 
 		testTracker := progress.NewTestTracker(make(chan types.ProgressParams, 100000), make(chan bool, 1))
-		_, err := bundler.Upload(context.Background(), Bundle{SnykCode: snykCodeService, missingFiles: missingFiles, logger: c.Logger()}, bundleFileMap, testTracker)
+		_, err := bundler.Upload(context.Background(), Bundle{SnykCode: snykCodeService, missingFiles: missingFiles, logger: c.Logger(), Files: bundleFileMap}, testTracker)
 
 		assert.True(t, snykCodeService.HasExtendedBundle)
 		assert.Equal(t, 2, snykCodeService.TotalBundleCount)

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -387,7 +387,7 @@ func (sc *Scanner) UploadAndAnalyze(ctx context.Context, files <-chan string, pa
 		}
 	}
 
-	uploadedBundle, err := sc.BundleUploader.Upload(span.Context(), bundle, bundle.Files, t)
+	uploadedBundle, err := sc.BundleUploader.Upload(span.Context(), bundle, t)
 	if err != nil {
 		if ctx.Err() == nil { // Only handle errors that are not intentional cancellations
 			msg := "error uploading files..."
@@ -500,14 +500,19 @@ func (sc *Scanner) createBundle(ctx context.Context, requestId string, rootPath 
 		if !supported {
 			continue
 		}
+		fileInfo, err := os.Stat(absoluteFilePath)
+		if err != nil {
+			sc.c.Logger().Error().Err(err).Str("filePath", absoluteFilePath).Msg("could not open file")
+			continue
+		}
+
+		if fileInfo.Size() == 0 || fileInfo.Size() > maxFileSize {
+			continue
+		}
 
 		fileContent, err := os.ReadFile(absoluteFilePath)
 		if err != nil {
 			sc.C.Logger().Error().Err(err).Str("filePath", absoluteFilePath).Msg("could not load content of file")
-			continue
-		}
-
-		if !(len(fileContent) > 0 && len(fileContent) <= maxFileSize) {
 			continue
 		}
 
@@ -517,6 +522,7 @@ func (sc *Scanner) createBundle(ctx context.Context, requestId string, rootPath 
 		}
 		relativePath = EncodePath(relativePath)
 
+		// TODO: Check if we need to calculate hash for createBundle and if we can't calculate when triggering uploadBatch.
 		bundleFile := sc.getFileFrom(absoluteFilePath, fileContent)
 		bundleFiles[relativePath] = bundleFile
 		fileHashes[relativePath] = bundleFile.Hash

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -502,7 +502,7 @@ func (sc *Scanner) createBundle(ctx context.Context, requestId string, rootPath 
 		}
 		fileInfo, err := os.Stat(absoluteFilePath)
 		if err != nil {
-			sc.c.Logger().Error().Err(err).Str("filePath", absoluteFilePath).Msg("could not open file")
+			sc.C.Logger().Error().Err(err).Str("filePath", absoluteFilePath).Msg("could not open file")
 			continue
 		}
 

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -335,12 +335,6 @@ func (s *SarifConverter) toIssues(baseDir string) (issues []snyk.Issue, err erro
 			endLine := util.Max(position.EndLine-1, startLine)
 			startCol := position.StartColumn - 1
 			endCol := util.Max(position.EndColumn-1, 0)
-			fileContent, err := os.ReadFile(absPath)
-			if err != nil {
-				s.c.Logger().Err(err).Msgf("failed to read file %s, skipping", absPath)
-				errs = errors.Join(errs, err)
-				continue
-			}
 			myRange := snyk.Range{
 				Start: snyk.Position{
 					Line:      startLine,
@@ -416,7 +410,6 @@ func (s *SarifConverter) toIssues(baseDir string) (issues []snyk.Issue, err erro
 				FormattedMessage:    formattedMessage,
 				IssueType:           issueType,
 				AffectedFilePath:    absPath,
-				FileContent:         fileContent,
 				Product:             product.ProductCode,
 				IssueDescriptionURL: ruleLink,
 				References:          s.getReferences(testRule),

--- a/infrastructure/code/upload_batch.go
+++ b/infrastructure/code/upload_batch.go
@@ -41,15 +41,15 @@ func NewUploadBatch() *UploadBatch {
 
 // todo simplify the size computation
 // maybe consider an addFile / canFitFile interface with proper error handling
-func (b *UploadBatch) canFitFile(uri string, content []byte) bool {
-	docPayloadSize := b.getTotalDocPayloadSize(uri, content)
+func (b *UploadBatch) canFitFile(uri string, size int) bool {
+	docPayloadSize := b.getTotalDocPayloadSize(uri, size)
 	newSize := docPayloadSize + b.getSize()
 	b.size += docPayloadSize
 	return newSize < maxUploadBatchSize
 }
 
-func (b *UploadBatch) getTotalDocPayloadSize(documentURI string, content []byte) int {
-	return len(jsonHashSizePerFile) + len(jsonOverheadPerFile) + len([]byte(documentURI)) + len(content)
+func (b *UploadBatch) getTotalDocPayloadSize(documentURI string, size int) int {
+	return len(jsonHashSizePerFile) + len(jsonOverheadPerFile) + len([]byte(documentURI)) + size
 }
 
 func (b *UploadBatch) getSize() int {
@@ -68,4 +68,5 @@ func (b *UploadBatch) hasContent() bool {
 type BundleFile struct {
 	Hash    string `json:"hash"`
 	Content string `json:"content"`
+	Size    int    `json:"-"`
 }

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -41,9 +41,9 @@ var issuesSeverity = map[string]snyk.Severity{
 	"medium":   snyk.Medium,
 }
 
-func toIssue(affectedFilePath string, issue ossIssue, scanResult *scanResult, issueDepNode *ast.Node, learnService learn.Service, ep error_reporting.ErrorReporter, fileContent []byte) snyk.Issue {
+func toIssue(affectedFilePath string, issue ossIssue, scanResult *scanResult, issueDepNode *ast.Node, learnService learn.Service, ep error_reporting.ErrorReporter) snyk.Issue {
 	// this needs to be first so that the lesson from Snyk Learn is added
-	codeActions := issue.AddCodeActions(learnService, ep, affectedFilePath, issueDepNode, fileContent)
+	codeActions := issue.AddCodeActions(learnService, ep, affectedFilePath, issueDepNode)
 
 	var codelensCommands []types.CommandData
 	for _, codeAction := range codeActions {
@@ -97,7 +97,6 @@ func toIssue(affectedFilePath string, issue ossIssue, scanResult *scanResult, is
 		Range:               getRangeFromNode(issueDepNode),
 		Severity:            issue.ToIssueSeverity(),
 		AffectedFilePath:    affectedFilePath,
-		FileContent:         fileContent,
 		Product:             product.ProductOpenSource,
 		IssueDescriptionURL: issue.CreateIssueURL(),
 		IssueType:           snyk.DependencyVulnerability,
@@ -138,7 +137,7 @@ func convertScanResultToIssues(c *config.Config, res *scanResult, targetFilePath
 			continue
 		}
 		node := getDependencyNode(c, targetFilePath, issue, fileContent)
-		snykIssue := toIssue(targetFilePath, issue, res, node, ls, ep, fileContent)
+		snykIssue := toIssue(targetFilePath, issue, res, node, ls, ep)
 		packageIssueCache[packageKey] = append(packageIssueCache[packageKey], snykIssue)
 		issues = append(issues, snykIssue)
 		duplicateCheckMap[duplicateKey] = true

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -106,7 +106,7 @@ func Test_toIssue_LearnParameterConversion(t *testing.T) {
 		learnService: getLearnMock(t),
 	}
 
-	issue := toIssue("testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, nil)
+	issue := toIssue("testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter)
 
 	assert.Equal(t, sampleOssIssue.Id, issue.ID)
 	assert.Equal(t, sampleOssIssue.Identifiers.CWE, issue.CWEs)
@@ -147,7 +147,7 @@ func Test_toIssue_CodeActions(t *testing.T) {
 			sampleOssIssue.PackageManager = test.packageManager
 			sampleOssIssue.UpgradePath = []any{"false", test.packageName}
 
-			issue := toIssue("testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, nil)
+			issue := toIssue("testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter)
 
 			assert.Equal(t, sampleOssIssue.Id, issue.ID)
 			assert.Equal(t, flashy+test.expectedUpgrade, issue.CodeActions[0].Title)
@@ -173,7 +173,7 @@ func Test_toIssue_CodeActions_WithoutFix(t *testing.T) {
 	}
 	sampleOssIssue.UpgradePath = []any{"*"}
 
-	issue := toIssue("testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, nil)
+	issue := toIssue("testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter)
 
 	assert.Equal(t, sampleOssIssue.Id, issue.ID)
 	assert.Equal(t, 2, len(issue.CodeActions))


### PR DESCRIPTION
### Description

* VS sends folderPath with a trailing slash which breaks fileFilter.
* Improve memory usage

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
