### PR TITLE
fix: add snyk-ls- prefix to x-snyk-ide header [IDE-1244]

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -223,7 +223,7 @@ func initNetworkAccessHeaders() {
 	gafConfig := engine.GetConfiguration()
 	ua := util.GetUserAgent(gafConfig, config.Version)
 	engine.GetNetworkAccess().RemoveHeaderField("x-snyk-cli-version")
-	engine.GetNetworkAccess().AddHeaderField("x-snyk-ide", ua.AppVersion)
+	engine.GetNetworkAccess().AddHeaderField("x-snyk-ide", "snyk-ls-"+ua.AppVersion)
 	engine.GetNetworkAccess().AddHeaderField("User-Agent", ua.String())
 }
 

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -222,7 +222,7 @@ func initNetworkAccessHeaders() {
 	engine := config.CurrentConfig().Engine()
 	gafConfig := engine.GetConfiguration()
 	ua := util.GetUserAgent(gafConfig, config.Version)
-	engine.GetNetworkAccess().RemoveHeaderField("x-snyk-cli-version")
+	// X-Snyk-Cli-Version is added by the CLI and is needed for LCE verification in registry.
 	engine.GetNetworkAccess().AddHeaderField("x-snyk-ide", "snyk-ls-"+ua.AppVersion)
 	engine.GetNetworkAccess().AddHeaderField("User-Agent", ua.String())
 }


### PR DESCRIPTION
### Description

Add `snyk-ls-` prefix to `x-snyk-ide` header. 
Backend requires this prefix 

Also add X-Snyk-CLI-Version header back, since current version checking in registry will break for LS  and it will prioritize checking for the CLI header, if it exists first

This is a temp workaround until the backend logic is fixed. Also this change basically reverts the headers change to how it was before.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
