### PR TITLE
chore: use ImmutableDefaultValueFunction instead of CB fn [CLI-965]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -263,9 +263,7 @@ func newConfig(engine workflow.Engine) *Config {
 		c.engine = engine
 	}
 	gafConfig := c.engine.GetConfiguration()
-	gafConfig.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue interface{}) (interface{}, error) {
-		return true, nil
-	})
+	gafConfig.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, configuration.ImmutableDefaultValueFunction(true))
 	gafConfig.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 	gafConfig.Set("configfile", c.configFile)
 	c.deviceId = c.determineDeviceId()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/snyk/snyk-ls
 
-go 1.23.8
+go 1.24
+
+toolchain go1.24.5
 
 require (
 	github.com/adrg/strutil v0.3.1
@@ -27,7 +29,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/snyk/code-client-go v1.22.3
-	github.com/snyk/go-application-framework v0.0.0-20250723170126-556d18b1b13f
+	github.com/snyk/go-application-framework v0.0.0-20250805115432-96f4ad97cd27
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/snyk/code-client-go v1.22.3 h1:xDT/SHwHd6ondz0uEiysoc7S6b9L1NMeWUIH7u
 github.com/snyk/code-client-go v1.22.3/go.mod h1:Jx3Jpo8kHlqHjhGa7a0ROQzPu+X15TBN0zRD+wNcUds=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250625135845-2d6f9a31f318 h1:2bNOlUstBBWHa3doBvdOBlMSu8AC01IHyNexT9MoKiM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250625135845-2d6f9a31f318/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20250723170126-556d18b1b13f h1:1kOY4VVXkusmfauEX0AEU5mWgyjkV6M28VtBulpq13s=
-github.com/snyk/go-application-framework v0.0.0-20250723170126-556d18b1b13f/go.mod h1:1Er3gtOGkvSQU6hA2RXQXJoximomPaksC6vwHlj/XQI=
+github.com/snyk/go-application-framework v0.0.0-20250805115432-96f4ad97cd27 h1:wY7G9tIU1u2C/NxTRBP1eza1/Ju4Cyi7wYaBkt7Ss8s=
+github.com/snyk/go-application-framework v0.0.0-20250805115432-96f4ad97cd27/go.mod h1:QnT6WoIaMq7tbleWR0cKTmKWGPBPeYF/HcHRLBLq08M=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
### Description

This PR uses the `ImmutableDefaultValueFunction` method instead of passing a custom callback, which will break <s>once https://github.com/snyk/go-application-framework/pull/392 is merged</s>.

Edit: Now https://github.com/snyk/go-application-framework/pull/394
