### PR TITLE
fix: lazy instantiation deepcode LLM binding 

### DIFF
--- a/application/di/init.go
+++ b/application/di/init.go
@@ -179,19 +179,11 @@ func initInfrastructure(c *config.Config) {
 }
 
 func initApplication(c *config.Config) {
-	deepCodeLLMBinding = llm.NewDeepcodeLLMBinding(
-		llm.WithLogger(c.Logger()),
-		llm.WithOutputFormat(llm.HTML),
-		llm.WithHTTPClient(func() codeClientHTTP.HTTPClient {
-			return c.Engine().GetNetworkAccess().GetHttpClient()
-		}),
-	)
-
 	w := workspace.New(c, instrumentor, scanner, hoverService, scanNotifier, notifier, scanPersister, scanStateAggregator) // don't use getters or it'll deadlock
 	c.SetWorkspace(w)
 	fileWatcher = watcher.NewFileWatcher()
 	codeActionService = codeaction.NewService(c, w, fileWatcher, notifier, snykCodeClient)
-	command.SetService(command.NewService(authenticationService, notifier, learnService, w, snykCodeClient, snykCodeScanner, snykCli, deepCodeLLMBinding))
+	command.SetService(command.NewService(authenticationService, notifier, learnService, w, snykCodeClient, snykCodeScanner, snykCli))
 }
 
 /*

--- a/application/di/init.go
+++ b/application/di/init.go
@@ -21,8 +21,6 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/snyk/code-client-go/llm"
-
 	"github.com/snyk/snyk-ls/domain/scanstates"
 	"github.com/snyk/snyk-ls/domain/snyk/persistence"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -62,7 +60,6 @@ var snykApiClient snyk_api.SnykApiClient
 var snykCodeClient code.SnykCodeClient
 var snykCodeBundleUploader *code.BundleUploader
 var snykCodeScanner *code.Scanner
-var deepCodeLLMBinding llm.DeepCodeLLMBinding
 var infrastructureAsCodeScanner *iac.Scanner
 var openSourceScanner types.ProductScanner
 var scanInitializer initialize.Initializer

--- a/application/server/execute_command_test.go
+++ b/application/server/execute_command_test.go
@@ -133,7 +133,7 @@ func Test_loginCommand_StartsAuthentication(t *testing.T) {
 	fakeAuthenticationProvider.IsAuthenticated = false
 
 	// reset to use real service
-	command.SetService(command.NewService(authenticationService, di.Notifier(), di.LearnService(), nil, nil, nil, nil, nil))
+	command.SetService(command.NewService(authenticationService, di.Notifier(), di.LearnService(), nil, nil, nil, nil))
 
 	_, err := loc.Client.Call(ctx, "initialize", nil)
 	if err != nil {

--- a/domain/ide/command/code_fix_apply_edit.go
+++ b/domain/ide/command/code_fix_apply_edit.go
@@ -54,7 +54,7 @@ func (cmd *applyAiFixEditCommand) Execute(ctx context.Context) (any, error) {
 		return nil, fmt.Errorf("invalid edit")
 	}
 
-	htmlRenderer, err := code.GetHTMLRenderer(cmd.c, cmd.deepCodeLLMBinding)
+	htmlRenderer, err := code.GetHTMLRenderer(cmd.c)
 	if err != nil {
 		cmd.logger.Debug().Str("method", "applyAiFixEditCommand.Execute").Msgf("Unable to get the htmlRenderer")
 		return nil, err

--- a/domain/ide/command/code_fix_apply_edit.go
+++ b/domain/ide/command/code_fix_apply_edit.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/code-client-go/llm"
 	sglsp "github.com/sourcegraph/go-lsp"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -35,13 +34,12 @@ import (
 )
 
 type applyAiFixEditCommand struct {
-	command            types.CommandData
-	issueProvider      snyk.IssueProvider
-	notifier           notification.Notifier
-	deepCodeLLMBinding llm.DeepCodeLLMBinding
-	apiClient          SnykCodeHttpClient
-	c                  *config.Config
-	logger             *zerolog.Logger
+	command       types.CommandData
+	issueProvider snyk.IssueProvider
+	notifier      notification.Notifier
+	apiClient     SnykCodeHttpClient
+	c             *config.Config
+	logger        *zerolog.Logger
 }
 
 func (cmd *applyAiFixEditCommand) Command() types.CommandData {

--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/code-client-go/llm"
 	"github.com/sourcegraph/go-lsp"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -36,13 +35,12 @@ import (
 )
 
 type codeFixDiffs struct {
-	command            types.CommandData
-	srv                types.Server
-	notifier           notification.Notifier
-	issueProvider      snyk.IssueProvider
-	codeScanner        *code.Scanner
-	deepCodeLLMBinding llm.DeepCodeLLMBinding
-	c                  *config.Config
+	command       types.CommandData
+	srv           types.Server
+	notifier      notification.Notifier
+	issueProvider snyk.IssueProvider
+	codeScanner   *code.Scanner
+	c             *config.Config
 }
 
 func (cmd *codeFixDiffs) Command() types.CommandData {

--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -89,7 +89,7 @@ func (cmd *codeFixDiffs) Execute(ctx context.Context) (any, error) {
 		return nil, errors.New("failed to find issue")
 	}
 
-	htmlRenderer, err := code.GetHTMLRenderer(cmd.c, cmd.deepCodeLLMBinding)
+	htmlRenderer, err := code.GetHTMLRenderer(cmd.c)
 	if err != nil {
 		logger.Err(err).Msg("failed to get html renderer")
 		return nil, err

--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/code-client-go/llm"
-
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/code"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
@@ -83,11 +81,10 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 		C:              c,
 	}
 	cut := codeFixDiffs{
-		notifier:           notification.NewMockNotifier(),
-		codeScanner:        codeScanner,
-		c:                  c,
-		srv:                &ServerImplMock{},
-		deepCodeLLMBinding: llm.NewDeepcodeLLMBinding(),
+		notifier:    notification.NewMockNotifier(),
+		codeScanner: codeScanner,
+		c:           c,
+		srv:         &ServerImplMock{},
 	}
 	if runtime.GOOS == "windows" {
 		codeScanner.AddBundleHash("\\folderPath", "bundleHash")

--- a/domain/ide/command/command_factory.go
+++ b/domain/ide/command/command_factory.go
@@ -19,8 +19,6 @@ package command
 import (
 	"fmt"
 
-	"github.com/snyk/code-client-go/llm"
-
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/authentication"
@@ -34,12 +32,12 @@ import (
 
 // CreateFromCommandData gets a command based on the given parameters that can be passed to the CommandService
 // nolint: gocyclo, nolintlint // this is a factory, it's ok to have high cyclomatic complexity here
-func CreateFromCommandData(c *config.Config, commandData types.CommandData, srv types.Server, authService authentication.AuthenticationService, learnService learn.Service, notifier noti.Notifier, issueProvider snyk.IssueProvider, codeApiClient SnykCodeHttpClient, codeScanner *code.Scanner, cli cli.Executor, deepCodeLLMBinding llm.DeepCodeLLMBinding) (types.Command, error) {
+func CreateFromCommandData(c *config.Config, commandData types.CommandData, srv types.Server, authService authentication.AuthenticationService, learnService learn.Service, notifier noti.Notifier, issueProvider snyk.IssueProvider, codeApiClient SnykCodeHttpClient, codeScanner *code.Scanner, cli cli.Executor) (types.Command, error) {
 	httpClient := c.Engine().GetNetworkAccess().GetHttpClient
 
 	switch commandData.CommandId {
 	case types.NavigateToRangeCommand:
-		return &navigateToRangeCommand{command: commandData, srv: srv, logger: c.Logger(), deepCodeLLMBinding: deepCodeLLMBinding, c: c}, nil
+		return &navigateToRangeCommand{command: commandData, srv: srv, logger: c.Logger(), c: c}, nil
 	case types.WorkspaceScanCommand:
 		return &workspaceScanCommand{command: commandData, srv: srv, c: c}, nil
 	case types.WorkspaceFolderScanCommand:
@@ -71,19 +69,17 @@ func CreateFromCommandData(c *config.Config, commandData types.CommandData, srv 
 	case types.CodeFixCommand:
 		return &fixCodeIssue{command: commandData, issueProvider: issueProvider, notifier: notifier, logger: c.Logger()}, nil
 	case types.CodeFixApplyEditCommand:
-		return &applyAiFixEditCommand{command: commandData, issueProvider: issueProvider, notifier: notifier,
-			deepCodeLLMBinding: deepCodeLLMBinding, apiClient: codeApiClient, c: c, logger: c.Logger()}, nil
+		return &applyAiFixEditCommand{command: commandData, issueProvider: issueProvider, notifier: notifier, apiClient: codeApiClient, c: c, logger: c.Logger()}, nil
 	case types.CodeSubmitFixFeedback:
 		return &codeFixFeedback{command: commandData, apiClient: codeApiClient}, nil
 	case types.CodeFixDiffsCommand:
 		return &codeFixDiffs{
-			command:            commandData,
-			codeScanner:        codeScanner,
-			srv:                srv,
-			issueProvider:      issueProvider,
-			notifier:           notifier,
-			deepCodeLLMBinding: deepCodeLLMBinding,
-			c:                  c,
+			command:       commandData,
+			codeScanner:   codeScanner,
+			srv:           srv,
+			issueProvider: issueProvider,
+			notifier:      notifier,
+			c:             c,
 		}, nil
 	case types.ExecuteCLICommand:
 		return &executeCLICommand{command: commandData, authService: authService, notifier: notifier, logger: c.Logger(), cli: cli}, nil
@@ -92,7 +88,7 @@ func CreateFromCommandData(c *config.Config, commandData types.CommandData, srv 
 	case types.ClearCacheCommand:
 		return &clearCache{command: commandData, c: c}, nil
 	case types.GenerateIssueDescriptionCommand:
-		return &generateIssueDescription{command: commandData, issueProvider: issueProvider, deepCodeLLMBinding: deepCodeLLMBinding}, nil
+		return &generateIssueDescription{command: commandData, issueProvider: issueProvider}, nil
 	}
 
 	return nil, fmt.Errorf("unknown command %v", commandData)

--- a/domain/ide/command/command_service.go
+++ b/domain/ide/command/command_service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/snyk/code-client-go/llm"
 	sglsp "github.com/sourcegraph/go-lsp"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -36,26 +35,24 @@ import (
 var instance types.CommandService
 
 type serviceImpl struct {
-	authService        authentication.AuthenticationService
-	notifier           noti.Notifier
-	learnService       learn.Service
-	issueProvider      snyk.IssueProvider
-	codeApiClient      SnykCodeHttpClient
-	codeScanner        *code.Scanner
-	cli                cli.Executor
-	deepCodeLLMBinding llm.DeepCodeLLMBinding
+	authService   authentication.AuthenticationService
+	notifier      noti.Notifier
+	learnService  learn.Service
+	issueProvider snyk.IssueProvider
+	codeApiClient SnykCodeHttpClient
+	codeScanner   *code.Scanner
+	cli           cli.Executor
 }
 
-func NewService(authService authentication.AuthenticationService, notifier noti.Notifier, learnService learn.Service, issueProvider snyk.IssueProvider, codeApiClient SnykCodeHttpClient, codeScanner *code.Scanner, cli cli.Executor, deepCodeLLMBinding llm.DeepCodeLLMBinding) types.CommandService {
+func NewService(authService authentication.AuthenticationService, notifier noti.Notifier, learnService learn.Service, issueProvider snyk.IssueProvider, codeApiClient SnykCodeHttpClient, codeScanner *code.Scanner, cli cli.Executor) types.CommandService {
 	return &serviceImpl{
-		authService:        authService,
-		notifier:           notifier,
-		learnService:       learnService,
-		issueProvider:      issueProvider,
-		codeApiClient:      codeApiClient,
-		codeScanner:        codeScanner,
-		cli:                cli,
-		deepCodeLLMBinding: deepCodeLLMBinding,
+		authService:   authService,
+		notifier:      notifier,
+		learnService:  learnService,
+		issueProvider: issueProvider,
+		codeApiClient: codeApiClient,
+		codeScanner:   codeScanner,
+		cli:           cli,
 	}
 }
 
@@ -80,7 +77,7 @@ func (s *serviceImpl) ExecuteCommandData(ctx context.Context, commandData types.
 
 	logger.Debug().Msgf("executing command %s", commandData.CommandId)
 
-	command, err := CreateFromCommandData(c, commandData, server, s.authService, s.learnService, s.notifier, s.issueProvider, s.codeApiClient, s.codeScanner, s.cli, s.deepCodeLLMBinding)
+	command, err := CreateFromCommandData(c, commandData, server, s.authService, s.learnService, s.notifier, s.issueProvider, s.codeApiClient, s.codeScanner, s.cli)
 	if err != nil {
 		logger.Err(err).Msg("failed to create command")
 		return nil, err

--- a/domain/ide/command/command_service_test.go
+++ b/domain/ide/command/command_service_test.go
@@ -33,7 +33,7 @@ func Test_ExecuteCommand(t *testing.T) {
 		ExpectedAuthURL: "https://auth.url",
 	}
 	authenticationService := authentication.NewAuthenticationService(c, authProvider, nil, nil)
-	service := NewService(authenticationService, nil, nil, nil, nil, nil, nil, nil)
+	service := NewService(authenticationService, nil, nil, nil, nil, nil, nil)
 	cmd := types.CommandData{
 		CommandId: types.CopyAuthLinkCommand,
 	}

--- a/domain/ide/command/generate_issue_description.go
+++ b/domain/ide/command/generate_issue_description.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/code-client-go/llm"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
@@ -33,9 +32,8 @@ import (
 )
 
 type generateIssueDescription struct {
-	command            types.CommandData
-	issueProvider      snyk.IssueProvider
-	deepCodeLLMBinding llm.DeepCodeLLMBinding
+	command       types.CommandData
+	issueProvider snyk.IssueProvider
 }
 
 func (cmd *generateIssueDescription) Command() types.CommandData {
@@ -60,7 +58,7 @@ func (cmd *generateIssueDescription) Execute(_ context.Context) (any, error) {
 	if issue.GetProduct() == product.ProductInfrastructureAsCode {
 		return getIacHtml(c, logger, issue)
 	} else if issue.GetProduct() == product.ProductCode {
-		return getCodeHtml(c, logger, issue, cmd.deepCodeLLMBinding)
+		return getCodeHtml(c, logger, issue)
 	} else if issue.GetProduct() == product.ProductOpenSource {
 		return getOssHtml(c, logger, issue)
 	}
@@ -78,7 +76,7 @@ func getOssHtml(c *config.Config, logger zerolog.Logger, issue types.Issue) (str
 	return html, nil
 }
 
-func getCodeHtml(c *config.Config, logger zerolog.Logger, issue types.Issue, deepCodeLLMBinding llm.DeepCodeLLMBinding) (string, error) {
+func getCodeHtml(c *config.Config, logger zerolog.Logger, issue types.Issue) (string, error) {
 	htmlRender, err := code.GetHTMLRenderer(c)
 	if err != nil {
 		logger.Err(err).Msg("Cannot create Code HTML render")

--- a/domain/ide/command/generate_issue_description.go
+++ b/domain/ide/command/generate_issue_description.go
@@ -79,7 +79,7 @@ func getOssHtml(c *config.Config, logger zerolog.Logger, issue types.Issue) (str
 }
 
 func getCodeHtml(c *config.Config, logger zerolog.Logger, issue types.Issue, deepCodeLLMBinding llm.DeepCodeLLMBinding) (string, error) {
-	htmlRender, err := code.GetHTMLRenderer(c, deepCodeLLMBinding)
+	htmlRender, err := code.GetHTMLRenderer(c)
 	if err != nil {
 		logger.Err(err).Msg("Cannot create Code HTML render")
 		return "", err

--- a/domain/ide/command/navigate_to_range.go
+++ b/domain/ide/command/navigate_to_range.go
@@ -19,10 +19,8 @@ package command
 import (
 	"context"
 	"encoding/json"
-
 	"strings"
 
-	"github.com/snyk/code-client-go/llm"
 	sglsp "github.com/sourcegraph/go-lsp"
 
 	"github.com/pkg/errors"
@@ -36,11 +34,10 @@ import (
 )
 
 type navigateToRangeCommand struct {
-	command            types.CommandData
-	srv                types.Server
-	logger             *zerolog.Logger
-	deepCodeLLMBinding llm.DeepCodeLLMBinding
-	c                  *config.Config
+	command types.CommandData
+	srv     types.Server
+	logger  *zerolog.Logger
+	c       *config.Config
 }
 
 func (cmd *navigateToRangeCommand) Command() types.CommandData {
@@ -75,7 +72,7 @@ func (cmd *navigateToRangeCommand) Execute(_ context.Context) (any, error) {
 	} else {
 		documentUri = sglsp.DocumentURI(path)
 		// TODO: move this to a new command to process snyk magnet link
-		renderer, rendererErr := code.GetHTMLRenderer(cmd.c, cmd.deepCodeLLMBinding)
+		renderer, rendererErr := code.GetHTMLRenderer(cmd.c)
 		if rendererErr == nil {
 			renderer.AiFixHandler.SetAutoTriggerAiFix(true)
 		}

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/code-client-go v1.16.0
+	github.com/snyk/code-client-go v1.16.1
 	github.com/snyk/go-application-framework v0.0.0-20250307155453-ce7aaf72fe7d
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/code-client-go v1.16.0 h1:bx9s3b3FGv1nQO1Kjq5YXQLtbYr99gWJw2WorfTsxWU=
-github.com/snyk/code-client-go v1.16.0/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
+github.com/snyk/code-client-go v1.16.1 h1:SwqiXzHCHH5XiP8jkRi8fX3/9dMT3Y+ZMRo6EnV/+b8=
+github.com/snyk/code-client-go v1.16.1/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60 h1:iB6z2BhBpfN9p0/dEZfwWvs7fpdZk3loooAih8yspS8=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.0.0-20250307155453-ce7aaf72fe7d h1:eC0V150YUGvO3mEwXBMELQXzWGHFngxD1Y5fAtzWQC0=

--- a/infrastructure/code/ai_fix_handler_test.go
+++ b/infrastructure/code/ai_fix_handler_test.go
@@ -1,0 +1,49 @@
+/*
+ * © 2025 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"github.com/google/uuid"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_getExplain_Endpoint(t *testing.T) {
+	t.Run("should return default explain endpoint", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+		random, _ := uuid.NewRandom()
+		orgUUID := random.String()
+		c.SetOrganization(orgUUID)
+		actualEndpoint := getExplainEndpoint(c).String()
+		expectedEndpoint := "https://api.snyk.io/rest/orgs/" + orgUUID + "/explain-fix"
+		assert.Equal(t, expectedEndpoint, actualEndpoint)
+	})
+}
+
+func Test_GetExplain_Endpoint_With_Updated_API_Endpoints(t *testing.T) {
+	t.Run("should return correct explain endpoint", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+		random, _ := uuid.NewRandom()
+		orgUUID := random.String()
+		c.SetOrganization(orgUUID)
+		c.UpdateApiEndpoints("https://test.snyk.io")
+		actualEndpoint := getExplainEndpoint(c).String()
+		expectedEndpoint := "https://test.snyk.io/rest/orgs/" + orgUUID + "/explain-fix"
+		assert.Equal(t, expectedEndpoint, actualEndpoint)
+	})
+}

--- a/infrastructure/code/ai_fix_handler_test.go
+++ b/infrastructure/code/ai_fix_handler_test.go
@@ -17,10 +17,13 @@
 package code
 
 import (
-	"github.com/google/uuid"
-	"github.com/snyk/snyk-ls/internal/testutil"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_getExplain_Endpoint(t *testing.T) {

--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/code-client-go/llm"
 
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -80,7 +79,7 @@ type HtmlRenderer struct {
 
 var codeRenderer *HtmlRenderer
 
-func GetHTMLRenderer(c *config.Config, deepCodeLLMBinding llm.DeepCodeLLMBinding) (*HtmlRenderer, error) {
+func GetHTMLRenderer(c *config.Config) (*HtmlRenderer, error) {
 	if codeRenderer != nil && codeRenderer.c == c {
 		return codeRenderer, nil
 	}
@@ -102,8 +101,7 @@ func GetHTMLRenderer(c *config.Config, deepCodeLLMBinding llm.DeepCodeLLMBinding
 		globalTemplate: globalTemplate,
 	}
 	codeRenderer.AiFixHandler = &AiFixHandler{
-		aiFixDiffState:  aiResultState{status: AiFixNotStarted},
-		deepCodeBinding: deepCodeLLMBinding,
+		aiFixDiffState: aiResultState{status: AiFixNotStarted},
 	}
 	return codeRenderer, nil
 }

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -53,7 +53,7 @@ func Test_Code_Html_getCodeDetailsHtml(t *testing.T) {
 	}
 
 	// invoke method under test
-	htmlRenderer, err := GetHTMLRenderer(c, nil)
+	htmlRenderer, err := GetHTMLRenderer(c)
 	assert.NoError(t, err)
 	codePanelHtml := htmlRenderer.GetDetailsHtml(issue)
 
@@ -118,7 +118,7 @@ func Test_Code_Html_getCodeDetailsHtml_withAIfix(t *testing.T) {
 	}
 
 	// invoke method under test
-	htmlRenderer, err := GetHTMLRenderer(c, nil)
+	htmlRenderer, err := GetHTMLRenderer(c)
 	assert.NoError(t, err)
 	codePanelHtml := htmlRenderer.GetDetailsHtml(issue)
 	// assert Fixes section
@@ -159,7 +159,7 @@ func Test_Code_Html_getCodeDetailsHtml_ignored(t *testing.T) {
 	}
 
 	// invoke method under test
-	htmlRenderer, err := GetHTMLRenderer(c, nil)
+	htmlRenderer, err := GetHTMLRenderer(c)
 	assert.NoError(t, err)
 	codePanelHtml := htmlRenderer.GetDetailsHtml(issue)
 
@@ -198,7 +198,7 @@ func Test_Code_Html_getCodeDetailsHtml_ignored_expired(t *testing.T) {
 	}
 
 	// invoke method under test
-	htmlRenderer, err := GetHTMLRenderer(c, nil)
+	htmlRenderer, err := GetHTMLRenderer(c)
 	assert.NoError(t, err)
 	codePanelHtml := htmlRenderer.GetDetailsHtml(issue)
 
@@ -243,7 +243,7 @@ func Test_Code_Html_getCodeDetailsHtml_ignored_customEndpoint(t *testing.T) {
 	}
 
 	// invoke method under test
-	htmlRenderer, err := GetHTMLRenderer(c, nil)
+	htmlRenderer, err := GetHTMLRenderer(c)
 	assert.NoError(t, err)
 	codePanelHtml := htmlRenderer.GetDetailsHtml(issue)
 
@@ -309,7 +309,7 @@ func Test_Code_Html_getCodeDetailsHtml_hasCSS(t *testing.T) {
 	}
 
 	// invoke method under test
-	htmlRenderer, err := GetHTMLRenderer(c, nil)
+	htmlRenderer, err := GetHTMLRenderer(c)
 	assert.NoError(t, err)
 	codePanelHtml := htmlRenderer.GetDetailsHtml(issue)
 	// assert Fixes section

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -605,7 +605,7 @@ func Test_enhanceIssuesDetails(t *testing.T) {
 
 	// Act
 	scanner.enhanceIssuesDetails(issues, "")
-	htmlRenderer, err := GetHTMLRenderer(c, nil)
+	htmlRenderer, err := GetHTMLRenderer(c)
 	assert.Nil(t, err)
 	html := htmlRenderer.GetDetailsHtml(issues[0])
 	// Assert

--- a/licenses/github.com/hashicorp/hcl/go.mod
+++ b/licenses/github.com/hashicorp/hcl/go.mod
@@ -1,3 +1,5 @@
 module github.com/hashicorp/hcl
 
+go 1.23.6
+
 require github.com/davecgh/go-spew v1.1.1

--- a/licenses/github.com/hashicorp/hcl/go.mod
+++ b/licenses/github.com/hashicorp/hcl/go.mod
@@ -1,5 +1,3 @@
 module github.com/hashicorp/hcl
 
-go 1.23.6
-
 require github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
The DeepCode LLM Binding initializing was moved from `init.go` to avoid further complication with uninitialized components, as of know it is only used in the `ai_fix_handler.go` so it is initialized as it's used.

It will be initialized `WithEndpoint` using the current API Endpoint configured.
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
