### PR TITLE
feat(MCP): add Snyk Learn tool [IDE-1213]

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,39 @@
+# Cursor Rules for Snyk LS Project
+
+## Project Setup
+- Always determine the absolute path of the project directory (use `pwd` command in shell)
+- Use the absolute path when running Snyk scans and tests
+
+## Security Scanning
+- Always use Snyk for SCA (Software Composition Analysis) and code scanning
+- Scan with both Snyk Code and Snyk SCA tools
+- Pass the absolute path of the directory being scanned as a parameter
+- Run `snyk code test` after each code edit (pass absolute path)
+- Run `snyk sca test` after updating package manager/manifest/build files (pass absolute path)
+- Fix issues if they are fixable, taking Snyk scan results as input
+
+## Testing Guidelines
+- Always write and update test cases
+- Iterate until tests pass
+- Use existing mocks, don't create new ones
+- When using mocks, use gomock to generate them
+- Always run tests after editing code
+
+## Code Quality
+- Always lint code using `make lint`
+- Consider the Makefile for build and linting operations
+- Be concise, direct, and avoid unnecessary explanations
+
+## Git Workflow
+- Use Conventional Commit Style (Subject + Body) for commit messages
+- Be descriptive in commit message body
+- If JIRA issue (IDE-XXXX) exists in branch name, use it as postfix: `[IDE-XXXX]`
+- When pushing, use: `git push --set-upstream origin $(current_branch)`
+- Never force push
+- Never push without asking for confirmation
+- Never commit hashicorp gomod files
+- Regularly fetch main branch and offer to merge into current branch
+
+## Code Standards
+- Don't modify copyright headers
+- Maintain existing code patterns and conventions 

--- a/infrastructure/learn/service.go
+++ b/infrastructure/learn/service.go
@@ -183,11 +183,13 @@ func (s *serviceImpl) updateCaches(lessons []Lesson) []Lesson {
 	s.lessonsByEcosystemCache.RemoveAll()
 	s.lessonsByRuleCache.RemoveAll()
 
+	var filteredLessons []Lesson
 	for _, lesson := range lessons {
 		notSupported := strings.HasPrefix(lesson.Description, learnLessonNotSupportedText)
 		if !lesson.Published || notSupported {
 			continue
 		}
+		filteredLessons = append(filteredLessons, lesson)
 		for _, rule := range lesson.Rules {
 			lessonsForRule, exists := s.lessonsByRuleCache.Get(rule)
 			if !exists {
@@ -205,7 +207,7 @@ func (s *serviceImpl) updateCaches(lessons []Lesson) []Lesson {
 			s.lessonsByEcosystemCache.Set(ecosystem, lessonsForEcosystem, expiration)
 		}
 	}
-	return nil
+	return filteredLessons
 }
 
 func (s *serviceImpl) GetLesson(ecosystem string, rule string, cwes []string, cves []string, issueType types.IssueType) (lesson *Lesson, err error) {

--- a/internal/types/command.go
+++ b/internal/types/command.go
@@ -18,10 +18,10 @@ package types
 
 import (
 	"context"
-	"os"
 	"sync"
 
 	"github.com/pkg/browser"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -57,7 +57,7 @@ type OpenBrowserFunc func(url string)
 
 var (
 	DefaultOpenBrowserFunc OpenBrowserFunc = func(url string) {
-		browser.Stdout = os.Stderr
+		browser.Stdout = log.Logger
 		_ = browser.OpenURL(url)
 	}
 )

--- a/internal/types/command.go
+++ b/internal/types/command.go
@@ -53,8 +53,10 @@ const (
 	ExecuteMCPToolCall = "snyk.executeMCPToolCall"
 )
 
+type OpenBrowserFunc func(url string)
+
 var (
-	DefaultOpenBrowserFunc = func(url string) {
+	DefaultOpenBrowserFunc OpenBrowserFunc = func(url string) {
 		browser.Stdout = os.Stderr
 		_ = browser.OpenURL(url)
 	}

--- a/licenses/github.com/hashicorp/hcl/go.mod
+++ b/licenses/github.com/hashicorp/hcl/go.mod
@@ -1,5 +1,3 @@
 module github.com/hashicorp/hcl
 
-go 1.24.0
-
 require github.com/davecgh/go-spew v1.1.1

--- a/licenses/github.com/hashicorp/hcl/go.mod
+++ b/licenses/github.com/hashicorp/hcl/go.mod
@@ -1,3 +1,5 @@
 module github.com/hashicorp/hcl
 
+go 1.24.0
+
 require github.com/davecgh/go-spew v1.1.1

--- a/mcp_extension/README.md
+++ b/mcp_extension/README.md
@@ -43,7 +43,6 @@ To start the Snyk MCP server, use the `snyk mcp` command for a supported transpo
 * `snyk_logout` (logout)
 * `snyk_auth_status` (authentication status check)
 * `snyk_version` (version information)
-* `snyk_get_all_learn_lessons` (retrieves all Snyk Learn lessons)
 * `snyk_open_learn_lesson` (opens a Snyk Learn lesson in the browser by its title)
 
 ## Environment variables for MCP

--- a/mcp_extension/README.md
+++ b/mcp_extension/README.md
@@ -43,6 +43,8 @@ To start the Snyk MCP server, use the `snyk mcp` command for a supported transpo
 * `snyk_logout` (logout)
 * `snyk_auth_status` (authentication status check)
 * `snyk_version` (version information)
+* `snyk_get_all_learn_lessons` (retrieves all Snyk Learn lessons)
+* `snyk_open_learn_lesson` (opens a Snyk Learn lesson in the browser by its title)
 
 ## Environment variables for MCP
 

--- a/mcp_extension/learn_tool.go
+++ b/mcp_extension/learn_tool.go
@@ -1,0 +1,174 @@
+/*
+ * © 2025 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mcp_extension
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/rs/zerolog"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+)
+
+// NewDefaultLearnService creates and returns a new learn.Service instance
+// using default production dependencies from the invocation context.
+func NewDefaultLearnService(invocationContext workflow.InvocationContext, logger *zerolog.Logger) learn.Service {
+	l := logger.With().Str("component", "learn_service_creation").Logger()
+
+	engine := invocationContext.GetEngine()
+
+	serviceInstance := learn.New(engine.GetConfiguration(), &l, engine.GetNetworkAccess().GetUnauthorizedHttpClient)
+
+	if serviceInstance == nil {
+		l.Error().Msg("Failed to create learn service instance from learn.New.")
+		return nil
+	}
+
+	go serviceInstance.MaintainCache()
+	l.Debug().Msg("Learn service instance created via default factory and cache maintenance started.")
+	return serviceInstance
+}
+
+// LessonOutput defines the structure for JSON output
+type LessonOutput struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Ecosystems  string `json:"ecosystems"`
+}
+
+func (m *McpLLMBinding) snykGetAllLearnLessonsHandler(_ workflow.InvocationContext, toolDef SnykMcpToolsDefinition) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		logger := m.logger.With().Str("method", toolDef.Name).Logger()
+		logger.Debug().Str("toolName", toolDef.Name).Msg("Received call for tool")
+
+		if m.learnService == nil {
+			logger.Error().Msg("Learn service is not initialized on McpLLMBinding.")
+			return nil, fmt.Errorf("learn service not initialized on McpLLMBinding")
+		}
+
+		lessons, err := m.learnService.GetAllLessons()
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to get all learn lessons.")
+			return nil, fmt.Errorf("failed to get learn lessons: %w", err)
+		}
+
+		var lessonOutputs []LessonOutput
+		for _, lesson := range lessons {
+			if strings.HasPrefix(lesson.Description, "This course is no longer supported.") {
+				continue
+			}
+			lessonOutputs = append(lessonOutputs, LessonOutput{
+				Title:       lesson.Title,
+				Description: lesson.Description,
+				Ecosystems:  strings.Join(lesson.Ecosystems, " & "),
+			})
+		}
+
+		var buf bytes.Buffer
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		err = encoder.Encode(lessonOutputs)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to encode lessons to JSON.")
+			return nil, fmt.Errorf("failed to encode lessons to JSON: %w", err)
+		}
+
+		return mcp.NewToolResultText(buf.String()), nil
+	}
+}
+
+func (m *McpLLMBinding) snykOpenLearnLessonHandler(_ workflow.InvocationContext, toolDef SnykMcpToolsDefinition) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		logger := m.logger.With().Str("method", toolDef.Name).Logger()
+		logger.Debug().Str("toolName", toolDef.Name).Msg("Received call for tool")
+
+		args := request.GetArguments()
+		lessonTitleVal, ok := args["lessonTitle"]
+		if !ok {
+			err := fmt.Errorf("missing 'lessonTitle' parameter for tool %s", toolDef.Name)
+			logger.Error().Err(err).Msg("Parameter error")
+			return nil, err
+		}
+
+		lessonTitle, ok := lessonTitleVal.(string)
+		if !ok {
+			err := fmt.Errorf("'lessonTitle' parameter is not a string for tool %s", toolDef.Name)
+			logger.Error().Err(err).Interface("value", lessonTitleVal).Msg("Parameter type error")
+			return nil, err
+		}
+
+		if lessonTitle == "" {
+			err := fmt.Errorf("'lessonTitle' parameter cannot be empty for tool %s", toolDef.Name)
+			logger.Error().Err(err).Msg("Parameter value error")
+			return nil, err
+		}
+
+		logger.Info().Str("lessonTitle", lessonTitle).Msg("Parsed parameters for snyk_open_learn_lesson")
+
+		if m.learnService == nil {
+			err := fmt.Errorf("learn service not initialized on McpLLMBinding")
+			logger.Error().Err(err).Msg("Service error")
+			return nil, err
+		}
+
+		allLessons, err := m.learnService.GetAllLessons()
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to get all learn lessons")
+			return nil, fmt.Errorf("failed to retrieve lessons: %w", err)
+		}
+
+		var targetLesson *learn.Lesson
+		for i := range allLessons {
+			// Case-insensitive comparison for robustness
+			if strings.EqualFold(allLessons[i].Title, lessonTitle) {
+				targetLesson = &allLessons[i]
+				break
+			}
+		}
+
+		if targetLesson == nil {
+			errNotFound := fmt.Errorf("lesson with title '%s' not found", lessonTitle)
+			logger.Warn().Err(errNotFound).Msg("Lesson not found")
+			return nil, errNotFound
+		}
+
+		lessonURL := targetLesson.Url
+		if !strings.Contains(lessonURL, "loc=ide") {
+			if strings.Contains(lessonURL, "?") {
+				lessonURL += "&loc=ide"
+			} else {
+				lessonURL += "?loc=ide"
+			}
+		}
+
+		logger.Info().Str("lessonURL", lessonURL).Msg("Attempting to open lesson URL in browser")
+
+		m.openBrowserFunc(lessonURL)
+
+		resultText := fmt.Sprintf("Successfully requested to open lesson: %s", lessonTitle)
+		logger.Info().Msg(resultText)
+		return mcp.NewToolResultText(resultText), nil
+	}
+}

--- a/mcp_extension/learn_tool.go
+++ b/mcp_extension/learn_tool.go
@@ -18,7 +18,6 @@ package mcp_extension
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -49,39 +48,6 @@ func NewDefaultLearnService(invocationContext workflow.InvocationContext, logger
 	go serviceInstance.MaintainCache()
 	l.Debug().Msg("Learn service instance created via default factory and cache maintenance started.")
 	return serviceInstance
-}
-
-// LessonOutput defines the structure for JSON output
-type LessonOutput struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Ecosystems  string `json:"ecosystems"`
-}
-
-func (m *McpLLMBinding) snykGetAllLearnLessonsHandler(_ workflow.InvocationContext, toolDef SnykMcpToolsDefinition) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		logger := m.logger.With().Str("method", toolDef.Name).Logger()
-		logger.Debug().Str("toolName", toolDef.Name).Msg("Received call for tool")
-
-		if m.learnService == nil {
-			logger.Error().Msg("Learn service is not initialized on McpLLMBinding.")
-			return nil, fmt.Errorf("learn service not initialized on McpLLMBinding")
-		}
-
-		lessons, err := m.learnService.GetAllLessons()
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to get all learn lessons.")
-			return nil, fmt.Errorf("failed to get learn lessons: %w", err)
-		}
-
-		marshal, err := json.Marshal(lessons)
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to encode lessons to JSON.")
-			return nil, fmt.Errorf("failed to encode lessons to JSON: %w", err)
-		}
-
-		return mcp.NewToolResultText(string(marshal)), nil
-	}
 }
 
 func (m *McpLLMBinding) snykOpenLearnLessonHandler(_ workflow.InvocationContext, toolDef SnykMcpToolsDefinition) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/mcp_extension/learn_tool.go
+++ b/mcp_extension/learn_tool.go
@@ -89,7 +89,7 @@ func buildLessonURL(lessonURL string) (string, error) {
 		return "", fmt.Errorf("invalid lesson URL: %w", err)
 	}
 	q := u.Query()
-	q.Set("loc", "ide")
+	q.Set("loc", "MCP")
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/mcp_extension/learn_tool.go
+++ b/mcp_extension/learn_tool.go
@@ -112,7 +112,7 @@ func (m *McpLLMBinding) snykOpenLearnLessonHandler(_ workflow.InvocationContext,
 		}
 		targetLesson, err := m.learnService.GetLesson(ecosystemString, ruleString, cweArray, cveArray, issueType)
 		if err != nil {
-			err = fmt.Errorf("failed to retrieve the learn lessen, error: %w", err)
+			err = fmt.Errorf("failed to retrieve the learn lesson, error: %w", err)
 			logger.Err(err).Send()
 			return mcp.NewToolResultText(err.Error()), nil
 		}

--- a/mcp_extension/learn_tool_test.go
+++ b/mcp_extension/learn_tool_test.go
@@ -83,7 +83,7 @@ func TestSnykOpenLearnLessonHandler(t *testing.T) {
 		textContent, ok := result.Content[0].(mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, textContent.Text, "Successfully requested to open lesson: Test Lesson")
-		assert.Equal(t, "https://learn.snyk.io/lesson1?loc=ide", openedURL)
+		assert.Equal(t, "https://learn.snyk.io/lesson1?loc=MCP", openedURL)
 	})
 
 	t.Run("opens lesson successfully with SAST issue type", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestSnykOpenLearnLessonHandler(t *testing.T) {
 		textContent, ok := result.Content[0].(mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, textContent.Text, "Successfully requested to open lesson: SQL Injection Lesson")
-		assert.Equal(t, "https://learn.snyk.io/lesson1?loc=ide", openedURL)
+		assert.Equal(t, "https://learn.snyk.io/lesson1?loc=MCP", openedURL)
 	})
 
 	t.Run("opens lesson with existing query parameters", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestSnykOpenLearnLessonHandler(t *testing.T) {
 		textContent, ok := result.Content[0].(mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, textContent.Text, "Successfully requested to open lesson: Test Lesson")
-		assert.Equal(t, "https://learn.snyk.io/lesson1?existing=param&loc=ide", openedURL)
+		assert.Equal(t, "https://learn.snyk.io/lesson1?existing=param&loc=MCP", openedURL)
 	})
 
 	t.Run("handles missing optional parameters", func(t *testing.T) {
@@ -227,9 +227,11 @@ func TestSnykOpenLearnLessonHandler(t *testing.T) {
 
 		result, err := handler(context.Background(), request)
 
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.Equal(t, expectedError, err)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		assert.True(t, ok)
+		assert.Contains(t, textContent.Text, "failed to retrieve the learn lesson")
 	})
 
 	t.Run("returns error when lesson URL is invalid", func(t *testing.T) {
@@ -267,9 +269,9 @@ func TestSnykOpenLearnLessonHandler(t *testing.T) {
 
 		result, err := handler(context.Background(), request)
 
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "invalid lesson URL")
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result.Content[0].(mcp.TextContent).Text, "invalid lesson URL")
 	})
 
 	t.Run("parses comma-separated CVEs and CWEs", func(t *testing.T) {

--- a/mcp_extension/learn_tool_test.go
+++ b/mcp_extension/learn_tool_test.go
@@ -17,266 +17,497 @@
 package mcp_extension
 
 import (
-	"testing"
-	// Core Go testing package
-
-	"github.com/golang/mock/gomock"
-	// Gomock for creating mock objects
-
-	gaf_mocks "github.com/snyk/go-application-framework/pkg/mocks"
-	"github.com/stretchr/testify/require"
-
-	// Testify for assertions
-	// Mocks from the Go Application Framework, aliased
-
-	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
-	// Mock for the learn service
-
-	"io"
-	"net/http" // For http.DefaultClient
-
-	"github.com/mark3labs/mcp-go/server" // For mcpServer in McpLLMBinding
-	"github.com/rs/zerolog"
-	"github.com/snyk/go-application-framework/pkg/configuration"
-	"github.com/snyk/go-application-framework/pkg/workflow" // Needed for LearnServiceFactoryFunc
-
-	"github.com/snyk/snyk-ls/mcp_extension/trust" // For folderTrust in McpLLMBinding
-
 	"context"
 	"encoding/json"
+	"errors"
+	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"strings" // For URL assertions
+	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
-// learnTestFixture defines the test fixture.
-// learnTestFixture defines the test fixture.
-// Fields will be populated by setupLearnTestFixture.
-// This structure is adapted from learnTestFixture in mcp_extension/scan_tool_test.go
-type learnTestFixture struct {
-	t                *testing.T
-	mockCtrl         *gomock.Controller
-	mockEngine       *gaf_mocks.MockEngine
-	mockInvCtx       *gaf_mocks.MockInvocationContext
-	mockLearnService *mock_learn.MockService
-	binding          *McpLLMBinding
-	loadedTools      *SnykMcpTools // Holds all tools loaded from snyk_tools.json
-	capturedOpenURL  string        // To capture the URL passed to the mock open browser function
-}
+func TestSnykGetAllLearnLessonsHandler(t *testing.T) {
+	t.Run("returns all lessons successfully", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-// setupLearnTestFixture initializes a new learnTestFixture for testing.
-// It adapts the setup pattern from setupTestFixture in mcp_extension/scan_tool_test.go.
-func setupLearnTestFixture(t *testing.T) *learnTestFixture {
-	t.Helper()
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
 
-	mockCtrl := gomock.NewController(t)
-
-	// Mock GAF Engine & Configuration (similar to scan_tool_test.go)
-	mockEngine := gaf_mocks.NewMockEngine(mockCtrl)
-	mockNetworkAccess := gaf_mocks.NewMockNetworkAccess(mockCtrl) // Create MockNetworkAccess
-	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
-	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
-	mockEngine.EXPECT().GetNetworkAccess().Return(mockNetworkAccess).AnyTimes()                  // Expect GetNetworkAccess call
-	mockNetworkAccess.EXPECT().GetUnauthorizedHttpClient().Return(http.DefaultClient).AnyTimes() // Expect GetUnauthorizedHttpClient call
-
-	// Add a mock storage, as it might be accessed via config.SetStorage in McpLLMBinding or its dependencies
-	mockStorage := gaf_mocks.NewMockStorage(mockCtrl)
-	engineConfig.SetStorage(mockStorage)
-
-	// Mock InvocationContext (similar to scan_tool_test.go)
-	logger := zerolog.New(io.Discard) // Discard logs for cleaner test output
-	mockInvCtx := gaf_mocks.NewMockInvocationContext(mockCtrl)
-	mockInvCtx.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
-	mockInvCtx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
-	mockInvCtx.EXPECT().GetEngine().Return(mockEngine).AnyTimes() // Needed for InitLearnService
-
-	// Mock Learn Service
-	mockLearnSvc := mock_learn.NewMockService(mockCtrl)
-
-	// Define a test-specific factory that returns the mockLearnSvc
-	testLearnServiceFactory := func(invCtx workflow.InvocationContext, testLogger *zerolog.Logger) learn.Service {
-		return mockLearnSvc
-	}
-
-	// Initialize McpLLMBinding (as done in scan_tool_test.go for its fixture)
-	// We don't need a real CLI path for these tests as learn tools don't directly call CLI.
-
-	// fixtureRefForClosure is used to allow the mockOpenBrowser closure to refer to the fixture instance
-	// once it's fully initialized.
-	var fixtureRefForClosure **learnTestFixture
-	mockOpenBrowser := func(url string) {
-		if fixtureRefForClosure != nil && *fixtureRefForClosure != nil {
-			(*fixtureRefForClosure).capturedOpenURL = url
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
 		}
-	}
 
-	binding := NewMcpLLMBinding(
-		WithLogger(&logger),
-		WithOpenBrowserFunc(mockOpenBrowser),
-		WithLearnServiceFactory(testLearnServiceFactory), // Use the test factory
-	)
-	binding.mcpServer = server.NewMCPServer("Snyk", "test-version") // Basic server for registration
-	// Manually set learnService using the factory, simulating McpLLMBinding.Start() behavior
-	// This ensures m.learnService is populated before addSnykTools is called.
-	if binding.learnServiceFactory != nil {
-		binding.learnService = binding.learnServiceFactory(mockInvCtx, &logger)
-	} else {
-		// Fallback or error if factory somehow wasn't set (should not happen with current NewMcpLLMBinding)
-		t.Fatal("learnServiceFactory was not set on binding")
-	}
-
-	// Ensure the learnService on the binding is indeed our mock for sanity
-	if _, ok := binding.learnService.(*mock_learn.MockService); !ok {
-		t.Fatalf("binding.learnService is not the mock instance, type is %T", binding.learnService)
-	}
-	binding.folderTrust = trust.NewFolderTrust(&logger, engineConfig) // Initialize folderTrust
-
-	// Load SnykMcpTools (tool definitions from JSON)
-	// This function is defined in mcp_extension/scan_tool.go
-	loadedTools, err := loadMcpToolsFromJson()
-	require.NoError(t, err, "Failed to load SnykMcpTools from JSON")
-
-	currentFixture := &learnTestFixture{
-		t:                t,
-		mockCtrl:         mockCtrl,
-		mockEngine:       mockEngine,
-		mockInvCtx:       mockInvCtx,
-		mockLearnService: mockLearnSvc,
-		binding:          binding,
-		loadedTools:      loadedTools,
-	}
-	// Point fixtureRefForClosure to the address of currentFixture
-	fixtureRefForClosure = &currentFixture
-
-	// Call InitLearnService to ensure globalLearnService is set up if any part of the binding relies on it
-	// even if we override globalLearnService directly for handler tests.
-	// This also starts the cache maintenance goroutine if the real InitLearnService is called.
-	// For handler unit tests, directly using the mocked globalLearnService is primary.
-	// However, McpLLMBinding.Start calls InitLearnService. If we were testing Start, this would be critical.
-	// For now, ensure the mock is in place.
-	// The InitLearnService in learn_tool.go will use the globalLearnService we just set if it's called.
-	// Let's ensure our mock is used by InitLearnService if it were to be called by the binding logic under test.
-	// The most direct way for handler tests is that the handlers *themselves* use the global var.
-	// InitLearnService(currentFixture.mockInvCtx, &logger) // This call overwrites the globalLearnService mock. Removing it.
-
-	// Add Snyk tools to the binding's MCP server.
-	// This step is crucial for the binding to know about the tools and their handlers.
-	// The handlers for learn tools (snykGetAllLearnLessonsHandler, snykOpenLearnLessonHandler)
-	// are methods on McpLLMBinding and will be registered here.
-	err = currentFixture.binding.addSnykTools(currentFixture.mockInvCtx)
-	require.NoError(t, err, "binding.addSnykTools failed")
-
-	return currentFixture
-}
-
-func TestSnykGetAllLearnLessonsHandler_SuccessfulRetrieval(t *testing.T) {
-	fixture := setupLearnTestFixture(t)
-	toolName := SnykGetAllLearnLessons // Constant defined in scan_tool.go
-	toolDef := getToolWithName(t, fixture.loadedTools, toolName)
-	require.NotNil(t, toolDef, "Tool definition for %s not found", toolName)
-
-	// Prepare mock lessons
-	mockLessons := []learn.Lesson{
-		{Title: "Lesson 1", Description: "Desc 1", Ecosystems: []string{"js", "ts"}},
-		{Title: "Lesson 2", Description: "This course is no longer supported.", Ecosystems: []string{"java"}},
-		{Title: "Lesson 3", Description: "Desc 3", Ecosystems: []string{"go"}},
-	}
-	expectedOutputLessons := []LessonOutput{ // LessonOutput is defined in learn_tool.go
-		{Title: "Lesson 1", Description: "Desc 1", Ecosystems: "js & ts"},
-		{Title: "Lesson 3", Description: "Desc 3", Ecosystems: "go"},
-	}
-
-	fixture.mockLearnService.EXPECT().GetAllLessons().Return(mockLessons, nil).Times(1)
-
-	// Create request (no arguments needed for this tool)
-	request := mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
-			Arguments: map[string]interface{}{},
-		},
-	}
-
-	// Get the handler
-	handler := fixture.binding.snykGetAllLearnLessonsHandler(fixture.mockInvCtx, *toolDef)
-
-	// Call the handler
-	result, err := handler(context.Background(), request)
-
-	// Assertions
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Content, 1, "Expected one content item in the result")
-
-	textContent, ok := result.Content[0].(mcp.TextContent)
-	require.True(t, ok, "Expected result content to be mcp.TextContent")
-
-	var actualOutputLessons []LessonOutput
-	err = json.Unmarshal([]byte(textContent.Text), &actualOutputLessons)
-	require.NoError(t, err, "Failed to unmarshal result text into []LessonOutput")
-
-	require.Equal(t, expectedOutputLessons, actualOutputLessons, "Output lessons do not match expected lessons")
-}
-
-func TestSnykOpenLearnLessonHandler_SuccessfulOpening(t *testing.T) {
-	fixture := setupLearnTestFixture(t)
-	toolName := SnykOpenLearnLesson // Constant defined in scan_tool.go
-	toolDef := getToolWithName(t, fixture.loadedTools, toolName)
-	require.NotNil(t, toolDef, "Tool definition for %s not found", toolName)
-
-	lessonTitleToOpen := "Found Lesson"
-	lessonURL := "http://example.com/found"
-	mockLessons := []learn.Lesson{
-		{Title: "Another Lesson", Url: "http://example.com/another"},
-		{Title: lessonTitleToOpen, Url: lessonURL, Ecosystems: []string{"js"}},
-	}
-
-	fixture.mockLearnService.EXPECT().GetAllLessons().Return(mockLessons, nil).Times(1)
-
-	fixture.capturedOpenURL = "" // Reset before the call
-
-	// Create request
-	request := mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
-			Arguments: map[string]interface{}{
-				"lessonTitle": lessonTitleToOpen,
+		expectedLessons := []learn.Lesson{
+			{
+				LessonId:    "lesson1",
+				Title:       "Test Lesson 1",
+				Description: "Test description 1",
+				Ecosystems:  []string{"javascript"},
+				Url:         "https://learn.snyk.io/lesson1",
 			},
+			{
+				LessonId:    "lesson2",
+				Title:       "Test Lesson 2",
+				Description: "Test description 2",
+				Ecosystems:  []string{"python"},
+				Url:         "https://learn.snyk.io/lesson2",
+			},
+		}
+
+		mockLearnService.EXPECT().GetAllLessons().Return(expectedLessons, nil)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykGetAllLearnLessonsHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{})
+		result, err := handler(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		var actualLessons []learn.Lesson
+		err = json.Unmarshal([]byte(textContent.Text), &actualLessons)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLessons, actualLessons)
+	})
+
+	t.Run("returns error when learn service is not initialized", func(t *testing.T) {
+		logger := zerolog.Nop()
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: nil,
+		}
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykGetAllLearnLessonsHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{})
+		result, err := handler(context.Background(), request)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "learn service not initialized")
+	})
+
+	t.Run("returns error when GetAllLessons fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
+		}
+
+		expectedError := errors.New("failed to get lessons")
+		mockLearnService.EXPECT().GetAllLessons().Return(nil, expectedError)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykGetAllLearnLessonsHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{})
+		result, err := handler(context.Background(), request)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get learn lessons")
+	})
+}
+
+func TestSnykOpenLearnLessonHandler(t *testing.T) {
+	t.Run("opens lesson successfully with all parameters", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
+		var openedURL string
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
+			openBrowserFunc: func(url string) {
+				openedURL = url
+			},
+		}
+
+		expectedLesson := &learn.Lesson{
+			LessonId: "lesson1",
+			Title:    "Test Lesson",
+			Url:      "https://learn.snyk.io/lesson1",
+		}
+
+		mockLearnService.EXPECT().GetLesson(
+			"javascript",
+			"SNYK-JS-ASYNC-2441827",
+			[]string{"CWE-601"},
+			[]string{"CVE-2024-1234"},
+			types.DependencyVulnerability,
+		).Return(expectedLesson, nil)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykOpenLearnLessonHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{
+			"issueType": "sca",
+			"cves":      "CVE-2024-1234",
+			"cwes":      "CWE-601",
+			"rule":      "SNYK-JS-ASYNC-2441827",
+			"ecosystem": "javascript",
+		})
+
+		result, err := handler(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "Successfully requested to open lesson: Test Lesson")
+		assert.Equal(t, "https://learn.snyk.io/lesson1?loc=ide", openedURL)
+	})
+
+	t.Run("opens lesson successfully with SAST issue type", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
+		var openedURL string
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
+			openBrowserFunc: func(url string) {
+				openedURL = url
+			},
+		}
+
+		expectedLesson := &learn.Lesson{
+			LessonId: "lesson1",
+			Title:    "SQL Injection Lesson",
+			Url:      "https://learn.snyk.io/lesson1",
+		}
+
+		mockLearnService.EXPECT().GetLesson(
+			"javascript",
+			"javascript/sqlinjection",
+			[]string{"CWE-89"},
+			[]string{},
+			types.CodeSecurityVulnerability,
+		).Return(expectedLesson, nil)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykOpenLearnLessonHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{
+			"issueType": "sast",
+			"cwes":      "CWE-89",
+			"rule":      "javascript/sqlinjection",
+			"ecosystem": "javascript",
+		})
+
+		result, err := handler(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "Successfully requested to open lesson: SQL Injection Lesson")
+		assert.Equal(t, "https://learn.snyk.io/lesson1?loc=ide", openedURL)
+	})
+
+	t.Run("opens lesson with existing query parameters", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
+		var openedURL string
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
+			openBrowserFunc: func(url string) {
+				openedURL = url
+			},
+		}
+
+		expectedLesson := &learn.Lesson{
+			LessonId: "lesson1",
+			Title:    "Test Lesson",
+			Url:      "https://learn.snyk.io/lesson1?existing=param",
+		}
+
+		mockLearnService.EXPECT().GetLesson(
+			"javascript",
+			"SNYK-JS-ASYNC-2441827",
+			[]string{},
+			[]string{},
+			types.DependencyVulnerability,
+		).Return(expectedLesson, nil)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykOpenLearnLessonHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{
+			"issueType": "sca",
+			"rule":      "SNYK-JS-ASYNC-2441827",
+			"ecosystem": "javascript",
+		})
+
+		result, err := handler(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "Successfully requested to open lesson: Test Lesson")
+		assert.Equal(t, "https://learn.snyk.io/lesson1?existing=param&loc=ide", openedURL)
+	})
+
+	t.Run("handles missing optional parameters", func(t *testing.T) {
+		testBasicLearnLessonHandler(t, map[string]interface{}{
+			"issueType": "sca",
+		}, "handles missing optional parameters")
+	})
+
+	t.Run("defaults to DependencyVulnerability for unknown issue type", func(t *testing.T) {
+		testBasicLearnLessonHandler(t, map[string]interface{}{
+			"issueType": "unknown",
+		}, "defaults to DependencyVulnerability for unknown issue type")
+	})
+
+	t.Run("returns error when GetLesson fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
+		}
+
+		expectedError := errors.New("failed to get lesson")
+		mockLearnService.EXPECT().GetLesson(
+			"",
+			"",
+			[]string{},
+			[]string{},
+			types.DependencyVulnerability,
+		).Return(nil, expectedError)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykOpenLearnLessonHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{
+			"issueType": "sca",
+		})
+
+		result, err := handler(context.Background(), request)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Equal(t, expectedError, err)
+	})
+
+	t.Run("returns error when lesson URL is invalid", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
+		}
+
+		expectedLesson := &learn.Lesson{
+			LessonId: "lesson1",
+			Title:    "Test Lesson",
+			Url:      "://invalid-url",
+		}
+
+		mockLearnService.EXPECT().GetLesson(
+			"",
+			"",
+			[]string{},
+			[]string{},
+			types.DependencyVulnerability,
+		).Return(expectedLesson, nil)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykOpenLearnLessonHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{
+			"issueType": "sca",
+		})
+
+		result, err := handler(context.Background(), request)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "invalid lesson URL")
+	})
+
+	t.Run("parses comma-separated CVEs and CWEs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLearnService := mock_learn.NewMockService(ctrl)
+		logger := zerolog.Nop()
+
+		mcpBinding := &McpLLMBinding{
+			logger:       &logger,
+			learnService: mockLearnService,
+			openBrowserFunc: func(url string) {
+				// do nothing
+			},
+		}
+
+		expectedLesson := &learn.Lesson{
+			LessonId: "lesson1",
+			Title:    "Test Lesson",
+			Url:      "https://learn.snyk.io/lesson1",
+		}
+
+		mockLearnService.EXPECT().GetLesson(
+			"",
+			"",
+			[]string{"CWE-89", "CWE-601"},
+			[]string{"CVE-2024-1234", "CVE-2024-5678"},
+			types.DependencyVulnerability,
+		).Return(expectedLesson, nil)
+
+		toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+		handler := mcpBinding.snykOpenLearnLessonHandler(nil, toolDef)
+
+		request := createMockRequest(map[string]interface{}{
+			"issueType": "sca",
+			"cves":      "CVE-2024-1234,CVE-2024-5678",
+			"cwes":      "CWE-89,CWE-601",
+		})
+
+		result, err := handler(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "Successfully requested to open lesson: Test Lesson")
+	})
+}
+
+func TestLessonOutput(t *testing.T) {
+	t.Run("marshals LessonOutput correctly", func(t *testing.T) {
+		lessonOutput := LessonOutput{
+			Title:       "Test Lesson",
+			Description: "Test description",
+			Ecosystems:  "javascript,python",
+		}
+
+		jsonData, err := json.Marshal(lessonOutput)
+		require.NoError(t, err)
+
+		expected := `{"title":"Test Lesson","description":"Test description","ecosystems":"javascript,python"}`
+		assert.JSONEq(t, expected, string(jsonData))
+	})
+
+	t.Run("unmarshals LessonOutput correctly", func(t *testing.T) {
+		jsonData := `{"title":"Test Lesson","description":"Test description","ecosystems":"javascript,python"}`
+
+		var lessonOutput LessonOutput
+		err := json.Unmarshal([]byte(jsonData), &lessonOutput)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Test Lesson", lessonOutput.Title)
+		assert.Equal(t, "Test description", lessonOutput.Description)
+		assert.Equal(t, "javascript,python", lessonOutput.Ecosystems)
+	})
+}
+
+func TestLearnServiceIntegration(t *testing.T) {
+	t.Run("learn service factory function is stored correctly", func(t *testing.T) {
+		factoryCalled := false
+		mockFactory := func(invocationContext workflow.InvocationContext, logger *zerolog.Logger) learn.Service {
+			factoryCalled = true
+			return nil
+		}
+
+		binding := NewMcpLLMBinding(WithLearnServiceFactory(mockFactory))
+		assert.NotNil(t, binding)
+		assert.NotNil(t, binding.learnServiceFactory)
+
+		// Factory should not be called during construction
+		assert.False(t, factoryCalled)
+	})
+}
+
+// Helper function to create a mock request
+func createMockRequest(args map[string]interface{}) mcp.CallToolRequest {
+	var request mcp.CallToolRequest
+	request.Params.Arguments = args
+	return request
+}
+
+// Helper function to test basic learn lesson handler scenarios with minimal setup
+func testBasicLearnLessonHandler(t *testing.T, args map[string]interface{}, testDescription string) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLearnService := mock_learn.NewMockService(ctrl)
+	logger := zerolog.Nop()
+
+	mcpBinding := &McpLLMBinding{
+		logger:       &logger,
+		learnService: mockLearnService,
+		openBrowserFunc: func(url string) {
+			// do nothing
 		},
 	}
 
-	// Get the handler
-	handler := fixture.binding.snykOpenLearnLessonHandler(fixture.mockInvCtx, *toolDef)
+	expectedLesson := &learn.Lesson{
+		LessonId: "lesson1",
+		Title:    "Test Lesson",
+		Url:      "https://learn.snyk.io/lesson1",
+	}
 
-	// Call the handler
+	mockLearnService.EXPECT().GetLesson(
+		"",
+		"",
+		[]string{},
+		[]string{},
+		types.DependencyVulnerability,
+	).Return(expectedLesson, nil)
+
+	toolDef := SnykMcpToolsDefinition{Name: "test_tool"}
+	handler := mcpBinding.snykOpenLearnLessonHandler(nil, toolDef)
+
+	request := createMockRequest(args)
 	result, err := handler(context.Background(), request)
 
-	// Assertions
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Content, 1, "Expected one content item in the result")
-
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
 	textContent, ok := result.Content[0].(mcp.TextContent)
-	require.True(t, ok, "Expected result content to be mcp.TextContent")
-
-	expectedMessage := "Successfully requested to open lesson: " + lessonTitleToOpen
-	require.Equal(t, expectedMessage, textContent.Text)
-
-	// Assert that the mock open browser function was called with the correct URL
-	require.True(t, strings.HasPrefix(fixture.capturedOpenURL, lessonURL), "Opened URL should start with the base lesson URL. Got: %s", fixture.capturedOpenURL)
-	require.True(t, strings.Contains(fixture.capturedOpenURL, "loc=ide"), "Opened URL should contain 'loc=ide'. Got: %s", fixture.capturedOpenURL)
-
-	// Test URL construction when original URL has query params
-	lessonURLWithQuery := "http://example.com/found?param=true"
-	mockLessonsWithQuery := []learn.Lesson{
-		{Title: lessonTitleToOpen, Url: lessonURLWithQuery, Ecosystems: []string{"js"}},
-	}
-	fixture.mockLearnService.EXPECT().GetAllLessons().Return(mockLessonsWithQuery, nil).Times(1)
-	fixture.capturedOpenURL = "" // Reset for next call
-
-	_, err = handler(context.Background(), request) // Call handler again with new mock setup
-	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(fixture.capturedOpenURL, lessonURLWithQuery), "Opened URL should start with the base lesson URL with query. Got: %s", fixture.capturedOpenURL)
-	require.True(t, strings.Contains(fixture.capturedOpenURL, "loc=ide"), "Opened URL should contain 'loc=ide'. Got: %s", fixture.capturedOpenURL)
-	require.True(t, strings.Contains(fixture.capturedOpenURL, "&loc=ide"), "Opened URL should append with '&loc=ide' when query params exist. Got: %s", fixture.capturedOpenURL)
+	require.True(t, ok)
+	assert.Contains(t, textContent.Text, "Successfully requested to open lesson: Test Lesson")
 }

--- a/mcp_extension/learn_tool_test.go
+++ b/mcp_extension/learn_tool_test.go
@@ -416,34 +416,6 @@ func TestSnykOpenLearnLessonHandler(t *testing.T) {
 	})
 }
 
-func TestLessonOutput(t *testing.T) {
-	t.Run("marshals LessonOutput correctly", func(t *testing.T) {
-		lessonOutput := LessonOutput{
-			Title:       "Test Lesson",
-			Description: "Test description",
-			Ecosystems:  "javascript,python",
-		}
-
-		jsonData, err := json.Marshal(lessonOutput)
-		require.NoError(t, err)
-
-		expected := `{"title":"Test Lesson","description":"Test description","ecosystems":"javascript,python"}`
-		assert.JSONEq(t, expected, string(jsonData))
-	})
-
-	t.Run("unmarshals LessonOutput correctly", func(t *testing.T) {
-		jsonData := `{"title":"Test Lesson","description":"Test description","ecosystems":"javascript,python"}`
-
-		var lessonOutput LessonOutput
-		err := json.Unmarshal([]byte(jsonData), &lessonOutput)
-		require.NoError(t, err)
-
-		assert.Equal(t, "Test Lesson", lessonOutput.Title)
-		assert.Equal(t, "Test description", lessonOutput.Description)
-		assert.Equal(t, "javascript,python", lessonOutput.Ecosystems)
-	})
-}
-
 func TestLearnServiceIntegration(t *testing.T) {
 	t.Run("learn service factory function is stored correctly", func(t *testing.T) {
 		factoryCalled := false

--- a/mcp_extension/learn_tool_test.go
+++ b/mcp_extension/learn_tool_test.go
@@ -1,0 +1,282 @@
+/*
+ * © 2025 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mcp_extension
+
+import (
+	"testing"
+	// Core Go testing package
+
+	"github.com/golang/mock/gomock"
+	// Gomock for creating mock objects
+
+	gaf_mocks "github.com/snyk/go-application-framework/pkg/mocks"
+	"github.com/stretchr/testify/require"
+
+	// Testify for assertions
+	// Mocks from the Go Application Framework, aliased
+
+	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
+	// Mock for the learn service
+
+	"io"
+	"net/http" // For http.DefaultClient
+
+	"github.com/mark3labs/mcp-go/server" // For mcpServer in McpLLMBinding
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow" // Needed for LearnServiceFactoryFunc
+
+	"github.com/snyk/snyk-ls/mcp_extension/trust" // For folderTrust in McpLLMBinding
+
+	"context"
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"strings" // For URL assertions
+
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+)
+
+// learnTestFixture defines the test fixture.
+// learnTestFixture defines the test fixture.
+// Fields will be populated by setupLearnTestFixture.
+// This structure is adapted from learnTestFixture in mcp_extension/scan_tool_test.go
+type learnTestFixture struct {
+	t                *testing.T
+	mockCtrl         *gomock.Controller
+	mockEngine       *gaf_mocks.MockEngine
+	mockInvCtx       *gaf_mocks.MockInvocationContext
+	mockLearnService *mock_learn.MockService
+	binding          *McpLLMBinding
+	loadedTools      *SnykMcpTools // Holds all tools loaded from snyk_tools.json
+	capturedOpenURL  string        // To capture the URL passed to the mock open browser function
+}
+
+// setupLearnTestFixture initializes a new learnTestFixture for testing.
+// It adapts the setup pattern from setupTestFixture in mcp_extension/scan_tool_test.go.
+func setupLearnTestFixture(t *testing.T) *learnTestFixture {
+	t.Helper()
+
+	mockCtrl := gomock.NewController(t)
+
+	// Mock GAF Engine & Configuration (similar to scan_tool_test.go)
+	mockEngine := gaf_mocks.NewMockEngine(mockCtrl)
+	mockNetworkAccess := gaf_mocks.NewMockNetworkAccess(mockCtrl) // Create MockNetworkAccess
+	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
+	mockEngine.EXPECT().GetNetworkAccess().Return(mockNetworkAccess).AnyTimes()                  // Expect GetNetworkAccess call
+	mockNetworkAccess.EXPECT().GetUnauthorizedHttpClient().Return(http.DefaultClient).AnyTimes() // Expect GetUnauthorizedHttpClient call
+
+	// Add a mock storage, as it might be accessed via config.SetStorage in McpLLMBinding or its dependencies
+	mockStorage := gaf_mocks.NewMockStorage(mockCtrl)
+	engineConfig.SetStorage(mockStorage)
+
+	// Mock InvocationContext (similar to scan_tool_test.go)
+	logger := zerolog.New(io.Discard) // Discard logs for cleaner test output
+	mockInvCtx := gaf_mocks.NewMockInvocationContext(mockCtrl)
+	mockInvCtx.EXPECT().GetConfiguration().Return(engineConfig).AnyTimes()
+	mockInvCtx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+	mockInvCtx.EXPECT().GetEngine().Return(mockEngine).AnyTimes() // Needed for InitLearnService
+
+	// Mock Learn Service
+	mockLearnSvc := mock_learn.NewMockService(mockCtrl)
+
+	// Define a test-specific factory that returns the mockLearnSvc
+	testLearnServiceFactory := func(invCtx workflow.InvocationContext, testLogger *zerolog.Logger) learn.Service {
+		return mockLearnSvc
+	}
+
+	// Initialize McpLLMBinding (as done in scan_tool_test.go for its fixture)
+	// We don't need a real CLI path for these tests as learn tools don't directly call CLI.
+
+	// fixtureRefForClosure is used to allow the mockOpenBrowser closure to refer to the fixture instance
+	// once it's fully initialized.
+	var fixtureRefForClosure **learnTestFixture
+	mockOpenBrowser := func(url string) {
+		if fixtureRefForClosure != nil && *fixtureRefForClosure != nil {
+			(*fixtureRefForClosure).capturedOpenURL = url
+		}
+	}
+
+	binding := NewMcpLLMBinding(
+		WithLogger(&logger),
+		WithOpenBrowserFunc(mockOpenBrowser),
+		WithLearnServiceFactory(testLearnServiceFactory), // Use the test factory
+	)
+	binding.mcpServer = server.NewMCPServer("Snyk", "test-version") // Basic server for registration
+	// Manually set learnService using the factory, simulating McpLLMBinding.Start() behavior
+	// This ensures m.learnService is populated before addSnykTools is called.
+	if binding.learnServiceFactory != nil {
+		binding.learnService = binding.learnServiceFactory(mockInvCtx, &logger)
+	} else {
+		// Fallback or error if factory somehow wasn't set (should not happen with current NewMcpLLMBinding)
+		t.Fatal("learnServiceFactory was not set on binding")
+	}
+
+	// Ensure the learnService on the binding is indeed our mock for sanity
+	if _, ok := binding.learnService.(*mock_learn.MockService); !ok {
+		t.Fatalf("binding.learnService is not the mock instance, type is %T", binding.learnService)
+	}
+	binding.folderTrust = trust.NewFolderTrust(&logger, engineConfig) // Initialize folderTrust
+
+	// Load SnykMcpTools (tool definitions from JSON)
+	// This function is defined in mcp_extension/scan_tool.go
+	loadedTools, err := loadMcpToolsFromJson()
+	require.NoError(t, err, "Failed to load SnykMcpTools from JSON")
+
+	currentFixture := &learnTestFixture{
+		t:                t,
+		mockCtrl:         mockCtrl,
+		mockEngine:       mockEngine,
+		mockInvCtx:       mockInvCtx,
+		mockLearnService: mockLearnSvc,
+		binding:          binding,
+		loadedTools:      loadedTools,
+	}
+	// Point fixtureRefForClosure to the address of currentFixture
+	fixtureRefForClosure = &currentFixture
+
+	// Call InitLearnService to ensure globalLearnService is set up if any part of the binding relies on it
+	// even if we override globalLearnService directly for handler tests.
+	// This also starts the cache maintenance goroutine if the real InitLearnService is called.
+	// For handler unit tests, directly using the mocked globalLearnService is primary.
+	// However, McpLLMBinding.Start calls InitLearnService. If we were testing Start, this would be critical.
+	// For now, ensure the mock is in place.
+	// The InitLearnService in learn_tool.go will use the globalLearnService we just set if it's called.
+	// Let's ensure our mock is used by InitLearnService if it were to be called by the binding logic under test.
+	// The most direct way for handler tests is that the handlers *themselves* use the global var.
+	// InitLearnService(currentFixture.mockInvCtx, &logger) // This call overwrites the globalLearnService mock. Removing it.
+
+	// Add Snyk tools to the binding's MCP server.
+	// This step is crucial for the binding to know about the tools and their handlers.
+	// The handlers for learn tools (snykGetAllLearnLessonsHandler, snykOpenLearnLessonHandler)
+	// are methods on McpLLMBinding and will be registered here.
+	err = currentFixture.binding.addSnykTools(currentFixture.mockInvCtx)
+	require.NoError(t, err, "binding.addSnykTools failed")
+
+	return currentFixture
+}
+
+func TestSnykGetAllLearnLessonsHandler_SuccessfulRetrieval(t *testing.T) {
+	fixture := setupLearnTestFixture(t)
+	toolName := SnykGetAllLearnLessons // Constant defined in scan_tool.go
+	toolDef := getToolWithName(t, fixture.loadedTools, toolName)
+	require.NotNil(t, toolDef, "Tool definition for %s not found", toolName)
+
+	// Prepare mock lessons
+	mockLessons := []learn.Lesson{
+		{Title: "Lesson 1", Description: "Desc 1", Ecosystems: []string{"js", "ts"}},
+		{Title: "Lesson 2", Description: "This course is no longer supported.", Ecosystems: []string{"java"}},
+		{Title: "Lesson 3", Description: "Desc 3", Ecosystems: []string{"go"}},
+	}
+	expectedOutputLessons := []LessonOutput{ // LessonOutput is defined in learn_tool.go
+		{Title: "Lesson 1", Description: "Desc 1", Ecosystems: "js & ts"},
+		{Title: "Lesson 3", Description: "Desc 3", Ecosystems: "go"},
+	}
+
+	fixture.mockLearnService.EXPECT().GetAllLessons().Return(mockLessons, nil).Times(1)
+
+	// Create request (no arguments needed for this tool)
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{},
+		},
+	}
+
+	// Get the handler
+	handler := fixture.binding.snykGetAllLearnLessonsHandler(fixture.mockInvCtx, *toolDef)
+
+	// Call the handler
+	result, err := handler(context.Background(), request)
+
+	// Assertions
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1, "Expected one content item in the result")
+
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok, "Expected result content to be mcp.TextContent")
+
+	var actualOutputLessons []LessonOutput
+	err = json.Unmarshal([]byte(textContent.Text), &actualOutputLessons)
+	require.NoError(t, err, "Failed to unmarshal result text into []LessonOutput")
+
+	require.Equal(t, expectedOutputLessons, actualOutputLessons, "Output lessons do not match expected lessons")
+}
+
+func TestSnykOpenLearnLessonHandler_SuccessfulOpening(t *testing.T) {
+	fixture := setupLearnTestFixture(t)
+	toolName := SnykOpenLearnLesson // Constant defined in scan_tool.go
+	toolDef := getToolWithName(t, fixture.loadedTools, toolName)
+	require.NotNil(t, toolDef, "Tool definition for %s not found", toolName)
+
+	lessonTitleToOpen := "Found Lesson"
+	lessonURL := "http://example.com/found"
+	mockLessons := []learn.Lesson{
+		{Title: "Another Lesson", Url: "http://example.com/another"},
+		{Title: lessonTitleToOpen, Url: lessonURL, Ecosystems: []string{"js"}},
+	}
+
+	fixture.mockLearnService.EXPECT().GetAllLessons().Return(mockLessons, nil).Times(1)
+
+	fixture.capturedOpenURL = "" // Reset before the call
+
+	// Create request
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"lessonTitle": lessonTitleToOpen,
+			},
+		},
+	}
+
+	// Get the handler
+	handler := fixture.binding.snykOpenLearnLessonHandler(fixture.mockInvCtx, *toolDef)
+
+	// Call the handler
+	result, err := handler(context.Background(), request)
+
+	// Assertions
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1, "Expected one content item in the result")
+
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok, "Expected result content to be mcp.TextContent")
+
+	expectedMessage := "Successfully requested to open lesson: " + lessonTitleToOpen
+	require.Equal(t, expectedMessage, textContent.Text)
+
+	// Assert that the mock open browser function was called with the correct URL
+	require.True(t, strings.HasPrefix(fixture.capturedOpenURL, lessonURL), "Opened URL should start with the base lesson URL. Got: %s", fixture.capturedOpenURL)
+	require.True(t, strings.Contains(fixture.capturedOpenURL, "loc=ide"), "Opened URL should contain 'loc=ide'. Got: %s", fixture.capturedOpenURL)
+
+	// Test URL construction when original URL has query params
+	lessonURLWithQuery := "http://example.com/found?param=true"
+	mockLessonsWithQuery := []learn.Lesson{
+		{Title: lessonTitleToOpen, Url: lessonURLWithQuery, Ecosystems: []string{"js"}},
+	}
+	fixture.mockLearnService.EXPECT().GetAllLessons().Return(mockLessonsWithQuery, nil).Times(1)
+	fixture.capturedOpenURL = "" // Reset for next call
+
+	_, err = handler(context.Background(), request) // Call handler again with new mock setup
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(fixture.capturedOpenURL, lessonURLWithQuery), "Opened URL should start with the base lesson URL with query. Got: %s", fixture.capturedOpenURL)
+	require.True(t, strings.Contains(fixture.capturedOpenURL, "loc=ide"), "Opened URL should contain 'loc=ide'. Got: %s", fixture.capturedOpenURL)
+	require.True(t, strings.Contains(fixture.capturedOpenURL, "&loc=ide"), "Opened URL should append with '&loc=ide' when query params exist. Got: %s", fixture.capturedOpenURL)
+}

--- a/mcp_extension/llm_binding_test.go
+++ b/mcp_extension/llm_binding_test.go
@@ -202,7 +202,7 @@ func TestMiddleware(t *testing.T) {
 		sseServer := server.NewSSEServer(mcpServer)
 		handler := middleware(sseServer)
 
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Host = "localhost"
 		req.Header.Set("Origin", "http://localhost:3000")
 
@@ -218,7 +218,7 @@ func TestMiddleware(t *testing.T) {
 		sseServer := server.NewSSEServer(mcpServer)
 		handler := middleware(sseServer)
 
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Host = "example.com"
 		req.Header.Set("Origin", "http://example.com")
 
@@ -241,7 +241,8 @@ func TestHandleStdioServer(t *testing.T) {
 			go func() {
 				defer func() {
 					if r := recover(); r != nil {
-						// Expected to panic due to nil mcpServer, this is fine
+						// Expected to panic due to nil mcpServer, this is fine for testing
+						_ = r // Explicitly ignore the recovered value
 					}
 				}()
 				_ = binding.HandleStdioServer()

--- a/mcp_extension/options.go
+++ b/mcp_extension/options.go
@@ -20,6 +20,11 @@ import (
 	"net/url"
 
 	"github.com/rs/zerolog"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 type Option func(server *McpLLMBinding)
@@ -40,5 +45,23 @@ func WithCliPath(cliPath string) Option {
 func WithBaseURL(baseURL *url.URL) func(server *McpLLMBinding) {
 	return func(server *McpLLMBinding) {
 		server.baseURL = baseURL
+	}
+}
+
+func WithOpenBrowserFunc(fn types.OpenBrowserFunc) Option {
+	return func(server *McpLLMBinding) {
+		server.openBrowserFunc = fn
+	}
+}
+
+// LearnServiceFactoryFunc defines the signature for a function that can create a learn.Service.
+type LearnServiceFactoryFunc func(invocationContext workflow.InvocationContext, logger *zerolog.Logger) learn.Service
+
+// WithLearnServiceFactory provides an option to set a custom factory for creating the learn.Service.
+func WithLearnServiceFactory(factory LearnServiceFactoryFunc) Option {
+	return func(server *McpLLMBinding) {
+		if factory != nil {
+			server.learnServiceFactory = factory
+		}
 	}
 }

--- a/mcp_extension/scan_tool.go
+++ b/mcp_extension/scan_tool.go
@@ -32,13 +32,15 @@ import (
 
 // Tool name constants to maintain backward compatibility
 const (
-	SnykScaTest    = "snyk_sca_scan"
-	SnykCodeTest   = "snyk_code_scan"
-	SnykVersion    = "snyk_version"
-	SnykAuth       = "snyk_auth"
-	SnykAuthStatus = "snyk_auth_status"
-	SnykLogout     = "snyk_logout"
-	SnykTrust      = "snyk_trust"
+	SnykScaTest            = "snyk_sca_scan"
+	SnykCodeTest           = "snyk_code_scan"
+	SnykVersion            = "snyk_version"
+	SnykAuth               = "snyk_auth"
+	SnykAuthStatus         = "snyk_auth_status"
+	SnykLogout             = "snyk_logout"
+	SnykTrust              = "snyk_trust"
+	SnykGetAllLearnLessons = "snyk_get_all_learn_lessons"
+	SnykOpenLearnLesson    = "snyk_open_learn_lesson"
 )
 
 type SnykMcpToolsDefinition struct {
@@ -91,6 +93,10 @@ func (m *McpLLMBinding) addSnykTools(invocationCtx workflow.InvocationContext) e
 			m.mcpServer.AddTool(tool, m.snykLogoutHandler(invocationCtx, toolDef))
 		case SnykTrust:
 			m.mcpServer.AddTool(tool, m.snykTrustHandler(invocationCtx, toolDef))
+		case SnykGetAllLearnLessons:
+			m.mcpServer.AddTool(tool, m.snykGetAllLearnLessonsHandler(invocationCtx, toolDef))
+		case SnykOpenLearnLesson:
+			m.mcpServer.AddTool(tool, m.snykOpenLearnLessonHandler(invocationCtx, toolDef))
 		default:
 			m.mcpServer.AddTool(tool, m.defaultHandler(invocationCtx, toolDef))
 		}

--- a/mcp_extension/scan_tool.go
+++ b/mcp_extension/scan_tool.go
@@ -93,8 +93,6 @@ func (m *McpLLMBinding) addSnykTools(invocationCtx workflow.InvocationContext) e
 			m.mcpServer.AddTool(tool, m.snykLogoutHandler(invocationCtx, toolDef))
 		case SnykTrust:
 			m.mcpServer.AddTool(tool, m.snykTrustHandler(invocationCtx, toolDef))
-		case SnykGetAllLearnLessons:
-			m.mcpServer.AddTool(tool, m.snykGetAllLearnLessonsHandler(invocationCtx, toolDef))
 		case SnykOpenLearnLesson:
 			m.mcpServer.AddTool(tool, m.snykOpenLearnLessonHandler(invocationCtx, toolDef))
 		default:

--- a/mcp_extension/scan_tool.go
+++ b/mcp_extension/scan_tool.go
@@ -32,14 +32,14 @@ import (
 
 // Tool name constants to maintain backward compatibility
 const (
-	SnykScaTest            = "snyk_sca_scan"
-	SnykCodeTest           = "snyk_code_scan"
-	SnykVersion            = "snyk_version"
-	SnykAuth               = "snyk_auth"
-	SnykAuthStatus         = "snyk_auth_status"
-	SnykLogout             = "snyk_logout"
-	SnykTrust              = "snyk_trust"
-	SnykOpenLearnLesson    = "snyk_open_learn_lesson"
+	SnykScaTest         = "snyk_sca_scan"
+	SnykCodeTest        = "snyk_code_scan"
+	SnykVersion         = "snyk_version"
+	SnykAuth            = "snyk_auth"
+	SnykAuthStatus      = "snyk_auth_status"
+	SnykLogout          = "snyk_logout"
+	SnykTrust           = "snyk_trust"
+	SnykOpenLearnLesson = "snyk_open_learn_lesson"
 )
 
 type SnykMcpToolsDefinition struct {

--- a/mcp_extension/scan_tool.go
+++ b/mcp_extension/scan_tool.go
@@ -39,7 +39,6 @@ const (
 	SnykAuthStatus         = "snyk_auth_status"
 	SnykLogout             = "snyk_logout"
 	SnykTrust              = "snyk_trust"
-	SnykGetAllLearnLessons = "snyk_get_all_learn_lessons"
 	SnykOpenLearnLesson    = "snyk_open_learn_lesson"
 )
 

--- a/mcp_extension/snyk_tools.json
+++ b/mcp_extension/snyk_tools.json
@@ -1165,6 +1165,29 @@
           "description": "Path to the project folder to trust (default is the absolute path of the current directory, formatted according to the operating system's conventions)."
         }
       ]
+    },
+    {
+      "name": "snyk_get_all_learn_lessons",
+      "description": "Retrieves Snyk Learn lessons for all ecosystems / programming languages / build systems. It is the agent's responsibility to filter to only relevant lessons for the current ecosystem.",
+      "command": [],
+      "ignoreTrust": true,
+      "standardParams": [],
+      "params": []
+    },
+    {
+      "name": "snyk_open_learn_lesson",
+      "description": "Opens a Snyk Learn lesson in the browser for a given title.",
+      "command": [],
+      "ignoreTrust": true,
+      "standardParams": [],
+      "params": [
+        {
+          "name": "lessonTitle",
+          "type": "string",
+          "isRequired": true,
+          "description": "The exact title of the Snyk Learn lesson to open."
+        }
+      ]
     }
   ]
 }

--- a/mcp_extension/snyk_tools.json
+++ b/mcp_extension/snyk_tools.json
@@ -979,7 +979,6 @@
       ],
       "ignoreTrust": true,
       "params": [
-
         {
           "name": "file",
           "type": "string",
@@ -1113,7 +1112,9 @@
         "whoami"
       ],
       "ignoreTrust": true,
-      "standardParams": ["experimental"],
+      "standardParams": [
+        "experimental"
+      ],
       "params": []
     },
     {
@@ -1156,8 +1157,7 @@
       "command": [],
       "standardParams": [],
       "ignoreTrust": true,
-      "params":
-      [
+      "params": [
         {
           "name": "path",
           "type": "string",
@@ -1167,25 +1167,41 @@
       ]
     },
     {
-      "name": "snyk_get_all_learn_lessons",
-      "description": "Retrieves Snyk Learn lessons for all ecosystems / programming languages / build systems. It is the agent's responsibility to filter to only relevant lessons for the current ecosystem.",
-      "command": [],
-      "ignoreTrust": true,
-      "standardParams": [],
-      "params": []
-    },
-    {
       "name": "snyk_open_learn_lesson",
-      "description": "Opens a Snyk Learn lesson in the browser for a given title.",
+      "description": "Opens a Snyk Learn lesson in the browser. Offer this tool, when issues were found. When to use: after a user requests to open a learn lesson. The output from `snyk_sca_scan` and `snyk_code_scan` contain the information for the parameters. Else the user must specify the parameters for filtering.",
       "command": [],
       "ignoreTrust": true,
       "standardParams": [],
       "params": [
         {
-          "name": "lessonTitle",
+          "name": "issueType",
           "type": "string",
           "isRequired": true,
-          "description": "The exact title of the Snyk Learn lesson to open."
+          "description": "the issue type. allowed values: `sca`, `sast`"
+        },
+        {
+          "name": "cves",
+          "type": "string",
+          "isRequired": false,
+          "description": "the comma separated list of associated cve codes, empty if none (output from the scan tools or manually entered)"
+        },
+        {
+          "name": "cwes",
+          "type": "string",
+          "isRequired": false,
+          "description": "the comma separated list of associated cwe codes, empty if none (output from the scan tools or manually entered)"
+        },
+        {
+          "name": "rule",
+          "type": "string",
+          "isRequired": false,
+          "description": "the associated rule for a lesson (output from the scan tools or manually entered)"
+        },
+        {
+          "name": "ecosystem",
+          "type": "string",
+          "isRequired": false,
+          "description": "The ecosystem for which the lesson is searched (output from the scan tools or manually entered). Ecosystems mappings from input to parameter value: `\"js\":             \"javascript\",\n\t\"ts\":             \"javascript\",\n\t\"npm\":            \"javascript\",\n\t\"yarn\":           \"javascript\",\n\t\"yarn-workspace\": \"javascript\",\n\t\"typescript\":     \"javascript\",\n\t\"javascript\":     \"javascript\",\n\n\t\"maven\":  \"java\",\n\t\"gradle\": \"java\",\n\t\"java\":   \"java\",\n\n\t\"pip\":    \"python\",\n\t\"poetry\": \"python\",\n\t\"pipenv\": \"python\",\n\t\"python\": \"python\",\n\n\t\"nuget\":  \"csharp\",\n\t\"paket\":  \"csharp\",\n\t\"csharp\": \"csharp\",\n\n\t\"golangdep\": \"golang\",\n\t\"govendor\":  \"golang\",\n\t\"gomodules\": \"golang\",\n\t\"golang\":    \"golang\",\n\n\t\"composer\": \"php\",\n\t\"php\":      \"php\",\n\n\t\"rubygems\": \"ruby\",\n\t\"ruby\":     \"ruby\",\n\t\"hex\":      \"elixir\",\n\t\"elixir\":   \"elixir\",\n}`"
         }
       ]
     }

--- a/mcp_extension/snyk_tools.json
+++ b/mcp_extension/snyk_tools.json
@@ -1152,7 +1152,7 @@
           "name": "ecosystem",
           "type": "string",
           "isRequired": false,
-          "description": "The ecosystem for which the lesson is searched (output from the scan tools or manually entered). Ecosystems mappings from input to parameter value: `\"js\":             \"javascript\",\n\t\"ts\":             \"javascript\",\n\t\"npm\":            \"javascript\",\n\t\"yarn\":           \"javascript\",\n\t\"yarn-workspace\": \"javascript\",\n\t\"typescript\":     \"javascript\",\n\t\"javascript\":     \"javascript\",\n\n\t\"maven\":  \"java\",\n\t\"gradle\": \"java\",\n\t\"java\":   \"java\",\n\n\t\"pip\":    \"python\",\n\t\"poetry\": \"python\",\n\t\"pipenv\": \"python\",\n\t\"python\": \"python\",\n\n\t\"nuget\":  \"csharp\",\n\t\"paket\":  \"csharp\",\n\t\"csharp\": \"csharp\",\n\n\t\"golangdep\": \"golang\",\n\t\"govendor\":  \"golang\",\n\t\"gomodules\": \"golang\",\n\t\"golang\":    \"golang\",\n\n\t\"composer\": \"php\",\n\t\"php\":      \"php\",\n\n\t\"rubygems\": \"ruby\",\n\t\"ruby\":     \"ruby\",\n\t\"hex\":      \"elixir\",\n\t\"elixir\":   \"elixir\",\n}`"
+          "description": "The ecosystem for which the lesson is searched (output from the scan tools or manually entered). Ecosystems accepted values: `js`, `ts`, `npm`, `yarn`, `yarn-workspace`, `typescript`, `javascript`, `maven`, `gradle`, `java`, `pip`, `python`, `poetry`, `pipenv`, `nuget`, `csharp`, `paket`, `golang`, `dep`, `govendor`, `gomodules`, `composer`, `php`, `rubygems`, `ruby`, `hex`, `elixir`"
         }
       ]
     }


### PR DESCRIPTION
# 🚀 MCP Learn Tools Integration + Code Quality Improvements

## 📋 Overview
This PR introduces MCP (Model Context Protocol) integration with Snyk Learn tools, along with significant code quality improvements, UI enhancements for ignore functionality, and comprehensive testing additions. The changes span multiple components to provide a cohesive developer experience.

## ✨ Major Features Added

### 🔧 MCP Learn Tools Integration
- **`snyk_open_learn_lesson`** - Opens relevant Snyk Learn lessons in browser based on vulnerability context
- **Smart parameter handling** - Supports CVEs, CWEs, rules, ecosystems, and issue types  
- **Ecosystem mapping** - Automatic translation between package managers and learn ecosystems
- **URL enhancement** - Adds IDE context parameters for better lesson targeting
- **Factory pattern implementation** - Clean dependency injection for learn service

### 📋 Development Experience Enhancements
- **Cursor Rules file** - Complete development guidelines for the project
- **Type safety improvements** - Added `OpenBrowserFunc` type definition

## 🐛 Critical Bug Fixes

### Learn Service Improvements
- **Fixed `updateCaches()` return value** - Now returns filtered lessons instead of `nil`
- **Enhanced lesson filtering** - Removes unsupported lessons based on description text
- **Resolved empty lesson list bug** - `GetAllLessons()` now returns actual results
- **Simplified ecosystem handling** - Removed redundant npm->javascript mapping

### Code Quality & Testing
- **81.9% test coverage** across MCP extension package
- **560+ lines of comprehensive tests** - Edge cases, error scenarios, mock integration
- **Linting compliance** - Fixed HTTP method constants, empty branches, unused variables
- **Reduced cyclomatic complexity** - Extracted helper functions for maintainability

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [x] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A


[IDE-1213]: https://snyksec.atlassian.net/browse/IDE-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ