### PR TITLE
fix: inline ignores only for vscode [IDE-789]

### DIFF
--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -234,14 +234,16 @@ func (renderer *HtmlRenderer) updateFeatureFlags() {
 	conf := renderer.c.Engine().GetConfiguration()
 	logger := renderer.c.Logger().With().Str("method", "updateFeatureFlags").Logger()
 	renderer.iawEnabled = conf.GetBool(configuration.FF_IAW_ENABLED)
-	ffInlineIgnores := "snykCodeInlineIgnore"
-	status, err := renderer.snykApiClient.FeatureFlagStatus(snyk_api.FeatureFlagType(ffInlineIgnores))
-	if err != nil {
-		msg := fmt.Sprintf("Failed to retrieve feature flag status (%s), assuming deactivated", ffInlineIgnores)
-		logger.Warn().Err(err).Msg(msg)
+	renderer.inlineIgnoresEnabled = false
+	if renderer.c.IntegrationName() == "VS_CODE" {
+		ffInlineIgnores := "snykCodeInlineIgnore"
+		status, err := renderer.snykApiClient.FeatureFlagStatus(snyk_api.FeatureFlagType(ffInlineIgnores))
+		if err != nil {
+			msg := fmt.Sprintf("Failed to retrieve feature flag status (%s), assuming deactivated", ffInlineIgnores)
+			logger.Warn().Err(err).Msg(msg)
+		}
+		renderer.inlineIgnoresEnabled = status.Ok
 	}
-
-	codeRenderer.inlineIgnoresEnabled = status.Ok
 }
 
 func getLineToIgnoreAction(issue types.Issue) int {

--- a/infrastructure/code/code_html_inline_ignores_test.go
+++ b/infrastructure/code/code_html_inline_ignores_test.go
@@ -29,6 +29,7 @@ import (
 
 func Test_Code_Html_InlineIgnores_Enabled(t *testing.T) {
 	c := testutil.UnitTest(t)
+	c.SetIntegrationName("VS_CODE")
 
 	// Create a fake API client with the feature flag enabled
 	apiClient := &snyk_api.FakeApiClient{


### PR DESCRIPTION
### Description

- Added unit tests for the updateFeatureFlags method in code_html.go to cover scenarios with VS Code and non-VS Code integrations, and when the feature flag is enabled or disabled.
- Fixed a bug in updateFeatureFlags where the global codeRenderer's inlineIgnoresEnabled field was being updated instead of the instance's field.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
