### PR TITLE
fix: cleanup inconsistent auth configuration when needed [IDE-916]

### DIFF
--- a/domain/snyk/issues.go
+++ b/domain/snyk/issues.go
@@ -305,6 +305,9 @@ func (i *Issue) GetGlobalIdentity() string {
 }
 
 func (i *Issue) SetGlobalIdentity(id string) {
+	i.m.Lock()
+	defer i.m.Unlock()
+
 	i.GlobalIdentity = id
 }
 

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -278,17 +278,21 @@ func (a *AuthenticationServiceImpl) isAuthenticated() bool {
 func (a *AuthenticationServiceImpl) handleProviderInconsistencies() {
 	msg := fmt.Sprintf("inconsistent auth provider, resetting (authMethod: %s, authenticator: %s)", a.c.AuthenticationMethod(), reflect.TypeOf(a.authProvider))
 	var ok = true
-	if a.authProvider == nil {
+	switch {
+	case a.authProvider == nil:
 		ok = false
 		msg = "auth provider is not set, resetting to default"
-	} else if a.c.AuthenticationMethod() == types.OAuthAuthentication {
+	case a.c.AuthenticationMethod() == types.OAuthAuthentication:
 		_, ok = a.authProvider.(*OAuth2Provider)
-	} else if a.c.AuthenticationMethod() == types.TokenAuthentication {
+	case a.c.AuthenticationMethod() == types.TokenAuthentication:
 		_, ok = a.authProvider.(*CliAuthenticationProvider)
-	} else if a.c.AuthenticationMethod() == types.FakeAuthentication {
+	case a.c.AuthenticationMethod() == types.FakeAuthentication:
 		_, fake := a.authProvider.(*FakeAuthenticationProvider)
 		_, cli := a.authProvider.(*CliAuthenticationProvider)
 		ok = fake || cli
+	default:
+		ok = false
+		msg = fmt.Sprintf("Unsupported authentication method: %s", a.c.AuthenticationMethod())
 	}
 	if !ok {
 		a.c.Logger().Warn().Msg(msg)

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -277,7 +277,7 @@ func (a *AuthenticationServiceImpl) isAuthenticated() bool {
 // configure providers, if needed, as specified in the config
 func (a *AuthenticationServiceImpl) handleProviderInconsistencies() {
 	msg := fmt.Sprintf("inconsistent auth provider, resetting (authMethod: %s, authenticator: %s)", a.c.AuthenticationMethod(), reflect.TypeOf(a.authProvider))
-	var ok = true
+	var ok bool
 	switch {
 	case a.authProvider == nil:
 		ok = false

--- a/infrastructure/authentication/auth_service_impl_test.go
+++ b/infrastructure/authentication/auth_service_impl_test.go
@@ -175,6 +175,7 @@ func Test_Authenticate(t *testing.T) {
 func Test_IsAuthenticated(t *testing.T) {
 	t.Run("User is authenticated", func(t *testing.T) {
 		c := testutil.UnitTest(t)
+		c.SetAuthenticationMethod(types.FakeAuthentication)
 
 		provider := FakeAuthenticationProvider{IsAuthenticated: true, C: c}
 		service := NewAuthenticationService(c, &provider, error_reporting.NewTestErrorReporter(), notification.NewNotifier())

--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -238,7 +238,7 @@ func (cliScanner *CLIScanner) updateArgs(workDir types.FilePath, commandLineArgs
 	folderConfigArgs := folderConfig.AdditionalParameters
 
 	// this asks the client for the current SDK and blocks on it
-	additionalParameters := cliScanner.updateSDKs(workDir)
+	additionalParameters := cliScanner.updateSDKs(folderConfig.FolderPath)
 
 	if len(folderConfigArgs) > 0 {
 		additionalParameters = append(additionalParameters, folderConfigArgs...)

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snyk/snyk-ls/internal/storage"
 	storedConfig "github.com/snyk/snyk-ls/internal/storedconfig"
 	"github.com/snyk/snyk-ls/internal/testsupport"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 func IntegTest(t *testing.T) *config.Config {
@@ -52,6 +53,7 @@ func UnitTest(t *testing.T) *config.Config {
 	c.ConfigureLogging(nil)
 	c.SetToken("00000000-0000-0000-0000-000000000001")
 	c.SetTrustedFolderFeatureEnabled(false)
+	c.SetAuthenticationMethod(types.FakeAuthentication)
 	setMCPServerURL(t, c)
 	redirectConfigAndDataHome(t, c)
 	config.SetCurrentConfig(c)
@@ -119,6 +121,7 @@ func prepareTestHelper(t *testing.T, envVar string, useConsistentIgnores bool) *
 	c := config.New()
 	c.ConfigureLogging(nil)
 	c.SetToken(testsupport.GetEnvironmentToken(useConsistentIgnores))
+	c.SetAuthenticationMethod(types.TokenAuthentication)
 	c.SetErrorReportingEnabled(false)
 	c.SetTrustedFolderFeatureEnabled(false)
 	setMCPServerURL(t, c)


### PR DESCRIPTION
### Description

- Reset authentication configuration if authentication method does not match the provider, and the API reports a credential problem.
- Retrieve SDK configuration always with the path of the working directory

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
