### PR TITLE
chore(MCP): remove monitor and sbom tools

### DIFF
--- a/mcp_extension/snyk_tools.json
+++ b/mcp_extension/snyk_tools.json
@@ -578,7 +578,7 @@
         {
           "name": "json_file_output",
           "type": "string",
-          "description": "Saves the AIBOM output as a JSON data structure to the specified file path. The target directory must exist and be writable. Only use this parameter if explicitly instructed to use it."
+          "description": "Saves the AIBOM output as a JSON data structure to the specified file path. The target directory must exist and be writable."
         }
       ]
     },


### PR DESCRIPTION
### Description
* Removed `monitor` `sbom` and `policy` tools
* Removed `sarif_file_output` and `json_file_output` since in my last tests with Claude and Gemini they were almost always used to persist results even when instructed not to do so. Except for AIBom since it might be necessary to persist it there.

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
