### PR TITLE
fix(ci): use correct pact install location [IDE-1377]

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,15 @@
+name: 'Setup Go'
+description: 'Determine Go version from go.mod and set up Go with caching'
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine Go version
+      shell: bash
+      run: |
+        sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: "true"

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -1,0 +1,16 @@
+name: 'Setup tools (`make tools`)'
+description: 'Cache and install tools from Makefile'
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache tools
+      id: cache-tools
+      uses: actions/cache@v4
+      with:
+        path: .bin
+        key: ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}
+
+    - name: Install tools (`make tools`)
+      shell: bash
+      if: steps.cache-tools.outputs.cache-hit != 'true'
+      run: make tools

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,18 +27,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
-
-      - name: Install tools
-        run: make tools
+      - name: Setup tools (`make tools`)
+        uses: ./.github/actions/setup-tools
 
       - name: Run go generate commands
         run: make generate
@@ -59,31 +52,14 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - name: Set up Snyk CLI
         uses: snyk/actions/setup@master
 
-      - name: Cache Pact CLI tools
-        id: cache-pact
-        uses: actions/cache@v4
-        with:
-          path: ~/pact
-          key: ${{ runner.os }}-pact
-
-      - name: Set up Pact CLI tools
-        shell: bash
-        if: steps.cache-pact.outputs.cache-hit != 'true'
-        run: |
-          make tools
+      - name: Setup tools (`make tools`)
+        uses: ./.github/actions/setup-tools
 
       - name: Run tests
         env:
@@ -91,7 +67,7 @@ jobs:
           SNYK_TOKEN: ${{secrets.SNYK_TOKEN }}
           SNYK_TOKEN_CONSISTENT_IGNORES: ${{secrets.SNYK_TOKEN_CONSISTENT_IGNORES }}
         run: |
-          export PATH=$PATH:~/pact/bin
+          export PATH=$PWD/.bin/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -113,29 +89,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
-
-      - name: Cache Pact CLI tools
+      - name: Setup tools (`make tools`)
         if: matrix.os != 'windows-latest'
-        id: cache-pact
-        uses: actions/cache@v4
-        with:
-          path: ~/pact
-          key: ${{ runner.os }}-pact
-
-      - name: Set up Pact CLI tools
-        shell: bash
-        if: steps.cache-pact.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
-        run: |
-          make tools
+        uses: ./.github/actions/setup-tools
 
       - name: Run integration & smoke tests with Pact
         if: matrix.os == 'ubuntu-latest'
@@ -145,7 +104,7 @@ jobs:
           INTEG_TESTS: "true"
           SMOKE_TESTS: "true"
         run: |
-          export PATH=$PATH:~/pact/bin
+          export PATH=$PWD/.bin/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -162,7 +121,7 @@ jobs:
           INTEG_TESTS: "true"
           SMOKE_TESTS: "true"
         run: |
-          export PATH=$PATH:~/pact/bin
+          export PATH=$PWD/.bin/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -200,23 +159,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Pact CLI tools
-        shell: bash
-        run: |
-          make tools
 
-      - name: Cache Pact CLI tools
-        id: cache-pact
-        uses: actions/cache@v4
-        with:
-          path: ~/pact
-          key: ${{ runner.os }}-pact
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup tools (`make tools`)
+        uses: ./.github/actions/setup-tools
 
       - name: Run race tests
         env:
           SNYK_TOKEN: ${{secrets.SNYK_TOKEN }}
         run: |
-          export PATH=$PATH:~/pact/bin
+          export PATH=$PWD/.bin/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -239,19 +193,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.HAMMERHEAD_GITHUB_PAT_SNYKLS }}
 
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
+      - name: Setup tools (`make tools`)
+        uses: ./.github/actions/setup-tools
 
       - name: update licenses
         run: |
-          make tools license-update
+          make license-update
 
       - name: commit license changes
         uses: EndBug/add-and-commit@v9
@@ -271,20 +221,15 @@ jobs:
         with:
           fetch-depth: 0 # does an unshallow checkout with tags & branches
 
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
+      - name: Setup tools (`make tools`)
+        uses: ./.github/actions/setup-tools
 
       - name: Create License Report
         id: create_license_report
         run: |
-          make tools
           LICENSES=$(make licenses)
           echo 'LICENSES<<EOF' >> $GITHUB_OUTPUT
           echo $LICENSES >> $GITHUB_OUTPUT

--- a/.github/workflows/create-cli-pr.yaml
+++ b/.github/workflows/create-cli-pr.yaml
@@ -14,15 +14,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/instance-tests.yaml
+++ b/.github/workflows/instance-tests.yaml
@@ -33,15 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - name: Run Instance Tests
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,33 +36,15 @@ jobs:
         with:
           fetch-depth: 0 # does an unshallow checkout with tags & branches
 
-      # this step can be removed if setup-go will support reading go-version from go.mod
-      - name: Determine Go version
-        run: |
-          sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "true"
-
-      - name: Cache Pact CLI tools
-        id: cache-pact
-        uses: actions/cache@v4
-        with:
-          path: ~/pact
-          key: ${{ runner.os }}-pact
-
-      - name: Set up Pact CLI tools
-        shell: bash
-        if: steps.cache-pact.outputs.cache-hit != 'true'
-        run: |
-          make tools
+      - name: Setup tools (`make tools`)
+        uses: ./.github/actions/setup-tools
 
       - name: Lint source code
         run: |
-          make tools lint
+          make lint
 
       - name: Set up Snyk CLI # Tests need it
         uses: snyk/actions/setup@master
@@ -72,7 +54,7 @@ jobs:
           DEEPROXY_API_URL: ${{secrets.DEEPROXY_API_URL}}
           SNYK_TOKEN: ${{secrets.SNYK_TOKEN }}
         run: |
-          export PATH=$PATH:~/pact/bin
+          export PATH=$PWD/.bin/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -89,7 +71,7 @@ jobs:
           INTEG_TESTS: "true"
           SMOKE_TESTS: "true"
         run: |
-          export PATH=$PATH:~/pact/bin
+          export PATH=$PWD/.bin/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -110,7 +92,6 @@ jobs:
       - name: Create License Report
         id: create_license_report
         run: |
-          make tools
           LICENSES=$(make licenses)
           echo 'LICENSES<<EOF' >> $GITHUB_OUTPUT
           echo $LICENSES >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description

Cache .bin after `make tools`, keyed on the hash of the Makefile, so if anything updates we get fresh tools.
Add common actions for setting up Go and tools.

### Checklist

- [x] Tests added and all succeed
 - None added, but still pass in CI 😀 
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [ ] Linted (`make lint-fix`)
 - N/A
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
