### PR TITLE
fix: expose issue id for IDE scripts to use [IDE-1127]

### DIFF
--- a/domain/ide/command/ignores_request.go
+++ b/domain/ide/command/ignores_request.go
@@ -242,7 +242,7 @@ func getStringArgument(cmd *submitIgnoreRequest, index int, argName string) (str
 func initializeBaseConfiguration(gafConfig configuration.Configuration, contentRoot types.FilePath) configuration.Configuration {
 	gafConfig.Set(ignore_workflow.EnrichResponseKey, true)
 	gafConfig.Set(ignore_workflow.InteractiveKey, false)
-	gafConfig.Set(configuration.INPUT_DIRECTORY, contentRoot)
+	gafConfig.Set(configuration.INPUT_DIRECTORY, string(contentRoot))
 	return gafConfig
 }
 

--- a/domain/ide/command/ignores_request_test.go
+++ b/domain/ide/command/ignores_request_test.go
@@ -638,7 +638,7 @@ func Test_createBaseConfiguration(t *testing.T) {
 	// Assert
 	assert.Equal(t, true, result.Get(ignore_workflow.EnrichResponseKey))
 	assert.Equal(t, false, result.Get(ignore_workflow.InteractiveKey))
-	assert.Equal(t, contentRoot, result.Get(configuration.INPUT_DIRECTORY))
+	assert.Equal(t, string(contentRoot), result.Get(configuration.INPUT_DIRECTORY))
 }
 
 func Test_addCreateAndUpdateConfiguration(t *testing.T) {

--- a/domain/ide/command/ignores_request_test.go
+++ b/domain/ide/command/ignores_request_test.go
@@ -384,7 +384,7 @@ func Test_submitIgnoreRequest_initializeCreateConfiguration(t *testing.T) {
 				ignore_workflow.FindingsIdKey:     "finding123",
 				ignore_workflow.EnrichResponseKey: true,
 				ignore_workflow.InteractiveKey:    false,
-				configuration.INPUT_DIRECTORY:     types.FilePath("/test/content/root"),
+				configuration.INPUT_DIRECTORY:     "/test/content/root",
 				ignore_workflow.IgnoreTypeKey:     "wont_fix",
 				ignore_workflow.ReasonKey:         "reason",
 				ignore_workflow.ExpirationKey:     "expiration",

--- a/infrastructure/code/code_html_test.go
+++ b/infrastructure/code/code_html_test.go
@@ -83,7 +83,7 @@ func Test_Code_Html_getCodeDetailsHtml(t *testing.T) {
 	assert.Contains(t, codePanelHtml, ` id="ai-fix-wrapper" class="hidden">`)
 	assert.Contains(t, codePanelHtml, ` id="no-ai-fix-wrapper"`)
 	assert.Contains(t, codePanelHtml, `<button id="generate-ai-fix" folder-path="" file-path=""
-                  issue-id="" class="generate-ai-fix`)
+                  class="generate-ai-fix`)
 	expectedFixesDescription := fmt.Sprintf(`This type of vulnerability was fixed in %d open source projects.`, repoCount)
 	assert.Regexp(t, regexp.MustCompile(expectedFixesDescription), codePanelHtml)
 	assert.Contains(t, codePanelHtml, `<span id="example-link" class="example-repo-link">`, "GitHub icon preceding the repo name is present")

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -228,7 +228,7 @@
 
               <div class="sn-fix-wrapper">
                 <button id="generate-ai-fix" folder-path="{{.FolderPath}}" file-path="{{.FilePath}}"
-                  issue-id="{{.IssueId}}" class="generate-ai-fix {{if eq .AiFixDiffStatus "NOT_STARTED"}} show {{else}} hidden {{end}}">✨ Generate AI fix</button>
+                  class="generate-ai-fix {{if eq .AiFixDiffStatus "NOT_STARTED"}} show {{else}} hidden {{end}}">✨ Generate AI fix</button>
                 <div id="fix-loading-indicator" class="sn-loading {{if eq .AiFixDiffStatus "IN_PROGRESS"}} show {{else}} hidden {{end}}">
                   <div class="sn-loading-icon">
                     {{.ScanAnimation}}
@@ -569,6 +569,7 @@
   <!-- Embedded script from LS  -->
   <script nonce="{{.Nonce}}">
     var suggestion = JSON.parse("{{.AiFixResult}}" || "[]")
+    var issueId = "{{.IssueId}}"
     {{.Scripts}}
     // some IDEs take longer to inject their handler functions
     // TODO: Should we add an event listener when the IDE functions are loaded?

--- a/infrastructure/code/template/scripts.js
+++ b/infrastructure/code/template/scripts.js
@@ -27,7 +27,6 @@ function generateAIFix() {
   if (!suggestion) return;
   toggleElement(generateAIFixButton, 'hide');
   toggleElement(fixLoadingIndicatorElem, 'show');
-  var issueId = generateAIFixButton.getAttribute('issue-id');
   var folderPath = generateAIFixButton.getAttribute('folder-path');
   var filePath = generateAIFixButton.getAttribute('file-path');
   var generateFixQueryString = folderPath + '@|@' + filePath + '@|@' + issueId;


### PR DESCRIPTION
### Description

Needed in the IDE scripts for things like submit ignore request, so making it generally available.
Also fixed a bug where the input directory was being stored as `types.FilePath` in the GAF config instead of as the expected `string`.

### Checklist

- [ ] Tests added and all succeed
 - None added, just updated.
- [ ] Linted
 - N/A
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
