### PR TITLE
fix: remove packageManager check [IDE-1174]

### DIFF
--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -343,7 +343,7 @@ func (cliScanner *CLIScanner) unmarshallAndRetrieveAnalysis(ctx context.Context,
 		targetFilePath := getAbsTargetFilePath(cliScanner.config, scanResult, workDir, path)
 		var fileContent []byte
 
-		if targetFilePath != "" && uri.IsReadableFile(targetFilePath) {
+		if targetFilePath != "" && uri.IsRegularFile(targetFilePath) {
 			fileContent, err = os.ReadFile(string(targetFilePath))
 			if err != nil {
 				reportedErr := fmt.Errorf("skipping scanResult for path: %s displayTargetFile: %s in workDir: %s as we can't determine the absolute filesystem path. %w", scanResult.Path, scanResult.DisplayTargetFile, workDir, err)

--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -342,7 +342,8 @@ func (cliScanner *CLIScanner) unmarshallAndRetrieveAnalysis(ctx context.Context,
 	for _, scanResult := range scanResults {
 		targetFilePath := getAbsTargetFilePath(cliScanner.config, scanResult, workDir, path)
 		var fileContent []byte
-		if targetFilePath != "" && scanResult.PackageManager != packageManagerUnmanaged {
+
+		if targetFilePath != "" && uri.IsReadableFile(targetFilePath) {
 			fileContent, err = os.ReadFile(string(targetFilePath))
 			if err != nil {
 				reportedErr := fmt.Errorf("skipping scanResult for path: %s displayTargetFile: %s in workDir: %s as we can't determine the absolute filesystem path. %w", scanResult.Path, scanResult.DisplayTargetFile, workDir, err)

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -42,8 +42,6 @@ type reference struct {
 	Url   types.Uri `json:"url"`
 }
 
-const packageManagerUnmanaged = "Unmanaged (C/C++)"
-
 type ossIssue struct {
 	Id                   string             `json:"id"`
 	Name                 string             `json:"name"`

--- a/internal/uri/uri_util.go
+++ b/internal/uri/uri_util.go
@@ -136,6 +136,11 @@ func IsDirectory(path types.FilePath) bool {
 	return stat.IsDir()
 }
 
+func IsReadableFile(path types.FilePath) bool {
+	stat, err := os.Stat(string(path))
+	return err == nil && stat.Mode().IsRegular()
+}
+
 func IsDotSnykFile(uri sglsp.DocumentURI) bool {
 	return strings.HasSuffix(string(uri), ".snyk")
 }

--- a/internal/uri/uri_util.go
+++ b/internal/uri/uri_util.go
@@ -136,7 +136,7 @@ func IsDirectory(path types.FilePath) bool {
 	return stat.IsDir()
 }
 
-func IsReadableFile(path types.FilePath) bool {
+func IsRegularFile(path types.FilePath) bool {
 	stat, err := os.Stat(string(path))
 	return err == nil && stat.Mode().IsRegular()
 }

--- a/internal/uri/uri_util_test.go
+++ b/internal/uri/uri_util_test.go
@@ -275,12 +275,12 @@ func TestIsReadableFile(t *testing.T) {
 	tmpFile.Close()
 	os.Chmod(tmpFile.Name(), 0400) // Owner read only
 
-	if !IsReadableFile(types.FilePath(tmpFile.Name())) {
+	if !IsRegularFile(types.FilePath(tmpFile.Name())) {
 		t.Errorf("Expected true for readable file")
 	}
 
 	// Test for non-existent file
-	if IsReadableFile(types.FilePath("/non/existent/file")) {
+	if IsRegularFile(types.FilePath("/non/existent/file")) {
 		t.Errorf("Expected false for non-existent file")
 	}
 
@@ -288,8 +288,8 @@ func TestIsReadableFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	defer os.RemoveAll(tmpDir)
 
-	// IsReadableFile should return false for a directory
-	if IsReadableFile(types.FilePath(tmpDir)) {
+	// IsRegularFile should return false for a directory
+	if IsRegularFile(types.FilePath(tmpDir)) {
 		t.Errorf("Expected false for directory, got true: %s", tmpDir)
 	}
 }

--- a/internal/uri/uri_util_test.go
+++ b/internal/uri/uri_util_test.go
@@ -264,3 +264,32 @@ func getTestRange() Range {
 		EndChar:   10,
 	}
 }
+
+func TestIsReadableFile(t *testing.T) {
+	// Create a temp file with read permission
+	tmpFile, err := os.CreateTemp(t.TempDir(), "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+	os.Chmod(tmpFile.Name(), 0400) // Owner read only
+
+	if !IsReadableFile(types.FilePath(tmpFile.Name())) {
+		t.Errorf("Expected true for readable file")
+	}
+
+	// Test for non-existent file
+	if IsReadableFile(types.FilePath("/non/existent/file")) {
+		t.Errorf("Expected false for non-existent file")
+	}
+
+	// Create a temporary directory
+	tmpDir := t.TempDir()
+	defer os.RemoveAll(tmpDir)
+
+	// IsReadableFile should return false for a directory
+	if IsReadableFile(types.FilePath(tmpDir)) {
+		t.Errorf("Expected false for directory, got true: %s", tmpDir)
+	}
+}


### PR DESCRIPTION
### Description

The pull request removes the packageManager check in cli_scanner.go and the packageManagerUnmanaged constant in types.go. 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
