### PR TITLE
fix: use affectedFilePath as targetFilePath for OSS issues

### DIFF
--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -67,11 +67,11 @@ func toIssue(affectedFilePath types.FilePath, issue ossIssue, scanResult *scanRe
 	for _, otherIssue := range scanResult.Vulnerabilities {
 		if otherIssue.Id == issue.Id {
 			matchingIssues = append(matchingIssues, otherIssue.toAdditionalData(scanResult,
-				[]snyk.OssIssueData{}))
+				[]snyk.OssIssueData{}, affectedFilePath))
 		}
 	}
 
-	additionalData := issue.toAdditionalData(scanResult, matchingIssues)
+	additionalData := issue.toAdditionalData(scanResult, matchingIssues, affectedFilePath)
 
 	title := issue.Title
 	if config.CurrentConfig().Format() == config.FormatHtml {

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -19,7 +19,6 @@ package oss
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -110,15 +109,10 @@ type Annotation struct {
 	Reason string `json:"reason,omitempty"`
 }
 
-func (i *ossIssue) toAdditionalData(scanResult *scanResult, matchingIssues []snyk.OssIssueData) snyk.OssIssueData {
+func (i *ossIssue) toAdditionalData(scanResult *scanResult, matchingIssues []snyk.OssIssueData, affectedFilePath types.FilePath) snyk.OssIssueData {
 	var additionalData snyk.OssIssueData
 
-	targetFilePath := filepath.Base(scanResult.DisplayTargetFile)
-	if scanResult.Path != "" {
-		targetFilePath = filepath.Join(scanResult.Path, targetFilePath)
-	}
-
-	additionalData.Key = util.GetIssueKey(i.Id, targetFilePath, i.LineNumber, i.LineNumber, 0, 0)
+	additionalData.Key = util.GetIssueKey(i.Id, string(affectedFilePath), i.LineNumber, i.LineNumber, 0, 0)
 	additionalData.Title = i.Title
 	additionalData.Name = i.Name
 	additionalData.Identifiers = snyk.Identifiers{
@@ -141,7 +135,7 @@ func (i *ossIssue) toAdditionalData(scanResult *scanResult, matchingIssues []sny
 	additionalData.Exploit = i.Exploit
 	additionalData.IsPatchable = i.IsPatchable
 	additionalData.ProjectName = scanResult.ProjectName
-	additionalData.DisplayTargetFile = types.FilePath(targetFilePath)
+	additionalData.DisplayTargetFile = affectedFilePath
 	additionalData.Language = i.Language
 	additionalData.MatchingIssues = matchingIssues
 	if i.lesson != nil || i.isLicenseIssue() {

--- a/infrastructure/oss/types_test.go
+++ b/infrastructure/oss/types_test.go
@@ -18,6 +18,7 @@ package oss
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 func Test_ossIssueContainsPolicyAnnotations(t *testing.T) {
@@ -47,7 +49,8 @@ func Test_ossIssue_toAdditionalData_ConvertsPolicyAnnotations(t *testing.T) {
 		ProjectName:       "test",
 	}
 
-	convertedIssue := issue.toAdditionalData(fakeScanResult, []snyk.OssIssueData{})
+	path := types.FilePath(fmt.Sprintf("/path/to/%s", fakeScanResult.DisplayTargetFile))
+	convertedIssue := issue.toAdditionalData(fakeScanResult, []snyk.OssIssueData{}, path)
 
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.Annotation.Value)
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.Annotation.Reason)
@@ -60,8 +63,8 @@ func Test_ossIssue_toAdditionalData_HasLicenseLearnURL(t *testing.T) {
 		DisplayTargetFile: "testFile",
 		ProjectName:       "test",
 	}
-
-	convertedIssue := issue.toAdditionalData(fakeScanResult, []snyk.OssIssueData{})
+	path := types.FilePath(fmt.Sprintf("/path/to/%s", fakeScanResult.DisplayTargetFile))
+	convertedIssue := issue.toAdditionalData(fakeScanResult, []snyk.OssIssueData{}, path)
 
 	assert.Equal(t, "https://learn.snyk.io/lesson/license-policy-management/?loc=ide", convertedIssue.Lesson)
 }
@@ -73,8 +76,8 @@ func Test_ossIssue_toAdditionalData_ConvertsSeverityChange(t *testing.T) {
 		DisplayTargetFile: "testFile",
 		ProjectName:       "test",
 	}
-
-	convertedIssue := issue.toAdditionalData(fakeScanResult, []snyk.OssIssueData{})
+	path := types.FilePath(fmt.Sprintf("/path/to/%s", fakeScanResult.DisplayTargetFile))
+	convertedIssue := issue.toAdditionalData(fakeScanResult, []snyk.OssIssueData{}, path)
 
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.SeverityChange.OriginalSeverity)
 	require.NotEmpty(t, convertedIssue.AppliedPolicyRules.SeverityChange.NewSeverity)


### PR DESCRIPTION
### Description
Issue.DisplayTargetFile had the wrong value if the displayTargetFile exists in a subfolder.
Which broke our cache deduplication logic. Since issues that were included in subfolders had basically DisplayTargetFile value of= root + fileName
This resulted in issues having the same displayTargetFile when they exist in other folders.

This fix will use the pre-calculated affectedFilePAth and will set it's value to issue.DisplayTargetFile.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
