### PR TITLE
fix: hide AI fix for ignored issues [IDE-941]

### DIFF
--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -80,9 +80,9 @@ func (b *IssueEnhancer) addIssueActions(ctx context.Context, issues []types.Issu
 			continue
 		}
 
-		issueData.HasAIFix = autoFixEnabled && issueData.IsAutofixable
+		issueData.HasAIFix = autoFixEnabled && issueData.IsAutofixable && !issues[i].GetIsIgnored()
 
-		if issueData.HasAIFix && !issues[i].GetIsIgnored() {
+		if issueData.HasAIFix {
 			codeActionShowDocument := b.createShowDocumentCodeAction(issues[i])
 			issues[i].SetCodeActions(append(issues[i].GetCodeActions(), codeActionShowDocument))
 

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -94,15 +94,16 @@
         <span data-tab="ignore-details" id="ignore-details-tab" class="tab-item is-selected ignore-details-tab">
           Ignore Details
         </span>
-        {{end}}
+        {{else}}
         <span data-tab="fix-analysis" id="fix-analysis-tab"
-          class="tab-item {{if not .IsIgnored}}is-selected{{end}} sn-fix-analysis fix-analysis-tab">
+          class="tab-item is-selected sn-fix-analysis fix-analysis-tab">
           Fix Analysis
         </span>
         {{if gt (len .DataFlow) 0}}
         <span data-tab="data-flow-data-tab" id="data-flow-tab" class="tab-item sn-data-flow data-flow-tab">
           Data Flow
         </span>
+        {{end}}
         {{end}}
         {{if .IssueOverview}}
         <span data-tab="vuln-overview" id="vuln-overview-tab" class="tab-item sn-vuln-overview vuln-overview-tab">


### PR DESCRIPTION
### Description

For ignored issues this will: hide the "Fix Analysis" and "Data Flow" tabs; remove the lightning bolt from ignored issues in the tree view; hide any code actions to do with AI fixing; and stop the issue from being counted in the total for AI fixable issues.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshots

![Screenshot 2025-03-03 at 15 38 31](https://github.com/user-attachments/assets/04b6d146-18b9-4a6f-a722-56eced71ecf1)

