### PR TITLE
fix: test for unmanaged scans as smoke test [IDE-850]

### DIFF
--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1024,12 +1024,10 @@ func Test_SmokeSnykCodeDelta_NoNewIssuesFound_JavaGoof(t *testing.T) {
 }
 
 func Test_SmokeScanUnmanaged(t *testing.T) {
-	c := testutil.IntegTest(t)
 	testsupport.NotOnWindows(t, "git clone does not work here. dunno why. ") // FIXME
+	c := testutil.SmokeTest(t, false)
 	loc, jsonRPCRecorder := setupServer(t, c)
-	c.SetSnykOssEnabled(true)
 	c.SetSnykIacEnabled(false)
-	c.EnableSnykCodeQuality(false)
 	cleanupChannels()
 	di.Init()
 


### PR DESCRIPTION
### Description

Cleanup smoke test for unmanaged scans and make it run as a smoke test.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
