### PR TITLE
hotfix/1.1297.2

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -216,8 +216,8 @@ func workspaceDidChangeWorkspaceFoldersHandler(c *config.Config, srv *jrpc2.Serv
 	})
 }
 
-func initNetworkAccessHeaders() {
-	engine := config.CurrentConfig().Engine()
+func initNetworkAccessHeaders(c *config.Config) {
+	engine := c.Engine()
 	gafConfig := engine.GetConfiguration()
 	ua := util.GetUserAgent(gafConfig, config.Version)
 	// X-Snyk-Cli-Version is added by the CLI and is needed for LCE verification in registry.
@@ -233,7 +233,7 @@ func initializeHandler(c *config.Config, srv *jrpc2.Server) handler.Func {
 		defer logger.Info().Any("params", params).Msg("RECEIVING")
 
 		c.SetClientCapabilities(params.Capabilities)
-		setClientInformation(params)
+		setClientInformation(c, params)
 		// update storage
 		file, err := storedconfig.ConfigFile(c.IdeName())
 		if err != nil {
@@ -577,7 +577,7 @@ func addWorkspaceFolders(c *config.Config, params types.InitializeParams) {
 // The integration version refers to the plugin version, not the IDE version.
 // The function attempts to pull the values from the initialization options, then the client info, and finally
 // from the environment variables.
-func setClientInformation(initParams types.InitializeParams) {
+func setClientInformation(c *config.Config, initParams types.InitializeParams) {
 	var integrationName, integrationVersion string
 	clientInfoName := initParams.ClientInfo.Name
 	clientInfoVersion := initParams.ClientInfo.Version
@@ -602,13 +602,12 @@ func setClientInformation(initParams types.InitializeParams) {
 		integrationVersion = strings.Split(integrationVersion, "@@")[1]
 	}
 
-	c := config.CurrentConfig()
 	c.SetIntegrationName(integrationName)
 	c.SetIntegrationVersion(integrationVersion)
 	c.SetIdeName(clientInfoName)
 	c.SetIdeVersion(clientInfoVersion)
 
-	initNetworkAccessHeaders()
+	initNetworkAccessHeaders(c)
 }
 
 func monitorClientProcess(pid int) time.Duration {

--- a/infrastructure/authentication/auth_configuration.go
+++ b/infrastructure/authentication/auth_configuration.go
@@ -99,6 +99,7 @@ func NewOAuthProvider(
 		auth.WithOpenBrowserFunc(openBrowserFunc),
 		auth.WithTokenRefresherFunc(customTokenRefresherFunc),
 		auth.WithLogger(c.Logger()),
+		auth.WithHttpClient(engine.GetNetworkAccess().GetUnauthorizedHttpClient()),
 	)
 	return newOAuthProvider(conf, authenticator, c.Logger())
 }


### PR DESCRIPTION
### Description

This pull request is a hotfix that primarily focuses on improving how configuration is accessed and passed within the server initialization logic. It moves away from using a global configuration instance in certain functions towards explicit dependency injection. Additionally, it makes necessary adjustments to network headers and the HTTP client used by the OAuth authentication provider.

Highlights
Configuration Handling Refactor: I've refactored initNetworkAccessHeaders and setClientInformation in application/server/server.go to explicitly accept a *config.Config object instead of relying on config.CurrentConfig(). This improves testability and clarity.
Network Header Adjustment: In initNetworkAccessHeaders, I've modified the x-snyk-ide header format to prepend snyk-ls- and stopped removing the x-snyk-cli-version header, adding a comment explaining its necessity for LCE verification.
OAuth Client Configuration: I've updated the NewOAuthProvider function in infrastructure/authentication/auth_configuration.go to use the unauthorized HTTP client obtained from the network access layer when configuring the OAuth provider.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
