### PR TITLE
fix: unblock trust folder request by running in separate go func [IDE-982]

### DIFF
--- a/domain/ide/command/folder_handler.go
+++ b/domain/ide/command/folder_handler.go
@@ -82,19 +82,19 @@ func HandleUntrustedFolders(ctx context.Context, c *config.Config, srv types.Ser
 	if w.IsTrustRequestOngoing() {
 		return
 	}
-	w.StartRequestTrustCommunication()
-	defer w.EndRequestTrustCommunication()
-
 	_, untrusted := w.GetFolderTrust()
 	if len(untrusted) > 0 {
-		decision, err := showTrustDialog(c, srv, untrusted, DoTrust, DontTrust)
-		if err != nil {
-			return
-		}
-
-		if decision.Title == DoTrust {
-			w.TrustFoldersAndScan(ctx, untrusted)
-		}
+		go func() {
+			w.StartRequestTrustCommunication()
+			defer w.EndRequestTrustCommunication()
+			decision, err := showTrustDialog(c, srv, untrusted, DoTrust, DontTrust)
+			if err != nil {
+				return
+			}
+			if decision.Title == DoTrust {
+				w.TrustFoldersAndScan(ctx, untrusted)
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
### Description

When asking the user for folder trust, the Language Server was blocked waiting for the user to respond to the pop-up, this meant that if the user was not responding, certain actions such as removing a file in the IDE could not be performed due to this blockage.

To fix this, the trust dialog callback will run in a separate `go func`
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
