### PR TITLE
bump code-client version to latest change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/snyk/code-client-go v1.21.2
+	github.com/snyk/code-client-go v1.22.0
 	github.com/snyk/go-application-framework v0.0.0-20250423203408-8884fd0a504f
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/code-client-go v1.21.2 h1:6SnfB/abNyzbgs3A7RhZHOfx0Ng3FKTdS9NrUsBGUUs=
-github.com/snyk/code-client-go v1.21.2/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
+github.com/snyk/code-client-go v1.22.0 h1:8nTlYb4SuXvdNhAvgcGPVNjOVMcZWv39RhiM3cAHFmo=
+github.com/snyk/code-client-go v1.22.0/go.mod h1:Jx3Jpo8kHlqHjhGa7a0ROQzPu+X15TBN0zRD+wNcUds=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60 h1:iB6z2BhBpfN9p0/dEZfwWvs7fpdZk3loooAih8yspS8=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.0.0-20250423203408-8884fd0a504f h1:0E8Ilfv0JFt7ssh43FjlKpGjG4I6Hhiau9odLnmC4Tc=


### PR DESCRIPTION
Bumped up `go.mod` version to include [PR#101](https://github.com/snyk/code-client-go/pull/101) from code-client-go.
