### PR TITLE
feat: added a new code action and code lens for showDocument

### DIFF
--- a/domain/ide/command/navigate_to_range.go
+++ b/domain/ide/command/navigate_to_range.go
@@ -19,6 +19,8 @@ package command
 import (
 	"context"
 	"encoding/json"
+	sglsp "github.com/sourcegraph/go-lsp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -60,8 +62,16 @@ func (cmd *navigateToRangeCommand) Execute(_ context.Context) (any, error) {
 	if !ok {
 		return nil, errors.Errorf("invalid range path: %s", args[0])
 	}
+
+	var documentUri sglsp.DocumentURI
+	if !strings.HasPrefix(path, "snyk://") {
+		documentUri = uri.PathToUri(path)
+	} else {
+		documentUri = sglsp.DocumentURI(path)
+	}
+
 	params := types.ShowDocumentParams{
-		Uri:       uri.PathToUri(path),
+		Uri:       documentUri,
 		External:  false,
 		TakeFocus: true,
 		Selection: converter.ToRange(myRange),

--- a/domain/ide/command/navigate_to_range.go
+++ b/domain/ide/command/navigate_to_range.go
@@ -19,8 +19,9 @@ package command
 import (
 	"context"
 	"encoding/json"
-	sglsp "github.com/sourcegraph/go-lsp"
 	"strings"
+
+	sglsp "github.com/sourcegraph/go-lsp"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62
 	github.com/google/uuid v1.6.0
+	github.com/gosimple/hashdir v1.0.2
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/otiai10/copy v1.14.0
 	github.com/pact-foundation/pact-go v1.10.0
@@ -70,7 +71,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/gosimple/hashdir v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -118,7 +118,7 @@ func (sc *Scanner) GetAutofixDiffs(
 		return unifiedDiffSuggestions, fmt.Errorf("bundle hash not found for baseDir: %s", baseDir)
 	}
 
-	encodedNormalizedPath, err := ToEncodedNormalizedPath(baseDir, filePath)
+	encodedNormalizedPath, err := toEncodedNormalizedPath(baseDir, filePath)
 	if err != nil {
 		return unifiedDiffSuggestions, err
 	}
@@ -155,4 +155,15 @@ func (sc *Scanner) GetAutofixDiffs(
 			// If err == nil and fixStatus.message != completeStatus, we will keep polling.
 		}
 	}
+}
+
+func toEncodedNormalizedPath(rootPath string, filePath string) (string, error) {
+	relativePath, err := ToRelativeUnixPath(rootPath, filePath)
+	if err != nil {
+		// couldn't make it relative, so it's already relative
+		relativePath = filePath
+	}
+
+	encodedRelativePath := EncodePath(relativePath)
+	return encodedRelativePath, nil
 }

--- a/infrastructure/code/bundle.go
+++ b/infrastructure/code/bundle.go
@@ -140,7 +140,7 @@ func (b *Bundle) retrieveAnalysis(ctx context.Context, t *progress.Tracker) ([]s
 			logger.Trace().Msg("sending diagnostics...")
 			t.ReportWithMessage(90, "Analysis complete.")
 
-			b.issueEnhancer.addIssueActions(ctx, issues, b.BundleHash)
+			b.issueEnhancer.addIssueActions(ctx, issues)
 
 			return issues, nil
 		} else if status.message == "ANALYZING" {

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -461,7 +461,7 @@ func (sc *Scanner) UploadAndAnalyzeWithIgnores(ctx context.Context, path string,
 		path,
 		sc.C,
 	)
-	issueEnhancer.addIssueActions(ctx, issues, bundleHash)
+	issueEnhancer.addIssueActions(ctx, issues)
 
 	return issues, nil
 }

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -79,7 +79,7 @@ func setupTestData() (issue snyk.Issue, expectedURI string, expectedTitle string
 	}
 
 	expectedURI = "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=123&action=showInDetailPanel"
-	expectedTitle = "⚡ Get AI Fixes for issue: Test Issue (Snyk)"
+	expectedTitle = "⚡ Fix this issue: Test Issue (Snyk)"
 
 	return
 }

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -266,7 +266,7 @@ func setupCreateBundleTest(t *testing.T, extension string) (*FakeSnykCodeClient,
 
 func setupTestScanner(t *testing.T) (*FakeSnykCodeClient, *Scanner) {
 	t.Helper()
-	c := config.CurrentConfig()
+	c := testutil.UnitTest(t)
 	snykCodeMock := &FakeSnykCodeClient{C: c}
 	learnMock := mock_learn.NewMockService(gomock.NewController(t))
 	learnMock.
@@ -663,7 +663,7 @@ func writeGitIgnoreIntoDir(t *testing.T, ignorePatterns string, tempDir string) 
 }
 
 func Test_IsEnabled(t *testing.T) {
-	c := config.CurrentConfig()
+	c := testutil.UnitTest(t)
 	scanner := &Scanner{errorReporter: newTestCodeErrorReporter(), C: c}
 	t.Run(
 		"should return true if Snyk Code is generally enabled", func(t *testing.T) {
@@ -717,7 +717,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 		GetLesson(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&learn.Lesson{}, nil).AnyTimes()
 
-	c := config.CurrentConfig()
+	c := testutil.UnitTest(t)
 
 	issueEnhancer := IssueEnhancer{
 		SnykCode:     &FakeSnykCodeClient{C: c},
@@ -813,7 +813,7 @@ func TestUploadAnalyzeWithAutofix(t *testing.T) {
 }
 
 func TestIssueEnhancer_createShowDocumentCodeAction(t *testing.T) {
-	c := config.CurrentConfig()
+	c := testutil.UnitTest(t)
 	issueEnhancer := IssueEnhancer{
 		SnykCode:     &FakeSnykCodeClient{C: c},
 		instrumentor: NewCodeInstrumentor(),

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -18,7 +18,6 @@ package code
 
 import (
 	"context"
-	"github.com/snyk/snyk-ls/internal/product"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -26,6 +25,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/snyk/snyk-ls/internal/product"
 
 	"github.com/snyk/snyk-ls/internal/progress"
 	"github.com/snyk/snyk-ls/internal/types"

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -19,9 +19,10 @@ package code
 import (
 	"context"
 	"fmt"
-	codeClientObservability "github.com/snyk/code-client-go/observability"
 	"net/url"
 	"strconv"
+
+	codeClientObservability "github.com/snyk/code-client-go/observability"
 
 	"github.com/snyk/snyk-ls/internal/types"
 

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -123,6 +123,8 @@ func (b *IssueEnhancer) addIssueActions(ctx context.Context, issues []snyk.Issue
 }
 
 // returns the deferred code action CodeAction which calls autofix.
+//
+//lint:ignore U1000 Remove this function when autofixFeedbackActions has been migrated to new flow.
 func (b *IssueEnhancer) createDeferredAutofixCodeAction(ctx context.Context, issue snyk.Issue) *snyk.CodeAction {
 	autofixEditCallback := b.autofixFunc(ctx, issue)
 	action, err := snyk.NewDeferredCodeAction("⚡ Fix this issue: "+issueTitle(issue)+" (Snyk)", &autofixEditCallback, nil, "", "")

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -71,17 +71,15 @@ func TestIssueEnhancer_autofixShowDetailsFunc(t *testing.T) {
 		rootPath:     "/Users/user/workspace/blah",
 		c:            c,
 	}
+	issue := snyk.Issue{
+		AffectedFilePath: "/Users/user/workspace/blah/app.js",
+		Product:          product.ProductCode,
+		AdditionalData:   snyk.CodeIssueData{Key: "123"},
+		Range:            fakeRange,
+	}
+	expectedURI := "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=123&action=showInDetailPanel"
 
 	t.Run("returns CommandData with correct URI and range", func(t *testing.T) {
-		issue := snyk.Issue{
-			AffectedFilePath: "app.js",
-			Product:          product.ProductCode,
-			AdditionalData:   snyk.CodeIssueData{Key: "123"},
-			Range:            fakeRange,
-		}
-
-		expectedURI := "snyk://Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=123&action=showInDetailPanel"
-
 		commandDataFunc := issueEnhancer.autofixShowDetailsFunc(context.Background(), issue)
 		commandData := commandDataFunc()
 
@@ -307,33 +305,15 @@ func Test_addIssueActions(t *testing.T) {
 
 func Test_ideSnykURI(t *testing.T) {
 	t.Run("generates correct URI", func(t *testing.T) {
-		rootPath := "/Users/user/workspace/blah"
-		issue := snyk.Issue{
-			AffectedFilePath: "app.js",
-			Product:          "Code",
-			AdditionalData:   snyk.CodeIssueData{Key: "123"}, // Provide additional data
-		}
-		ideAction := "showInDetailPanel"
-
-		expectedURI := "snyk:///Users/user/workspace/blah/app.js?product=Code&issueId=123&action=showInDetailPanel"
-
-		actualURI, err := ideSnykURI(rootPath, issue, ideAction)
+		issue, ideAction, expectedURI := setupAiFixTestData()
+		actualURI, err := ideSnykURI(issue, ideAction)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURI, actualURI)
 	})
 
 	t.Run("handles missing Key in additional data", func(t *testing.T) {
-		rootPath := "/Users/user/workspace/blah" // This will cause ToEncodedNormalizedPath to return an error
-		issue := snyk.Issue{
-			AffectedFilePath: "app.js",
-			Product:          product.ProductCode,
-			ID:               "uuid-123-456", // Default ID if no key in additional data
-		}
-		ideAction := "showInDetailPanel"
-
-		expectedURI := "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=uuid-123-456&action=showInDetailPanel"
-
-		actualURI, err := ideSnykURI(rootPath, issue, ideAction)
+		issue, ideAction, expectedURI := setupAiFixTestData()
+		actualURI, err := ideSnykURI(issue, ideAction)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURI, actualURI)
 	})
@@ -383,4 +363,16 @@ func TestIssueId(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupAiFixTestData() (issue snyk.Issue, ideAction string, expectedURI string) {
+	issue = snyk.Issue{
+		AffectedFilePath: "/Users/user/workspace/blah/app.js",
+		Product:          "Code",
+		AdditionalData:   snyk.CodeIssueData{Key: "123"}, // Provide additional data
+	}
+	ideAction = "showInDetailPanel"
+	expectedURI = "snyk:///Users/user/workspace/blah/app.js?product=Code&issueId=123&action=showInDetailPanel"
+
+	return
 }

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -303,11 +303,9 @@ func Test_addIssueActions(t *testing.T) {
 		assert.Len(t, fakeIssues[0].CodelensCommands, 1)
 		assert.Len(t, fakeIssues[0].CodeActions, 1)
 	})
-
 }
 
 func Test_ideSnykURI(t *testing.T) {
-
 	t.Run("generates correct URI", func(t *testing.T) {
 		rootPath := "/Users/user/workspace/blah"
 		issue := snyk.Issue{

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -80,7 +80,7 @@ func TestIssueEnhancer_autofixShowDetailsFunc(t *testing.T) {
 			Range:            fakeRange,
 		}
 
-		expectedURI := "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=123&action=showInDetailPanel"
+		expectedURI := "snyk://Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=123&action=showInDetailPanel"
 
 		commandDataFunc := issueEnhancer.autofixShowDetailsFunc(context.Background(), issue)
 		commandData := commandDataFunc()
@@ -331,7 +331,7 @@ func Test_ideSnykURI(t *testing.T) {
 		}
 		ideAction := "showInDetailPanel"
 
-		expectedURI := "snyk://Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=uuid-123-456&action=showInDetailPanel"
+		expectedURI := "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=uuid-123-456&action=showInDetailPanel"
 
 		actualURI, err := ideSnykURI(rootPath, issue, ideAction)
 		assert.NoError(t, err)

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -18,10 +18,11 @@ package code
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -327,11 +327,11 @@ func Test_ideSnykURI(t *testing.T) {
 		issue := snyk.Issue{
 			AffectedFilePath: "app.js",
 			Product:          product.ProductCode,
-			ID:               "SNYK-JS-FOO-456", // Default ID if no key in additional data
+			ID:               "uuid-123-456", // Default ID if no key in additional data
 		}
 		ideAction := "showInDetailPanel"
 
-		expectedURI := "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=SNYK-JS-FOO-456&action=showInDetailPanel"
+		expectedURI := "snyk://Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=uuid-123-456&action=showInDetailPanel"
 
 		actualURI, err := ideSnykURI(rootPath, issue, ideAction)
 		assert.NoError(t, err)

--- a/infrastructure/code/path.go
+++ b/infrastructure/code/path.go
@@ -39,17 +39,6 @@ func EncodePath(relativePath string) string {
 	return encodedPath
 }
 
-func EncodeAbsolutePath(absolutePathPath string) string {
-	segments := strings.Split(filepath.ToSlash(absolutePathPath), "/")
-	encodedPath := "/"
-	for _, segment := range segments {
-		encodedSegment := url.PathEscape(segment)
-		encodedPath = path.Join(encodedPath, encodedSegment)
-	}
-
-	return encodedPath
-}
-
 func DecodePath(encodedRelativePath string) (string, error) {
 	return url.PathUnescape(encodedRelativePath)
 }

--- a/infrastructure/code/path.go
+++ b/infrastructure/code/path.go
@@ -39,6 +39,17 @@ func EncodePath(relativePath string) string {
 	return encodedPath
 }
 
+func EncodeAbsolutePath(absolutePathPath string) string {
+	segments := strings.Split(filepath.ToSlash(absolutePathPath), "/")
+	encodedPath := "/"
+	for _, segment := range segments {
+		encodedSegment := url.PathEscape(segment)
+		encodedPath = path.Join(encodedPath, encodedSegment)
+	}
+
+	return encodedPath
+}
+
 func DecodePath(encodedRelativePath string) (string, error) {
 	return url.PathUnescape(encodedRelativePath)
 }


### PR DESCRIPTION
### Description

The LSP pre-defined message for this is: window/showDocument.

We should encode the Action in a URI, e.g.
`snyk:///Users/basti/workspace/blah/app.js?product=Code%20Quality&issueId=123&action=showInDetailPanel`

Each IDE must intercept the `window/showDocument` message, and if it encounters the snyk scheme in the URI, it must not pass it on to the default handler, but do the appropriate action, in this case open the issue in the product issue detail panel.



For the encoded URI we would need:
- FilePath
- Product
- IssueId
- Action

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
