### PR TITLE
fix: wip determine env and PATH

### DIFF
--- a/application/di/init.go
+++ b/application/di/init.go
@@ -17,15 +17,11 @@
 package di
 
 import (
-	"path/filepath"
-	"runtime"
 	"sync"
 
 	"github.com/snyk/snyk-ls/domain/scanstates"
 	"github.com/snyk/snyk-ls/domain/snyk/persistence"
 	"github.com/snyk/snyk-ls/internal/types"
-
-	"github.com/adrg/xdg"
 
 	codeClient "github.com/snyk/code-client-go"
 	codeClientHTTP "github.com/snyk/code-client-go/http"
@@ -98,25 +94,6 @@ func initDomain(c *config.Config) {
 }
 
 func initInfrastructure(c *config.Config) {
-	//goland:noinspection GoBoolExpressions
-	if runtime.GOOS == "windows" {
-		go c.AddBinaryLocationsToPath([]string{
-			"C:\\Program Files",
-			"C:\\Program Files (x86)",
-		})
-	} else {
-		go c.AddBinaryLocationsToPath(
-			[]string{
-				filepath.Join(xdg.Home, ".sdkman"),
-				"/usr/lib",
-				"/usr/java",
-				"/usr/local/bin",
-				"/opt/homebrew/bin",
-				"/opt",
-				"/Library",
-			})
-	}
-
 	engine := c.Engine()
 	gafConfiguration := engine.GetConfiguration()
 	// init NetworkAccess

--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -276,6 +276,8 @@ func (cliScanner *CLIScanner) prepareScanCommand(args []string, parameterBlackli
 	allProjectsParamAllowed := true
 	allProjectsParam := "--all-projects"
 
+	<-cliScanner.config.PrepareDefaultEnvChannel()
+
 	cmd := cliScanner.cli.ExpandParametersFromConfig([]string{
 		cliScanner.config.CliSettings().Path(),
 		"test",

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -40,6 +40,7 @@ func UpdateEnvironmentAndReturnAdditionalParams(c *config.Config, sdks []types.L
 		switch {
 		case strings.Contains(strings.ToLower(sdk.Type), "java"):
 			env["JAVA_HOME"] = path
+			pathExt = filepath.Dir(path)
 		case strings.Contains(strings.ToLower(sdk.Type), "python"):
 			pathExt = filepath.Dir(path)
 			additionalParameters = append(additionalParameters, "--command="+path)


### PR DESCRIPTION
### Description

GAF change as well:
```go
// LoadConfiguredEnvironment updates the environment with local configuration. Precedence as follows:
//  1. std folder-based config files
//  2. given command-line parameter config file
//  3. std config file in home directory
//  4. global shell configuration
//
// VVV NEW COMMENT HERE VVV
// Any PATH will be appended to the current PATH.
// ^^^ NEW COMMENT HERE ^^^
func LoadConfiguredEnvironment(customConfigFiles []string, workingDirectory string) {
	bashOutput := getEnvFromShell("bash")

	// this is applied at the end always, as it does not overwrite existing variables
	defer func() { _ = gotenv.Apply(strings.NewReader(bashOutput)) }() //nolint:errcheck // we can't do anything with the error

	env := gotenv.Parse(strings.NewReader(bashOutput))
	specificShell, ok := env["SHELL"]
	if ok {
		fromSpecificShell := getEnvFromShell(specificShell)
		_ = gotenv.Apply(strings.NewReader(fromSpecificShell)) //nolint:errcheck // we can't do anything with the error

		// VVV NEW CODE HERE VVV
		env = gotenv.Parse(strings.NewReader(fromSpecificShell))
		if val, ok := env["PATH"]; ok {
			UpdatePath(val, false)
		}
		// ^^^ NEW CODE HERE ^^^
	}

	// process config files
	for _, file := range customConfigFiles {
		if !filepath.IsAbs(file) {
			file = filepath.Join(workingDirectory, file)
		}
		loadFile(file)
	}
}
```

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
