### PR TITLE
chore: update ignore never expire value

### DIFF
--- a/domain/ide/command/ignores_request.go
+++ b/domain/ide/command/ignores_request.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snyk/code-client-go/sarif"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/ignore_workflow"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
@@ -222,6 +223,9 @@ func GetCommandArgs(cmd *submitIgnoreRequest) (ignoreType string, reason string,
 	expiration, err = getStringArgument(cmd, expirationIndex, "expiration")
 	if err != nil {
 		return "", "", "", err
+	}
+	if expiration == "" {
+		expiration = local_models.DefaultSuppressionExpiration
 	}
 
 	return ignoreType, reason, expiration, nil

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/snyk/code-client-go v1.22.1
-	github.com/snyk/go-application-framework v0.0.0-20250618114212-411107267280
+	github.com/snyk/go-application-framework v0.0.0-20250623133541-b839adde73f3
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/snyk/code-client-go v1.22.1 h1:bgMaShTO+zoCGNp7SRT6tKSngfhVBn0IRK2QEv
 github.com/snyk/code-client-go v1.22.1/go.mod h1:Jx3Jpo8kHlqHjhGa7a0ROQzPu+X15TBN0zRD+wNcUds=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e h1:XFGkHDWA8JTPLr82QzoKVqGytofEYBf68VqoUq8yvXk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20250618114212-411107267280 h1:CppbOeoLSWbXpCNVP/jRz2BXeLvQmylo6eniSr0XWHQ=
-github.com/snyk/go-application-framework v0.0.0-20250618114212-411107267280/go.mod h1:4DSu9PL2hypUjZhrT+zaMh3H5stAerMVfUs5XP1ST8U=
+github.com/snyk/go-application-framework v0.0.0-20250623133541-b839adde73f3 h1:hVtkGhifvAhIsvUYOq7zUFllE3XHJdpd4F6WNcpgWp4=
+github.com/snyk/go-application-framework v0.0.0-20250623133541-b839adde73f3/go.mod h1:4DSu9PL2hypUjZhrT+zaMh3H5stAerMVfUs5XP1ST8U=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
### Description

From our [E2E test](https://snyksec.atlassian.net/wiki/spaces/CLI/pages/3339747813/E2E+Tests) meeting it was decided that the `--expiration` flag for the ignore create workflow should take the value `never` for ignores that don't have an expiration date, instead of allowing an empty string like it was previously used. 

This [GAF PR](https://github.com/snyk/go-application-framework/pull/343) added this [change](https://github.com/snyk/go-application-framework/pull/350/commits/746f2ed0c96e8e786dbca8bf0f92abf1107b0b70#diff-489229b85a1c04519bb0ee241858ce475b4d87c3f7c95d1f1ec31ac5dd673f09L229-L234) to the ignore workflow, and some other presentation changes for the CLI. The changes to the `ignore_request.go` just map the new ignore expiration input value to the new requirement.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
