### PR TITLE
fix: reference folder not found for delta scans [IDE-1425]

### DIFF
--- a/internal/storedconfig/cross_platform_test.go
+++ b/internal/storedconfig/cross_platform_test.go
@@ -59,6 +59,10 @@ func Test_GetOrCreateFolderConfig_CrossPlatformPaths(t *testing.T) {
 			name:      "Path with whitespace",
 			inputPath: "  /Users/foo/project  ",
 		},
+		{
+			name:      "Unix path with Windows separators",
+			inputPath: `\Users\foo\project`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -77,7 +81,7 @@ func Test_GetOrCreateFolderConfig_CrossPlatformPaths(t *testing.T) {
 			// Verify the config is stored with the normalized path as key
 			sc, err := GetStoredConfig(conf, &logger)
 			require.NoError(t, err)
-			normalizedKey := util.NormalizePath(tt.inputPath)
+			normalizedKey := util.GenerateFolderConfigKey(tt.inputPath)
 			require.NotNil(t, sc.FolderConfigs[normalizedKey])
 			require.Equal(t, folderConfig, sc.FolderConfigs[normalizedKey])
 		})

--- a/internal/storedconfig/stored_config_test.go
+++ b/internal/storedconfig/stored_config_test.go
@@ -56,7 +56,7 @@ func Test_GetOrCreateFolderConfig_shouldStoreEverythingInStorageFile(t *testing.
 	var sc StoredConfig
 	err = json.Unmarshal([]byte(scJson), &sc)
 	require.NoError(t, err)
-	require.Equal(t, actual, sc.FolderConfigs[util.NormalizePath(path)])
+	require.Equal(t, actual, sc.FolderConfigs[util.GenerateFolderConfigKey(path)])
 
 	bytes, err := os.ReadFile(storageFile)
 	require.NoError(t, err)

--- a/internal/storedconfig/xdg.go
+++ b/internal/storedconfig/xdg.go
@@ -51,7 +51,7 @@ func folderConfigFromStorage(conf configuration.Configuration, path types.FilePa
 		return nil, err
 	}
 
-	normalizedPath := util.NormalizePath(path)
+	normalizedPath := util.GenerateFolderConfigKey(path)
 
 	if sc.FolderConfigs[normalizedPath] == nil {
 		folderConfig := &types.FolderConfig{}
@@ -80,7 +80,7 @@ func GetStoredConfig(conf configuration.Configuration, logger *zerolog.Logger) (
 		if sc != nil && sc.FolderConfigs != nil {
 			normalized := make(map[types.FilePath]*types.FolderConfig, len(sc.FolderConfigs))
 			for k, v := range sc.FolderConfigs {
-				nk := util.NormalizePath(k)
+				nk := util.GenerateFolderConfigKey(k)
 				normalized[nk] = v
 			}
 			sc.FolderConfigs = normalized
@@ -122,8 +122,8 @@ func UpdateFolderConfig(conf configuration.Configuration, folderConfig *types.Fo
 		return err
 	}
 
-	// Normalize the folder path for consistent cross-platform keys
-	normalizedPath := util.NormalizePath(folderConfig.FolderPath)
+	// Generate normalized key for consistent cross-platform storage
+	normalizedPath := util.GenerateFolderConfigKey(folderConfig.FolderPath)
 
 	sc.FolderConfigs[normalizedPath] = folderConfig
 	err = Save(conf, sc)

--- a/internal/storedconfig/xdg_test.go
+++ b/internal/storedconfig/xdg_test.go
@@ -52,5 +52,5 @@ func Test_folderConfigFromFallbackStorage_never_nil_and_added_to_config(t *testi
 
 	storedConfig := conf.Get(ConfigMainKey).(StoredConfig)
 	require.NotNil(t, storedConfig)
-	require.Equal(t, folderConfig, storedConfig.FolderConfigs[util.NormalizePath(types.FilePath("testPath"))])
+	require.Equal(t, folderConfig, storedConfig.FolderConfigs[util.GenerateFolderConfigKey(types.FilePath("testPath"))])
 }

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -6,8 +6,9 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
-// NormalizePath converts to forward slashes, trims whitespace, and removes trailing slashes (except root)
-func NormalizePath(p types.FilePath) types.FilePath {
+// GenerateFolderConfigKey creates a normalized key for folder config storage
+// This ensures consistent cross-platform map keys while preserving original paths
+func GenerateFolderConfigKey(p types.FilePath) types.FilePath {
 	s := strings.TrimSpace(string(p))
 	if s == "" {
 		return ""

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
-func TestNormalizePath(t *testing.T) {
+func TestGenerateFolderConfigKey(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    types.FilePath
@@ -73,7 +73,7 @@ func TestNormalizePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := NormalizePath(tt.input)
+			result := GenerateFolderConfigKey(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
### Description

Fixed ReferenceFolderPath not being found - Consistent path keys ensure FolderConfig lookup works correctly.
It will remove backslash to the path key, so there will not be difference for folderconfig keys created with //home/test and //home/test/. 
Migrating existing stored configurations to use normalized keys.

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
