### PR TITLE
fix: prevent test leaking config changes

### DIFF
--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -67,7 +67,9 @@ func UnitTest(t *testing.T) *config.Config {
 		Enabled: false,
 	},
 	})
+	originalLsProtocolVersion := config.LsProtocolVersion
 	t.Cleanup(func() {
+		config.LsProtocolVersion = originalLsProtocolVersion
 		cleanupFakeCliFile(c)
 		progress.CleanupChannels()
 	})


### PR DESCRIPTION
### Description

A test in `application/server/server_test.go` sets `config.LsProtocolVersion` to a specific value and never set it back after.
Also checked for the specific callback required, Gemini suggested it.
The leak was required for another unit test in the same file, so I have also set it for that test.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
