### PR TITLE
chore: migrate AI Fix JS logic from IDEs to LS [IDE-655]

### DIFF
--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -114,6 +114,11 @@ func (renderer *HtmlRenderer) GetDetailsHtml(issue snyk.Issue) string {
 		renderer.c.Logger().Error().Msg("Failed to cast additional data to CodeIssueData")
 		return ""
 	}
+	nonce, err := html.GenerateSecurityNonce()
+	if err != nil {
+		renderer.c.Logger().Warn().Msgf("Failed to generate security nonce: %s", err)
+		return ""
+	}
 	folderPath := renderer.determineFolderPath(issue.AffectedFilePath)
 	exampleCommits := prepareExampleCommits(additionalData.ExampleCommitFixes)
 	commitFixes := parseExampleCommitsToTemplateJS(exampleCommits, renderer.c.Logger())
@@ -152,6 +157,7 @@ func (renderer *HtmlRenderer) GetDetailsHtml(issue snyk.Issue) string {
 		"IssueId":            issue.AdditionalData.GetKey(),
 		"Styles":             template.CSS(panelStylesTemplate),
 		"Scripts":            template.JS(customScripts),
+		"Nonce":              nonce,
 	}
 
 	if issue.IsIgnored {

--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -67,6 +67,9 @@ var detailsHtmlTemplate string
 //go:embed template/styles.css
 var panelStylesTemplate string
 
+//go:embed template/scripts.js
+var customScripts string
+
 type HtmlRenderer struct {
 	c              *config.Config
 	globalTemplate *template.Template
@@ -148,6 +151,7 @@ func (renderer *HtmlRenderer) GetDetailsHtml(issue snyk.Issue) string {
 		"FilePath":           issue.Path(),
 		"IssueId":            issue.AdditionalData.GetKey(),
 		"Styles":             template.CSS(panelStylesTemplate),
+		"Scripts":            template.JS(customScripts),
 	}
 
 	if issue.IsIgnored {

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -23,14 +23,16 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Security-Policy"
-    content="style-src 'self' 'nonce-${nonce}' 'nonce-ideNonce' https://fonts.googleapis.com;
-             script-src 'nonce-${nonce}' https://fonts.googleapis.com;
+    content="style-src 'self' 'nonce-{{.Nonce}}' 'nonce-ideNonce' https://fonts.googleapis.com;
+             script-src 'nonce-{{.Nonce}}' https://fonts.googleapis.com;
              font-src 'self' https://fonts.gstatic.com;" />
 
-  <style nonce="${nonce}">
+  <style nonce="{{.Nonce}}">
     {{.Styles}}
   </style>
-  ${ideStyle}
+  <style nonce="{{.Nonce}}">
+    ${ideStyle}
+  </style>
 </head>
 
 <body>
@@ -345,7 +347,7 @@
   {{end}}
 
   <!-- Scripts -->
-  <script nonce=${nonce}>
+  <script nonce="{{.Nonce}}">
     /**
      * Represents a single line change in a commit.
      * @typedef {Object} ExampleLine
@@ -487,11 +489,11 @@
     });
   </script>
   <!-- Embedded script from LS  -->
-  <script nonce=${nonce}>
+  <script nonce="{{.Nonce}}">
     {{.Scripts}}
   </script>
   <!-- Custom IDE specific scripts  -->
-  <script nonce=${nonce}>
+  <script nonce="{{.Nonce}}">
     ${ideScript}
   </script>
 </body>

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -345,7 +345,7 @@
   {{end}}
 
   <!-- Scripts -->
-  <script nonce="${nonce}">
+  <script nonce=${nonce}>
     /**
      * Represents a single line change in a commit.
      * @typedef {Object} ExampleLine
@@ -391,21 +391,7 @@
       }
     }
 
-    function toggleElement(element, toggle) {
-      if (!element) {
-        return;
-      }
 
-      if (toggle === 'show') {
-        element.className = element.className.replace(/(?:^|\s)hidden(?!\S)/g, '');
-      } else if (toggle === 'hide') {
-        if (element.className.indexOf('hidden') === -1) {
-          element.className += ' hidden';
-        }
-      } else {
-        console.error('Unexpected toggle value', toggle);
-      }
-    }
 
     function polyfillClosest() {
       if (!Element.prototype.closest) {
@@ -497,11 +483,17 @@
       if (exampleNext) {
         exampleNext.onclick = nextExample;
       }
-
       showCurrentExample();
     });
   </script>
-  ${ideScript}
+  <!-- Embedded script from LS  -->
+  <script nonce=${nonce}>
+    {{.Scripts}}
+  </script>
+  <!-- Custom IDE specific scripts  -->
+  <script nonce=${nonce}>
+    ${ideScript}
+  </script>
 </body>
 
 </html>

--- a/infrastructure/code/template/scripts.js
+++ b/infrastructure/code/template/scripts.js
@@ -140,11 +140,7 @@ function getFilePathFromFix(fix) {
 }
 function showCurrentDiff() {
   // Some IDEs send back the suggestion, others send the suggestion.diffs directly.
-  let showSuggestion = suggestion;
-  if(suggestion?.diffs?.length){
-    showSuggestion = suggestion.diffs
-    console.log("NO suggestion.diffs " + suggestion)
-  }
+  let showSuggestion = getSuggestion();
 
   if (!showSuggestion.length) {
     toggleElement(noDiffsElem, 'show');

--- a/infrastructure/code/template/scripts.js
+++ b/infrastructure/code/template/scripts.js
@@ -1,0 +1,186 @@
+function toggleElement(element, toggle) {
+  if (!element) {
+    return;
+  }
+  if (toggle === 'show') {
+    element.className = element.className.replace(/(?:^|\s)hidden(?!\S)/g, '');
+  } else if (toggle === 'hide') {
+    if (element.className.indexOf('hidden') === -1) {
+      element.className += ' hidden';
+    }
+  } else {
+    console.error('Unexpected toggle value', toggle);
+  }
+}
+// different AI fix buttons
+const applyFixButton = document.getElementById('apply-fix');
+const retryGenerateFixButton = document.getElementById('retry-generate-fix');
+const generateAIFixButton = document.getElementById('generate-ai-fix');
+
+const fixLoadingIndicatorElem = document.getElementById('fix-loading-indicator');
+
+generateAIFixButton?.addEventListener('click', generateAIFix)
+retryGenerateFixButton?.addEventListener('click', retryGenerateAIFix);
+applyFixButton?.addEventListener('click', applyFix);
+
+function generateAIFix() {
+  if (!suggestion)
+    return;
+
+  toggleElement(generateAIFixButton, 'hide');
+  toggleElement(fixLoadingIndicatorElem, 'show');
+  ${ideGenerateAIFix}
+}
+
+
+function applyFix() {
+  if (!suggestion) return;
+  let showSuggestion = getSuggestion();
+
+  const diffSuggestion = showSuggestion[diffSelectedIndex];
+  const filePath = showSuggestion.filePath ? showSuggestion.filePath : getFilePathFromFix(diffSuggestion);
+  const patch = diffSuggestion.unifiedDiffsPerFile[filePath];
+  const fixId = diffSuggestion.fixId;
+
+  lastAppliedFix = diffSelectedIndex;
+  applyFixButton.disabled = true;
+  ${ideApplyAIFix}
+}
+
+
+const fixWrapperElem = document.getElementById('fix-wrapper');
+const fixSectionElem = document.getElementById('fixes-section');
+const fixErrorSectionElem = document.getElementById('fixes-error-section');
+
+// generated AI fix diffs
+const nextDiffElem = document.getElementById('next-diff');
+const previousDiffElem = document.getElementById('previous-diff');
+const diffSelectedIndexElem = document.getElementById('diff-counter');
+
+const diffTopElem = document.getElementById('diff-top');
+const diffElem = document.getElementById('diff');
+const noDiffsElem = document.getElementById('info-no-diffs');
+if (noDiffsElem) {
+  noDiffsElem.innerText = "We couldn't determine any fixes for this issue.";
+}
+const diffNumElem = document.getElementById('diff-number');
+const diffNum2Elem = document.getElementById('diff-number2');
+
+let diffSelectedIndex = 0;
+let lastAppliedFix = -1;
+
+function nextDiff() {
+  let showSuggestion = getSuggestion();
+
+  if (!showSuggestion || diffSelectedIndex >= showSuggestion.length - 1) return;
+  ++diffSelectedIndex;
+  applyFixButton.disabled = diffSelectedIndex == lastAppliedFix;
+  showCurrentDiff();
+}
+
+function retryGenerateAIFix() {
+  console.log('retrying generate AI Fix');
+
+  toggleElement(fixWrapperElem, 'show');
+  toggleElement(fixErrorSectionElem, 'hide');
+
+  generateAIFix();
+}
+
+function previousDiff() {
+  let showSuggestion = getSuggestion();
+
+  if (!showSuggestion || diffSelectedIndex <= 0) return;
+  --diffSelectedIndex;
+  applyFixButton.disabled = diffSelectedIndex == lastAppliedFix;
+  showCurrentDiff();
+}
+function generateDiffHtml(patch) {
+  const codeLines = patch.split('\n');
+
+  // the first two lines are the file names
+  codeLines.shift();
+  codeLines.shift();
+
+  const diffHtml = document.createElement('div');
+  let blockDiv = null;
+
+  for (const line of codeLines) {
+    if (line.startsWith('@@ ')) {
+      blockDiv = document.createElement('div');
+      blockDiv.className = 'example';
+
+      if (blockDiv) {
+        diffHtml.appendChild(blockDiv);
+      }
+    } else {
+      const lineDiv = document.createElement('div');
+      lineDiv.className = 'example-line';
+
+      if (line.startsWith('+')) {
+        lineDiv.classList.add('added');
+      } else if (line.startsWith('-')) {
+        lineDiv.classList.add('removed');
+      }
+
+      const lineCode = document.createElement('code');
+      // if line is empty, we need to fall back to ' '
+      // to make sure it displays in the diff
+      lineCode.innerText = line.slice(1, line.length) || ' ';
+
+      lineDiv.appendChild(lineCode);
+      blockDiv?.appendChild(lineDiv);
+    }
+  }
+
+  return diffHtml;
+}
+function getFilePathFromFix(fix) {
+  return Object.keys(fix.unifiedDiffsPerFile)[0];
+}
+function showCurrentDiff() {
+  // Some IDEs send back the suggestion, others send the suggestion.diffs directly.
+  let showSuggestion = suggestion;
+  if(suggestion?.diffs?.length){
+    showSuggestion = suggestion.diffs
+    console.log("NO suggestion.diffs " + suggestion)
+  }
+
+  if (!showSuggestion.length) {
+    toggleElement(noDiffsElem, 'show');
+    toggleElement(diffTopElem, 'hide');
+    toggleElement(diffElem, 'hide');
+    toggleElement(applyFixButton, 'hide');
+    return;
+  }
+
+  if (!showSuggestion.length || diffSelectedIndex < 0 || diffSelectedIndex >= showSuggestion.length) return;
+
+  toggleElement(noDiffsElem, 'hide');
+  toggleElement(diffTopElem, 'show');
+  toggleElement(diffElem, 'show');
+  toggleElement(applyFixButton, 'show');
+  diffNumElem.innerText = showSuggestion.length.toString();
+  diffNum2Elem.innerText = showSuggestion.length.toString();
+
+  diffSelectedIndexElem.innerText = (diffSelectedIndex + 1).toString();
+
+  const diffSuggestion = showSuggestion[diffSelectedIndex];
+  // IntelliJ way of getting file ? TODO: Investigate
+  const filePath = showSuggestion.filePath ? showSuggestion.filePath : getFilePathFromFix(diffSuggestion);
+  const patch = diffSuggestion.unifiedDiffsPerFile[filePath];
+  console.log()
+  // clear all elements
+  while (diffElem.firstChild) {
+    diffElem.removeChild(diffElem.firstChild);
+  }
+  diffElem.appendChild(generateDiffHtml(patch));
+}
+function getSuggestion(){
+  if(suggestion?.diffs?.length){
+    return suggestion.diffs;
+  }
+  return suggestion;
+}
+nextDiffElem.addEventListener('click', nextDiff);
+previousDiffElem.addEventListener('click', previousDiff);

--- a/infrastructure/code/template/styles.css
+++ b/infrastructure/code/template/styles.css
@@ -446,6 +446,7 @@ code {
   white-space: pre-wrap;
   font-weight: 400;
   background-color: transparent;
+  overflow-wrap: anywhere
 }
 
 .example-line.added>code::before,

--- a/infrastructure/iac/template/scripts.js
+++ b/infrastructure/iac/template/scripts.js
@@ -23,7 +23,7 @@
   function applyIgnoreInFile() {
     console.log('Applying ignore', issue);
     if (!issue) return;
-
+    // IntelliJ callback TODO: Inject it dynamically or remove
     window.applyIgnoreInFileQuery(issue + '|@' + filePath + ' > ' + resourcePath);
     toggleElement(ignoreInFileBtn, "hide");
     console.log('Applying ignore');


### PR DESCRIPTION
### Description

The logic between IDE's for handling AI Fix functionality is mostly the same, this means having separate scripts in each IDE for this feature also means a lot of duplication and difficulty in maintenance due to different nuances in the implementations.

This PR migrates AI Fix Logic, centralizes it in LS and unifies the logic, allowing injecting only the IDE Specific logic that is absolute necessary.
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
