### PR TITLE
refactor(test): reduce usage of `CurrentConfig()` [IDE-1314]

### DIFF
--- a/application/server/execute_command_test.go
+++ b/application/server/execute_command_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/ide/workspace"
@@ -113,7 +112,7 @@ func Test_executeWorkspaceScanCommand_shouldAskForTrust(t *testing.T) {
 	s := &scanner.TestScanner{}
 	c.Workspace().AddFolder(workspace.NewFolder(c, "dummy", "dummy", s, di.HoverService(), di.ScanNotifier(), di.Notifier(), di.ScanPersister(), di.ScanStateAggregator()))
 	// explicitly enable folder trust which is disabled by default in tests
-	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	c.SetTrustedFolderFeatureEnabled(true)
 
 	params := sglsp.ExecuteCommandParams{Command: types.WorkspaceScanCommand}
 	_, err := loc.Client.Call(ctx, "workspace/executeCommand", params)
@@ -132,7 +131,7 @@ func Test_executeWorkspaceScanCommand_shouldAcceptScanSourceParam(t *testing.T) 
 	s := &scanner.TestScanner{}
 	c.Workspace().AddFolder(workspace.NewFolder(c, "dummy", "dummy", s, di.HoverService(), di.ScanNotifier(), di.Notifier(), di.ScanPersister(), di.ScanStateAggregator()))
 	// explicitly enable folder trust which is disabled by default in tests
-	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	c.SetTrustedFolderFeatureEnabled(true)
 
 	params := sglsp.ExecuteCommandParams{Command: types.WorkspaceScanCommand, Arguments: []any{"LLM"}}
 	_, err := loc.Client.Call(ctx, "workspace/executeCommand", params)

--- a/domain/ide/command/code_fix_test.go
+++ b/domain/ide/command/code_fix_test.go
@@ -53,7 +53,8 @@ func setupClientCapability(config *config.Config) {
 	config.SetClientCapabilities(clientCapabilties)
 }
 
-func setupCommand(mockNotifier *notification.MockNotifier) *fixCodeIssue {
+func setupCommand(t *testing.T, c *config.Config, mockNotifier *notification.MockNotifier) *fixCodeIssue {
+	t.Helper()
 	cmdData := types.CommandData{
 		CommandId: types.CodeFixCommand,
 		Arguments: sampleArgs,
@@ -61,7 +62,7 @@ func setupCommand(mockNotifier *notification.MockNotifier) *fixCodeIssue {
 	cmd := &fixCodeIssue{
 		command:  cmdData,
 		notifier: mockNotifier,
-		logger:   config.CurrentConfig().Logger(),
+		logger:   c.Logger(),
 	}
 	return cmd
 }
@@ -122,7 +123,7 @@ func Test_fixCodeIssue_sendsSuccessfulEdit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockNotifier := notification.NewMockNotifier()
-	cmd := setupCommand(mockNotifier)
+	cmd := setupCommand(t, c, mockNotifier)
 
 	filePath := sampleArgs[1].(string)
 	path := types.FilePath(filePath)
@@ -162,7 +163,7 @@ func Test_fixCodeIssue_noEdit(t *testing.T) {
 	setupClientCapability(c)
 
 	mockNotifier := notification.NewMockNotifier()
-	cmd := setupCommand(mockNotifier)
+	cmd := setupCommand(t, c, mockNotifier)
 
 	filePath := sampleArgs[1].(string)
 	path := types.FilePath(filePath)
@@ -206,7 +207,7 @@ func Test_fixCodeIssue_NoIssueFound(t *testing.T) {
 	setupClientCapability(c)
 
 	mockNotifier := notification.NewMockNotifier()
-	cmd := setupCommand(mockNotifier)
+	cmd := setupCommand(t, c, mockNotifier)
 
 	issueProviderMock := mock_snyk.NewMockIssueProvider(ctrl)
 	issueProviderMock.EXPECT().Issues().Return(snyk.IssuesByFile{})

--- a/infrastructure/authentication/cli_provider_test.go
+++ b/infrastructure/authentication/cli_provider_test.go
@@ -114,7 +114,7 @@ func TestBuildCLICmd(t *testing.T) {
 		c := testutil.UnitTest(t)
 		ctx := t.Context()
 		provider := &CliAuthenticationProvider{c: c}
-		config.CurrentConfig().SetCliSettings(&config.CliSettings{
+		c.SetCliSettings(&config.CliSettings{
 			Insecure: true,
 			C:        c,
 		})
@@ -128,7 +128,7 @@ func TestBuildCLICmd(t *testing.T) {
 		c := testutil.UnitTest(t)
 		ctx := t.Context()
 		provider := &CliAuthenticationProvider{c: c}
-		config.CurrentConfig().UpdateApiEndpoints("https://api.eu.snyk.io")
+		c.UpdateApiEndpoints("https://api.eu.snyk.io")
 
 		cmd := provider.buildCLICmd(ctx, "auth")
 

--- a/infrastructure/cli/install/downloader_test.go
+++ b/infrastructure/cli/install/downloader_test.go
@@ -25,14 +25,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/progress"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
 func TestDownloader_Download(t *testing.T) {
-	testutil.IntegTest(t)
+	c := testutil.IntegTest(t)
 	r := getTestAsset()
 	progressCh := make(chan types.ProgressParams, 100000)
 	cancelProgressCh := make(chan bool, 1)
@@ -42,7 +41,7 @@ func TestDownloader_Download(t *testing.T) {
 	}
 	exec := (&Discovery{}).ExecutableName(false)
 	destination := filepath.Join(t.TempDir(), exec)
-	config.CurrentConfig().CliSettings().SetPath(destination)
+	c.CliSettings().SetPath(destination)
 	lockFileName, err := d.lockFileName()
 	require.NoError(t, err)
 	// remove any existing lockfile
@@ -63,7 +62,7 @@ func TestDownloader_Download(t *testing.T) {
 }
 
 func Test_DoNotDownloadIfCancelled(t *testing.T) {
-	testutil.UnitTest(t)
+	c := testutil.UnitTest(t)
 	progressCh := make(chan types.ProgressParams, 100000)
 	cancelProgressCh := make(chan bool, 1)
 	progressTracker := progress.NewTestTracker(progressCh, cancelProgressCh)
@@ -83,7 +82,7 @@ func Test_DoNotDownloadIfCancelled(t *testing.T) {
 	assert.Error(t, err)
 
 	// make sure cancellation cleanup works
-	lockFileName, err := config.CurrentConfig().CLIDownloadLockFileName()
+	lockFileName, err := c.CLIDownloadLockFileName()
 	require.NoError(t, err)
 	_, err = os.Stat(lockFileName)
 	assert.Error(t, err)

--- a/infrastructure/cli/install/installer_test.go
+++ b/infrastructure/cli/install/installer_test.go
@@ -56,8 +56,8 @@ func TestInstaller_Find(t *testing.T) {
 }
 
 func Test_Find_CliPathInSettings_CliPathFound(t *testing.T) {
+	c := testutil.IntegTest(t)
 	// Arrange
-	testutil.IntegTest(t)
 	file, err := os.CreateTemp(t.TempDir(), "snyk-win.exe")
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +73,7 @@ func Test_Find_CliPathInSettings_CliPathFound(t *testing.T) {
 	t.Setenv("PATH", "")
 	t.Setenv("SNYK_TOKEN", "")
 	t.Setenv("SNYK_CLI_PATH", "")
-	config.CurrentConfig().CliSettings().SetPath(cliPath)
+	c.CliSettings().SetPath(cliPath)
 	installer := NewInstaller(error_reporting.NewTestErrorReporter(), nil)
 
 	// Act
@@ -104,13 +104,13 @@ func TestInstaller_Install_DoNotDownloadIfLockfileFound(t *testing.T) {
 }
 
 func TestInstaller_Update_DoesntUpdateIfNoLatestRelease(t *testing.T) {
-	testutil.UnitTest(t)
+	c := testutil.UnitTest(t)
 	// prepare
 	i := NewInstaller(error_reporting.NewTestErrorReporter(), nil)
 
 	temp := t.TempDir()
 	fakeCliFile := testsupport.CreateTempFile(t, temp)
-	config.CurrentConfig().CliSettings().SetPath(fakeCliFile.Name())
+	c.CliSettings().SetPath(fakeCliFile.Name())
 
 	checksum, err := getChecksum(fakeCliFile.Name())
 	if err != nil {
@@ -149,7 +149,7 @@ func TestInstaller_Update_DoesntUpdateIfNoLatestRelease(t *testing.T) {
 }
 
 func TestInstaller_Update_DownloadsLatestCli(t *testing.T) {
-	testutil.IntegTest(t)
+	c := testutil.IntegTest(t)
 	testutil.CreateDummyProgressListener(t)
 
 	// prepare
@@ -161,7 +161,7 @@ func TestInstaller_Update_DownloadsLatestCli(t *testing.T) {
 	_ = fakeCliFile.Close()
 	cliDiscovery := Discovery{}
 	cliFilePath := path.Join(cliDir, cliDiscovery.ExecutableName(false))
-	config.CurrentConfig().CliSettings().SetPath(cliFilePath)
+	c.CliSettings().SetPath(cliFilePath)
 
 	err := os.Rename(fakeCliFile.Name(), cliFilePath) // rename temp file to CLI file
 	if err != nil {

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -676,7 +676,7 @@ func Test_IsEnabled(t *testing.T) {
 	scanner := &Scanner{errorReporter: newTestCodeErrorReporter(), C: c}
 	t.Run(
 		"should return true if Snyk Code is generally enabled", func(t *testing.T) {
-			config.CurrentConfig().SetSnykCodeEnabled(true)
+			c.SetSnykCodeEnabled(true)
 			enabled := scanner.IsEnabled()
 			assert.True(t, enabled)
 		},

--- a/infrastructure/learn/pact_test.go
+++ b/infrastructure/learn/pact_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
@@ -81,8 +80,7 @@ func TestSnykLearnServicePact(t *testing.T) { //nolint:gocognit // this is a tes
 			})
 
 		test := func() (err error) {
-			testutil.UnitTest(t)
-			c := config.CurrentConfig()
+			c := testutil.UnitTest(t)
 			c.UpdateApiEndpoints(fmt.Sprintf("http://%s", hostWithPort()))
 			httpClientFunc := c.Engine().GetNetworkAccess().GetUnauthorizedHttpClient
 			gafConfig := c.Engine().GetConfiguration()

--- a/infrastructure/learn/service_test.go
+++ b/infrastructure/learn/service_test.go
@@ -22,14 +22,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
 func Test_GetLearnEndpoint(t *testing.T) {
-	testutil.UnitTest(t)
-	c := config.CurrentConfig()
+	c := testutil.UnitTest(t)
 	c.UpdateApiEndpoints("https://api.snyk.io")
 	gafConfig := c.Engine().GetConfiguration()
 	logger := c.Logger()

--- a/infrastructure/sentry/sentry_error_reporter_test.go
+++ b/infrastructure/sentry/sentry_error_reporter_test.go
@@ -23,7 +23,6 @@ import (
 	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -46,11 +45,11 @@ func TestErrorReporting_CaptureError(t *testing.T) {
 	})
 	var target = NewSentryErrorReporter(c, notifier)
 
-	config.CurrentConfig().SetErrorReportingEnabled(false)
+	c.SetErrorReportingEnabled(false)
 	captured := target.CaptureError(e)
 	assert.False(t, captured)
 
-	config.CurrentConfig().SetErrorReportingEnabled(true)
+	c.SetErrorReportingEnabled(true)
 	captured = target.CaptureError(e)
 	assert.True(t, captured)
 
@@ -76,11 +75,11 @@ func TestErrorReporting_CaptureErrorAndReportAsIssue(t *testing.T) {
 	var target = NewSentryErrorReporter(c, notifier)
 
 	e := errors.New(text)
-	config.CurrentConfig().SetErrorReportingEnabled(false)
+	c.SetErrorReportingEnabled(false)
 	captured := target.CaptureErrorAndReportAsIssue(path, e)
 	assert.False(t, captured)
 
-	config.CurrentConfig().SetErrorReportingEnabled(true)
+	c.SetErrorReportingEnabled(true)
 	captured = target.CaptureErrorAndReportAsIssue(path, e)
 	assert.True(t, captured)
 

--- a/infrastructure/snyk_api/snyk_api_pact_test.go
+++ b/infrastructure/snyk_api/snyk_api_pact_test.go
@@ -55,7 +55,7 @@ func TestSnykApiPact(t *testing.T) {
 
 	t.Run("Get feature flag status", func(t *testing.T) {
 		organization := orgUUID
-		config.CurrentConfig().SetOrganization(organization)
+		c.SetOrganization(organization)
 		var featureFlagType FeatureFlagType = "snykCodeConsistentIgnores"
 
 		expectedResponse := FFResponse{
@@ -98,7 +98,7 @@ func TestSnykApiPact(t *testing.T) {
 
 	t.Run("Get feature flag status when disabled for a ORG", func(t *testing.T) {
 		organization := "00000000-0000-0000-0000-000000000099"
-		config.CurrentConfig().SetOrganization(organization)
+		c.SetOrganization(organization)
 		featureFlagType := FeatureFlagType("snykCodeConsistentIgnores")
 
 		message := "Org " + organization + " doesn't have '" + string(featureFlagType) + "' feature enabled"


### PR DESCRIPTION
### Description

Instead rely on the config reference already in the test.
The next step is ensuring that all tests that use the config (that aren't config tests) are set up properly as unit, integration, or smoke tests.
Why? The env work I am doing will make creating a config and then adapting environment variables have a slight race condition, these changes will mean I don't have to catch it / put in the workaround for tests in as many places.

### Checklist

- [x] Tests added and all succeed
 - None added, just amended.
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
