### PR TITLE
fix: git config migration precedence

### DIFF
--- a/internal/storedconfig/stored_config.go
+++ b/internal/storedconfig/stored_config.go
@@ -68,19 +68,19 @@ func mergeFolderConfigs(first *types.FolderConfig, second *types.FolderConfig) *
 		}
 	}
 
-	if first.LocalBranches == nil && second.LocalBranches != nil {
+	if second.LocalBranches != nil {
 		first.LocalBranches = second.LocalBranches
 	}
 
-	if first.BaseBranch == "" && second.BaseBranch != "" {
+	if second.BaseBranch != "" {
 		first.BaseBranch = second.BaseBranch
 	}
 
-	if first.ScanCommandConfig == nil && second.ScanCommandConfig != nil {
+	if second.ScanCommandConfig != nil {
 		first.ScanCommandConfig = second.ScanCommandConfig
 	}
 
-	if len(first.ReferenceFolderPath) == 0 && len(second.ReferenceFolderPath) > 0 {
+	if len(second.ReferenceFolderPath) > 0 {
 		first.ReferenceFolderPath = second.ReferenceFolderPath
 	}
 

--- a/internal/storedconfig/stored_config.go
+++ b/internal/storedconfig/stored_config.go
@@ -80,7 +80,7 @@ func mergeFolderConfigs(first *types.FolderConfig, second *types.FolderConfig) *
 		first.ScanCommandConfig = second.ScanCommandConfig
 	}
 
-	if len(second.ReferenceFolderPath) > 0 {
+	if second.ReferenceFolderPath != "" {
 		first.ReferenceFolderPath = second.ReferenceFolderPath
 	}
 


### PR DESCRIPTION
### Description
When merging git config set precedence of dynamic fields to the config loaded from Config if it exists.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
