### PR TITLE
feat: add config analytics [IDE-1475]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -57,18 +57,6 @@ import (
 	"github.com/snyk/snyk-ls/internal/util"
 )
 
-// InitializationPhase represents the current phase of the initialization process
-type InitializationPhase string
-
-const (
-	// PhaseEmptySettings represents the first phase where no settings have been loaded yet
-	PhaseEmptySettings InitializationPhase = "emptySettings"
-	// PhaseInitialSettings represents the second phase where initial settings have been loaded
-	PhaseInitialSettings InitializationPhase = "initialSettings"
-	// PhaseUserChanges represents the third phase where user/IDE changes are being processed
-	PhaseUserChanges InitializationPhase = "userChanges"
-)
-
 const (
 	deeproxyApiUrlKey     = "DEEPROXY_API_URL"
 	FormatHtml            = "html"

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -1313,6 +1313,10 @@ func (c *Config) FolderOrganization(path types.FilePath) string {
 			return fc.PreferredOrg
 		}
 	} else {
+		// If AutoDeterminedOrg is empty, fall back to global organization
+		if fc.AutoDeterminedOrg == "" {
+			return c.Organization()
+		}
 		return fc.AutoDeterminedOrg
 	}
 }

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -203,7 +203,6 @@ type Config struct {
 	mcpServerEnabled                 bool
 	mcpBaseURL                       *url.URL
 	isLSPInitialized                 bool
-	isFirstConfigurationChange       bool
 	snykAgentFixEnabled              bool
 	cachedOriginalPath               string
 	userSettingsPath                 string
@@ -270,7 +269,6 @@ func newConfig(engine workflow.Engine, opts ...ConfigOption) *Config {
 	c.trustedFoldersFeatureEnabled = true
 	c.automaticScanning = true
 	c.authenticationMethod = types.TokenAuthentication
-	c.isFirstConfigurationChange = true
 	if engine == nil {
 		initWorkFlowEngine(c)
 	} else {
@@ -1391,18 +1389,6 @@ func (c *Config) SetLSPInitialized(initialized bool) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	c.isLSPInitialized = initialized
-}
-
-func (c *Config) GetInitializationPhase() bool {
-	c.m.RLock()
-	defer c.m.RUnlock()
-	return c.isFirstConfigurationChange
-}
-
-func (c *Config) SetFirstConfigurationChangeProcessed() {
-	c.m.Lock()
-	defer c.m.Unlock()
-	c.isFirstConfigurationChange = false
 }
 
 func (c *Config) SetSnykAgentFixEnabled(enabled bool) {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -203,6 +203,7 @@ type Config struct {
 	mcpServerEnabled                 bool
 	mcpBaseURL                       *url.URL
 	isLSPInitialized                 bool
+	isFirstConfigurationChange       bool
 	snykAgentFixEnabled              bool
 	cachedOriginalPath               string
 	userSettingsPath                 string
@@ -269,6 +270,7 @@ func newConfig(engine workflow.Engine, opts ...ConfigOption) *Config {
 	c.trustedFoldersFeatureEnabled = true
 	c.automaticScanning = true
 	c.authenticationMethod = types.TokenAuthentication
+	c.isFirstConfigurationChange = true
 	if engine == nil {
 		initWorkFlowEngine(c)
 	} else {
@@ -1389,6 +1391,18 @@ func (c *Config) SetLSPInitialized(initialized bool) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	c.isLSPInitialized = initialized
+}
+
+func (c *Config) GetInitializationPhase() bool {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return c.isFirstConfigurationChange
+}
+
+func (c *Config) SetFirstConfigurationChangeProcessed() {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.isFirstConfigurationChange = false
 }
 
 func (c *Config) SetSnykAgentFixEnabled(enabled bool) {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -459,6 +459,13 @@ func (c *Config) SnykCodeApi() string {
 	return c.snykCodeApiUrl
 }
 
+func (c *Config) Endpoint() string {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	return c.snykApiUrl
+}
+
 func (c *Config) SnykUI() string {
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -57,6 +57,18 @@ import (
 	"github.com/snyk/snyk-ls/internal/util"
 )
 
+// InitializationPhase represents the current phase of the initialization process
+type InitializationPhase string
+
+const (
+	// PhaseEmptySettings represents the first phase where no settings have been loaded yet
+	PhaseEmptySettings InitializationPhase = "emptySettings"
+	// PhaseInitialSettings represents the second phase where initial settings have been loaded
+	PhaseInitialSettings InitializationPhase = "initialSettings"
+	// PhaseUserChanges represents the third phase where user/IDE changes are being processed
+	PhaseUserChanges InitializationPhase = "userChanges"
+)
+
 const (
 	deeproxyApiUrlKey     = "DEEPROXY_API_URL"
 	FormatHtml            = "html"

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -118,8 +118,8 @@ func writeSettings(c *config.Config, settings types.Settings, initialize bool, t
 	updateIssueViewOptions(c, settings.IssueViewOptions, triggerSource)
 	updateProductEnablement(c, settings, triggerSource, sendAnalytics)
 	updateCliConfig(c, settings)
-	updateApiEndpoints(c, settings, initialize, triggerSource) // Must be called before token is set, as it may trigger a logout which clears the token.
-	updateToken(settings.Token)                                // Must be called before the Authentication method is set, as the latter checks the token.
+	updateApiEndpoints(c, settings, initialize, triggerSource, sendAnalytics) // Must be called before token is set, as it may trigger a logout which clears the token.
+	updateToken(settings.Token)                                               // Must be called before the Authentication method is set, as the latter checks the token.
 	updateAuthenticationMethod(c, settings, triggerSource)
 	updateEnvironment(c, settings)
 	updatePathFromSettings(c, settings, initialize)
@@ -387,9 +387,9 @@ func updateToken(token string) {
 	di.AuthenticationService().UpdateCredentials(token, false, false)
 }
 
-func updateApiEndpoints(c *config.Config, settings types.Settings, initialization bool, triggerSource string) {
+func updateApiEndpoints(c *config.Config, settings types.Settings, initialization bool, triggerSource string, sendAnalytics bool) {
 	snykApiUrl := strings.Trim(settings.Endpoint, " ")
-	// TODO: Add getter method for Endpoint to enable analytics
+	oldEndpoint := c.Endpoint()
 	endpointsUpdated := c.UpdateApiEndpoints(snykApiUrl)
 
 	if endpointsUpdated && !initialization {
@@ -397,6 +397,11 @@ func updateApiEndpoints(c *config.Config, settings types.Settings, initializatio
 		authService.Logout(context.Background())
 		authService.ConfigureProviders(c)
 		c.Workspace().Clear()
+
+		// Send analytics for endpoint change
+		if sendAnalytics {
+			sendWorkspaceConfigChanged(c, "endpoint", oldEndpoint, snykApiUrl, triggerSource)
+		}
 	}
 
 	// a custom set snyk code api (e.g. for testing) always overwrites automatic config

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -48,7 +48,7 @@ func workspaceDidChangeConfiguration(c *config.Config, srv *jrpc2.Server) jrpc2.
 		emptySettings := types.Settings{}
 		if !reflect.DeepEqual(params.Settings, emptySettings) {
 			// client used settings push
-			UpdateSettings(c, params.Settings)
+			UpdateSettings(c, params.Settings, "user", true)
 			return true, nil
 		}
 
@@ -75,7 +75,7 @@ func workspaceDidChangeConfiguration(c *config.Config, srv *jrpc2.Server) jrpc2.
 		}
 
 		if !reflect.DeepEqual(fetchedSettings[0], emptySettings) {
-			UpdateSettings(c, fetchedSettings[0])
+			UpdateSettings(c, fetchedSettings[0], "user", true)
 			return true, nil
 		}
 
@@ -84,16 +84,16 @@ func workspaceDidChangeConfiguration(c *config.Config, srv *jrpc2.Server) jrpc2.
 }
 
 func InitializeSettings(c *config.Config, settings types.Settings) {
-	writeSettings(c, settings, true)
+	writeSettings(c, settings, true, "", false)
 	updateAutoAuthentication(c, settings)
 	updateDeviceInformation(c, settings)
-	updateAutoScan(c, settings)
+	updateAutoScan(c, settings, "")
 	c.SetClientProtocolVersion(settings.RequiredProtocolVersion)
 }
 
-func UpdateSettings(c *config.Config, settings types.Settings) {
+func UpdateSettings(c *config.Config, settings types.Settings, triggerSource string, sendAnalytics bool) {
 	previouslyEnabledProducts := c.DisplayableIssueTypes()
-	writeSettings(c, settings, false)
+	writeSettings(c, settings, false, triggerSource, sendAnalytics)
 
 	// If a product was removed, clear all issues for this product
 	ws := c.Workspace()
@@ -107,33 +107,33 @@ func UpdateSettings(c *config.Config, settings types.Settings) {
 	}
 }
 
-func writeSettings(c *config.Config, settings types.Settings, initialize bool) {
+func writeSettings(c *config.Config, settings types.Settings, initialize bool, triggerSource string, sendAnalytics bool) {
 	c.Engine().GetConfiguration().ClearCache()
 
 	emptySettings := types.Settings{}
 	if reflect.DeepEqual(settings, emptySettings) {
 		return
 	}
-	updateSeverityFilter(c, settings.FilterSeverity)
-	updateIssueViewOptions(c, settings.IssueViewOptions)
-	updateProductEnablement(c, settings)
+	updateSeverityFilter(c, settings.FilterSeverity, triggerSource)
+	updateIssueViewOptions(c, settings.IssueViewOptions, triggerSource)
+	updateProductEnablement(c, settings, triggerSource, sendAnalytics)
 	updateCliConfig(c, settings)
-	updateApiEndpoints(c, settings, initialize) // Must be called before token is set, as it may trigger a logout which clears the token.
-	updateToken(settings.Token)                 // Must be called before the Authentication method is set, as the latter checks the token.
-	updateAuthenticationMethod(c, settings)
+	updateApiEndpoints(c, settings, initialize, triggerSource) // Must be called before token is set, as it may trigger a logout which clears the token.
+	updateToken(settings.Token)                                // Must be called before the Authentication method is set, as the latter checks the token.
+	updateAuthenticationMethod(c, settings, triggerSource)
 	updateEnvironment(c, settings)
 	updatePathFromSettings(c, settings, initialize)
-	updateErrorReporting(c, settings)
-	updateOrganization(c, settings)
-	manageBinariesAutomatically(c, settings)
-	updateTrustedFolders(c, settings)
+	updateErrorReporting(c, settings, triggerSource)
+	updateOrganization(c, settings, triggerSource, sendAnalytics)
+	manageBinariesAutomatically(c, settings, triggerSource)
+	updateTrustedFolders(c, settings, triggerSource)
 	updateSnykCodeSecurity(c, settings)
 	updateRuntimeInfo(c, settings)
-	updateAutoScan(c, settings)
-	updateSnykLearnCodeActions(c, settings)
-	updateSnykOSSQuickFixCodeActions(c, settings)
-	updateSnykOpenBrowserCodeActions(c, settings)
-	updateDeltaFindings(c, settings)
+	updateAutoScan(c, settings, triggerSource)
+	updateSnykLearnCodeActions(c, settings, triggerSource)
+	updateSnykOSSQuickFixCodeActions(c, settings, triggerSource)
+	updateSnykOpenBrowserCodeActions(c, settings, triggerSource)
+	updateDeltaFindings(c, settings, triggerSource)
 	updateFolderConfig(c, settings, c.Logger())
 	updateHoverVerbosity(c, settings)
 	updateFormat(c, settings)
@@ -151,12 +151,13 @@ func updateHoverVerbosity(c *config.Config, settings types.Settings) {
 	}
 }
 
-func updateSnykOpenBrowserCodeActions(c *config.Config, settings types.Settings) {
+func updateSnykOpenBrowserCodeActions(c *config.Config, settings types.Settings, triggerSource string) {
 	enable := false
 	if settings.EnableSnykOpenBrowserActions == "true" {
 		enable = true
 	}
 
+	// TODO: Add getter method for SnykOpenBrowserActionsEnabled to enable analytics
 	c.SetSnykOpenBrowserActionsEnabled(enable)
 }
 
@@ -269,8 +270,13 @@ func updateAuthenticationMethod(c *config.Config, settings types.Settings) {
 		return
 	}
 
+	oldValue := c.AuthenticationMethod()
 	c.SetAuthenticationMethod(settings.AuthenticationMethod)
 	di.AuthenticationService().ConfigureProviders(c)
+
+	if oldValue != settings.AuthenticationMethod {
+		sendWorkspaceConfigChanged(c, "authenticationMethod", oldValue, settings.AuthenticationMethod, triggerSource)
+	}
 }
 
 func updateRuntimeInfo(c *config.Config, settings types.Settings) {
@@ -280,20 +286,28 @@ func updateRuntimeInfo(c *config.Config, settings types.Settings) {
 	c.SetRuntimeName(settings.RuntimeName)
 }
 
-func updateTrustedFolders(c *config.Config, settings types.Settings) {
+func updateTrustedFolders(c *config.Config, settings types.Settings, triggerSource string) {
 	trustedFoldersFeatureEnabled, err := strconv.ParseBool(settings.EnableTrustedFoldersFeature)
 	if err == nil {
+		oldValue := c.IsTrustedFolderFeatureEnabled()
 		c.SetTrustedFolderFeatureEnabled(trustedFoldersFeatureEnabled)
+		if oldValue != trustedFoldersFeatureEnabled {
+			sendWorkspaceConfigChanged(c, "enableTrustedFoldersFeature", oldValue, trustedFoldersFeatureEnabled, triggerSource)
+		}
 	} else {
 		c.SetTrustedFolderFeatureEnabled(true)
 	}
 
 	if settings.TrustedFolders != nil {
+		oldFolders := c.TrustedFolders()
 		var trustedFolders []types.FilePath
 		for _, folder := range settings.TrustedFolders {
 			trustedFolders = append(trustedFolders, types.FilePath(folder))
 		}
 		c.SetTrustedFolders(trustedFolders)
+
+		// Send analytics for trusted folders change
+		sendWorkspaceConfigChanged(c, "trustedFolders", oldFolders, trustedFolders, triggerSource)
 	}
 }
 
@@ -315,35 +329,46 @@ func updateDeviceInformation(c *config.Config, settings types.Settings) {
 	}
 }
 
-func updateAutoScan(c *config.Config, settings types.Settings) {
+func updateAutoScan(c *config.Config, settings types.Settings, triggerSource string) {
 	// Auto scan true by default unless the AutoScan value in the settings is not missing & false
 	autoScan := true
 	if settings.ScanningMode == "manual" {
 		autoScan = false
 	}
 
+	// TODO: Add getter method for AutomaticScanning to enable analytics
 	c.SetAutomaticScanning(autoScan)
 }
 
-func updateSnykLearnCodeActions(c *config.Config, settings types.Settings) {
+func updateSnykLearnCodeActions(c *config.Config, settings types.Settings, triggerSource string) {
 	enable := true
 	if settings.EnableSnykLearnCodeActions == "false" {
 		enable = false
 	}
 
+	oldValue := c.IsSnykLearnCodeActionsEnabled()
 	c.SetSnykLearnCodeActionsEnabled(enable)
+
+	if oldValue != enable {
+		sendWorkspaceConfigChanged(c, "enableSnykLearnCodeActions", oldValue, enable, triggerSource)
+	}
 }
 
-func updateSnykOSSQuickFixCodeActions(c *config.Config, settings types.Settings) {
+func updateSnykOSSQuickFixCodeActions(c *config.Config, settings types.Settings, triggerSource string) {
 	enable := true
 	if settings.EnableSnykOSSQuickFixCodeActions == "false" {
 		enable = false
 	}
 
+	oldValue := c.IsSnykOSSQuickFixCodeActionsEnabled()
 	c.SetSnykOSSQuickFixCodeActionsEnabled(enable)
+
+	if oldValue != enable {
+		sendWorkspaceConfigChanged(c, "enableSnykOSSQuickFixCodeActions", oldValue, enable, triggerSource)
+	}
 }
 
-func updateDeltaFindings(c *config.Config, settings types.Settings) {
+func updateDeltaFindings(c *config.Config, settings types.Settings, triggerSource string) {
 	enable := true
 	if settings.EnableDeltaFindings == "" || settings.EnableDeltaFindings == "false" {
 		enable = false
@@ -353,7 +378,7 @@ func updateDeltaFindings(c *config.Config, settings types.Settings) {
 
 	modified := c.SetDeltaFindingsEnabled(enable)
 	if modified {
-		sendWorkspaceConfigChanged(c, "enableDeltaFindings", oldValue, enable)
+		sendWorkspaceConfigChanged(c, "enableDeltaFindings", oldValue, enable, triggerSource)
 	}
 }
 
@@ -362,8 +387,9 @@ func updateToken(token string) {
 	di.AuthenticationService().UpdateCredentials(token, false, false)
 }
 
-func updateApiEndpoints(c *config.Config, settings types.Settings, initialization bool) {
+func updateApiEndpoints(c *config.Config, settings types.Settings, initialization bool, triggerSource string) {
 	snykApiUrl := strings.Trim(settings.Endpoint, " ")
+	// TODO: Add getter method for Endpoint to enable analytics
 	endpointsUpdated := c.UpdateApiEndpoints(snykApiUrl)
 
 	if endpointsUpdated && !initialization {
@@ -375,37 +401,92 @@ func updateApiEndpoints(c *config.Config, settings types.Settings, initializatio
 
 	// a custom set snyk code api (e.g. for testing) always overwrites automatic config
 	if settings.SnykCodeApi != "" {
+		oldCodeApi := c.SnykCodeApi()
 		c.SetSnykCodeApi(settings.SnykCodeApi)
-	}
-}
-
-func updateOrganization(c *config.Config, settings types.Settings) {
-	newOrg := strings.TrimSpace(settings.Organization)
-	if newOrg != "" {
-		oldOrgId := c.Organization()
-		c.SetOrganization(newOrg)
-		newOrgId := c.Organization() // Read the org from config so we are guaranteed to have a UUID instead of a slug.
-		if oldOrgId != newOrgId {
-			go sendConfigChangedAnalyticsEvent(c, "organization", oldOrgId, newOrgId, "")
+		if oldCodeApi != settings.SnykCodeApi {
+			sendWorkspaceConfigChanged(c, "snykCodeApi", oldCodeApi, settings.SnykCodeApi, triggerSource)
 		}
 	}
 }
 
-func updateErrorReporting(c *config.Config, settings types.Settings) {
+func updateOrganization(c *config.Config, settings types.Settings, triggerSource string, sendAnalytics bool) {
+	// Persist per-folder orgs using stored config.
+	updatedAny := false
+	for _, fc := range settings.FolderConfigs {
+		org := strings.TrimSpace(fc.Organization)
+		if org == "" {
+			continue
+		}
+		// Persist to stored folder config
+		current, err := storedconfig.GetOrCreateFolderConfig(c.Engine().GetConfiguration(), fc.FolderPath, c.Logger())
+		if err == nil {
+			if current.Organization != org {
+				oldOrg := current.Organization
+				current.Organization = org
+				_ = storedconfig.UpdateFolderConfig(c.Engine().GetConfiguration(), current, c.Logger())
+				// Send analytics for organization change (only if user-triggered)
+				if sendAnalytics {
+					go sendConfigChangedAnalyticsEvent(c, "organization", oldOrg, org, fc.FolderPath, triggerSource)
+				}
+				updatedAny = true
+			}
+		}
+	}
+
+	// Legacy migration: if no folder configs provided orgs but legacy settings.Organization is set,
+	// copy it into all provided folder configs and then clear global org.
+	if !updatedAny {
+		newOrg := strings.TrimSpace(settings.Organization)
+		if newOrg != "" {
+			migrated := 0
+			for _, fc := range settings.FolderConfigs {
+				current, err := storedconfig.GetOrCreateFolderConfig(c.Engine().GetConfiguration(), fc.FolderPath, c.Logger())
+				if err == nil {
+					if current.Organization != newOrg {
+						oldOrg := current.Organization
+						current.Organization = newOrg
+						_ = storedconfig.UpdateFolderConfig(c.Engine().GetConfiguration(), current, c.Logger())
+						// Send analytics for organization change (only if user-triggered)
+						if sendAnalytics {
+							go sendConfigChangedAnalyticsEvent(c, "organization", oldOrg, newOrg, fc.FolderPath, triggerSource)
+						}
+						migrated++
+					}
+				}
+			}
+			if migrated > 0 {
+				// clear legacy global org after successful migration
+				c.SetOrganization("")
+			}
+		}
+	}
+}
+
+func updateErrorReporting(c *config.Config, settings types.Settings, triggerSource string) {
 	parseBool, err := strconv.ParseBool(settings.SendErrorReports)
 	if err != nil {
 		c.Logger().Debug().Msgf("couldn't read send error reports %s", settings.SendErrorReports)
 	} else {
+		oldValue := c.IsErrorReportingEnabled()
 		c.SetErrorReportingEnabled(parseBool)
+
+		if oldValue != parseBool {
+			sendWorkspaceConfigChanged(c, "sendErrorReports", oldValue, parseBool, triggerSource)
+		}
 	}
 }
 
-func manageBinariesAutomatically(c *config.Config, settings types.Settings) {
+func manageBinariesAutomatically(c *config.Config, settings types.Settings, triggerSource string) {
 	parseBool, err := strconv.ParseBool(settings.ManageBinariesAutomatically)
 	if err != nil {
 		c.Logger().Debug().Msgf("couldn't read manage binaries automatically %s", settings.ManageBinariesAutomatically)
 	} else {
+		oldValue := c.ManageBinariesAutomatically()
 		c.SetManageBinariesAutomatically(parseBool)
+
+		if oldValue != parseBool {
+			sendWorkspaceConfigChanged(c, "manageBinariesAutomatically", oldValue, parseBool, triggerSource)
+		}
 	}
 }
 
@@ -479,47 +560,64 @@ func updateCliConfig(c *config.Config, settings types.Settings) {
 	currentConfig.SetCliSettings(cliSettings)
 }
 
-func updateProductEnablement(c *config.Config, settings types.Settings) {
+func updateProductEnablement(c *config.Config, settings types.Settings, triggerSource string, sendAnalytics bool) {
+	// Snyk Code
 	parseBool, err := strconv.ParseBool(settings.ActivateSnykCode)
 	if err != nil {
 		c.Logger().Debug().Msg("couldn't parse code setting")
 	} else {
+		oldValue := c.IsSnykCodeEnabled()
 		c.SetSnykCodeEnabled(parseBool)
 		c.EnableSnykCodeSecurity(parseBool)
+		if oldValue != parseBool && sendAnalytics {
+			sendWorkspaceConfigChanged(c, "activateSnykCode", oldValue, parseBool, triggerSource)
+		}
 	}
+
+	// Snyk Open Source
 	parseBool, err = strconv.ParseBool(settings.ActivateSnykOpenSource)
 	if err != nil {
 		c.Logger().Debug().Msg("couldn't parse open source setting")
 	} else {
+		oldValue := c.IsSnykOssEnabled()
 		c.SetSnykOssEnabled(parseBool)
+		if oldValue != parseBool && sendAnalytics {
+			sendWorkspaceConfigChanged(c, "activateSnykOpenSource", oldValue, parseBool, triggerSource)
+		}
 	}
+
+	// Snyk IaC
 	parseBool, err = strconv.ParseBool(settings.ActivateSnykIac)
 	if err != nil {
 		c.Logger().Debug().Msg("couldn't parse iac setting")
 	} else {
+		oldValue := c.IsSnykIacEnabled()
 		c.SetSnykIacEnabled(parseBool)
+		if oldValue != parseBool && sendAnalytics {
+			sendWorkspaceConfigChanged(c, "activateSnykIac", oldValue, parseBool, triggerSource)
+		}
 	}
 }
 
-func updateIssueViewOptions(c *config.Config, s *types.IssueViewOptions) {
+func updateIssueViewOptions(c *config.Config, s *types.IssueViewOptions, triggerSource string) {
 	c.Logger().Debug().Str("method", "updateIssueViewOptions").Interface("issueViewOptions", s).Msg("Updating issue view options:")
 	modified := c.SetIssueViewOptions(s)
 
 	if modified {
-		sendWorkspaceConfigChanged(c, "", nil, nil)
+		sendWorkspaceConfigChanged(c, "", nil, nil, triggerSource)
 	}
 }
 
-func updateSeverityFilter(c *config.Config, s *types.SeverityFilter) {
+func updateSeverityFilter(c *config.Config, s *types.SeverityFilter, triggerSource string) {
 	c.Logger().Debug().Str("method", "updateSeverityFilter").Interface("severityFilter", s).Msg("Updating severity filter:")
 	modified := c.SetSeverityFilter(s)
 
 	if modified {
-		sendWorkspaceConfigChanged(c, "", nil, nil)
+		sendWorkspaceConfigChanged(c, "", nil, nil, triggerSource)
 	}
 }
 
-func sendWorkspaceConfigChanged(c *config.Config, configName string, oldVal any, newVal any) {
+func sendWorkspaceConfigChanged(c *config.Config, configName string, oldVal any, newVal any, triggerSource string) {
 	ws := c.Workspace()
 	if ws == nil {
 		return
@@ -530,16 +628,17 @@ func sendWorkspaceConfigChanged(c *config.Config, configName string, oldVal any,
 		return
 	}
 	for _, folder := range ws.Folders() {
-		go sendConfigChangedAnalyticsEvent(c, configName, oldVal, newVal, folder.Path())
+		go sendConfigChangedAnalyticsEvent(c, configName, oldVal, newVal, folder.Path(), triggerSource)
 	}
 }
 
-func sendConfigChangedAnalyticsEvent(c *config.Config, field string, oldValue, newValue interface{}, path types.FilePath) {
+func sendConfigChangedAnalyticsEvent(c *config.Config, field string, oldValue, newValue interface{}, path types.FilePath, triggerSource string) {
 	event := analytics.NewAnalyticsEventParam("Config changed", nil, path)
 
 	event.Extension = map[string]any{
-		"config::" + field + "::oldValue": oldValue,
-		"config::" + field + "::newValue": newValue,
+		"config::" + field + "::oldValue":      oldValue,
+		"config::" + field + "::newValue":      newValue,
+		"config::" + field + "::triggerSource": triggerSource,
 	}
 	analytics.SendAnalytics(c.Engine(), c.DeviceID(), event, nil)
 }

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -556,7 +556,7 @@ func Test_updateFolderConfig_MigratedConfig_UserSetWithNonEmptyOrg(t *testing.T)
 			},
 		},
 	}
-	updateFolderConfig(c, settings, logger)
+	updateFolderConfig(c, settings, logger, "test", true)
 
 	// Verify the org was kept - with the current implementation, UpdateFolderConfigOrg is always called
 	// due to pointer comparison, but the org should remain the same since it's user-set
@@ -575,6 +575,15 @@ func Test_updateFolderConfig_MigratedConfig_InheritingFromBlankGlobal(t *testing
 
 	// Call updateFolderConfig
 	setup.callUpdateFolderConfig("")
+	settings := types.Settings{
+		FolderConfigs: []types.FolderConfig{
+			{
+				FolderPath:   folderPath,
+				Organization: "",
+			},
+		},
+	}
+	updateFolderConfig(c, settings, logger, "test", true)
 
 	// Verify: When both folder and global org are empty and LDX-Sync is called
 	updatedConfig := setup.getUpdatedConfig()
@@ -593,6 +602,15 @@ func Test_updateFolderConfig_NotMigrated_EmptyStoredOrg(t *testing.T) {
 	// Note: Since folderConfig doesn't have OrgMigratedFromGlobalConfig set,
 	// folderConfigsOrgSettingsEqual will return false, triggering UpdateFolderConfigOrg
 	setup.callUpdateFolderConfig("")
+	settings := types.Settings{
+		FolderConfigs: []types.FolderConfig{
+			{
+				FolderPath:   folderPath,
+				Organization: "",
+			},
+		},
+	}
+	updateFolderConfig(c, settings, logger, "test", true)
 
 	// Verify UpdateFolderConfigOrg was called and set the migration flag
 	updatedConfig := setup.getUpdatedConfig()
@@ -611,6 +629,15 @@ func Test_updateFolderConfig_NotMigrated_LdxSyncReturnsDifferentOrg(t *testing.T
 	// Note: Since folderConfig doesn't have OrgMigratedFromGlobalConfig set,
 	// folderConfigsOrgSettingsEqual will return false, triggering UpdateFolderConfigOrg
 	setup.callUpdateFolderConfig("initial-org")
+	settings := types.Settings{
+		FolderConfigs: []types.FolderConfig{
+			{
+				FolderPath:   folderPath,
+				Organization: "initial-org",
+			},
+		},
+	}
+	updateFolderConfig(c, settings, logger, "test", true)
 
 	// Verify UpdateFolderConfigOrg was called and set the migration flag
 	updatedConfig := setup.getUpdatedConfig()
@@ -626,6 +653,15 @@ func Test_updateFolderConfig_MigratedConfig_UserSetButInheritingFromBlank(t *tes
 
 	// Call updateFolderConfig
 	setup.callUpdateFolderConfig("")
+	settings := types.Settings{
+		FolderConfigs: []types.FolderConfig{
+			{
+				FolderPath:   folderPath,
+				Organization: "",
+			},
+		},
+	}
+	updateFolderConfig(c, settings, logger, "test", true)
 
 	// Verify: should attempt to resolve from LDX-Sync because inheriting from blank global
 	updatedConfig := setup.getUpdatedConfig()

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -222,7 +222,7 @@ func Test_UpdateSettings(t *testing.T) {
 		err = initTestRepo(t, tempDir2)
 		assert.NoError(t, err)
 
-		UpdateSettings(c, settings)
+		UpdateSettings(c, settings, "test", true)
 
 		assert.Equal(t, false, c.IsSnykCodeEnabled())
 		assert.Equal(t, false, c.IsSnykOssEnabled())
@@ -276,7 +276,7 @@ func Test_UpdateSettings(t *testing.T) {
 
 	t.Run("hover defaults are set", func(t *testing.T) {
 		c := testutil.UnitTest(t)
-		UpdateSettings(c, types.Settings{})
+		UpdateSettings(c, types.Settings{}, "test", true)
 
 		assert.Equal(t, 3, c.HoverVerbosity())
 		assert.Equal(t, c.Format(), config.FormatMd)
@@ -285,7 +285,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("empty snyk code api is ignored and default is used", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{})
+		UpdateSettings(c, types.Settings{}, "test", true)
 
 		assert.Equal(t, config.DefaultDeeproxyApiUrl, c.SnykCodeApi())
 	})
@@ -294,7 +294,7 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		c.SetOrganization(expectedOrgId)
 
-		UpdateSettings(c, types.Settings{Organization: " "})
+		UpdateSettings(c, types.Settings{Organization: " "}, "test", true)
 
 		assert.Equal(t, expectedOrgId, c.Organization())
 	})
@@ -302,7 +302,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("incomplete env vars", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{AdditionalEnv: "a="})
+		UpdateSettings(c, types.Settings{AdditionalEnv: "a="}, "test", true)
 
 		assert.Empty(t, os.Getenv("a"))
 	})
@@ -311,7 +311,7 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		varCount := len(os.Environ())
 
-		UpdateSettings(c, types.Settings{AdditionalEnv: " "})
+		UpdateSettings(c, types.Settings{AdditionalEnv: " "}, "test", true)
 
 		assert.Equal(t, varCount, len(os.Environ()))
 	})
@@ -319,7 +319,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("broken env variables", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{AdditionalEnv: "a=; b"})
+		UpdateSettings(c, types.Settings{AdditionalEnv: "a=; b"}, "test", true)
 
 		assert.Empty(t, os.Getenv("a"))
 		assert.Empty(t, os.Getenv("b"))
@@ -328,7 +328,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("trusted folders", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{TrustedFolders: []string{"/a/b", "/b/c"}})
+		UpdateSettings(c, types.Settings{TrustedFolders: []string{"/a/b", "/b/c"}}, "test", true)
 
 		assert.Contains(t, c.TrustedFolders(), types.FilePath("/a/b"))
 		assert.Contains(t, c.TrustedFolders(), types.FilePath("/b/c"))
@@ -339,14 +339,14 @@ func Test_UpdateSettings(t *testing.T) {
 		t.Run("true", func(t *testing.T) {
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "true",
-			})
+			}, "test", true)
 
 			assert.True(t, c.ManageBinariesAutomatically())
 		})
 		t.Run("false", func(t *testing.T) {
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "false",
-			})
+			}, "test", true)
 
 			assert.False(t, c.ManageBinariesAutomatically())
 		})
@@ -354,11 +354,11 @@ func Test_UpdateSettings(t *testing.T) {
 		t.Run("invalid value does not update", func(t *testing.T) {
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "true",
-			})
+			}, "test", true)
 
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "dog",
-			})
+			}, "test", true)
 
 			assert.True(t, c.ManageBinariesAutomatically())
 		})
@@ -367,20 +367,20 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("activateSnykCodeSecurity is passed", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{ActivateSnykCodeSecurity: "true"})
+		UpdateSettings(c, types.Settings{ActivateSnykCodeSecurity: "true"}, "test", true)
 
 		assert.Equal(t, true, c.IsSnykCodeSecurityEnabled())
 	})
 	t.Run("activateSnykCodeSecurity is not passed", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{})
+		UpdateSettings(c, types.Settings{}, "test", true)
 
 		assert.Equal(t, false, c.IsSnykCodeSecurityEnabled())
 
 		c.EnableSnykCodeSecurity(true)
 
-		UpdateSettings(c, types.Settings{})
+		UpdateSettings(c, types.Settings{}, "test", true)
 
 		assert.Equal(t, true, c.IsSnykCodeSecurityEnabled())
 	})
@@ -389,7 +389,7 @@ func Test_UpdateSettings(t *testing.T) {
 
 		UpdateSettings(c, types.Settings{
 			ActivateSnykCode: "true",
-		})
+		}, "test", true)
 
 		assert.Equal(t, true, c.IsSnykCodeSecurityEnabled())
 		assert.Equal(t, true, c.IsSnykCodeEnabled())
@@ -399,22 +399,22 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		t.Run("filtering gets passed", func(t *testing.T) {
 			mixedSeverityFilter := types.NewSeverityFilter(true, false, true, false)
-			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter})
+			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter}, "test", true)
 
 			assert.Equal(t, mixedSeverityFilter, c.FilterSeverity())
 		})
 		t.Run("equivalent of the \"empty\" struct as a filter gets passed", func(t *testing.T) {
 			emptyLikeSeverityFilter := types.NewSeverityFilter(false, false, false, false)
-			UpdateSettings(c, types.Settings{FilterSeverity: &emptyLikeSeverityFilter})
+			UpdateSettings(c, types.Settings{FilterSeverity: &emptyLikeSeverityFilter}, "test", true)
 
 			assert.Equal(t, emptyLikeSeverityFilter, c.FilterSeverity())
 		})
 		t.Run("omitting filter does not cause an update", func(t *testing.T) {
 			mixedSeverityFilter := types.NewSeverityFilter(false, false, true, false)
-			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter})
+			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter}, "test", true)
 			assert.Equal(t, mixedSeverityFilter, c.FilterSeverity())
 
-			UpdateSettings(c, types.Settings{})
+			UpdateSettings(c, types.Settings{}, "test", true)
 			assert.Equal(t, mixedSeverityFilter, c.FilterSeverity())
 		})
 	})
@@ -423,22 +423,22 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		t.Run("filtering gets passed", func(t *testing.T) {
 			mixedIssueViewOptions := types.NewIssueViewOptions(false, true)
-			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions})
+			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions}, "test", true)
 
 			assert.Equal(t, mixedIssueViewOptions, c.IssueViewOptions())
 		})
 		t.Run("equivalent of the \"empty\" struct as a filter gets passed", func(t *testing.T) {
 			emptyLikeIssueViewOptions := types.NewIssueViewOptions(false, false)
-			UpdateSettings(c, types.Settings{IssueViewOptions: &emptyLikeIssueViewOptions})
+			UpdateSettings(c, types.Settings{IssueViewOptions: &emptyLikeIssueViewOptions}, "test", true)
 
 			assert.Equal(t, emptyLikeIssueViewOptions, c.IssueViewOptions())
 		})
 		t.Run("omitting filter does not cause an update", func(t *testing.T) {
 			mixedIssueViewOptions := types.NewIssueViewOptions(false, true)
-			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions})
+			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions}, "test", true)
 			assert.Equal(t, mixedIssueViewOptions, c.IssueViewOptions())
 
-			UpdateSettings(c, types.Settings{})
+			UpdateSettings(c, types.Settings{}, "test", true)
 			assert.Equal(t, mixedIssueViewOptions, c.IssueViewOptions())
 		})
 	})
@@ -757,16 +757,16 @@ func Test_InitializeSettings(t *testing.T) {
 		t.Setenv(caseSensitivePathKey, "something_meaningful")
 
 		// update path to hold a custom value
-		UpdateSettings(c, types.Settings{Path: first})
+		UpdateSettings(c, types.Settings{Path: first}, "test", true)
 		assert.True(t, strings.HasPrefix(os.Getenv(upperCasePathKey), first+string(os.PathListSeparator)))
 
 		// update path to hold another value
-		UpdateSettings(c, types.Settings{Path: second})
+		UpdateSettings(c, types.Settings{Path: second}, "test", true)
 		assert.True(t, strings.HasPrefix(os.Getenv(upperCasePathKey), second+string(os.PathListSeparator)))
 		assert.False(t, strings.Contains(os.Getenv(upperCasePathKey), first))
 
 		// reset path with non-empty settings
-		UpdateSettings(c, types.Settings{Path: "", AuthenticationMethod: "token"})
+		UpdateSettings(c, types.Settings{Path: "", AuthenticationMethod: "token"}, "test", true)
 		assert.False(t, strings.Contains(os.Getenv(upperCasePathKey), second))
 
 		assert.True(t, keyFoundInEnv(upperCasePathKey))

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
-	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/storedconfig"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -230,7 +229,7 @@ func Test_UpdateSettings(t *testing.T) {
 		err = initTestRepo(t, tempDir2)
 		assert.NoError(t, err)
 
-		UpdateSettings(c, settings, "test", true)
+		UpdateSettings(c, settings, "test")
 
 		assert.Equal(t, false, c.IsSnykCodeEnabled())
 		assert.Equal(t, false, c.IsSnykOssEnabled())
@@ -284,7 +283,7 @@ func Test_UpdateSettings(t *testing.T) {
 
 	t.Run("hover defaults are set", func(t *testing.T) {
 		c := testutil.UnitTest(t)
-		UpdateSettings(c, types.Settings{}, "test", true)
+		UpdateSettings(c, types.Settings{}, "test")
 
 		assert.Equal(t, 3, c.HoverVerbosity())
 		assert.Equal(t, c.Format(), config.FormatMd)
@@ -293,7 +292,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("empty snyk code api is ignored and default is used", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{}, "test", true)
+		UpdateSettings(c, types.Settings{}, "test")
 
 		assert.Equal(t, config.DefaultDeeproxyApiUrl, c.SnykCodeApi())
 	})
@@ -302,7 +301,7 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		c.SetOrganization(expectedOrgId)
 
-		UpdateSettings(c, types.Settings{Organization: " "}, "test", true)
+		UpdateSettings(c, types.Settings{Organization: " "}, "test")
 
 		assert.Equal(t, expectedOrgId, c.Organization())
 	})
@@ -310,7 +309,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("incomplete env vars", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{AdditionalEnv: "a="}, "test", true)
+		UpdateSettings(c, types.Settings{AdditionalEnv: "a="}, "test")
 
 		assert.Empty(t, os.Getenv("a"))
 	})
@@ -319,7 +318,7 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		varCount := len(os.Environ())
 
-		UpdateSettings(c, types.Settings{AdditionalEnv: " "}, "test", true)
+		UpdateSettings(c, types.Settings{AdditionalEnv: " "}, "test")
 
 		assert.Equal(t, varCount, len(os.Environ()))
 	})
@@ -327,7 +326,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("broken env variables", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{AdditionalEnv: "a=; b"}, "test", true)
+		UpdateSettings(c, types.Settings{AdditionalEnv: "a=; b"}, "test")
 
 		assert.Empty(t, os.Getenv("a"))
 		assert.Empty(t, os.Getenv("b"))
@@ -336,7 +335,7 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("trusted folders", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{TrustedFolders: []string{"/a/b", "/b/c"}}, "test", true)
+		UpdateSettings(c, types.Settings{TrustedFolders: []string{"/a/b", "/b/c"}}, "test")
 
 		assert.Contains(t, c.TrustedFolders(), types.FilePath("/a/b"))
 		assert.Contains(t, c.TrustedFolders(), types.FilePath("/b/c"))
@@ -347,14 +346,14 @@ func Test_UpdateSettings(t *testing.T) {
 		t.Run("true", func(t *testing.T) {
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "true",
-			}, "test", true)
+			}, "test")
 
 			assert.True(t, c.ManageBinariesAutomatically())
 		})
 		t.Run("false", func(t *testing.T) {
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "false",
-			}, "test", true)
+			}, "test")
 
 			assert.False(t, c.ManageBinariesAutomatically())
 		})
@@ -362,11 +361,11 @@ func Test_UpdateSettings(t *testing.T) {
 		t.Run("invalid value does not update", func(t *testing.T) {
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "true",
-			}, "test", true)
+			}, "test")
 
 			UpdateSettings(c, types.Settings{
 				ManageBinariesAutomatically: "dog",
-			}, "test", true)
+			}, "test")
 
 			assert.True(t, c.ManageBinariesAutomatically())
 		})
@@ -375,20 +374,20 @@ func Test_UpdateSettings(t *testing.T) {
 	t.Run("activateSnykCodeSecurity is passed", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{ActivateSnykCodeSecurity: "true"}, "test", true)
+		UpdateSettings(c, types.Settings{ActivateSnykCodeSecurity: "true"}, "test")
 
 		assert.Equal(t, true, c.IsSnykCodeSecurityEnabled())
 	})
 	t.Run("activateSnykCodeSecurity is not passed", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 
-		UpdateSettings(c, types.Settings{}, "test", true)
+		UpdateSettings(c, types.Settings{}, "test")
 
 		assert.Equal(t, false, c.IsSnykCodeSecurityEnabled())
 
 		c.EnableSnykCodeSecurity(true)
 
-		UpdateSettings(c, types.Settings{}, "test", true)
+		UpdateSettings(c, types.Settings{}, "test")
 
 		assert.Equal(t, true, c.IsSnykCodeSecurityEnabled())
 	})
@@ -397,7 +396,7 @@ func Test_UpdateSettings(t *testing.T) {
 
 		UpdateSettings(c, types.Settings{
 			ActivateSnykCode: "true",
-		}, "test", true)
+		}, "test")
 
 		assert.Equal(t, true, c.IsSnykCodeSecurityEnabled())
 		assert.Equal(t, true, c.IsSnykCodeEnabled())
@@ -407,22 +406,22 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		t.Run("filtering gets passed", func(t *testing.T) {
 			mixedSeverityFilter := types.NewSeverityFilter(true, false, true, false)
-			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter}, "test", true)
+			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter}, "test")
 
 			assert.Equal(t, mixedSeverityFilter, c.FilterSeverity())
 		})
 		t.Run("equivalent of the \"empty\" struct as a filter gets passed", func(t *testing.T) {
 			emptyLikeSeverityFilter := types.NewSeverityFilter(false, false, false, false)
-			UpdateSettings(c, types.Settings{FilterSeverity: &emptyLikeSeverityFilter}, "test", true)
+			UpdateSettings(c, types.Settings{FilterSeverity: &emptyLikeSeverityFilter}, "test")
 
 			assert.Equal(t, emptyLikeSeverityFilter, c.FilterSeverity())
 		})
 		t.Run("omitting filter does not cause an update", func(t *testing.T) {
 			mixedSeverityFilter := types.NewSeverityFilter(false, false, true, false)
-			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter}, "test", true)
+			UpdateSettings(c, types.Settings{FilterSeverity: &mixedSeverityFilter}, "test")
 			assert.Equal(t, mixedSeverityFilter, c.FilterSeverity())
 
-			UpdateSettings(c, types.Settings{}, "test", true)
+			UpdateSettings(c, types.Settings{}, "test")
 			assert.Equal(t, mixedSeverityFilter, c.FilterSeverity())
 		})
 	})
@@ -431,22 +430,22 @@ func Test_UpdateSettings(t *testing.T) {
 		c := testutil.UnitTest(t)
 		t.Run("filtering gets passed", func(t *testing.T) {
 			mixedIssueViewOptions := types.NewIssueViewOptions(false, true)
-			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions}, "test", true)
+			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions}, "test")
 
 			assert.Equal(t, mixedIssueViewOptions, c.IssueViewOptions())
 		})
 		t.Run("equivalent of the \"empty\" struct as a filter gets passed", func(t *testing.T) {
 			emptyLikeIssueViewOptions := types.NewIssueViewOptions(false, false)
-			UpdateSettings(c, types.Settings{IssueViewOptions: &emptyLikeIssueViewOptions}, "test", true)
+			UpdateSettings(c, types.Settings{IssueViewOptions: &emptyLikeIssueViewOptions}, "test")
 
 			assert.Equal(t, emptyLikeIssueViewOptions, c.IssueViewOptions())
 		})
 		t.Run("omitting filter does not cause an update", func(t *testing.T) {
 			mixedIssueViewOptions := types.NewIssueViewOptions(false, true)
-			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions}, "test", true)
+			UpdateSettings(c, types.Settings{IssueViewOptions: &mixedIssueViewOptions}, "test")
 			assert.Equal(t, mixedIssueViewOptions, c.IssueViewOptions())
 
-			UpdateSettings(c, types.Settings{}, "test", true)
+			UpdateSettings(c, types.Settings{}, "test")
 			assert.Equal(t, mixedIssueViewOptions, c.IssueViewOptions())
 		})
 	})
@@ -520,13 +519,46 @@ func (s *folderConfigTestSetup) callUpdateFolderConfig(org string) {
 			},
 		},
 	}
-	updateFolderConfig(s.c, settings, s.logger, "test", true)
+	updateFolderConfig(s.c, settings, s.logger, "test")
 }
 
 func (s *folderConfigTestSetup) getUpdatedConfig() *types.FolderConfig {
 	updatedConfig, err := storedconfig.GetOrCreateFolderConfig(s.engineConfig, s.folderPath, s.logger)
 	assert.NoError(s.t, err)
 	return updatedConfig
+}
+
+// setupMigratedConfigInheritingFromBlankGlobal sets up the test scenario where
+// a migrated config inherits from a blank global organization
+func (s *folderConfigTestSetup) setupMigratedConfigInheritingFromBlankGlobal() {
+	// Setup stored config with empty org, migrated flag set to true, and userSet to false
+	s.createStoredConfig("", true, false)
+
+	// Set global organization to empty
+	s.c.SetOrganization("")
+
+	// Call updateFolderConfig with empty org
+	s.callUpdateFolderConfig("")
+}
+
+// setupNotMigratedLdxSyncReturnsDifferentOrg sets up the test scenario where
+// a non-migrated config has LDX-Sync return a different organization
+func (s *folderConfigTestSetup) setupNotMigratedLdxSyncReturnsDifferentOrg() {
+	// Setup stored config without migration flag, with initial org, and userSet to false
+	s.createStoredConfig("initial-org", false, false)
+
+	// Set global organization
+	s.c.SetOrganization("global-org-id")
+}
+
+// setupMigratedConfigUserSetButInheritingFromBlank sets up the test scenario where
+// a migrated config was previously user-set but now inherits from blank global
+func (s *folderConfigTestSetup) setupMigratedConfigUserSetButInheritingFromBlank() {
+	// Setup stored config with empty org, migrated flag set to true, and userSet to true
+	s.createStoredConfig("", true, true)
+
+	// Set global organization to empty
+	s.c.SetOrganization("")
 }
 
 // Test scenarios for updateFolderConfig with LDX-Sync integration
@@ -564,7 +596,7 @@ func Test_updateFolderConfig_MigratedConfig_UserSetWithNonEmptyOrg(t *testing.T)
 			},
 		},
 	}
-	updateFolderConfig(c, settings, logger, "test", true)
+	updateFolderConfig(c, settings, logger, "test")
 
 	// Verify the org was kept - with the current implementation, UpdateFolderConfigOrg is always called
 	// due to pointer comparison, but the org should remain the same since it's user-set
@@ -576,34 +608,20 @@ func Test_updateFolderConfig_MigratedConfig_UserSetWithNonEmptyOrg(t *testing.T)
 
 func Test_updateFolderConfig_MigratedConfig_InheritingFromBlankGlobal(t *testing.T) {
 	setup := setupFolderConfigTest(t)
-	c := setup.c
-	folderPath := setup.folderPath
-	engineConfig := setup.engineConfig
-	logger := setup.logger
 
-	// Setup stored config with empty org
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  folderPath,
-		PreferredOrg:                "",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
-	err := storedconfig.UpdateFolderConfig(engineConfig, storedConfig, logger)
-	assert.NoError(t, err)
+	// Setup the test scenario
+	setup.setupMigratedConfigInheritingFromBlankGlobal()
 
-	c.SetOrganization("")
-
-	// Call updateFolderConfig
-	setup.callUpdateFolderConfig("")
+	// Create settings and call updateFolderConfig
 	settings := types.Settings{
 		FolderConfigs: []types.FolderConfig{
 			{
-				FolderPath:   folderPath,
+				FolderPath:   setup.folderPath,
 				PreferredOrg: "",
 			},
 		},
 	}
-	updateFolderConfig(c, settings, logger, "test", true)
+	updateFolderConfig(setup.c, settings, setup.logger, "test")
 
 	// Verify: When both folder and global org are empty and LDX-Sync is called
 	updatedConfig := setup.getUpdatedConfig()
@@ -631,7 +649,7 @@ func Test_updateFolderConfig_NotMigrated_EmptyStoredOrg(t *testing.T) {
 			},
 		},
 	}
-	updateFolderConfig(setup.c, settings, setup.logger, "test", true)
+	updateFolderConfig(setup.c, settings, setup.logger, "test")
 
 	// Verify UpdateFolderConfigOrg was called and set the migration flag
 	updatedConfig := setup.getUpdatedConfig()
@@ -640,26 +658,10 @@ func Test_updateFolderConfig_NotMigrated_EmptyStoredOrg(t *testing.T) {
 }
 
 func Test_updateFolderConfig_NotMigrated_LdxSyncReturnsDifferentOrg(t *testing.T) {
-	c := testutil.UnitTest(t)
-	di.TestInit(t)
+	setup := setupFolderConfigTest(t)
 
-	folderPath := types.FilePath(t.TempDir())
-	err := initTestRepo(t, string(folderPath))
-	assert.NoError(t, err)
-
-	// Setup stored config without migration
-	engineConfig := c.Engine().GetConfiguration()
-	logger := c.Logger()
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  folderPath,
-		PreferredOrg:                "initial-org",
-		OrgMigratedFromGlobalConfig: false,
-		OrgSetByUser:                false,
-	}
-	err = storedconfig.UpdateFolderConfig(engineConfig, storedConfig, logger)
-	assert.NoError(t, err)
-
-	c.SetOrganization("global-org-id")
+	// Setup the test scenario
+	setup.setupNotMigratedLdxSyncReturnsDifferentOrg()
 
 	// Call updateFolderConfig
 	// Note: Since folderConfig doesn't have OrgMigratedFromGlobalConfig set,
@@ -667,57 +669,38 @@ func Test_updateFolderConfig_NotMigrated_LdxSyncReturnsDifferentOrg(t *testing.T
 	settings := types.Settings{
 		FolderConfigs: []types.FolderConfig{
 			{
-				FolderPath:   folderPath,
+				FolderPath:   setup.folderPath,
 				PreferredOrg: "initial-org",
 			},
 		},
 	}
-	updateFolderConfig(c, settings, logger, "test", true)
+	updateFolderConfig(setup.c, settings, setup.logger, "test")
 
 	// Verify UpdateFolderConfigOrg was called and set the migration flag
-	updatedConfig, err := storedconfig.GetOrCreateFolderConfig(engineConfig, folderPath, logger)
-	assert.NoError(t, err)
+	updatedConfig := setup.getUpdatedConfig()
 	assert.True(t, updatedConfig.OrgMigratedFromGlobalConfig, "OrgMigratedFromGlobalConfig should be true after migration")
 }
 
 func Test_updateFolderConfig_MigratedConfig_UserSetButInheritingFromBlank(t *testing.T) {
-	c := testutil.UnitTest(t)
-	di.TestInit(t)
+	setup := setupFolderConfigTest(t)
 
-	folderPath := types.FilePath(t.TempDir())
-	err := initTestRepo(t, string(folderPath))
-	assert.NoError(t, err)
-
-	// Setup: previously user-set, but now both folder and global are empty
-	engineConfig := c.Engine().GetConfiguration()
-	logger := c.Logger()
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  folderPath,
-		PreferredOrg:                "",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                true, // Was previously set by user
-	}
-	err = storedconfig.UpdateFolderConfig(engineConfig, storedConfig, logger)
-	assert.NoError(t, err)
-
-	// Both folder and global org are empty - this is the key difference from the first test
-	c.SetOrganization("")
+	// Setup the test scenario
+	setup.setupMigratedConfigUserSetButInheritingFromBlank()
 
 	// Call updateFolderConfig with empty org settings
 	settings := types.Settings{
 		FolderConfigs: []types.FolderConfig{
 			{
-				FolderPath:   folderPath,
+				FolderPath:   setup.folderPath,
 				PreferredOrg: "",
 			},
 		},
 	}
-	updateFolderConfig(c, settings, logger, "test", false)
+	updateFolderConfig(setup.c, settings, setup.logger, "test")
 
 	// Verify: should attempt to resolve from LDX-Sync because inheriting from blank global
 	// This test specifically checks the case where both folder and global orgs are empty
-	updatedConfig, err := storedconfig.GetOrCreateFolderConfig(engineConfig, folderPath, logger)
-	assert.NoError(t, err)
+	updatedConfig := setup.getUpdatedConfig()
 	// When LDX-Sync is called, OrgSetByUser behavior depends on the result
 	assert.Empty(t, updatedConfig.PreferredOrg, "PreferredOrg should remain empty when inheriting from blank global")
 }
@@ -758,7 +741,7 @@ func Test_updateFolderConfig_SkipsUpdateWhenConfigUnchanged(t *testing.T) {
 			},
 		},
 	}
-	updateFolderConfig(c, settings, logger, "test", true)
+	updateFolderConfig(c, settings, logger, "test")
 
 	// Verify config remains unchanged (UpdateFolderConfigOrg was skipped)
 	updatedConfig, err := storedconfig.GetOrCreateFolderConfig(engineConfig, folderPath, logger)
@@ -789,7 +772,7 @@ func Test_updateFolderConfig_HandlesNilStoredConfig(t *testing.T) {
 	}
 
 	// Should not panic and should handle nil gracefully
-	updateFolderConfig(c, settings, logger, "test", false)
+	updateFolderConfig(c, settings, logger, "test")
 	// If we get here without panic, the nil check worked
 }
 
@@ -846,16 +829,16 @@ func Test_InitializeSettings(t *testing.T) {
 		t.Setenv(caseSensitivePathKey, "something_meaningful")
 
 		// update path to hold a custom value
-		UpdateSettings(c, types.Settings{Path: first}, "test", true)
+		UpdateSettings(c, types.Settings{Path: first}, "test")
 		assert.True(t, strings.HasPrefix(os.Getenv(upperCasePathKey), first+string(os.PathListSeparator)))
 
 		// update path to hold another value
-		UpdateSettings(c, types.Settings{Path: second}, "test", true)
+		UpdateSettings(c, types.Settings{Path: second}, "test")
 		assert.True(t, strings.HasPrefix(os.Getenv(upperCasePathKey), second+string(os.PathListSeparator)))
 		assert.False(t, strings.Contains(os.Getenv(upperCasePathKey), first))
 
 		// reset path with non-empty settings
-		UpdateSettings(c, types.Settings{Path: "", AuthenticationMethod: "token"}, "test", true)
+		UpdateSettings(c, types.Settings{Path: "", AuthenticationMethod: "token"}, "test")
 		assert.False(t, strings.Contains(os.Getenv(upperCasePathKey), second))
 
 		assert.True(t, keyFoundInEnv(upperCasePathKey))
@@ -863,258 +846,141 @@ func Test_InitializeSettings(t *testing.T) {
 	})
 }
 
-// Test scenarios for updateFolderConfigOrg - already migrated configs
-func Test_updateFolderConfigOrg_MigratedConfig_Initialization_NonUserSet_CallsLdxSync(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
+func Test_sendCollectionChangeAnalytics(t *testing.T) {
+	t.Run("sends analytics for array changes", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "ldx-resolved-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
+		// Test data
+		oldValue := []string{"item1", "item2", "item3"}
+		newValue := []string{"item1", "item4", "item5", "item6"}
+		field := "testField"
+		triggerSource := "test"
 
-	folderConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "ldx-resolved-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
+		// Test the logic by calling the function and verifying it doesn't panic
+		// Since we can't easily mock the analytics function, we'll test the core logic
+		// by verifying the function executes without errors
+		assert.NotPanics(t, func() {
+			sendCollectionChangeAnalytics(c, field, oldValue, newValue, triggerSource, "Added", "Removed", "Count")
+		})
+	})
 
-	notifier := notification.NewMockNotifier()
-	updateFolderConfigOrg(c, notifier, storedConfig, folderConfig)
+	t.Run("handles empty arrays", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 
-	// Should have called LDX-Sync (we can't easily verify this without mocking, but we can check the behavior)
-	// The org should remain as resolved by LDX-Sync
-	assert.False(t, folderConfig.OrgSetByUser, "Should remain not user-set")
+		oldValue := []string{}
+		newValue := []string{"item1", "item2"}
+		field := "testField"
+		triggerSource := "test"
+
+		assert.NotPanics(t, func() {
+			sendCollectionChangeAnalytics(c, field, oldValue, newValue, triggerSource, "Added", "Removed", "Count")
+		})
+	})
+
+	t.Run("handles identical arrays", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+
+		value := []string{"item1", "item2"}
+		field := "testField"
+		triggerSource := "test"
+
+		assert.NotPanics(t, func() {
+			sendCollectionChangeAnalytics(c, field, value, value, triggerSource, "Added", "Removed", "Count")
+		})
+	})
 }
 
-func Test_updateFolderConfigOrg_MigratedConfig_Initialization_UserSetWithBlankOrg(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("") // Blank global org
+func Test_sendMapChangeAnalytics(t *testing.T) {
+	t.Run("sends analytics for map changes", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "", // Blank folder org
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                true,
-	}
+		// Test data
+		oldValue := map[string]int{
+			"key1": 1,
+			"key2": 2,
+			"key3": 3,
+		}
+		newValue := map[string]int{
+			"key1": 10, // modified
+			"key4": 4,  // added
+			"key5": 5,  // added
+		}
+		field := "testField"
+		triggerSource := "test"
 
-	folderConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                true,
-	}
+		assert.NotPanics(t, func() {
+			sendMapChangeAnalytics(c, field, oldValue, newValue, triggerSource, "KeyAdded", "KeyModified", "KeyRemoved", "Count")
+		})
+	})
 
-	notifier := notification.NewMockNotifier()
-	updateFolderConfigOrg(c, notifier, storedConfig, folderConfig)
+	t.Run("handles empty maps", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 
-	// User explicitly set the org (even if blank), so OrgSetByUser should remain true
-	assert.True(t, folderConfig.OrgSetByUser, "Should remain user-set when user explicitly set blank org")
+		oldValue := map[string]int{}
+		newValue := map[string]int{"key1": 1, "key2": 2}
+		field := "testField"
+		triggerSource := "test"
+
+		assert.NotPanics(t, func() {
+			sendMapChangeAnalytics(c, field, oldValue, newValue, triggerSource, "KeyAdded", "KeyModified", "KeyRemoved", "Count")
+		})
+	})
+
+	t.Run("handles identical maps", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+
+		value := map[string]int{"key1": 1, "key2": 2}
+		field := "testField"
+		triggerSource := "test"
+
+		assert.NotPanics(t, func() {
+			sendMapChangeAnalytics(c, field, value, value, triggerSource, "KeyAdded", "KeyModified", "KeyRemoved", "Count")
+		})
+	})
 }
 
-func Test_updateFolderConfigOrg_MigratedConfig_Initialization_UserSet_KeepsExisting(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
+func Test_sendArrayConfigChangedAnalytics(t *testing.T) {
+	t.Run("calls sendCollectionChangeAnalytics with correct parameters", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "user-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                true,
-	}
+		oldValue := []string{"item1", "item2"}
+		newValue := []string{"item1", "item3"}
+		field := "testField"
+		path := types.FilePath("/test/path")
+		triggerSource := "test"
 
-	folderConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "user-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                true,
-	}
-
-	notifier := notification.NewMockNotifier()
-	updateFolderConfigOrg(c, notifier, storedConfig, folderConfig)
-
-	// Should keep the user-set org
-	assert.Equal(t, "user-org", folderConfig.PreferredOrg, "Should keep user-set org")
-	assert.True(t, folderConfig.OrgSetByUser, "Should remain user-set")
+		assert.NotPanics(t, func() {
+			sendArrayConfigChangedAnalytics(c, field, oldValue, newValue, path, triggerSource)
+		})
+	})
 }
 
-func Test_updateFolderConfigOrg_MigratedConfig_Update_OrgChanged_StoresNewOrg(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
+func Test_sendMapConfigChangedAnalytics(t *testing.T) {
+	t.Run("calls sendMapChangeAnalytics with correct parameters", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "old-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
+		oldValue := map[string]int{"key1": 1}
+		newValue := map[string]int{"key1": 2, "key2": 3}
+		field := "testField"
+		path := types.FilePath("/test/path")
+		triggerSource := "test"
 
-	folderConfig := &types.FolderConfig{
-		PreferredOrg:                "new-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
-
-	notifier := notification.NewMockNotifier()
-	updateFolderConfigOrg(c, notifier, storedConfig, folderConfig)
-
-	// The actual org value depends on LDX-Sync resolution
-	assert.False(t, folderConfig.OrgSetByUser, "Should not be user-set when OrgSetByUser flag is false")
+		assert.NotPanics(t, func() {
+			sendMapConfigChangedAnalytics(c, field, oldValue, newValue, path, triggerSource)
+		})
+	})
 }
 
-func Test_updateFolderConfigOrg_MigratedConfig_Update_OrgSetByUser_StoresNewOrg(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
+func Test_sendTrustedFoldersAnalytics(t *testing.T) {
+	t.Run("calls sendCollectionChangeAnalytics with correct parameters", func(t *testing.T) {
+		c := testutil.UnitTest(t)
 
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "old-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
+		oldFolders := []types.FilePath{"/old/path1", "/old/path2"}
+		newFolders := []types.FilePath{"/old/path1", "/new/path3"}
+		triggerSource := "test"
 
-	folderConfig := &types.FolderConfig{
-		PreferredOrg:                "user-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                true,
-	}
-
-	notifier := notification.NewMockNotifier()
-	updateFolderConfigOrg(c, notifier, storedConfig, folderConfig)
-
-	// Should store the user-provided org
-	assert.Equal(t, "user-org", folderConfig.PreferredOrg, "Should store user org")
-	assert.True(t, folderConfig.OrgSetByUser, "Should mark as user-set")
-}
-
-func Test_updateFolderConfigOrg_MigratedConfig_Update_InheritingFromBlankGlobal_CallsLdxSync(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("") // Blank global org
-
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "old-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                true,
-	}
-
-	folderConfig := &types.FolderConfig{
-		PreferredOrg:                "", // Blank folder org
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
-
-	notifier := notification.NewMockNotifier()
-	updateFolderConfigOrg(c, notifier, storedConfig, folderConfig)
-
-	// Should call LDX-Sync because inheriting from blank global
-	// The org will be resolved by LDX-Sync (we can't verify the exact value without mocking)
-	// But we can verify the OrgSetByUser flag
-	assert.False(t, folderConfig.OrgSetByUser, "Should not be user-set when inheriting from blank global")
-}
-
-func Test_updateFolderConfigOrg_MigratedConfig_Update_NoChangeNotUserSet_CallsLdxSync(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
-
-	storedConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "ldx-org",
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
-
-	folderConfig := &types.FolderConfig{
-		PreferredOrg:                "ldx-org", // Same org
-		OrgMigratedFromGlobalConfig: true,
-		OrgSetByUser:                false,
-	}
-
-	notifier := notification.NewMockNotifier()
-	updateFolderConfigOrg(c, notifier, storedConfig, folderConfig)
-
-	// Should call LDX-Sync because not user-set
-	assert.False(t, folderConfig.OrgSetByUser, "Should remain not user-set")
-}
-
-// Test scenarios for migrateFolderConfigOrg - new configs
-func Test_migrateFolderConfigOrg_WithUserProvidedOrg_SkipsLdxSync(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
-
-	folderConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "user-org",
-		OrgMigratedFromGlobalConfig: false,
-		OrgSetByUser:                true, // Set to true to indicate user provided this org
-	}
-
-	notifier := notification.NewMockNotifier()
-	migrateFolderConfigOrg(c, notifier, folderConfig)
-
-	// Should store the user-provided org and skip LDX-Sync
-	assert.Equal(t, "user-org", folderConfig.PreferredOrg, "Should store user-provided org")
-	assert.True(t, folderConfig.OrgSetByUser, "Should mark as user-set")
-	assert.True(t, folderConfig.OrgMigratedFromGlobalConfig, "Should mark as migrated")
-}
-
-func Test_migrateFolderConfigOrg_WithOrgSetByUserFlag_SkipsLdxSync(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
-
-	folderConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "",
-		OrgMigratedFromGlobalConfig: false,
-		OrgSetByUser:                true,
-	}
-
-	notifier := notification.NewMockNotifier()
-	migrateFolderConfigOrg(c, notifier, folderConfig)
-
-	// Should skip LDX-Sync when OrgSetByUser is true
-	assert.Equal(t, "", folderConfig.PreferredOrg, "Should store empty org")
-	assert.True(t, folderConfig.OrgSetByUser, "Should mark as user-set")
-	assert.True(t, folderConfig.OrgMigratedFromGlobalConfig, "Should mark as migrated")
-}
-
-func Test_migrateFolderConfigOrg_NoOrg_LdxReturnsDifferent_MarksNotUserSet(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
-
-	folderConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "",
-		OrgMigratedFromGlobalConfig: false,
-		OrgSetByUser:                false,
-	}
-
-	notifier := notification.NewMockNotifier()
-	migrateFolderConfigOrg(c, notifier, folderConfig)
-
-	// Should call LDX-Sync and mark as not user-set if different from global
-	// (We can't verify the exact org without mocking LDX-Sync, but we can verify the migration flag)
-	assert.True(t, folderConfig.OrgMigratedFromGlobalConfig, "Should mark as migrated")
-}
-
-func Test_migrateFolderConfigOrg_NoOrg_InitialMigration(t *testing.T) {
-	c := testutil.UnitTest(t)
-	c.SetOrganization("global-org")
-
-	folderConfig := &types.FolderConfig{
-		FolderPath:                  "/test/path",
-		PreferredOrg:                "",
-		OrgMigratedFromGlobalConfig: false,
-		OrgSetByUser:                false,
-	}
-
-	notifier := notification.NewMockNotifier()
-	migrateFolderConfigOrg(c, notifier, folderConfig)
-
-	// Should use global org initially and call LDX-Sync
-	assert.True(t, folderConfig.OrgMigratedFromGlobalConfig, "Should mark as migrated")
-	// The final org and OrgSetByUser depend on LDX-Sync response
+		assert.NotPanics(t, func() {
+			sendTrustedFoldersAnalytics(c, oldFolders, newFolders, triggerSource)
+		})
+	})
 }

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -712,7 +712,7 @@ func Test_updateFolderConfig_MigratedConfig_UserSetButInheritingFromBlank(t *tes
 			},
 		},
 	}
-	updateFolderConfig(c, settings, logger, "test", true)
+	updateFolderConfig(c, settings, logger, "test", false)
 
 	// Verify: should attempt to resolve from LDX-Sync because inheriting from blank global
 	// This test specifically checks the case where both folder and global orgs are empty

--- a/infrastructure/cli/cli_extension_executor.go
+++ b/infrastructure/cli/cli_extension_executor.go
@@ -82,9 +82,18 @@ func (c ExtensionExecutor) doExecute(ctx context.Context, cmd []string, workingD
 	legacyCLIConfig.Set(configuration.RAW_CMD_ARGS, cmd[1:])
 	legacyCLIConfig.Set(configuration.WORKFLOW_USE_STDIO, false)
 	// Use folder-level organization if we are executing from within a project folder.
+	// If no folder-specific org is configured, fall back to global organization.
 	if workingDir != "" {
 		folderOrg := c.c.FolderOrganization(workingDir)
-		legacyCLIConfig.Set(configuration.ORGANIZATION, folderOrg)
+		if folderOrg != "" {
+			legacyCLIConfig.Set(configuration.ORGANIZATION, folderOrg)
+		} else {
+			// Fall back to global organization if no folder-specific org is configured
+			legacyCLIConfig.Set(configuration.ORGANIZATION, c.c.Organization())
+		}
+	} else {
+		// If no working directory, use global organization
+		legacyCLIConfig.Set(configuration.ORGANIZATION, c.c.Organization())
 	}
 
 	envvars.LoadConfiguredEnvironment(legacyCLIConfig.GetStringSlice(configuration.CUSTOM_CONFIG_FILES), string(workingDir))

--- a/infrastructure/code/ai_fix_handler_test.go
+++ b/infrastructure/code/ai_fix_handler_test.go
@@ -34,7 +34,7 @@ func Test_getExplain_Endpoint(t *testing.T) {
 		random, _ := uuid.NewRandom()
 		orgUUID := random.String()
 		folder := types.FilePath(t.TempDir())
-		_ = storedconfig.UpdateFolderConfig(c.Engine().GetConfiguration(), &types.FolderConfig{FolderPath: folder, PreferredOrg: orgUUID}, c.Logger())
+		_ = storedconfig.UpdateFolderConfig(c.Engine().GetConfiguration(), &types.FolderConfig{FolderPath: folder, PreferredOrg: orgUUID, OrgSetByUser: true}, c.Logger())
 		actualEndpoint := getExplainEndpoint(c, folder).String()
 		expectedEndpoint := "https://api.snyk.io/rest/orgs/" + orgUUID + "/explain-fix?version=2024-10-15"
 		assert.Equal(t, expectedEndpoint, actualEndpoint)
@@ -47,7 +47,7 @@ func Test_GetExplain_Endpoint_With_Updated_API_Endpoints(t *testing.T) {
 		random, _ := uuid.NewRandom()
 		orgUUID := random.String()
 		folder := types.FilePath(t.TempDir())
-		_ = storedconfig.UpdateFolderConfig(c.Engine().GetConfiguration(), &types.FolderConfig{FolderPath: folder, PreferredOrg: orgUUID}, c.Logger())
+		_ = storedconfig.UpdateFolderConfig(c.Engine().GetConfiguration(), &types.FolderConfig{FolderPath: folder, PreferredOrg: orgUUID, OrgSetByUser: true}, c.Logger())
 		c.UpdateApiEndpoints("https://test.snyk.io")
 		actualEndpoint := getExplainEndpoint(c, folder).String()
 		expectedEndpoint := "https://test.snyk.io/rest/orgs/" + orgUUID + "/explain-fix?version=2024-10-15"


### PR DESCRIPTION
### Description


Function Call Examples:

// User-triggered changes (sends analytics)
UpdateSettings(c, params.Settings, "user", true)

// Initialization (no analytics)
writeSettings(c, settings, true, "", false)

// Tests (sends analytics)
UpdateSettings(c, settings, "test", true)

Analytics Event Format:

```
{
  "interaction": {
    "type": "Config changed",
    "targetId": "pkg:filesystem/path/to/folder",
    "extension": {
      "config::organization::oldValue": "oldOrg",
      "config::organization::newValue": "newOrg",
      "config::organization::triggerSource": "user"
    }
  }
}
```


### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
