### PR TITLE
chore(ci): correct docs sync path pt.2 [IDA-563]

### DIFF
--- a/.github/workflows/update-compatibility-matrix.yaml
+++ b/.github/workflows/update-compatibility-matrix.yaml
@@ -92,7 +92,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
 
           # Commit changes
-          git add docs/cli-ide-and-ci-cd-integrations/snyk-ide-plugins-and-extensions/compatibility-matrix.md
+          git add docs/developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md
 
           # Check if there are changes to commit
           if git diff --staged --quiet; then


### PR DESCRIPTION
### Description

Attempt 2, because I missed a path in attempt 1.

### Checklist

- [ ] Tests added and all succeed
 - N/A
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [ ] Linted (`make lint-fix`)
 - N/A
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
