### PR TITLE
fix: update scan summary wording to account for users who have multiple open projects [IDE-978]

### DIFF
--- a/domain/scanstates/template/details.html
+++ b/domain/scanstates/template/details.html
@@ -62,10 +62,10 @@
 
 <div class="snx-summary">
   {{if or .AnyScanSucceededReference .AnyScanSucceededWorkingDirectory }}
-  <p class="snx-message">⚠️ <span class="snx-highlight">{{.CurrentIssuesFound}} issues</span> found in your project</p>
+  <p class="snx-message">⚠️ <span class="snx-highlight">{{.CurrentIssuesFound}} issues</span> found in your open projects.</p>
   <p class="snx-message">⚡ <span class="snx-highlight">{{.CurrentFixableIssueCount}} issues</span> are fixable.</p>
   {{else}}
-  <p class="snx-message">⚠️ Scanning for issues in your project.</p>
+  <p class="snx-message">⚠️ Scanning for issues in your open projects.</p>
   <p class="snx-message">⚡ Identifying fixable issues.</p>
   {{end}}
 </div>


### PR DESCRIPTION
### Description

IDE users may have multiple open projects. Snyk scans all of them and reports the scan summary (including deltas) for all open projects.

This could cause confusion where it's not obvious that more than one project is open (especially bad in the JetBrains IDEs, where each project has its own IDE instance, but because those instances share a language server, they also share a scan summary.

This is a pragmatic fix to update the wording in the summary to indicate that the summary totals apply to all open projects. Ideally we would eventually enhance language server to only scan and report on issues for the currently active/foregrounded project, but this requires significant work.

Before
<img width="813" alt="Screenshot 2025-03-07 at 15 19 32" src="https://github.com/user-attachments/assets/25d377ca-234c-40a4-9ec2-188075bf8231" />

After
<img width="813" alt="Screenshot 2025-03-07 at 15 20 49" src="https://github.com/user-attachments/assets/45906ed6-1ddb-4b90-944d-1952aac3c6d8" />

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
