### PR TITLE
refactor(test): reduce usage of `CurrentConfig()` [IDE-1314]

### DIFF
--- a/domain/ide/codelens/codelens_test.go
+++ b/domain/ide/codelens/codelens_test.go
@@ -46,7 +46,7 @@ func Test_GetCodeLensFromCommand(t *testing.T) {
 func Test_GetCodeLensForPath(t *testing.T) {
 	c := testutil.IntegTest(t)
 	di.TestInit(t) // IntegTest doesn't automatically inits DI
-	testutil.OnlyEnableCode()
+	testutil.OnlyEnableCode(t, c)
 	c.Engine().GetConfiguration().Set(code_workflow.ConfigurationSastSettings, &sast_contract.SastResponse{SastEnabled: true})
 	// this is using the real progress channel, so we need to listen to it
 	dummyProgressListeners(t)

--- a/domain/ide/command/execute_cli_test.go
+++ b/domain/ide/command/execute_cli_test.go
@@ -32,7 +32,7 @@ func Test_executeCLI_callsCli(t *testing.T) {
 	expected := `{ "outputKey": "outputValue" }`
 	dir := t.TempDir()
 
-	cli := cli2.NewTestExecutorWithResponse(expected)
+	cli := cli2.NewTestExecutorWithResponse(c, expected)
 
 	args := []any{dir, "iac", "test", "--json"}
 	cut := executeCLICommand{

--- a/infrastructure/cli/cli_fake.go
+++ b/infrastructure/cli/cli_fake.go
@@ -39,12 +39,12 @@ type TestExecutor struct {
 	logger          *zerolog.Logger
 }
 
-func NewTestExecutor() *TestExecutor {
-	return &TestExecutor{ExecuteResponse: []byte("{}"), logger: config.CurrentConfig().Logger()}
+func NewTestExecutor(c *config.Config) *TestExecutor {
+	return &TestExecutor{ExecuteResponse: []byte("{}"), logger: c.Logger()}
 }
 
-func NewTestExecutorWithResponse(executeResponse string) *TestExecutor {
-	return &TestExecutor{ExecuteResponse: []byte(executeResponse), logger: config.CurrentConfig().Logger()}
+func NewTestExecutorWithResponse(c *config.Config, executeResponse string) *TestExecutor {
+	return &TestExecutor{ExecuteResponse: []byte(executeResponse), logger: c.Logger()}
 }
 
 func NewTestExecutorWithResponseFromFile(executeResponsePath string, logger *zerolog.Logger) *TestExecutor {

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -35,22 +35,32 @@ import (
 	"github.com/snyk/snyk-ls/internal/testutil"
 )
 
-func SetupInitializer(t *testing.T) *Initializer {
+func SetupInitializer(t *testing.T, c *config.Config) *Initializer {
 	t.Helper()
-	return SetupInitializerWithInstaller(t, install.NewFakeInstaller())
+	return SetupInitializerWithInstaller(t, c, install.NewFakeInstaller())
 }
 
-func SetupInitializerWithInstaller(t *testing.T, installer install.Installer) *Initializer {
+func SetupInitializerWithInstaller(t *testing.T, c *config.Config, installer install.Installer) *Initializer {
 	t.Helper()
 	return NewInitializer(error_reporting.NewTestErrorReporter(),
 		installer,
 		notification.NewNotifier(),
-		dummyCli)
+		getDummyCLI(t, c))
+}
+
+var dummyCLI *TestExecutor
+
+func getDummyCLI(t *testing.T, c *config.Config) *TestExecutor {
+	t.Helper()
+	if dummyCLI == nil {
+		dummyCLI = NewTestExecutorWithResponse(c, "0.0.0test")
+	}
+	return dummyCLI
 }
 
 func Test_EnsureCliShouldFindOrDownloadCliAndAddPathToEnv(t *testing.T) {
 	c := testutil.IntegTest(t)
-	initializer := SetupInitializer(t)
+	initializer := SetupInitializer(t, c)
 	testutil.CreateDummyProgressListener(t)
 
 	c.CliSettings().SetPath("")
@@ -63,7 +73,7 @@ func Test_EnsureCliShouldFindOrDownloadCliAndAddPathToEnv(t *testing.T) {
 
 func Test_EnsureCLIShouldRespectCliPathInEnv(t *testing.T) {
 	c := testutil.UnitTest(t)
-	initializer := SetupInitializer(t)
+	initializer := SetupInitializer(t, c)
 
 	tempDir := t.TempDir()
 	tempFile := testsupport.CreateTempFile(t, tempDir)
@@ -83,7 +93,7 @@ func TestInitializer_whenNoCli_Installs(t *testing.T) {
 	c.SetCliSettings(settings)
 
 	installer := install.NewFakeInstaller()
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	go func() { _ = initializer.Init() }()
 
@@ -100,7 +110,7 @@ func TestInitializer_whenNoCli_InstallsToDefaultCliPath(t *testing.T) {
 
 	clientFunc := func() *http.Client { return http.DefaultClient }
 	installer := install.NewInstaller(error_reporting.NewTestErrorReporter(), clientFunc)
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	// ensure CLI is not installed on the system
 	existingCliPath, _ := installer.Find()
@@ -149,7 +159,7 @@ func TestInitializer_whenBinaryUpdatesNotAllowed_DoesNotInstall(t *testing.T) {
 	c.SetManageBinariesAutomatically(false)
 
 	installer := install.NewFakeInstaller()
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	go func() { _ = initializer.Init() }()
 	time.Sleep(time.Second)
@@ -165,7 +175,7 @@ func TestInitializer_whenOutdated_Updates(t *testing.T) {
 	createDummyCliBinaryWithCreatedDate(t, c, fiveDaysAgo)
 
 	installer := install.NewFakeInstaller()
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	_ = initializer.Init()
 
@@ -181,7 +191,7 @@ func TestInitializer_whenUpToDate_DoesNotUpdates(t *testing.T) {
 	createDummyCliBinaryWithCreatedDate(t, c, threeDaysAgo)
 
 	installer := install.NewFakeInstaller()
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	_ = initializer.Init()
 
@@ -196,7 +206,7 @@ func TestInitializer_whenBinaryUpdatesNotAllowed_PreventsUpdate(t *testing.T) {
 	createDummyCliBinaryWithCreatedDate(t, c, fiveDaysAgo)
 
 	installer := install.NewFakeInstaller()
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	_ = initializer.Init()
 
@@ -210,7 +220,7 @@ func TestInitializer_whenBinaryUpdatesNotAllowed_PreventsInstall(t *testing.T) {
 	c.SetManageBinariesAutomatically(false)
 
 	installer := install.NewFakeInstaller()
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	_ = initializer.Init()
 
@@ -225,7 +235,7 @@ func TestInitializer_whenBinaryUpdatesAllowed_Updates(t *testing.T) {
 	createDummyCliBinaryWithCreatedDate(t, c, fiveDaysAgo)
 
 	installer := install.NewFakeInstaller()
-	initializer := SetupInitializerWithInstaller(t, installer)
+	initializer := SetupInitializerWithInstaller(t, c, installer)
 
 	_ = initializer.Init()
 
@@ -249,5 +259,3 @@ func createDummyCliBinaryWithCreatedDate(t *testing.T, c *config.Config, binaryC
 }
 
 var fiveDaysAgo = time.Now().Add(-time.Hour * 24 * 5)
-
-var dummyCli = NewTestExecutorWithResponse("0.0.0test")

--- a/infrastructure/iac/iac_html_test.go
+++ b/infrastructure/iac/iac_html_test.go
@@ -94,8 +94,7 @@ func createIacIssueSample() snyk.Issue {
 }
 
 func TestHtmlRenderer_GetDetailsHtml_PathEncoded(t *testing.T) {
-	testutil.UnitTest(t)
-	c := config.New()
+	c := testutil.UnitTest(t)
 
 	renderer, err := NewHtmlRenderer(c)
 	assert.NoError(t, err)

--- a/infrastructure/iac/iac_test.go
+++ b/infrastructure/iac/iac_test.go
@@ -38,7 +38,7 @@ import (
 func Test_Scan_IsInstrumented(t *testing.T) {
 	c := testutil.UnitTest(t)
 	instrumentor := performance.NewInstrumentor()
-	scanner := New(c, instrumentor, error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
+	scanner := New(c, instrumentor, error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c))
 
 	_, _ = scanner.Scan(t.Context(), "fake.yml", "", nil)
 
@@ -54,7 +54,7 @@ func Test_Scan_IsInstrumented(t *testing.T) {
 
 func Test_toHover_asHTML(t *testing.T) {
 	c := testutil.UnitTest(t)
-	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
+	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c))
 	c.SetFormat(config.FormatHtml)
 
 	h := scanner.getExtendedMessage(sampleIssue())
@@ -68,7 +68,7 @@ func Test_toHover_asHTML(t *testing.T) {
 
 func Test_toHover_asMD(t *testing.T) {
 	c := testutil.UnitTest(t)
-	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
+	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c))
 	c.SetFormat(config.FormatMd)
 
 	h := scanner.getExtendedMessage(sampleIssue())
@@ -83,7 +83,7 @@ func Test_toHover_asMD(t *testing.T) {
 func Test_Scan_CancelledContext_DoesNotScan(t *testing.T) {
 	// Arrange
 	c := testutil.UnitTest(t)
-	cliMock := cli.NewTestExecutor()
+	cliMock := cli.NewTestExecutor(c)
 	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cliMock)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -98,7 +98,7 @@ func Test_Scan_CancelledContext_DoesNotScan(t *testing.T) {
 func Test_retrieveIssues_IgnoresParsingErrors(t *testing.T) {
 	c := testutil.UnitTest(t)
 
-	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
+	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c))
 
 	results := []iacScanResult{
 		{
@@ -125,7 +125,7 @@ func Test_retrieveIssues_IgnoresParsingErrors(t *testing.T) {
 func Test_createIssueDataForCustomUI_SuccessfullyParses(t *testing.T) {
 	c := testutil.UnitTest(t)
 	sampleIssue := sampleIssue()
-	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
+	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c))
 	issue, err := scanner.toIssue("/path/to/issue", "test.yml", sampleIssue, "")
 
 	expectedAdditionalData := snyk.IaCIssueData{
@@ -169,7 +169,7 @@ func Test_createIssueDataForCustomUI_SuccessfullyParses(t *testing.T) {
 func Test_toIssue_issueHasHtmlTemplate(t *testing.T) {
 	c := testutil.UnitTest(t)
 	sampleIssue := sampleIssue()
-	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor())
+	scanner := New(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c))
 	issue, err := scanner.toIssue("/path/to/issue", "test.yml", sampleIssue, "")
 
 	assert.NoError(t, err)

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -182,7 +182,7 @@ func TestCLIScanner_prepareScanCommand_RemovesAllProjectsParam(t *testing.T) {
 	c := testutil.UnitTest(t)
 
 	// Setup test CLI executor
-	cliExecutor := cli.NewTestExecutorWithResponse("{}")
+	cliExecutor := cli.NewTestExecutorWithResponse(c, "{}")
 
 	// Setup the scanner with necessary dependencies
 	instrumentor := performance.NewInstrumentor()

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -204,7 +204,7 @@ func Test_introducingPackageAndVersionJava(t *testing.T) {
 
 func Test_ContextCanceled_Scan_DoesNotScan(t *testing.T) {
 	c := testutil.UnitTest(t)
-	cliMock := cli.NewTestExecutor()
+	cliMock := cli.NewTestExecutor(c)
 	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cliMock, getLearnMock(t), notification.NewMockNotifier())
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -233,7 +233,7 @@ func mavenTestIssue() ossIssue {
 
 func TestUnmarshalOssJsonSingle(t *testing.T) {
 	c := testutil.UnitTest(t)
-	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
+	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -251,7 +251,7 @@ func TestUnmarshalOssJsonSingle(t *testing.T) {
 
 func TestUnmarshalOssJsonArray(t *testing.T) {
 	c := testutil.UnitTest(t)
-	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
+	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -269,7 +269,7 @@ func TestUnmarshalOssJsonArray(t *testing.T) {
 
 func TestUnmarshalOssErroneousJson(t *testing.T) {
 	c := testutil.UnitTest(t)
-	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
+	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -321,7 +321,7 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 	concurrentScanRequests := 10
 	workingDir, _ := os.Getwd()
 	folderPath := workingDir
-	fakeCli := cli.NewTestExecutor()
+	fakeCli := cli.NewTestExecutor(c)
 	fakeCli.ExecuteDuration = time.Second
 	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), fakeCli, getLearnMock(t), notification.NewMockNotifier())
 	wg := sync.WaitGroup{}
@@ -364,7 +364,7 @@ func sampleIssue() ossIssue {
 func Test_prepareScanCommand(t *testing.T) {
 	t.Run("Expands parameters", func(t *testing.T) {
 		c := testutil.UnitTest(t)
-		scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
+		scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
 		settings := config.CliSettings{
 			AdditionalOssParameters: []string{"--all-projects", "-d"},
@@ -385,7 +385,7 @@ func Test_prepareScanCommand(t *testing.T) {
 
 	t.Run("does not use --all-projects if --file is given", func(t *testing.T) {
 		c := testutil.UnitTest(t)
-		scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
+		scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
 		settings := config.CliSettings{
 			AdditionalOssParameters: []string{"--file=asdf", "-d"},
@@ -402,7 +402,7 @@ func Test_prepareScanCommand(t *testing.T) {
 
 	t.Run("Uses --all-projects by default", func(t *testing.T) {
 		c := testutil.UnitTest(t)
-		scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
+		scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
 		settings := config.CliSettings{
 			AdditionalOssParameters: []string{"-d"},
@@ -445,7 +445,7 @@ func Test_scheduleNewScanWithProductDisabled_NoScanRun(t *testing.T) {
 
 	// Arrange
 	c.SetSnykOssEnabled(false)
-	fakeCli := cli.NewTestExecutor()
+	fakeCli := cli.NewTestExecutor(c)
 	fakeCli.ExecuteDuration = time.Millisecond
 	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), fakeCli, getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
@@ -467,7 +467,7 @@ func Test_scheduleNewScanTwice_RunsOnlyOnce(t *testing.T) {
 	c := testutil.UnitTest(t)
 
 	// Arrange
-	fakeCli := cli.NewTestExecutor()
+	fakeCli := cli.NewTestExecutor(c)
 	fakeCli.ExecuteDuration = time.Millisecond
 	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), fakeCli, getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 
@@ -493,7 +493,7 @@ func Test_scheduleNewScan_ContextCancelledAfterScanScheduled_NoScanRun(t *testin
 	c := testutil.UnitTest(t)
 
 	// Arrange
-	fakeCli := cli.NewTestExecutor()
+	fakeCli := cli.NewTestExecutor(c)
 	fakeCli.ExecuteDuration = time.Millisecond
 	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), fakeCli, getLearnMock(t), notification.NewMockNotifier()).(*CLIScanner)
 

--- a/infrastructure/oss/vulnerability_count_test.go
+++ b/infrastructure/oss/vulnerability_count_test.go
@@ -150,7 +150,7 @@ func TestVulnerabilityCountImpl_ProcessVulnerabilityCount_GroupByRange(t *testin
 
 func TestScanner_toInlineValueAndAddToCache_shouldAddInlineValueToCache(t *testing.T) {
 	c := testutil.UnitTest(t)
-	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewNotifier()).(*CLIScanner)
+	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewNotifier()).(*CLIScanner)
 	myRange := testRange()
 	vci := VulnerabilityCountInformation{
 		path:                      vulnCountTestFilePath,
@@ -169,7 +169,7 @@ func TestScanner_toInlineValueAndAddToCache_shouldAddInlineValueToCache(t *testi
 
 func TestScanner_addVulnerabilityCountsAsInlineValuesToCache(t *testing.T) {
 	c := testutil.UnitTest(t)
-	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(), getLearnMock(t), notification.NewNotifier()).(*CLIScanner)
+	scanner := NewCLIScanner(c, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(), cli.NewTestExecutor(c), getLearnMock(t), notification.NewNotifier()).(*CLIScanner)
 
 	// we want issues from two ranges in the same file
 	r1 := testRange()

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -62,7 +62,7 @@ func UnitTest(t *testing.T) *config.Config {
 	setMCPServerURL(t, c)
 	redirectConfigAndDataHome(t, c)
 	config.SetCurrentConfig(c)
-	CLIDownloadLockFileCleanUp(t)
+	CLIDownloadLockFileCleanUp(t, c)
 	c.Engine().GetConfiguration().Set(code_workflow.ConfigurationSastSettings, &sast_contract.SastResponse{SastEnabled: true, LocalCodeEngine: sast_contract.LocalCodeEngine{
 		Enabled: false,
 	},
@@ -88,10 +88,10 @@ func cleanupFakeCliFile(c *config.Config) {
 	}
 }
 
-func CLIDownloadLockFileCleanUp(t *testing.T) {
+func CLIDownloadLockFileCleanUp(t *testing.T, c *config.Config) {
 	t.Helper()
 	// remove lock file before test and after test
-	lockFileName, _ := config.CurrentConfig().CLIDownloadLockFileName()
+	lockFileName, _ := c.CLIDownloadLockFileName()
 	file, _ := os.Open(lockFileName)
 	_ = file.Close()
 	_ = os.Remove(lockFileName)
@@ -138,7 +138,7 @@ func prepareTestHelper(t *testing.T, envVar string, useConsistentIgnores bool) *
 	redirectConfigAndDataHome(t, c)
 
 	config.SetCurrentConfig(c)
-	CLIDownloadLockFileCleanUp(t)
+	CLIDownloadLockFileCleanUp(t, c)
 	t.Cleanup(func() {
 		cleanupFakeCliFile(c)
 	})
@@ -163,10 +163,11 @@ func redirectConfigAndDataHome(t *testing.T, c *config.Config) {
 	conf.SetStorage(s)
 }
 
-func OnlyEnableCode() {
-	config.CurrentConfig().SetSnykIacEnabled(false)
-	config.CurrentConfig().SetSnykOssEnabled(false)
-	config.CurrentConfig().SetSnykCodeEnabled(true)
+func OnlyEnableCode(t *testing.T, c *config.Config) {
+	t.Helper()
+	c.SetSnykIacEnabled(false)
+	c.SetSnykOssEnabled(false)
+	c.SetSnykCodeEnabled(true)
 }
 
 func SetUpEngineMock(t *testing.T, c *config.Config) (*mocks.MockEngine, configuration.Configuration) {


### PR DESCRIPTION
### Description

Instead rely on the config reference already in the tests.
This is part 4, the majority was done previously.

Mainly made the fake CLI not use `CurrentConfig()` and removed usage in `test_setup.go`

### Checklist

- [x] Tests added and all succeed
 - Test amended and all pass.
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
