### PR TITLE
fix: copy auth link command should not use read locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ infrastructure/snyk_api/pacts/snykls-snykapi.json
 infrastructure/code/pacts/snykls-snykcodeapi.json
 infrastructure/analytics/pacts/snyk-ls-analyticsprovider.json
 infrastructure/oss/testdata/go.sum
+
+.qodo

--- a/domain/ide/command/copy_auth_link.go
+++ b/domain/ide/command/copy_auth_link.go
@@ -39,7 +39,7 @@ func (cmd *copyAuthLinkCommand) Command() types.CommandData {
 }
 
 func (cmd *copyAuthLinkCommand) Execute(ctx context.Context) (any, error) {
-	url := cmd.authService.Provider().AuthURL(ctx)
+	url := cmd.authService.AuthURL(ctx)
 
 	cmd.logger.Debug().Str("method", "copyAuthLinkCommand.Execute").
 		Str("url", url).

--- a/infrastructure/authentication/auth_service.go
+++ b/infrastructure/authentication/auth_service.go
@@ -52,4 +52,7 @@ type AuthenticationService interface {
 
 	// ConfigureProviders updates the providers based on the stored configuration
 	ConfigureProviders(c *config.Config)
+
+	// AuthURL retrieves the authentication URL
+	AuthURL(ctx context.Context) string
 }

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -68,6 +68,11 @@ func NewAuthenticationService(c *config.Config, authProviders AuthenticationProv
 	}
 }
 
+func (a *AuthenticationServiceImpl) AuthURL(ctx context.Context) string {
+	// no lock should be used here, as this is usually called during authentication flow, which write-locks the mutex
+	return a.authProvider.AuthURL(ctx)
+}
+
 func (a *AuthenticationServiceImpl) Provider() AuthenticationProvider {
 	a.m.RLock()
 	defer a.m.RUnlock()

--- a/infrastructure/authentication/auth_service_impl_test.go
+++ b/infrastructure/authentication/auth_service_impl_test.go
@@ -89,7 +89,7 @@ func Test_AuthURL(t *testing.T) {
 	// this would cause a timeout of the test, if auth url tries to obtain a lock
 	impl := service.(*AuthenticationServiceImpl)
 	impl.m.Lock()
-	defer impl.m.Unlock()
+	t.Cleanup(func() { impl.m.Unlock() })
 
 	// Call the AuthURL function
 	actualURL := service.AuthURL(context.Background())

--- a/infrastructure/authentication/auth_service_impl_test.go
+++ b/infrastructure/authentication/auth_service_impl_test.go
@@ -1,5 +1,5 @@
 /*
- * © 2022-2024 Snyk Limited
+ * © 2022-2025 Snyk Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,25 @@ func runAuthEventTest(t *testing.T, c *config.Config, status analytics.Status) e
 
 	_, err := service.Authenticate(context.Background())
 	return err
+}
+
+func Test_AuthURL(t *testing.T) {
+	expectedURL := "https://app.snyk.io/login?token=test"
+
+	c := testutil.UnitTest(t)
+	provider := &FakeAuthenticationProvider{ExpectedAuthURL: expectedURL, C: c}
+	service := NewAuthenticationService(c, provider, error_reporting.NewTestErrorReporter(), notification.NewNotifier())
+
+	// this would cause a timeout of the test, if auth url tries to obtain a lock
+	impl := service.(*AuthenticationServiceImpl)
+	impl.m.Lock()
+	defer impl.m.Unlock()
+
+	// Call the AuthURL function
+	actualURL := service.AuthURL(context.Background())
+
+	// Verify that the correct URL is returned from the provider
+	assert.Equal(t, expectedURL, actualURL)
 }
 
 func Test_UpdateCredentials(t *testing.T) {

--- a/infrastructure/authentication/oauth_provider.go
+++ b/infrastructure/authentication/oauth_provider.go
@@ -66,8 +66,7 @@ func (p *OAuth2Provider) ClearAuthentication(_ context.Context) error {
 }
 
 func (p *OAuth2Provider) AuthURL(_ context.Context) string {
-	p.m.Lock()
-	defer p.m.Unlock()
+	// no lock required here
 	return p.authURL
 }
 

--- a/infrastructure/authentication/oauth_provider.go
+++ b/infrastructure/authentication/oauth_provider.go
@@ -66,7 +66,7 @@ func (p *OAuth2Provider) ClearAuthentication(_ context.Context) error {
 }
 
 func (p *OAuth2Provider) AuthURL(_ context.Context) string {
-	// no lock required here
+	// no lock should be used here, as this is usually called during authentication flow, which write-locks the mutex
 	return p.authURL
 }
 


### PR DESCRIPTION
### Description

The auth URL is only relevant during authentication. When authentication is triggered, it obtains a write-lock on the authentication service. Thus, the copy auth link command was waiting for authentication to finish until it obtained the now obsolete auth URL.

This fix

- adds a method to the Authentication Service interface and its implementations for retrieving the Auth URL via the provider
- implements the retrieval without usage of any locks

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
