### PR TITLE
refactor(test): reduce usage of `CurrentConfig()` [IDE-1314]

### DIFF
--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -33,12 +33,10 @@ import (
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 
-	"github.com/snyk/snyk-ls/internal/types"
-
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
-
 	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 var sampleSettings = types.Settings{
@@ -93,9 +91,9 @@ func Test_WorkspaceDidChangeConfiguration_Push(t *testing.T) {
 	assert.Equal(t, "b", os.Getenv("a"))
 	assert.Equal(t, "d", os.Getenv("c"))
 	assert.True(t, strings.Contains(os.Getenv("PATH"), "addPath"))
-	assert.True(t, config.CurrentConfig().IsErrorReportingEnabled())
-	assert.Equal(t, "token", config.CurrentConfig().Token())
-	assert.Equal(t, sampleSettings.SnykCodeApi, config.CurrentConfig().SnykCodeApi())
+	assert.True(t, c.IsErrorReportingEnabled())
+	assert.Equal(t, "token", c.Token())
+	assert.Equal(t, sampleSettings.SnykCodeApi, c.SnykCodeApi())
 	assert.Equal(t, sampleSettings.EnableSnykLearnCodeActions, strconv.FormatBool(c.IsSnykLearnCodeActionsEnabled()))
 }
 
@@ -130,9 +128,9 @@ func Test_WorkspaceDidChangeConfiguration_Pull(t *testing.T) {
 	assert.Equal(t, []string{"--all-projects", "-d"}, c.CliSettings().AdditionalOssParameters)
 	assert.Equal(t, sampleSettings.Endpoint, c.SnykApi())
 	assert.Equal(t, c.SnykApi(), conf.GetString(configuration.API_URL))
-	assert.True(t, config.CurrentConfig().IsErrorReportingEnabled())
-	assert.Equal(t, "token", config.CurrentConfig().Token())
-	assert.Equal(t, sampleSettings.SnykCodeApi, config.CurrentConfig().SnykCodeApi())
+	assert.True(t, c.IsErrorReportingEnabled())
+	assert.Equal(t, "token", c.Token())
+	assert.Equal(t, sampleSettings.SnykCodeApi, c.SnykCodeApi())
 	assert.Equal(t, sampleSettings.EnableSnykLearnCodeActions, strconv.FormatBool(c.IsSnykLearnCodeActionsEnabled()))
 }
 
@@ -328,14 +326,14 @@ func Test_UpdateSettings(t *testing.T) {
 				ManageBinariesAutomatically: "true",
 			})
 
-			assert.True(t, config.CurrentConfig().ManageBinariesAutomatically())
+			assert.True(t, c.ManageBinariesAutomatically())
 		})
 		t.Run("false", func(t *testing.T) {
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "false",
 			})
 
-			assert.False(t, config.CurrentConfig().ManageBinariesAutomatically())
+			assert.False(t, c.ManageBinariesAutomatically())
 		})
 
 		t.Run("invalid value does not update", func(t *testing.T) {
@@ -347,7 +345,7 @@ func Test_UpdateSettings(t *testing.T) {
 				ManageBinariesAutomatically: "dog",
 			})
 
-			assert.True(t, config.CurrentConfig().ManageBinariesAutomatically())
+			assert.True(t, c.ManageBinariesAutomatically())
 		})
 	})
 

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -501,8 +501,8 @@ func Test_initialize_updatesSettings(t *testing.T) {
 	if err := rsp.UnmarshalResult(&result); err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, expectedOrgId, config.CurrentConfig().Organization())
-	assert.Equal(t, "xxx", config.CurrentConfig().Token())
+	assert.Equal(t, expectedOrgId, c.Organization())
+	assert.Equal(t, "xxx", c.Token())
 }
 
 func Test_initialize_integrationInInitializationOptions_readFromInitializationOptions(t *testing.T) {
@@ -534,9 +534,8 @@ func Test_initialize_integrationInInitializationOptions_readFromInitializationOp
 	}
 
 	// Assert
-	currentConfig := config.CurrentConfig()
-	assert.Equal(t, expectedIntegrationName, currentConfig.IntegrationName())
-	assert.Equal(t, expectedIntegrationVersion, currentConfig.IntegrationVersion())
+	assert.Equal(t, expectedIntegrationName, c.IntegrationName())
+	assert.Equal(t, expectedIntegrationVersion, c.IntegrationVersion())
 }
 
 func Test_initialize_integrationInClientInfo_readFromClientInfo(t *testing.T) {
@@ -569,10 +568,9 @@ func Test_initialize_integrationInClientInfo_readFromClientInfo(t *testing.T) {
 	}
 
 	// Assert
-	currentConfig := config.CurrentConfig()
-	assert.Equal(t, expectedIntegrationName, currentConfig.IntegrationName())
-	assert.Equal(t, expectedIntegrationVersion, currentConfig.IntegrationVersion())
-	assert.Equal(t, expectedIdeVersion, currentConfig.IdeVersion())
+	assert.Equal(t, expectedIntegrationName, c.IntegrationName())
+	assert.Equal(t, expectedIntegrationVersion, c.IntegrationVersion())
+	assert.Equal(t, expectedIdeVersion, c.IdeVersion())
 }
 
 func Test_initialize_integrationOnlyInEnvVars_readFromEnvVars(t *testing.T) {
@@ -592,9 +590,8 @@ func Test_initialize_integrationOnlyInEnvVars_readFromEnvVars(t *testing.T) {
 	}
 
 	// Assert
-	currentConfig := config.CurrentConfig()
-	assert.Equal(t, expectedIntegrationName, currentConfig.IntegrationName())
-	assert.Equal(t, expectedIntegrationVersion, currentConfig.IntegrationVersion())
+	assert.Equal(t, expectedIntegrationName, c.IntegrationName())
+	assert.Equal(t, expectedIntegrationVersion, c.IntegrationVersion())
 }
 
 func Test_initialize_shouldOfferAllCommands(t *testing.T) {
@@ -638,7 +635,7 @@ func Test_initialize_autoAuthenticateSetCorrectly(t *testing.T) {
 		_, err := loc.Client.Call(ctx, "initialize", params)
 
 		assert.Nil(t, err)
-		assert.True(t, config.CurrentConfig().AutomaticAuthentication())
+		assert.True(t, c.AutomaticAuthentication())
 	})
 
 	t.Run("Parses true value", func(t *testing.T) {
@@ -651,7 +648,7 @@ func Test_initialize_autoAuthenticateSetCorrectly(t *testing.T) {
 		_, err := loc.Client.Call(ctx, "initialize", params)
 
 		assert.Nil(t, err)
-		assert.True(t, config.CurrentConfig().AutomaticAuthentication())
+		assert.True(t, c.AutomaticAuthentication())
 	})
 
 	t.Run("Parses false value", func(t *testing.T) {
@@ -664,7 +661,7 @@ func Test_initialize_autoAuthenticateSetCorrectly(t *testing.T) {
 		params := types.InitializeParams{InitializationOptions: initializationOptions}
 		_, err := loc.Client.Call(ctx, "initialize", params)
 		assert.Nil(t, err)
-		assert.False(t, config.CurrentConfig().AutomaticAuthentication())
+		assert.False(t, c.AutomaticAuthentication())
 	})
 }
 
@@ -759,7 +756,7 @@ func Test_textDocumentDidSaveHandler_shouldAcceptDocumentItemAndPublishDiagnosti
 	c.SetLSPInitialized(true)
 
 	filePath, fileDir := code.TempWorkdirWithIssues(t)
-	fileUri := sendFileSavedMessage(t, filePath, fileDir, loc)
+	fileUri := sendFileSavedMessage(t, c, filePath, fileDir, loc)
 
 	// wait for publish
 	assert.Eventually(
@@ -814,7 +811,7 @@ func Test_textDocumentDidSaveHandler_shouldTriggerScanForDotSnykFile(t *testing.
 
 	snykFilePath, folderPath := createTemporaryDirectoryWithSnykFile(t)
 
-	sendFileSavedMessage(t, snykFilePath, folderPath, loc)
+	sendFileSavedMessage(t, c, snykFilePath, folderPath, loc)
 
 	// Wait for $/snyk.scan notification
 	assert.Eventually(
@@ -867,7 +864,7 @@ func Test_textDocumentDidOpenHandler_shouldPublishIfCached(t *testing.T) {
 	c.SetLSPInitialized(true)
 
 	filePath, fileDir := code.TempWorkdirWithIssues(t)
-	fileUri := sendFileSavedMessage(t, filePath, fileDir, loc)
+	fileUri := sendFileSavedMessage(t, c, filePath, fileDir, loc)
 
 	require.Eventually(
 		t,
@@ -910,7 +907,7 @@ func Test_textDocumentDidSave_manualScanningMode_doesNotScan(t *testing.T) {
 	c.SetAutomaticScanning(false)
 
 	filePath, fileDir := code.TempWorkdirWithIssues(t)
-	fileUri := sendFileSavedMessage(t, filePath, fileDir, loc)
+	fileUri := sendFileSavedMessage(t, c, filePath, fileDir, loc)
 
 	assert.Never(
 		t,
@@ -920,9 +917,8 @@ func Test_textDocumentDidSave_manualScanningMode_doesNotScan(t *testing.T) {
 	)
 }
 
-func sendFileSavedMessage(t *testing.T, filePath types.FilePath, fileDir types.FilePath, loc server.Local) sglsp.DocumentURI {
+func sendFileSavedMessage(t *testing.T, c *config.Config, filePath types.FilePath, fileDir types.FilePath, loc server.Local) sglsp.DocumentURI {
 	t.Helper()
-	c := config.CurrentConfig()
 	didSaveParams := sglsp.DidSaveTextDocumentParams{
 		TextDocument: sglsp.TextDocumentIdentifier{URI: uri.PathToUri(filePath)},
 	}

--- a/domain/ide/workspace/folder_test.go
+++ b/domain/ide/workspace/folder_test.go
@@ -200,7 +200,7 @@ func TestProcessResults_whenFilteringSeverity_ProcessesOnlyFilteredIssues(t *tes
 	c := testutil.UnitTest(t)
 
 	severityFilter := types.NewSeverityFilter(true, false, true, false)
-	config.CurrentConfig().SetSeverityFilter(&severityFilter)
+	c.SetSeverityFilter(&severityFilter)
 
 	f := NewMockFolder(c, notification.NewNotifier())
 
@@ -250,7 +250,7 @@ func TestProcessResults_whenFilteringIssueViewOptions_ProcessesOnlyFilteredIssue
 	c := testutil.UnitTest(t)
 
 	issueViewOptions := types.NewIssueViewOptions(false, true)
-	config.CurrentConfig().SetIssueViewOptions(&issueViewOptions)
+	c.SetIssueViewOptions(&issueViewOptions)
 
 	f := NewMockFolder(c, notification.NewNotifier())
 
@@ -270,7 +270,7 @@ func TestProcessResults_whenFilteringIssueViewOptions_ProcessesOnlyFilteredIssue
 
 	ctrl := gomock.NewController(t)
 	mockConfiguration := mocks.NewMockConfiguration(ctrl)
-	config.CurrentConfig().Engine().SetConfiguration(mockConfiguration)
+	c.Engine().SetConfiguration(mockConfiguration)
 	mockConfiguration.EXPECT().GetBool(configuration.FF_CODE_CONSISTENT_IGNORES).Return(true)
 
 	f.ProcessResults(t.Context(), data)
@@ -353,15 +353,15 @@ func Test_Clear(t *testing.T) {
 
 func Test_IsTrusted_shouldReturnFalseByDefault(t *testing.T) {
 	c := testutil.UnitTest(t)
-	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
+	c.SetTrustedFolderFeatureEnabled(true)
 	f := NewFolder(c, "dummy", "dummy", scanner.NewTestScanner(), hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(), persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator())
 	assert.False(t, f.IsTrusted())
 }
 
 func Test_IsTrusted_shouldReturnTrueForPathContainedInTrustedFolders(t *testing.T) {
 	c := testutil.UnitTest(t)
-	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
-	config.CurrentConfig().SetTrustedFolders([]types.FilePath{"dummy"})
+	c.SetTrustedFolderFeatureEnabled(true)
+	c.SetTrustedFolders([]types.FilePath{"dummy"})
 	f := NewFolder(c, "dummy", "dummy", scanner.NewTestScanner(), hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(), persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator())
 	assert.True(t, f.IsTrusted())
 }
@@ -369,16 +369,16 @@ func Test_IsTrusted_shouldReturnTrueForPathContainedInTrustedFolders(t *testing.
 func Test_IsTrusted_shouldReturnTrueForSubfolderOfTrustedFolders_Linux(t *testing.T) {
 	c := testutil.IntegTest(t)
 	testsupport.NotOnWindows(t, "Unix/macOS file paths are incompatible with Windows")
-	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
-	config.CurrentConfig().SetTrustedFolders([]types.FilePath{"/dummy"})
+	c.SetTrustedFolderFeatureEnabled(true)
+	c.SetTrustedFolders([]types.FilePath{"/dummy"})
 	f := NewFolder(c, "/dummy/dummyF", "dummy", scanner.NewTestScanner(), hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(), persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator())
 	assert.True(t, f.IsTrusted())
 }
 
 func Test_IsTrusted_shouldReturnFalseForDifferentFolder(t *testing.T) {
 	c := testutil.UnitTest(t)
-	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
-	config.CurrentConfig().SetTrustedFolders([]types.FilePath{"/dummy"})
+	c.SetTrustedFolderFeatureEnabled(true)
+	c.SetTrustedFolders([]types.FilePath{"/dummy"})
 	f := NewFolder(c, "/UntrustedPath", "dummy", scanner.NewTestScanner(), hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(), persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator())
 	assert.False(t, f.IsTrusted())
 }
@@ -386,8 +386,8 @@ func Test_IsTrusted_shouldReturnFalseForDifferentFolder(t *testing.T) {
 func Test_IsTrusted_shouldReturnTrueForSubfolderOfTrustedFolders(t *testing.T) {
 	c := testutil.IntegTest(t)
 	testsupport.OnlyOnWindows(t, "Windows specific test")
-	config.CurrentConfig().SetTrustedFolderFeatureEnabled(true)
-	config.CurrentConfig().SetTrustedFolders([]types.FilePath{"c:\\dummy"})
+	c.SetTrustedFolderFeatureEnabled(true)
+	c.SetTrustedFolders([]types.FilePath{"c:\\dummy"})
 	f := NewFolder(c, "c:\\dummy\\dummyF", "dummy", scanner.NewTestScanner(), hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(), persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator())
 	assert.True(t, f.IsTrusted())
 }

--- a/infrastructure/cli/cli_extension_executor_test.go
+++ b/infrastructure/cli/cli_extension_executor_test.go
@@ -19,9 +19,6 @@ package cli
 import (
 	"testing"
 
-	"github.com/snyk/snyk-ls/internal/testutil"
-	"github.com/snyk/snyk-ls/internal/types"
-
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 
@@ -29,7 +26,8 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 func Test_ExecuteLegacyCLI_SUCCESS(t *testing.T) {
@@ -59,7 +57,7 @@ func Test_ExecuteLegacyCLI_SUCCESS(t *testing.T) {
 	err = engine.Init()
 	assert.Nil(t, err)
 
-	config.CurrentConfig().SetEngine(engine)
+	c.SetEngine(engine)
 
 	// Run
 	executorUnderTest := NewExtensionExecutor(c)
@@ -77,7 +75,7 @@ func Test_ExecuteLegacyCLI_FAILED(t *testing.T) {
 
 	// Prepare
 	engine := app.CreateAppEngine()
-	config.CurrentConfig().SetEngine(engine)
+	c.SetEngine(engine)
 	cmd := []string{"snyk", "test"}
 	expectedPayload := []byte{}
 

--- a/infrastructure/cli/cli_test.go
+++ b/infrastructure/cli/cli_test.go
@@ -30,12 +30,12 @@ func Test_ExpandParametersFromConfig(t *testing.T) {
 	c := testutil.UnitTest(t)
 	testOrg, err := uuid.NewUUID()
 	assert.NoError(t, err)
-	config.CurrentConfig().SetOrganization(testOrg.String())
+	c.SetOrganization(testOrg.String())
 	settings := config.CliSettings{
 		Insecure: true,
 		C:        c,
 	}
-	config.CurrentConfig().SetCliSettings(&settings)
+	c.SetCliSettings(&settings)
 	var cmd = []string{"a", "b"}
 
 	cmd = (&SnykCli{}).ExpandParametersFromConfig(cmd)

--- a/infrastructure/cli/environment_test.go
+++ b/infrastructure/cli/environment_test.go
@@ -25,15 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
-	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
 func TestAddConfigValuesToEnv(t *testing.T) {
 	t.Run("Adds legacy token to env", func(t *testing.T) {
-		testutil.UnitTest(t)
-		c := config.CurrentConfig()
+		c := testutil.UnitTest(t)
 		c.SetAuthenticationMethod(types.TokenAuthentication)
 
 		updatedEnv := AppendCliEnvironmentVariables([]string{}, true)
@@ -43,13 +41,12 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 	})
 
 	t.Run("Adds values to env", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 		const expectedIntegrationName = "ECLIPSE"
 		const expectedIntegrationVersion = "20230606.182718"
 		const expectedIdeVersion = "4.27.0"
 		const expectedIdeName = "Eclipse"
 
-		testutil.UnitTest(t)
-		c := config.CurrentConfig()
 		c.SetAuthenticationMethod(types.OAuthAuthentication)
 		c.SetOrganization("testOrg")
 		c.UpdateApiEndpoints("https://api.eu.snyk.io")
@@ -80,8 +77,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		assert.NotContains(t, updatedEnv, "SNYK_CFG_DISABLE_ANALYTICS=1")
 	})
 	t.Run("Removes existing snyk token env variables", func(t *testing.T) {
-		testutil.UnitTest(t)
-		c := config.CurrentConfig()
+		c := testutil.UnitTest(t)
 		c.SetToken("{\"access_token\": \"testToken\"}")
 		c.SetAuthenticationMethod(types.OAuthAuthentication)
 		tokenVar := TokenEnvVar + "={asdf}"
@@ -95,8 +91,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		assert.NotContains(t, updatedEnv, tokenVar)
 	})
 	t.Run("Removes existing authentication env variables", func(t *testing.T) {
-		testutil.UnitTest(t)
-		c := config.CurrentConfig()
+		c := testutil.UnitTest(t)
 		c.SetToken("testToken")
 		oauthVar := SnykOauthTokenEnvVar + "={asdf}"
 		inputEnv := []string{oauthVar}
@@ -107,8 +102,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 		assert.NotContains(t, updatedEnv, oauthVar)
 	})
 	t.Run("Adds Snyk Token to env", func(t *testing.T) {
-		testutil.UnitTest(t)
-		c := config.CurrentConfig()
+		c := testutil.UnitTest(t)
 		c.SetToken("testToken")
 		c.SetAuthenticationMethod(types.TokenAuthentication)
 
@@ -119,8 +113,7 @@ func TestAddConfigValuesToEnv(t *testing.T) {
 	})
 
 	t.Run("Adds OAuth Token to env", func(t *testing.T) {
-		testutil.UnitTest(t)
-		c := config.CurrentConfig()
+		c := testutil.UnitTest(t)
 		c.SetAuthenticationMethod(types.OAuthAuthentication)
 		c.SetToken("{\"access_token\": \"testToken\"}")
 

--- a/infrastructure/code/snyk_code_http_client_pact_test.go
+++ b/infrastructure/code/snyk_code_http_client_pact_test.go
@@ -26,11 +26,10 @@ import (
 
 	codeClientSarif "github.com/snyk/code-client-go/sarif"
 
-	"github.com/snyk/snyk-ls/internal/testsupport"
-	"github.com/snyk/snyk-ls/internal/types"
-
 	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/util"
 )
 
@@ -51,10 +50,10 @@ var client *SnykCodeHTTPClient
 //nolint:gocyclo // TODO: address tech debt
 func TestSnykCodeBackendServicePact(t *testing.T) {
 	testsupport.NotOnWindows(t, "we don't have a pact cli")
-	testutil.UnitTest(t)
+	c := testutil.UnitTest(t)
 
-	setupPact(t)
-	config.CurrentConfig().UpdateApiEndpoints("http://localhost")
+	setupPact(t, c)
+	c.UpdateApiEndpoints("http://localhost")
 	defer pact.Teardown()
 
 	defer func() {
@@ -255,7 +254,7 @@ func TestSnykCodeBackendServicePact(t *testing.T) {
 	})
 }
 
-func setupPact(t *testing.T) {
+func setupPact(t *testing.T, c *config.Config) {
 	t.Helper()
 	pact = dsl.Pact{
 		Consumer: consumer,
@@ -267,7 +266,6 @@ func setupPact(t *testing.T) {
 	pact.Setup(true)
 
 	t.Setenv("DEEPROXY_API_URL", fmt.Sprintf("http://localhost:%d", pact.Server.Port))
-	c := config.CurrentConfig()
 	c.SetOrganization(orgUUID)
 
 	client = NewSnykCodeHTTPClient(c, NewCodeInstrumentor(), newTestCodeErrorReporter(),
@@ -294,11 +292,11 @@ func getSnykRequestIdMatcher() dsl.Matcher {
 
 func TestSnykCodeBackendServicePact_LocalCodeEngine(t *testing.T) {
 	testsupport.NotOnWindows(t, "we don't have a pact cli")
-	testutil.UnitTest(t)
+	c := testutil.UnitTest(t)
 
-	setupPact(t)
-	config.CurrentConfig().SetSnykCodeApi(fmt.Sprintf("http://localhost:%d", pact.Server.Port))
-	config.CurrentConfig().SetOrganization(orgUUID)
+	setupPact(t, c)
+	c.SetSnykCodeApi(fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+	c.SetOrganization(orgUUID)
 	defer pact.Teardown()
 
 	pact.AddInteraction().UponReceiving("Get filters").WithRequest(dsl.Request{

--- a/infrastructure/iac/iac_test.go
+++ b/infrastructure/iac/iac_test.go
@@ -55,7 +55,7 @@ func Test_Scan_IsInstrumented(t *testing.T) {
 func Test_toHover_asHTML(t *testing.T) {
 	c := testutil.UnitTest(t)
 	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
-	config.CurrentConfig().SetFormat(config.FormatHtml)
+	c.SetFormat(config.FormatHtml)
 
 	h := scanner.getExtendedMessage(sampleIssue())
 
@@ -69,7 +69,7 @@ func Test_toHover_asHTML(t *testing.T) {
 func Test_toHover_asMD(t *testing.T) {
 	c := testutil.UnitTest(t)
 	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
-	config.CurrentConfig().SetFormat(config.FormatMd)
+	c.SetFormat(config.FormatMd)
 
 	h := scanner.getExtendedMessage(sampleIssue())
 

--- a/infrastructure/oss/oss_integration_test.go
+++ b/infrastructure/oss/oss_integration_test.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
@@ -41,9 +42,8 @@ import (
 // This is an integration test that downloads and installs the CLI if necessary
 // it uses real CLI output for verification of functionality
 func Test_Scan(t *testing.T) {
-	testutil.SmokeTest(t, false)
+	c := testutil.SmokeTest(t, false)
 	testutil.CreateDummyProgressListener(t)
-	c := config.CurrentConfig()
 	c.SetFormat(config.FormatHtml)
 	ctx := t.Context()
 	di.Init()


### PR DESCRIPTION
### Description

Instead rely on the config reference already in the test.
This is part 2, half was done previously in #964.
The next step is ensuring that all tests that use the config (that aren't config tests) are set up properly as unit, integration, or smoke tests.
Why? The env work I am doing will make creating a config and then adapting environment variables have a slight race condition, these changes will mean I don't have to catch it / put in the workaround for tests in as many places.

### Checklist

- [x] Tests added and all succeed
 - None added, just amended.
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
