### PR TITLE
fix: update IAW wording to match web UI [IDE-1151]

### DIFF
--- a/infrastructure/code/code_html.go
+++ b/infrastructure/code/code_html.go
@@ -257,7 +257,7 @@ func prepareIgnoreDetailsRow(ignoreDetails *types.IgnoreDetails) []IgnoreDetail 
 		{"Ignored On", formatDate(ignoreDetails.IgnoredOn)},
 		{"Ignored By", ignoreDetails.IgnoredBy},
 		{"Reason", ignoreDetails.Reason},
-		{"Status", string(ignoreDetails.Status)},
+		{"Status", parseStatus(ignoreDetails.Status)},
 	}
 }
 
@@ -272,6 +272,19 @@ func parseCategory(category string) string {
 		return result
 	}
 	return category
+}
+
+func parseStatus(status codeClientSarif.SuppresionStatus) string {
+	statusMap := map[codeClientSarif.SuppresionStatus]string{
+		codeClientSarif.UnderReview: "Pending",
+		codeClientSarif.Accepted:    "Approved",
+		codeClientSarif.Rejected:    "Rejected",
+	}
+
+	if result, ok := statusMap[status]; ok {
+		return result
+	}
+	return string(status)
 }
 
 func prepareDataFlowTable(issue snyk.CodeIssueData) ([]string, map[string][]DataFlowItem) {

--- a/infrastructure/code/template/details.html
+++ b/infrastructure/code/template/details.html
@@ -391,7 +391,7 @@
     <div class="sn-field">
       <div class="sn-label">Expiration</div>
       <select class="sn-select" id="ignore-form-expiration-type">
-        <option value="do-not-expire">Do not expire</option>
+        <option value="never">Never</option>
         <option value="custom-expiration-date">Custom expiration date</option>
       </select>
       <input class="sn-input hidden" id="ignore-form-expiration-date" type="date" value="{{.ExpirationDate}}">

--- a/infrastructure/code/template/scripts.js
+++ b/infrastructure/code/template/scripts.js
@@ -222,7 +222,7 @@ if (ignoreFormContainer !== null && ignoreFormContainer !== void 0 && ignoreCrea
   var ignoreFormExpirationType = document.getElementById('ignore-form-expiration-type');
   var ignoreFormExpirationDate = document.getElementById('ignore-form-expiration-date');
   ignoreFormExpirationType.addEventListener('change', function(event) {
-    if (event.target.value === 'do-not-expire') {
+    if (event.target.value === 'never') {
       toggleElement(ignoreFormExpirationDate, 'hide');
     } else {
       toggleElement(ignoreFormExpirationDate, 'show');


### PR DESCRIPTION
### Description

"Expiration" "Do not expire" should be "Never".
Status should match the web UI e.g. (`underReview` should be "Pending")

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
