### PR TITLE
fix: uses runtime.ReadMemStats to print memory allocation

### DIFF
--- a/memstats.go
+++ b/memstats.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+    "fmt"
+    "runtime"
+)
+
+// Function to convert bytes to megabytes
+func bytesToMB(bytes uint64) float64 {
+    return float64(bytes) / (1024 * 1024)
+}
+
+// Function to print memory statistics
+func printMemoryStats() {
+    var memStats runtime.MemStats
+    runtime.ReadMemStats(&memStats)
+
+    fmt.Printf("Allocated Memory (MB): %.2f\n", bytesToMB(memStats.Alloc))
+    fmt.Printf("Heap Allocated Memory (MB): %.2f\n", bytesToMB(memStats.HeapAlloc))
+    fmt.Printf("Total Allocated Memory (MB): %.2f\n", bytesToMB(memStats.TotalAlloc))
+    fmt.Printf("System Memory (MB): %.2f\n", bytesToMB(memStats.Sys))
+    fmt.Printf("Number of Garbage Collections: %d\n", memStats.NumGC)
+}
+
+func main() {
+    printMemoryStats()
+}
+


### PR DESCRIPTION
### Description

This Go function uses runtime.ReadMemStats to print memory allocation in megabytes.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
