### PR TITLE
fix(MCP): create new rules for SAST only

### DIFF
--- a/mcp_extension/snyk_tools.json
+++ b/mcp_extension/snyk_tools.json
@@ -235,7 +235,7 @@
     },
     {
       "name": "snyk_code_scan",
-      "description": "Performs Static Application Security Testing (SAST) directly from the Snyk MCP. It analyzes an application's source code with a SAST scan to identify security vulnerabilities and weaknesses without executing the code. \nWhen to use: During local development, developers can run it on their feature branches for immediate feedback, or after you generate new code files. \nHow to use: Test directory: run snyk_code_scan with parameter <path>, add parameters as needed.",
+      "description": "Performs Static Application Security Testing (SAST) directly from the Snyk MCP. It analyzes an application's source code with a SAST scan to identify security vulnerabilities and weaknesses without executing the code. \nWhen to use: During local development, developers can run it on their feature branches for immediate feedback, or after you generate new code files. \nHow to use: Test directory: run snyk_code_scan with parameter <path>, add parameters as needed. \nLanguages that Snyk supports: Apex, C/C++, Dart and Flutter, Elixir, Go, Groovy, Java and Kotlin, Javascript, .NET, PHP, Python, Ruby, Rust, Scala, Swift and Objective-C, Typescript, VB.NET",
       "command": [
         "code",
         "test"


### PR DESCRIPTION
### Description

Changing the snyk_code_scan tool description to include the [list of languages](https://docs.snyk.io/supported-languages/supported-languages-list) that Snyk supports. There will be a change in the vscode-extention repo as well that updates the direction of running the snyk_code_scan tool for new first party code that is generated to running the snyk_code_scan tool for new first party code that is generated in a Snyk-supported language.

Jira Ticket: https://snyksec.atlassian.net/browse/AG-4

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
