### PR TITLE
feat: allow command cancelling [IDE-962]

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Right now the language server supports the following actions:
 #### Notifications
 
 - $/progress
+- $/cancelRequest
 - textDocument/publishDiagnostics
   - params: `types.PublishDiagnosticsParams`
   - example: Snyk Open Source

--- a/application/server/execute_command.go
+++ b/application/server/execute_command.go
@@ -38,6 +38,8 @@ func executeCommandHandler(srv *jrpc2.Server) jrpc2.Handler {
 
 		commandData := types.CommandData{CommandId: params.Command, Arguments: params.Arguments, Title: params.Command}
 
+		// The context is passed from JRPC to the commands, if the server shuts down or receives a $/cancelRequest, the context will be canceled.
+		// It is on the individual commands to decide if they want to use this context or create their own to not be canceled.
 		result, err := command.Service().ExecuteCommandData(ctx, commandData, srv)
 		logError(c.Logger(), err, fmt.Sprintf("Error executing command %v", commandData))
 		return result, err

--- a/application/server/execute_command.go
+++ b/application/server/execute_command.go
@@ -31,9 +31,6 @@ import (
 
 func executeCommandHandler(srv *jrpc2.Server) jrpc2.Handler {
 	return handler.New(func(ctx context.Context, params sglsp.ExecuteCommandParams) (any, error) {
-		// The context provided by the JSON-RPC server is canceled once a new message is being processed,
-		// so we don't want to propagate it to functions that start background operations
-		bgCtx := context.Background()
 		c := config.CurrentConfig()
 		method := "ExecuteCommandHandler"
 		c.Logger().Debug().Str("method", method).Interface("command", params).Msg("RECEIVING")
@@ -41,7 +38,7 @@ func executeCommandHandler(srv *jrpc2.Server) jrpc2.Handler {
 
 		commandData := types.CommandData{CommandId: params.Command, Arguments: params.Arguments, Title: params.Command}
 
-		result, err := command.Service().ExecuteCommandData(bgCtx, commandData, srv)
+		result, err := command.Service().ExecuteCommandData(ctx, commandData, srv)
 		logError(c.Logger(), err, fmt.Sprintf("Error executing command %v", commandData))
 		return result, err
 	})

--- a/application/server/execute_command_test.go
+++ b/application/server/execute_command_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"context"
 	"errors"
-	"github.com/snyk/snyk-ls/internal/testsupport"
 	"testing"
 	"time"
 
@@ -35,6 +34,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/domain/snyk/scanner"
 	"github.com/snyk/snyk-ls/infrastructure/authentication"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -114,6 +114,7 @@ func initHandlers(srv *jrpc2.Server, handlers handler.Map, c *config.Config) {
 	handlers["workspace/didChangeConfiguration"] = workspaceDidChangeConfiguration(c, srv)
 	handlers["window/workDoneProgress/cancel"] = windowWorkDoneProgressCancelHandler()
 	handlers["workspace/executeCommand"] = executeCommandHandler(srv)
+	handlers["$/cancelRequest"] = cancelRequestHandler(srv)
 }
 
 func textDocumentDidChangeHandler() jrpc2.Handler {
@@ -774,6 +775,13 @@ func codeActionResolveHandler(server types.Server) handler.Func {
 func textDocumentCodeActionHandler() handler.Func {
 	c := config.CurrentConfig()
 	return handler.New(GetCodeActionHandler(c))
+}
+
+func cancelRequestHandler(srv *jrpc2.Server) jrpc2.Handler {
+	return handler.New(func(_ context.Context, params sglsp.CancelParams) (any, error) {
+		srv.CancelRequest(params.ID.String())
+		return nil, nil
+	})
 }
 
 func noOpHandler() jrpc2.Handler {

--- a/domain/ide/command/code_fix_apply_edit.go
+++ b/domain/ide/command/code_fix_apply_edit.go
@@ -70,6 +70,8 @@ func (cmd *applyAiFixEditCommand) Execute(_ context.Context) (any, error) {
 
 	// send feedback asynchronously, so people can actually see the changes done by the fix
 	go func() {
+		// This un-awaited goroutine potentially outlives the command's execution.
+		// It cannot reuse the command's context, as the command executor will cancel it when the command finishes.
 		bgCtx := context.Background()
 		codeFixFeedbackCmd := codeFixFeedback{
 			command: types.CommandData{

--- a/domain/ide/command/code_fix_apply_edit.go
+++ b/domain/ide/command/code_fix_apply_edit.go
@@ -47,7 +47,7 @@ func (cmd *applyAiFixEditCommand) Command() types.CommandData {
 	return cmd.command
 }
 
-func (cmd *applyAiFixEditCommand) Execute(ctx context.Context) (any, error) {
+func (cmd *applyAiFixEditCommand) Execute(_ context.Context) (any, error) {
 	fixId, ok := cmd.command.Arguments[0].(string)
 	if !ok {
 		return nil, fmt.Errorf("invalid edit")
@@ -70,13 +70,14 @@ func (cmd *applyAiFixEditCommand) Execute(ctx context.Context) (any, error) {
 
 	// send feedback asynchronously, so people can actually see the changes done by the fix
 	go func() {
+		bgCtx := context.Background()
 		codeFixFeedbackCmd := codeFixFeedback{
 			command: types.CommandData{
 				Arguments: []any{fixId, code.FixAppliedUserEvent},
 			},
 		}
 
-		_, err := codeFixFeedbackCmd.Execute(ctx)
+		_, err := codeFixFeedbackCmd.Execute(bgCtx)
 		if err != nil {
 			cmd.logger.Err(err).Str("fixId", fixId).Str("feedback", code.FixAppliedUserEvent).Msg("failed to submit autofix feedback")
 		}

--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -42,8 +42,9 @@ func (cmd *codeFixDiffs) Command() types.CommandData {
 	return cmd.command
 }
 
-func (cmd *codeFixDiffs) Execute(ctx context.Context) (any, error) {
+func (cmd *codeFixDiffs) Execute(_ context.Context) (any, error) {
 	logger := cmd.c.Logger().With().Str("method", "codeFixDiffs.Execute").Logger()
+	bgCtx := context.Background()
 
 	args := cmd.command.Arguments
 	if len(args) != 1 {
@@ -65,7 +66,7 @@ func (cmd *codeFixDiffs) Execute(ctx context.Context) (any, error) {
 		logger.Err(err).Msg("failed to get html renderer")
 		return nil, err
 	}
-	go cmd.handleResponse(ctx, cmd.c, issue, htmlRenderer)
+	go cmd.handleResponse(bgCtx, cmd.c, issue, htmlRenderer)
 
 	return nil, err
 }

--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -44,7 +44,6 @@ func (cmd *codeFixDiffs) Command() types.CommandData {
 
 func (cmd *codeFixDiffs) Execute(_ context.Context) (any, error) {
 	logger := cmd.c.Logger().With().Str("method", "codeFixDiffs.Execute").Logger()
-	bgCtx := context.Background()
 
 	args := cmd.command.Arguments
 	if len(args) != 1 {
@@ -66,7 +65,10 @@ func (cmd *codeFixDiffs) Execute(_ context.Context) (any, error) {
 		logger.Err(err).Msg("failed to get html renderer")
 		return nil, err
 	}
-	go cmd.handleResponse(bgCtx, cmd.c, issue, htmlRenderer)
+
+	// This un-awaited goroutine outlives the command's execution.
+	// It cannot reuse the command's context, as the command executor will cancel it when the command finishes.
+	go cmd.handleResponse(context.Background(), cmd.c, issue, htmlRenderer)
 
 	return nil, err
 }

--- a/domain/ide/command/code_fix_feedback.go
+++ b/domain/ide/command/code_fix_feedback.go
@@ -36,7 +36,7 @@ func (cmd *codeFixFeedback) Command() types.CommandData {
 	return cmd.command
 }
 
-func (cmd *codeFixFeedback) Execute(ctx context.Context) (any, error) {
+func (cmd *codeFixFeedback) Execute(_ context.Context) (any, error) {
 	args := cmd.command.Arguments
 	fixId, ok := args[0].(string)
 	if !ok {
@@ -48,6 +48,7 @@ func (cmd *codeFixFeedback) Execute(ctx context.Context) (any, error) {
 	}
 
 	go func() {
+		bgCtx := context.Background()
 		c := config.CurrentConfig()
 		c.Logger().Info().Str("fixId", fixId).Str("feedback", feedback).Msg("Submiting autofix feedback")
 
@@ -72,7 +73,7 @@ func (cmd *codeFixFeedback) Execute(ctx context.Context) (any, error) {
 			IdeExtensionDetails: code.GetAutofixIdeExtensionDetails(c),
 		}
 
-		err = deepCodeLLMBinding.SubmitAutofixFeedback(ctx, fixId, options)
+		err = deepCodeLLMBinding.SubmitAutofixFeedback(bgCtx, fixId, options)
 		if err != nil {
 			c.Logger().Err(err).Str("fixId", fixId).Str("feedback", feedback).Msg("failed to submit autofix feedback")
 		}

--- a/domain/ide/command/code_fix_feedback.go
+++ b/domain/ide/command/code_fix_feedback.go
@@ -48,9 +48,11 @@ func (cmd *codeFixFeedback) Execute(_ context.Context) (any, error) {
 	}
 
 	go func() {
+		// This un-awaited goroutine outlives the command's execution.
+		// It cannot reuse the command's context, as the command executor will cancel it when the command finishes.
 		bgCtx := context.Background()
 		c := config.CurrentConfig()
-		c.Logger().Info().Str("fixId", fixId).Str("feedback", feedback).Msg("Submiting autofix feedback")
+		c.Logger().Info().Str("fixId", fixId).Str("feedback", feedback).Msg("Submitting autofix feedback")
 
 		host, err := code.GetCodeApiUrl(c)
 		if err != nil {

--- a/domain/ide/command/execute_mcp.go
+++ b/domain/ide/command/execute_mcp.go
@@ -40,7 +40,7 @@ func (cmd *executeMcpCallCommand) Command() types.CommandData {
 	return cmd.command
 }
 
-func (cmd *executeMcpCallCommand) Execute(ctx context.Context) (any, error) {
+func (cmd *executeMcpCallCommand) Execute(_ context.Context) (any, error) {
 	logger := cmd.logger.With().Str("method", "executeMcpCallCommand").Logger()
 	if cmd.baseURL == "" {
 		logger.Warn().Msg("No base URL set, cannot execute mcp command")
@@ -70,8 +70,9 @@ func (cmd *executeMcpCallCommand) Execute(ctx context.Context) (any, error) {
 	}(mcpClient)
 
 	go func() {
+		bgCtx := context.Background()
 		// start
-		err = mcpClient.Start(context.Background())
+		err = mcpClient.Start(bgCtx)
 		if err != nil {
 			logger.Error().Err(err).Msg("Error starting mcp client")
 			return
@@ -85,7 +86,7 @@ func (cmd *executeMcpCallCommand) Execute(ctx context.Context) (any, error) {
 			Version: config.Version,
 		}
 
-		_, err = mcpClient.Initialize(ctx, initRequest)
+		_, err = mcpClient.Initialize(bgCtx, initRequest)
 		if err != nil {
 			logger.Error().Err(err).Msg("Error initializing mcp client")
 			return
@@ -100,7 +101,7 @@ func (cmd *executeMcpCallCommand) Execute(ctx context.Context) (any, error) {
 		}
 
 		logger.Debug().Msgf("Executing mcp command: %s", mcpCommand)
-		_, err = mcpClient.CallTool(ctx, callToolRequest)
+		_, err = mcpClient.CallTool(bgCtx, callToolRequest)
 		if err != nil {
 			logger.Error().Err(err).Msg("error executing tool request")
 		}

--- a/domain/ide/command/execute_mcp.go
+++ b/domain/ide/command/execute_mcp.go
@@ -70,6 +70,8 @@ func (cmd *executeMcpCallCommand) Execute(_ context.Context) (any, error) {
 	}(mcpClient)
 
 	go func() {
+		// This un-awaited goroutine outlives the command's execution.
+		// It cannot reuse the command's context, as the command executor will cancel it when the command finishes.
 		bgCtx := context.Background()
 		// start
 		err = mcpClient.Start(bgCtx)

--- a/domain/ide/command/workspace_folder_scan.go
+++ b/domain/ide/command/workspace_folder_scan.go
@@ -36,8 +36,9 @@ func (cmd *workspaceFolderScanCommand) Command() types.CommandData {
 	return cmd.command
 }
 
-func (cmd *workspaceFolderScanCommand) Execute(ctx context.Context) (any, error) {
+func (cmd *workspaceFolderScanCommand) Execute(_ context.Context) (any, error) {
 	method := "workspaceFolderScanCommand.Execute"
+	bgCtx := context.Background()
 	args := cmd.Command().Arguments
 	w := cmd.c.Workspace()
 	if len(args) != 1 {
@@ -58,7 +59,7 @@ func (cmd *workspaceFolderScanCommand) Execute(ctx context.Context) (any, error)
 		return nil, err
 	}
 	f.Clear()
-	f.ScanFolder(ctx)
-	HandleUntrustedFolders(ctx, cmd.c, cmd.srv)
+	f.ScanFolder(bgCtx)
+	HandleUntrustedFolders(bgCtx, cmd.c, cmd.srv)
 	return nil, nil
 }

--- a/domain/ide/command/workspace_folder_scan.go
+++ b/domain/ide/command/workspace_folder_scan.go
@@ -36,9 +36,8 @@ func (cmd *workspaceFolderScanCommand) Command() types.CommandData {
 	return cmd.command
 }
 
-func (cmd *workspaceFolderScanCommand) Execute(_ context.Context) (any, error) {
+func (cmd *workspaceFolderScanCommand) Execute(ctx context.Context) (any, error) {
 	method := "workspaceFolderScanCommand.Execute"
-	bgCtx := context.Background()
 	args := cmd.Command().Arguments
 	w := cmd.c.Workspace()
 	if len(args) != 1 {
@@ -59,7 +58,9 @@ func (cmd *workspaceFolderScanCommand) Execute(_ context.Context) (any, error) {
 		return nil, err
 	}
 	f.Clear()
-	f.ScanFolder(bgCtx)
-	HandleUntrustedFolders(bgCtx, cmd.c, cmd.srv)
+	f.ScanFolder(ctx)
+	// HandleUntrustedFolders spawns un-awaited goroutines that outlive this command's execution.
+	// They cannot reuse the command's context, as the command executor will cancel it when the command finishes.
+	HandleUntrustedFolders(context.Background(), cmd.c, cmd.srv)
 	return nil, nil
 }

--- a/domain/ide/command/workspace_scan.go
+++ b/domain/ide/command/workspace_scan.go
@@ -34,11 +34,12 @@ func (cmd *workspaceScanCommand) Command() types.CommandData {
 	return cmd.command
 }
 
-func (cmd *workspaceScanCommand) Execute(ctx context.Context) (any, error) {
+func (cmd *workspaceScanCommand) Execute(_ context.Context) (any, error) {
 	w := cmd.c.Workspace()
 	w.Clear()
 	args := cmd.command.Arguments
-	enrichedCtx := cmd.enrichContextWithScanSource(ctx, args)
+	// Use a new background context so spawned threads aren't killed.
+	enrichedCtx := cmd.enrichContextWithScanSource(context.Background(), args)
 	w.ScanWorkspace(enrichedCtx)
 	HandleUntrustedFolders(enrichedCtx, cmd.c, cmd.srv)
 	return nil, nil

--- a/domain/ide/command/workspace_scan.go
+++ b/domain/ide/command/workspace_scan.go
@@ -38,7 +38,10 @@ func (cmd *workspaceScanCommand) Execute(_ context.Context) (any, error) {
 	w := cmd.c.Workspace()
 	w.Clear()
 	args := cmd.command.Arguments
-	// Use a new background context so spawned threads aren't killed.
+	// HandleUntrustedFolders spawns un-awaited goroutines that outlive this command's execution.
+	// They cannot reuse the command's context, as the command executor will cancel it when the command finishes.
+	// w.ScanWorkspace also needs the same enriched context, I don't want to copy the enriched values across contexts,
+	// so I gave it the same (background) context.
 	enrichedCtx := cmd.enrichContextWithScanSource(context.Background(), args)
 	w.ScanWorkspace(enrichedCtx)
 	HandleUntrustedFolders(enrichedCtx, cmd.c, cmd.srv)

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -53,10 +53,10 @@ type AuthenticationServiceImpl struct {
 	notifier      noti.Notifier
 	c             *config.Config
 	// key = token, value = isAuthenticated
-	authCache            *imcache.Cache[string, bool]
-	m                    sync.RWMutex
-	previousCancelFunc   context.CancelFunc
-	previousCancelFuncMu sync.Mutex
+	authCache                   *imcache.Cache[string, bool]
+	m                           sync.RWMutex
+	previousAuthCtxCancelFunc   context.CancelFunc
+	previousAuthCtxCancelFuncMu sync.Mutex
 }
 
 func NewAuthenticationService(c *config.Config, authProviders AuthenticationProvider, errorReporter error_reporting.ErrorReporter, notifier noti.Notifier) AuthenticationService {
@@ -87,16 +87,16 @@ func (a *AuthenticationServiceImpl) provider() AuthenticationProvider {
 }
 
 func (a *AuthenticationServiceImpl) Authenticate(ctx context.Context) (token string, err error) {
-	a.previousCancelFuncMu.Lock()
-	if a.previousCancelFunc != nil {
-		a.previousCancelFunc()
+	a.previousAuthCtxCancelFuncMu.Lock()
+	if a.previousAuthCtxCancelFunc != nil {
+		a.previousAuthCtxCancelFunc()
 	}
 	a.m.Lock()
 	defer a.m.Unlock()
 
-	ctx, a.previousCancelFunc = context.WithCancel(ctx)
-	a.previousCancelFuncMu.Unlock()
-	defer a.previousCancelFunc() // need to clean up resources if we weren't interrupted, impl should ensure its safe to double call
+	ctx, a.previousAuthCtxCancelFunc = context.WithCancel(ctx)
+	a.previousAuthCtxCancelFuncMu.Unlock()
+	defer a.previousAuthCtxCancelFunc() // need to clean up resources if we weren't interrupted, impl should ensure its safe to double call
 	return a.authenticate(ctx)
 }
 
@@ -199,12 +199,12 @@ func (a *AuthenticationServiceImpl) updateCredentials(newToken string, sendNotif
 }
 
 func (a *AuthenticationServiceImpl) Logout(ctx context.Context) {
-	a.previousCancelFuncMu.Lock()
-	if a.previousCancelFunc != nil {
-		a.previousCancelFunc()
+	a.previousAuthCtxCancelFuncMu.Lock()
+	if a.previousAuthCtxCancelFunc != nil {
 		// We don't set it back to nil as then we'd need to handle race conditions and double calling an old cancel function is already safe by the impl.
+		a.previousAuthCtxCancelFunc()
 	}
-	a.previousCancelFuncMu.Unlock()
+	a.previousAuthCtxCancelFuncMu.Unlock()
 
 	a.m.Lock()
 	defer a.m.Unlock()

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -199,6 +199,13 @@ func (a *AuthenticationServiceImpl) updateCredentials(newToken string, sendNotif
 }
 
 func (a *AuthenticationServiceImpl) Logout(ctx context.Context) {
+	a.previousCancelFuncMu.Lock()
+	if a.previousCancelFunc != nil {
+		a.previousCancelFunc()
+		// We don't set it back to nil as then we'd need to handle race conditions and double calling an old cancel function is already safe by the impl.
+	}
+	a.previousCancelFuncMu.Unlock()
+
 	a.m.Lock()
 	defer a.m.Unlock()
 

--- a/internal/testsupport/helpers.go
+++ b/internal/testsupport/helpers.go
@@ -3,10 +3,8 @@ package testsupport
 import (
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
@@ -43,40 +41,4 @@ func SetupEngineMock(t *testing.T) (*mocks.MockEngine, configuration.Configurati
 	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
 	return mockEngine, engineConfig
-}
-
-func ReadMessageWithFatalTimeout[T any](t *testing.T, channel chan T, timeoutDuration time.Duration) (msg T) {
-	t.Helper()
-
-	var ok bool
-	select {
-	case msg, ok = <-channel:
-		if !ok {
-			// Fatal failure (stop execution), as mishandled channels in Go can cause panics and infinite waits.
-			assert.FailNow(t, "Expected a message, but the channel was closed")
-		}
-		return msg
-	case <-time.After(timeoutDuration):
-		// Fatal failure (stop execution), as mishandled channels in Go can cause panics and infinite waits.
-		assert.FailNow(t, "Expected a message, but no message was available after %v", timeoutDuration)
-	}
-	return msg // Unreachable
-}
-
-func ReadMessageAssertNoWait[T any](t *testing.T, channel chan T) (msg T) {
-	t.Helper()
-
-	var ok bool
-	select {
-	case msg, ok = <-channel:
-		if !ok {
-			// Fatal failure (stop execution), as mishandled channels in Go can cause panics and infinite waits.
-			assert.FailNow(t, "Expected a message, but the channel was closed")
-		}
-		return msg
-	default:
-		// Fatal failure (stop execution), as mishandled channels in Go can cause panics and infinite waits.
-		assert.FailNow(t, "Expected a message, but no message was immediately available")
-	}
-	return msg // Unreachable
 }


### PR DESCRIPTION
### Description

`$/cancelRequest` support. See JRPC2 docs [here](https://pkg.go.dev/github.com/creachadair/jrpc2#hdr-Contexts_and_Cancellation).
Currently only for the login command.
Also, snuck in a change to make logouts cancel a previous login request.

### Checklist

- [x] Tests added and all succeed
 - UT only, should proably do an integration test, maybe later.
- [x] Linted
- [x] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
