### PR TITLE
fix: cancel progress properly in CLI download test

### DIFF
--- a/infrastructure/cli/install/downloader_test.go
+++ b/infrastructure/cli/install/downloader_test.go
@@ -66,8 +66,9 @@ func Test_DoNotDownloadIfCancelled(t *testing.T) {
 	testutil.UnitTest(t)
 	progressCh := make(chan types.ProgressParams, 100000)
 	cancelProgressCh := make(chan bool, 1)
+	progressTracker := progress.NewTestTracker(progressCh, cancelProgressCh)
 	d := &Downloader{
-		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh),
+		progressTracker: progressTracker,
 		httpClient:      func() *http.Client { return http.DefaultClient },
 	}
 
@@ -75,7 +76,7 @@ func Test_DoNotDownloadIfCancelled(t *testing.T) {
 
 	// simulate cancellation when some progress received
 	go func() {
-		cancelProgressCh <- true
+		progress.Cancel(progressTracker.GetToken())
 	}()
 
 	err := d.Download(r, false)


### PR DESCRIPTION
### Description

This is to prevent a hang where the test cleanup gets stuck writing to the cancel channel.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
