### PR TITLE
fix(test): flaky server test

### DIFF
--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -869,10 +869,10 @@ func Test_textDocumentDidOpenHandler_shouldPublishIfCached(t *testing.T) {
 	filePath, fileDir := code.TempWorkdirWithIssues(t)
 	fileUri := sendFileSavedMessage(t, filePath, fileDir, loc)
 
-	assert.Eventually(
+	require.Eventually(
 		t,
 		checkForPublishedDiagnostics(t, c, uri.PathFromUri(fileUri), 1, jsonRPCRecorder),
-		time.Second,
+		5*time.Second,
 		time.Millisecond,
 	)
 
@@ -1012,7 +1012,7 @@ func checkForPublishedDiagnostics(t *testing.T, c *config.Config, testPath types
 			_ = n.UnmarshalParams(&diagnosticsParams)
 			if diagnosticsParams.URI == uri.PathToUri(testPath) {
 				f := w.GetFolderContaining(testPath)
-				hasExpectedDiagnostics := f != nil && (expectedNumber == -1 && len(diagnosticsParams.Diagnostics) > 0) || (len(diagnosticsParams.Diagnostics) == expectedNumber)
+				hasExpectedDiagnostics := f != nil && ((expectedNumber == -1 && len(diagnosticsParams.Diagnostics) > 0) || (len(diagnosticsParams.Diagnostics) == expectedNumber))
 				if hasExpectedDiagnostics {
 					return true
 				}


### PR DESCRIPTION
### Description

`Test_textDocumentDidOpenHandler_shouldPublishIfCached` had the logical operation precedent wrong and wasn't waiting long enough.
Example: https://github.com/snyk/snyk-ls/actions/runs/16751012822/job/47422442770?pr=953

### Checklist

- [x] Tests added and all succeed
 - Test fixed.
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
