### PR TITLE
feat: send analytics on org change [IDE-880]

### DIFF
--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -289,7 +289,6 @@ func updateOrganization(c *config.Config, settings types.Settings) {
 		if oldOrgId != newOrgId {
 			go sendConfigChangedAnalyticsEvent(c, "organization", oldOrgId, newOrgId, "")
 		}
-
 	}
 }
 

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -281,9 +281,15 @@ func updateApiEndpoints(c *config.Config, settings types.Settings, initializatio
 }
 
 func updateOrganization(c *config.Config, settings types.Settings) {
-	org := strings.TrimSpace(settings.Organization)
-	if org != "" {
-		c.SetOrganization(org)
+	newOrg := strings.TrimSpace(settings.Organization)
+	if newOrg != "" {
+		oldOrgId := c.Organization()
+		c.SetOrganization(newOrg)
+		newOrgId := c.Organization() // Read the org from config so we are guaranteed to have a UUID instead of a slug.
+		if oldOrgId != newOrgId {
+			go sendConfigChangedAnalyticsEvent(c, "organization", oldOrgId, newOrgId, "")
+		}
+
 	}
 }
 
@@ -423,9 +429,8 @@ func sendConfigChangedAnalyticsEvent(c *config.Config, field string, oldValue, n
 	event := analytics.NewAnalyticsEventParam("Config changed", nil, path)
 
 	event.Extension = map[string]any{
-		"configuration": field,
-		"oldValue":      oldValue,
-		"newValue":      newValue,
+		"config::" + field + "::oldValue": oldValue,
+		"config::" + field + "::newValue": newValue,
 	}
 	analytics.SendAnalytics(c, event, nil)
 }

--- a/infrastructure/analytics/analytics.go
+++ b/infrastructure/analytics/analytics.go
@@ -43,6 +43,8 @@ func NewAnalyticsEventParam(interactionType string, err error, path types.FilePa
 	}
 
 	var targetId string
+	// If we have a file path, we use that to determine the target ID. For analytics such as authentication events, which
+	// are not associated with a file, we use the binary name as the target ID (with a fallback if that fails).
 	if path != "" {
 		targetId, _ = instrumentation.GetTargetId(string(path), instrumentation.AutoDetectedTargetId)
 	} else {

--- a/infrastructure/analytics/analytics.go
+++ b/infrastructure/analytics/analytics.go
@@ -18,6 +18,7 @@ package analytics
 
 import (
 	"encoding/json"
+	"os"
 	"sync"
 	"time"
 
@@ -40,7 +41,16 @@ func NewAnalyticsEventParam(interactionType string, err error, path types.FilePa
 	if err != nil {
 		status = string(analytics.Failure)
 	}
-	targetId, _ := instrumentation.GetTargetId(string(path), instrumentation.AutoDetectedTargetId)
+
+	var targetId string
+	if path != "" {
+		targetId, _ = instrumentation.GetTargetId(string(path), instrumentation.AutoDetectedTargetId)
+	} else {
+		targetId, _ = instrumentation.GetTargetId(os.Args[0], instrumentation.FilesystemTargetId)
+		if targetId == "" {
+			targetId = "pkg:filesystem/dummy/dummy"
+		}
+	}
 
 	return types.AnalyticsEventParam{
 		InteractionType: interactionType,

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -128,6 +128,8 @@ func (a *AuthenticationServiceImpl) authenticate(ctx context.Context) (token str
 
 func (a *AuthenticationServiceImpl) sendAuthenticationAnalytics() {
 	event := analytics2.NewAnalyticsEventParam("authenticated", nil, "")
+	// Add the authentication details in the extension fields. We only send the method name; we must not include any
+	// authentication tokens.
 	event.Extension = map[string]any{
 		"auth::auth-type": string(a.c.AuthenticationMethod()),
 	}

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -21,18 +21,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/snyk/go-application-framework/pkg/configuration"
-	"github.com/snyk/go-application-framework/pkg/instrumentation"
-
 	"github.com/erni27/imcache"
 	"github.com/rs/zerolog"
-	"github.com/snyk/go-application-framework/pkg/analytics"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	sglsp "github.com/sourcegraph/go-lsp"
 	"golang.org/x/oauth2"
 
@@ -131,19 +127,10 @@ func (a *AuthenticationServiceImpl) authenticate(ctx context.Context) (token str
 }
 
 func (a *AuthenticationServiceImpl) sendAuthenticationAnalytics() {
-	id, err2 := instrumentation.GetTargetId(os.Args[0], instrumentation.FilesystemTargetId)
-	if err2 != nil {
-		id = "pkg:filesystem/dummy/dummy"
+	event := analytics2.NewAnalyticsEventParam("authenticated", nil, "")
+	event.Extension = map[string]any{
+		"auth::auth-type": string(a.c.AuthenticationMethod()),
 	}
-	event := types.AnalyticsEventParam{
-		InteractionType: "authenticated",
-		Extension:       map[string]any{"auth::auth-type": string(a.c.AuthenticationMethod())},
-		Category:        []string{},
-		Status:          string(analytics.Success),
-		TargetId:        id,
-		TimestampMs:     time.Now().UnixMilli(),
-	}
-
 	analytics2.SendAnalytics(a.c, event, nil)
 }
 


### PR DESCRIPTION
### Description

Simplified Analytics Event Creation - Event creation now supports creating a target ID for a particular file, or for an instance of the Language server. This means that places in the code that send analytics just need to call the helper method to create a new event, then add their specific extension field.

Added analytics for Org changes: Uses the new mechanism to create an analytics event, then populates the extension with the old and new org values. Note that we use the Org UUIDs rather than the slug names.


### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
