### PR TITLE
fix: IAW UI improvements [IDE-1151]

### DIFF
--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -100,11 +100,6 @@
     <!-- Tabs Issue Overview Container -->
     <article class="code-issue-panel">
       <div class="main-tabs-nav">
-        {{if or .IsIgnored .IsPending}}
-        <span data-tab="ignore-details" id="ignore-details-tab" class="tab-item is-selected ignore-details-tab">
-          Ignore Details
-        </span>
-        {{end}}
         {{if not .IsIgnored}}
         <span data-tab="fix-analysis" id="fix-analysis-tab"
           class="tab-item {{if not .IsPending}}is-selected{{end}} sn-fix-analysis fix-analysis-tab">
@@ -121,6 +116,11 @@
           Issue Overview
         </span>
         {{end}}
+        {{if or .IsIgnored .IsPending}}
+        <span data-tab="ignore-details" id="ignore-details-tab" class="tab-item is-selected ignore-details-tab">
+          Ignore Details
+        </span>
+        {{end}}
       </div>
 
       <!-- Dynamic Content Sections -->
@@ -129,12 +129,14 @@
         <!-- Start Ignore Details section for tab id="ignore-details-tab" -->
         <div data-content="ignore-details" id="ignore-details-content" class="tab-content main-tab-content is-selected">
           <div class="ignore-details delimiter-top">
-            {{range .IgnoreDetails}}
-            <div class="ignore-details-row">
-              <div class="ignore-details-label">{{.Label}}</div>
-              <div class="ignore-details-value">{{.Value}}</div>
-            </div>
-            {{end}}
+            <table class="ignore-details-table">
+              {{range .IgnoreDetails}}
+              <tr class="ignore-details-row">
+                <td class="ignore-details-label">{{.Label}}</td>
+                <td class="ignore-details-value">{{.Value}}</td>
+              </tr>
+              {{end}}
+            </table>
             <div class="ignore-next-step-text">
               Ignores are currently managed in the Snyk web app.
               To edit or remove the ignore please go to:

--- a/infrastructure/code/template/styles.css
+++ b/infrastructure/code/template/styles.css
@@ -292,14 +292,15 @@ main {
 table {
   border-collapse: collapse;
 }
-table td {
-  background: var(--container-background-color);
-  padding: 4px;
-}
 
 .data-flow-table {
   background-color: var(--code-background-color);
   margin-top: 0.6rem;
+}
+
+.data-flow-table td {
+  background: var(--container-background-color);
+  padding: 4px;
 }
 
 .data-flow-row {
@@ -503,6 +504,7 @@ table > tbody > tr:last-child .data-flow-line {
   position: fixed;
   bottom: 0;
   width: 100%;
+  padding: 10px 20px;
   margin-block-end: 0;
   background-color: var(--background-color);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.075));
@@ -550,18 +552,20 @@ table > tbody > tr:last-child .data-flow-line {
   width: 100%;
 }
 
-.ignore-details-row {
-  display: flex;
-  justify-content: space-between;
+.ignore-details-table {
   width: 100%;
-  align-items: flex-start;
+  border-collapse: collapse;
+}
+
+.ignore-details-row {
 }
 
 .ignore-details-label {
-  width: 30%;
+  width: 1%;
+  white-space: nowrap;
   text-align: left;
   font-weight: bold;
-  padding-right: 10px;
+  padding-right: 30px;
 }
 
 .ignore-details-value {
@@ -834,6 +838,7 @@ button.sn-apply-fix:hover {
   font-size: inherit;
   height: 100%;
   line-height: inherit;
+  padding: 5px;
   resize: none;
   width: 100%;
 }


### PR DESCRIPTION
### Description

Moved the "Ignore Details" tab to be the last.
Halved the gap between the ignore detail label and value.
Gave the text area more padding in the form.
Moved the "Create ignore" button out from the corner a bit.

Checked in Visual Studio as well and it looked correct.

### Checklist

- [ ] Tests added and all succeed
 - N/A
- [ ] Linted
 - N/A
- [ ] README.md updated, if user-facing
 - No, it's EA.
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A

### Screenshots
 
Before (bad textarea padding):
<img width="634" alt="Screenshot 2025-06-26 at 17 51 18" src="https://github.com/user-attachments/assets/52d4949e-1850-442d-8271-b9337bf79cd7" />
After (better textarea padding):
<img width="628" alt="Screenshot 2025-06-26 at 17 36 32" src="https://github.com/user-attachments/assets/1193ff59-7520-42dd-b104-2b9a7dcd3203" />
(I don't think I broke the spacing below the submit button, I think it's dependant on container size, but I don't know CSS enough to be sure...)

Before (tab on right, spread detail columns):
<img width="631" alt="Screenshot 2025-06-26 at 17 51 44" src="https://github.com/user-attachments/assets/d5765c0b-6fb4-4673-bc18-173f5a2b676a" />
After (tab on left, more compact detail columns):
<img width="451" alt="Screenshot 2025-06-27 at 10 34 15" src="https://github.com/user-attachments/assets/0feb1a58-0cb4-416c-8821-7ad2aa72f243" />

Before (button in bottom left):
<img width="201" alt="Screenshot 2025-06-26 at 17 51 54" src="https://github.com/user-attachments/assets/7df94a68-a717-46f6-8583-84cab44f14d7" /> 
After (button away from bottom left):
<img width="284" alt="Screenshot 2025-06-26 at 17 37 18" src="https://github.com/user-attachments/assets/4934295d-4b4e-4ed5-a9c2-55f26bf3244f" />
