### PR TITLE
fix: better FC get performance [IDE-1773] [IDE-1887]

### DIFF
--- a/application/codeaction/codeaction.go
+++ b/application/codeaction/codeaction.go
@@ -96,7 +96,7 @@ func (c *CodeActionsService) GetCodeActions(params types.CodeActionParams) []typ
 		filteredIssues = issues
 	} else {
 		// Issue view options can be set per-folder, so use the folderConfig to fetch the effective value.
-		folderConfig := c.c.FolderConfig(folder.Path())
+		folderConfig := c.c.ImmutableFolderConfig(folder.Path())
 		issueViewOptions := types.ResolveIssueViewOptions(c.configResolver, c.c, folderConfig)
 		isViewingOpenIssues := issueViewOptions.OpenIssues
 		isViewingIgnoredIssues := issueViewOptions.IgnoredIssues

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -1363,12 +1363,12 @@ func (c *Config) FolderConfig(path types.FilePath) *types.FolderConfig {
 // ImmutableFolderConfig returns the folder config for a path without writing to storage or enriching from Git.
 // This is suitable for read-only configuration checks. If no config exists in storage, this creates one with default
 // values (OrgMigratedFromGlobalConfig=true, OrgSetByUser=false, FeatureFlags initialized) but does not persist it.
-func (c *Config) ImmutableFolderConfig(path types.FilePath) types.ImmutableFolderConfig {
+func (c *Config) ImmutableFolderConfig(path types.FilePath) *types.FolderConfig {
 	folderConfig, err := storedconfig.GetFolderConfigWithOptions(c.engine.GetConfiguration(), path, c.Logger(), storedconfig.GetFolderConfigOptions{
 		CreateIfNotExist: true,
 		ReadOnly:         true,
 	})
-	if err != nil {
+	if folderConfig == nil || err != nil {
 		c.logger.Err(err).Msg("unable to get or create folder config")
 		return c.getMinimalFolderConfig(path)
 	}
@@ -1396,10 +1396,10 @@ func (c *Config) BatchUpdateFolderConfigs(folderConfigs []*types.FolderConfig) e
 	return storedconfig.BatchUpdateFolderConfigs(c.engine.GetConfiguration(), folderConfigs, c.logger)
 }
 
-// FolderConfigForSubPath returns the folder config for the workspace folder containing the given path.
+// ImmutableFolderConfigForSubPath returns the folder config for the workspace folder containing the given path.
 // The path parameter can be a subdirectory or file within a workspace folder.
 // Returns an error if the workspace is nil or if no workspace folder contains the path.
-func (c *Config) FolderConfigForSubPath(path types.FilePath) (*types.FolderConfig, error) {
+func (c *Config) ImmutableFolderConfigForSubPath(path types.FilePath) (*types.FolderConfig, error) {
 	if c.Workspace() == nil {
 		return nil, fmt.Errorf("workspace is nil, so cannot determine folder config for path: %s", path)
 	}
@@ -1409,7 +1409,7 @@ func (c *Config) FolderConfigForSubPath(path types.FilePath) (*types.FolderConfi
 		return nil, fmt.Errorf("no workspace folder found for path: %s", path)
 	}
 
-	folderConfig := c.FolderConfig(workspaceFolder.Path())
+	folderConfig := c.ImmutableFolderConfig(workspaceFolder.Path())
 	return folderConfig, nil
 }
 

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -1367,7 +1367,6 @@ func (c *Config) ImmutableFolderConfig(path types.FilePath) types.ImmutableFolde
 	folderConfig, err := storedconfig.GetFolderConfigWithOptions(c.engine.GetConfiguration(), path, c.Logger(), storedconfig.GetFolderConfigOptions{
 		CreateIfNotExist: true,
 		ReadOnly:         true,
-		EnrichFromGit:    true,
 	})
 	if err != nil {
 		c.logger.Err(err).Msg("unable to get or create folder config")

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -1375,13 +1375,6 @@ func (c *Config) ImmutableFolderConfig(path types.FilePath) *types.FolderConfig 
 	return folderConfig
 }
 
-// GetFolderConfigWithOptions retrieves a folder config from storage using explicitly provided options.
-// This is the preferred way to access folder configs, allowing callers to explicitly declare if they need
-// to write to storage, enrich from Git, or create new configs.
-func (c *Config) GetFolderConfigWithOptions(path types.FilePath, opts storedconfig.GetFolderConfigOptions) (*types.FolderConfig, error) {
-	return storedconfig.GetFolderConfigWithOptions(c.engine.GetConfiguration(), path, c.Logger(), opts)
-}
-
 // getMinimalFolderConfig returns a folder config with only the path set, and no other fields. Used as a fallback
 // when a folder config cannot be retrieved from storage.
 func (c *Config) getMinimalFolderConfig(path types.FilePath) *types.FolderConfig {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -1376,6 +1376,13 @@ func (c *Config) ImmutableFolderConfig(path types.FilePath) types.ImmutableFolde
 	return folderConfig
 }
 
+// GetFolderConfigWithOptions retrieves a folder config from storage using explicitly provided options.
+// This is the preferred way to access folder configs, allowing callers to explicitly declare if they need
+// to write to storage, enrich from Git, or create new configs.
+func (c *Config) GetFolderConfigWithOptions(path types.FilePath, opts storedconfig.GetFolderConfigOptions) (*types.FolderConfig, error) {
+	return storedconfig.GetFolderConfigWithOptions(c.engine.GetConfiguration(), path, c.Logger(), opts)
+}
+
 // getMinimalFolderConfig returns a folder config with only the path set, and no other fields. Used as a fallback
 // when a folder config cannot be retrieved from storage.
 func (c *Config) getMinimalFolderConfig(path types.FilePath) *types.FolderConfig {

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -335,19 +335,10 @@ func processSingleLspFolderConfig(c *config.Config, path types.FilePath, incomin
 	logger := c.Logger().With().Str("method", "processSingleLspFolderConfig").Str("path", string(path)).Logger()
 
 	// Read-only load: no writes to storage
-	immutable := c.ImmutableFolderConfig(path)
-	var storedConfig *types.FolderConfig
-	if fc, ok := immutable.(*types.FolderConfig); ok && fc != nil {
-		storedConfig = fc
-	}
+	storedConfig := c.ImmutableFolderConfig(path)
 
 	// Start with existing stored config or create new
-	var folderConfig types.FolderConfig
-	if storedConfig != nil {
-		folderConfig = *storedConfig
-	} else {
-		folderConfig = types.FolderConfig{FolderPath: path}
-	}
+	folderConfig := *storedConfig
 
 	// Validate that the changes are allowed, then apply the new config.
 	normalizedPath := types.PathKey(path)
@@ -367,7 +358,7 @@ func processSingleLspFolderConfig(c *config.Config, path types.FilePath, incomin
 	updateFolderOrgIfNeeded(c, storedConfig, &folderConfig, notifier)
 	di.FeatureFlagService().PopulateFolderConfig(&folderConfig)
 
-	configChanged := storedConfig == nil || !cmp.Equal(folderConfig, *storedConfig)
+	configChanged := !cmp.Equal(folderConfig, *storedConfig)
 
 	return folderConfig, storedConfig, configChanged
 }

--- a/domain/ide/command/execute_cli.go
+++ b/domain/ide/command/execute_cli.go
@@ -57,7 +57,7 @@ func (cmd *executeCLICommand) Execute(ctx context.Context) (any, error) {
 		return nil, fmt.Errorf("workDir needs to be a string")
 	}
 
-	folderConfig := config.CurrentConfig().FolderConfig(types.FilePath(workDir))
+	folderConfig := config.CurrentConfig().ImmutableFolderConfig(types.FilePath(workDir))
 
 	args := []string{config.CurrentConfig().CliSettings().Path()}
 	for _, argument := range cmd.command.Arguments[1:] {

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -940,7 +940,7 @@ func (f *Folder) displayableIssueTypesForFolder(folderConfig types.ImmutableFold
 }
 
 func (f *Folder) sendSuccess(processedProduct product.Product) {
-	folderConfig := f.c.FolderConfig(f.path)
+	folderConfig := f.c.ImmutableFolderConfig(f.path)
 	if processedProduct != "" {
 		f.scanNotifier.SendSuccess(processedProduct, folderConfig)
 	} else {

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -288,7 +288,7 @@ func (f *Folder) markForEmptyDiagnostic(path types.FilePath) {
 	f.pendingEmptyDiagnostics.Store(path, struct{}{})
 }
 
-func (f *Folder) flushPendingEmptyDiagnostics() {
+func (f *Folder) postScanAction() {
 	f.pendingEmptyDiagnostics.Range(func(path types.FilePath, _ struct{}) bool {
 		f.pendingEmptyDiagnostics.Delete(path)
 		_, hasIssues := f.Issues()[path]
@@ -298,6 +298,9 @@ func (f *Folder) flushPendingEmptyDiagnostics() {
 		}
 		return true
 	})
+
+	// Send the final HTML and tree view again, just in case the trigger was missed due to timing issues.
+	f.scanStateAggregator.SummaryEmitter().Emit(f.scanStateAggregator.StateSnapshot())
 }
 
 func (f *Folder) IsScanned() bool {
@@ -334,7 +337,7 @@ func (f *Folder) scan(ctx context.Context, path types.FilePath) {
 		return
 	}
 	folderConfig := f.c.FolderConfig(f.path)
-	f.scanner.Scan(ctx, path, f.ProcessResults, folderConfig, f.flushPendingEmptyDiagnostics)
+	f.scanner.Scan(ctx, path, f.ProcessResults, folderConfig, f.postScanAction)
 }
 
 func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {

--- a/domain/ide/workspace/folder_test.go
+++ b/domain/ide/workspace/folder_test.go
@@ -363,7 +363,7 @@ func Test_Clear(t *testing.T) {
 		}
 	})
 
-	f.flushPendingEmptyDiagnostics()
+	f.postScanAction()
 
 	assert.Eventually(
 		t,
@@ -1227,7 +1227,7 @@ func Test_flushPendingEmptyDiagnostics_sendsForPathsWithNoIssues(t *testing.T) {
 	})
 
 	f.markForEmptyDiagnostic(path)
-	f.flushPendingEmptyDiagnostics()
+	f.postScanAction()
 
 	assert.Eventually(t, func() bool {
 		mtx.Lock()
@@ -1269,7 +1269,7 @@ func Test_flushPendingEmptyDiagnostics_skipsPathsWithIssues(t *testing.T) {
 	})
 
 	f.markForEmptyDiagnostic(path)
-	f.flushPendingEmptyDiagnostics()
+	f.postScanAction()
 
 	assert.Never(t, func() bool {
 		return sentCount > 0
@@ -1285,7 +1285,7 @@ func Test_flushPendingEmptyDiagnostics_drainsPendingSet(t *testing.T) {
 	f.markForEmptyDiagnostic("path1")
 	f.markForEmptyDiagnostic("path2")
 
-	f.flushPendingEmptyDiagnostics()
+	f.postScanAction()
 
 	assert.Equal(t, 0, f.pendingEmptyDiagnostics.Size())
 }

--- a/domain/scanstates/noop_state_aggregator.go
+++ b/domain/scanstates/noop_state_aggregator.go
@@ -1,5 +1,5 @@
 /*
- * © 2025 Snyk Limited
+ * © 2025-2026 Snyk Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,24 +56,4 @@ func (n NoopStateAggregator) SetScanDone(folderPath types.FilePath, p product.Pr
 }
 
 func (n NoopStateAggregator) SetScanInProgress(folderPath types.FilePath, p product.Product, isReferenceScan bool) {
-}
-
-func (n NoopStateAggregator) allScansStarted(_ bool) bool {
-	return false
-}
-
-func (n NoopStateAggregator) anyScanInProgress(_ bool) bool {
-	return false
-}
-
-func (n NoopStateAggregator) anyScanSucceeded(_ bool) bool {
-	return false
-}
-
-func (n NoopStateAggregator) allScansSucceeded(_ bool) bool {
-	return false
-}
-
-func (n NoopStateAggregator) anyScanError(_ bool) bool {
-	return false
 }

--- a/domain/scanstates/scan_state_aggregator.go
+++ b/domain/scanstates/scan_state_aggregator.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/product"
-	"github.com/snyk/snyk-ls/internal/storedconfig"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -95,11 +94,7 @@ func (agg *ScanStateAggregator) stateSnapshot() StateSnapshot {
 	getFolderConfigs := func(stateMap scanStateMap) {
 		for key := range stateMap {
 			if _, alreadyGot := folderConfigs[key.FolderPath]; !alreadyGot {
-				fc, _ := agg.c.GetFolderConfigWithOptions(key.FolderPath, storedconfig.GetFolderConfigOptions{
-					CreateIfNotExist: true,
-					ReadOnly:         true,
-					EnrichFromGit:    false,
-				})
+				fc := agg.c.ImmutableFolderConfig(key.FolderPath)
 				folderConfigs[key.FolderPath] = fc
 			}
 		}

--- a/domain/scanstates/scan_state_aggregator.go
+++ b/domain/scanstates/scan_state_aggregator.go
@@ -90,25 +90,28 @@ func (agg *ScanStateAggregator) StateSnapshot() StateSnapshot {
 }
 
 func (agg *ScanStateAggregator) stateSnapshot() StateSnapshot {
+	refStateMap := agg.scanStateForEnabledProducts(true)
+	wdStateMap := agg.scanStateForEnabledProducts(false)
+
 	ss := StateSnapshot{
-		AllScansStartedReference:          agg.allScansStarted(true),
-		AllScansStartedWorkingDirectory:   agg.allScansStarted(false),
-		AnyScanInProgressReference:        agg.anyScanInProgress(true),
-		AnyScanInProgressWorkingDirectory: agg.anyScanInProgress(false),
-		AnyScanSucceededReference:         agg.anyScanSucceeded(true),
-		AnyScanSucceededWorkingDirectory:  agg.anyScanSucceeded(false),
-		AllScansSucceededReference:        agg.allScansSucceeded(true),
-		AllScansSucceededWorkingDirectory: agg.allScansSucceeded(false),
-		AnyScanErrorReference:             agg.anyScanError(true),
-		AnyScanErrorWorkingDirectory:      agg.anyScanError(false),
-		TotalScansCount:                   agg.totalScansCount(),
-		ScansInProgressCount:              agg.scansCountInState(InProgress),
-		ScansSuccessCount:                 agg.scansCountInState(Success),
-		ScansErrorCount:                   agg.scansCountInState(Error),
-		AllScansFinishedWorkingDirectory:  agg.allScansFinished(false),
-		AllScansFinishedReference:         agg.allScansFinished(true),
-		ProductScanStates:                 agg.productScanStates(),
-		ProductScanErrors:                 agg.productScanErrors(),
+		AllScansStartedReference:          agg.allScansStarted(refStateMap),
+		AllScansStartedWorkingDirectory:   agg.allScansStarted(wdStateMap),
+		AnyScanInProgressReference:        agg.anyScanInProgress(refStateMap),
+		AnyScanInProgressWorkingDirectory: agg.anyScanInProgress(wdStateMap),
+		AnyScanSucceededReference:         agg.anyScanSucceeded(refStateMap),
+		AnyScanSucceededWorkingDirectory:  agg.anyScanSucceeded(wdStateMap),
+		AllScansSucceededReference:        agg.allScansSucceeded(refStateMap),
+		AllScansSucceededWorkingDirectory: agg.allScansSucceeded(wdStateMap),
+		AnyScanErrorReference:             agg.anyScanError(refStateMap),
+		AnyScanErrorWorkingDirectory:      agg.anyScanError(wdStateMap),
+		TotalScansCount:                   agg.totalScansCount(wdStateMap, refStateMap),
+		ScansInProgressCount:              agg.scansCountInState(wdStateMap, refStateMap, InProgress),
+		ScansSuccessCount:                 agg.scansCountInState(wdStateMap, refStateMap, Success),
+		ScansErrorCount:                   agg.scansCountInState(wdStateMap, refStateMap, Error),
+		AllScansFinishedWorkingDirectory:  agg.allScansFinished(wdStateMap),
+		AllScansFinishedReference:         agg.allScansFinished(refStateMap),
+		ProductScanStates:                 agg.productScanStates(wdStateMap),
+		ProductScanErrors:                 agg.productScanErrors(wdStateMap),
 	}
 	return ss
 }
@@ -116,9 +119,9 @@ func (agg *ScanStateAggregator) stateSnapshot() StateSnapshot {
 // productScanStates builds a per-(folder, product) map of whether a working-directory scan is in progress.
 // Only products that have actually started scanning are included; NotStarted products are omitted
 // so the tree builder can distinguish "not yet scanned" from "scan completed with 0 issues".
-func (agg *ScanStateAggregator) productScanStates() map[types.FilePath]map[product.Product]bool {
+func (agg *ScanStateAggregator) productScanStates(stateMap scanStateMap) map[types.FilePath]map[product.Product]bool {
 	states := make(map[types.FilePath]map[product.Product]bool)
-	for key, st := range agg.scanStateForEnabledProducts(false) {
+	for key, st := range stateMap {
 		if st.Status == NotStarted {
 			continue
 		}
@@ -135,9 +138,9 @@ func (agg *ScanStateAggregator) productScanStates() map[types.FilePath]map[produ
 }
 
 // productScanErrors builds a per-(folder, product) map of error messages for working-directory scans that ended in error.
-func (agg *ScanStateAggregator) productScanErrors() map[types.FilePath]map[product.Product]string {
+func (agg *ScanStateAggregator) productScanErrors(stateMap scanStateMap) map[types.FilePath]map[product.Product]string {
 	errs := make(map[types.FilePath]map[product.Product]string)
-	for key, st := range agg.scanStateForEnabledProducts(false) {
+	for key, st := range stateMap {
 		if st.Status == Error && st.Err != nil {
 			if errs[key.FolderPath] == nil {
 				errs[key.FolderPath] = make(map[product.Product]string)
@@ -277,49 +280,47 @@ func (agg *ScanStateAggregator) SetScanInProgress(folderPath types.FilePath, p p
 	agg.setScanState(folderPath, p, isReferenceScan, state)
 }
 
-func (agg *ScanStateAggregator) allScansStarted(isReference bool) bool {
-	return agg.allMatch(isReference, func(st *scanState) bool {
+func (agg *ScanStateAggregator) allScansStarted(stateMap scanStateMap) bool {
+	return agg.allMatch(stateMap, func(st *scanState) bool {
 		return st.Status != NotStarted
 	})
 }
 
-func (agg *ScanStateAggregator) anyScanInProgress(isReference bool) bool {
-	return agg.anyMatch(isReference, func(st *scanState) bool {
+func (agg *ScanStateAggregator) anyScanInProgress(stateMap scanStateMap) bool {
+	return agg.anyMatch(stateMap, func(st *scanState) bool {
 		return st.Status == InProgress
 	})
 }
 
-func (agg *ScanStateAggregator) anyScanSucceeded(isReference bool) bool {
-	return agg.anyMatch(isReference, func(st *scanState) bool {
+func (agg *ScanStateAggregator) anyScanSucceeded(stateMap scanStateMap) bool {
+	return agg.anyMatch(stateMap, func(st *scanState) bool {
 		return st.Status == Success
 	})
 }
 
-func (agg *ScanStateAggregator) allScansSucceeded(isReference bool) bool {
-	return agg.allMatch(isReference, func(st *scanState) bool {
+func (agg *ScanStateAggregator) allScansSucceeded(stateMap scanStateMap) bool {
+	return agg.allMatch(stateMap, func(st *scanState) bool {
 		return st.Status == Success && st.Err == nil
 	})
 }
 
-func (agg *ScanStateAggregator) allScansFinished(isReference bool) bool {
-	return agg.allMatch(isReference, func(st *scanState) bool { return st.Status == Success || st.Status == Error })
+func (agg *ScanStateAggregator) allScansFinished(stateMap scanStateMap) bool {
+	return agg.allMatch(stateMap, func(st *scanState) bool { return st.Status == Success || st.Status == Error })
 }
 
-func (agg *ScanStateAggregator) anyScanError(isReference bool) bool {
-	return agg.anyMatch(isReference, func(st *scanState) bool {
+func (agg *ScanStateAggregator) anyScanError(stateMap scanStateMap) bool {
+	return agg.anyMatch(stateMap, func(st *scanState) bool {
 		return st.Status == Error
 	})
 }
 
-func (agg *ScanStateAggregator) totalScansCount() int {
-	scansCount := len(agg.scanStateForEnabledProducts(false)) + len(agg.scanStateForEnabledProducts(true))
+func (agg *ScanStateAggregator) totalScansCount(wdStateMap, refStateMap scanStateMap) int {
+	scansCount := len(wdStateMap) + len(refStateMap)
 	return scansCount
 }
 
-func (agg *ScanStateAggregator) scansCountInState(status scanStatus) int {
+func (agg *ScanStateAggregator) scansCountInState(wdStateMap, refStateMap scanStateMap, status scanStatus) int {
 	count := 0
-	wdStateMap := agg.scanStateForEnabledProducts(false)
-	refStateMap := agg.scanStateForEnabledProducts(true)
 
 	for _, st := range wdStateMap {
 		if st.Status == status {
@@ -335,9 +336,7 @@ func (agg *ScanStateAggregator) scansCountInState(status scanStatus) int {
 	return count
 }
 
-func (agg *ScanStateAggregator) anyMatch(isReference bool, predicate func(*scanState) bool) bool {
-	stateMap := agg.scanStateForEnabledProducts(isReference)
-
+func (agg *ScanStateAggregator) anyMatch(stateMap scanStateMap, predicate func(*scanState) bool) bool {
 	for _, st := range stateMap {
 		if predicate(st) {
 			return true
@@ -346,9 +345,7 @@ func (agg *ScanStateAggregator) anyMatch(isReference bool, predicate func(*scanS
 	return false
 }
 
-func (agg *ScanStateAggregator) allMatch(isReference bool, predicate func(*scanState) bool) bool {
-	stateMap := agg.scanStateForEnabledProducts(isReference)
-
+func (agg *ScanStateAggregator) allMatch(stateMap scanStateMap, predicate func(*scanState) bool) bool {
 	for _, st := range stateMap {
 		if !predicate(st) {
 			return false
@@ -367,7 +364,7 @@ func (agg *ScanStateAggregator) scanStateForEnabledProducts(isReference bool) sc
 	scanStateMapWithEnabledProducts := make(scanStateMap)
 
 	for key, st := range stateMap {
-		folderConfig := agg.c.FolderConfig(key.FolderPath)
+		folderConfig := agg.c.ImmutableFolderConfig(key.FolderPath)
 		issueTypes := agg.displayableIssueTypesForFolder(folderConfig)
 		for displayableIssueType, enabled := range issueTypes {
 			p := displayableIssueType.ToProduct()

--- a/domain/scanstates/scan_state_aggregator.go
+++ b/domain/scanstates/scan_state_aggregator.go
@@ -96,10 +96,9 @@ func (agg *ScanStateAggregator) stateSnapshot() StateSnapshot {
 		for key := range stateMap {
 			if _, alreadyGot := folderConfigs[key.FolderPath]; !alreadyGot {
 				fc, _ := agg.c.GetFolderConfigWithOptions(key.FolderPath, storedconfig.GetFolderConfigOptions{
-					CreateIfNotExist:     false,
-					ReadOnly:             true,
-					EnrichFromGit:        false,
-					CreateMinimalFCOnErr: true,
+					CreateIfNotExist: true,
+					ReadOnly:         true,
+					EnrichFromGit:    false,
 				})
 				folderConfigs[key.FolderPath] = fc
 			}

--- a/domain/scanstates/scan_state_aggregator.go
+++ b/domain/scanstates/scan_state_aggregator.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/storedconfig"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -90,8 +91,25 @@ func (agg *ScanStateAggregator) StateSnapshot() StateSnapshot {
 }
 
 func (agg *ScanStateAggregator) stateSnapshot() StateSnapshot {
-	refStateMap := agg.scanStateForEnabledProducts(true)
-	wdStateMap := agg.scanStateForEnabledProducts(false)
+	folderConfigs := make(map[types.FilePath]types.ImmutableFolderConfig)
+	getFolderConfigs := func(stateMap scanStateMap) {
+		for key := range stateMap {
+			if _, alreadyGot := folderConfigs[key.FolderPath]; !alreadyGot {
+				fc, _ := agg.c.GetFolderConfigWithOptions(key.FolderPath, storedconfig.GetFolderConfigOptions{
+					CreateIfNotExist:     false,
+					ReadOnly:             true,
+					EnrichFromGit:        false,
+					CreateMinimalFCOnErr: true,
+				})
+				folderConfigs[key.FolderPath] = fc
+			}
+		}
+	}
+	getFolderConfigs(agg.referenceScanStates)
+	getFolderConfigs(agg.workingDirectoryScanStates)
+
+	refStateMap := agg.scanStateForEnabledProducts(agg.referenceScanStates, folderConfigs)
+	wdStateMap := agg.scanStateForEnabledProducts(agg.workingDirectoryScanStates, folderConfigs)
 
 	ss := StateSnapshot{
 		AllScansStartedReference:          agg.allScansStarted(refStateMap),
@@ -354,17 +372,15 @@ func (agg *ScanStateAggregator) allMatch(stateMap scanStateMap, predicate func(*
 	return true
 }
 
-func (agg *ScanStateAggregator) scanStateForEnabledProducts(isReference bool) scanStateMap {
-	var stateMap scanStateMap
-	if isReference {
-		stateMap = agg.referenceScanStates
-	} else {
-		stateMap = agg.workingDirectoryScanStates
-	}
+func (agg *ScanStateAggregator) scanStateForEnabledProducts(stateMap scanStateMap, folderConfigs map[types.FilePath]types.ImmutableFolderConfig) scanStateMap {
 	scanStateMapWithEnabledProducts := make(scanStateMap)
 
 	for key, st := range stateMap {
-		folderConfig := agg.c.ImmutableFolderConfig(key.FolderPath)
+		folderConfig := folderConfigs[key.FolderPath]
+		if folderConfig == nil {
+			continue
+		}
+
 		issueTypes := agg.displayableIssueTypesForFolder(folderConfig)
 		for displayableIssueType, enabled := range issueTypes {
 			p := displayableIssueType.ToProduct()

--- a/domain/scanstates/scan_state_aggregator_test.go
+++ b/domain/scanstates/scan_state_aggregator_test.go
@@ -27,14 +27,15 @@ func TestScanStateAggregator_Init(t *testing.T) {
 	agg.Init([]types.FilePath{folderPath})
 
 	// 3) Validate initial states
-	assert.False(t, agg.allScansStarted(true))
-	assert.False(t, agg.allScansStarted(false))
-	assert.False(t, agg.anyScanInProgress(true))
-	assert.False(t, agg.anyScanInProgress(false))
-	assert.False(t, agg.allScansSucceeded(true))
-	assert.False(t, agg.allScansSucceeded(false))
-	assert.False(t, agg.anyScanError(true))
-	assert.False(t, agg.anyScanError(false))
+	snapshot := agg.StateSnapshot()
+	assert.False(t, snapshot.AllScansStartedReference)
+	assert.False(t, snapshot.AllScansStartedWorkingDirectory)
+	assert.False(t, snapshot.AnyScanInProgressReference)
+	assert.False(t, snapshot.AnyScanInProgressWorkingDirectory)
+	assert.False(t, snapshot.AllScansSucceededReference)
+	assert.False(t, snapshot.AllScansSucceededWorkingDirectory)
+	assert.False(t, snapshot.AnyScanErrorReference)
+	assert.False(t, snapshot.AnyScanErrorWorkingDirectory)
 }
 
 func TestScanStateAggregator_SetState_InProgress(t *testing.T) {
@@ -58,8 +59,9 @@ func TestScanStateAggregator_SetState_InProgress(t *testing.T) {
 
 	// Emitter should have been called once
 
-	assert.False(t, agg.allScansStarted(false))
-	assert.True(t, agg.anyScanInProgress(false))
+	snapshot := agg.StateSnapshot()
+	assert.False(t, snapshot.AllScansStartedWorkingDirectory)
+	assert.True(t, snapshot.AnyScanInProgressWorkingDirectory)
 }
 
 func TestScanStateAggregator_SetState_Done(t *testing.T) {
@@ -80,8 +82,9 @@ func TestScanStateAggregator_SetState_Done(t *testing.T) {
 	}
 	agg.SetScanState(folderPath, product.ProductOpenSource, false, doneState)
 
-	assert.False(t, agg.allScansSucceeded(false))
-	assert.False(t, agg.anyScanError(false))
+	snapshot := agg.StateSnapshot()
+	assert.False(t, snapshot.AllScansSucceededWorkingDirectory)
+	assert.False(t, snapshot.AnyScanErrorWorkingDirectory)
 }
 
 func TestScanStateAggregator_SetState_Error(t *testing.T) {
@@ -102,8 +105,9 @@ func TestScanStateAggregator_SetState_Error(t *testing.T) {
 	}
 	agg.SetScanState(folderPath, product.ProductCode, false, errState)
 
-	assert.True(t, agg.anyScanError(false), "At least one working scan is in ERROR")
-	assert.False(t, agg.allScansSucceeded(false))
+	snapshot := agg.StateSnapshot()
+	assert.True(t, snapshot.AnyScanErrorWorkingDirectory, "At least one working scan is in ERROR")
+	assert.False(t, snapshot.AllScansSucceededWorkingDirectory)
 }
 
 func TestScanStateAggregator_SetState_AllSuccess(t *testing.T) {
@@ -134,10 +138,11 @@ func TestScanStateAggregator_SetState_AllSuccess(t *testing.T) {
 
 	// Emitter called 3 times total
 
-	assert.True(t, agg.allScansSucceeded(true))
-	assert.True(t, agg.allScansSucceeded(false))
-	assert.False(t, agg.anyScanError(true))
-	assert.False(t, agg.anyScanError(false))
+	snapshot := agg.StateSnapshot()
+	assert.True(t, snapshot.AllScansSucceededReference)
+	assert.True(t, snapshot.AllScansSucceededWorkingDirectory)
+	assert.False(t, snapshot.AnyScanErrorReference)
+	assert.False(t, snapshot.AnyScanErrorWorkingDirectory)
 }
 
 func TestScanStateAggregator_SetState_NonExistingFolder(t *testing.T) {
@@ -158,8 +163,9 @@ func TestScanStateAggregator_SetState_NonExistingFolder(t *testing.T) {
 	}
 	agg.SetScanState("/non/existing/folder", product.ProductOpenSource, true, doneState)
 
-	assert.False(t, agg.allScansStarted(true))
-	assert.False(t, agg.allScansStarted(false))
+	snapshot := agg.StateSnapshot()
+	assert.False(t, snapshot.AllScansStartedReference)
+	assert.False(t, snapshot.AllScansStartedWorkingDirectory)
 }
 
 func TestScanStateAggregator_SetScanInProgress(t *testing.T) {
@@ -176,8 +182,9 @@ func TestScanStateAggregator_SetScanInProgress(t *testing.T) {
 
 	agg.SetScanInProgress(folder, product.ProductOpenSource, false)
 
-	assert.True(t, agg.anyScanInProgress(false))
-	assert.False(t, agg.anyScanError(false))
+	snapshot := agg.StateSnapshot()
+	assert.True(t, snapshot.AnyScanInProgressWorkingDirectory)
+	assert.False(t, snapshot.AnyScanErrorWorkingDirectory)
 }
 
 func TestScanStateAggregator_SetScanDone(t *testing.T) {
@@ -197,13 +204,15 @@ func TestScanStateAggregator_SetScanDone(t *testing.T) {
 
 	agg.SetScanDone(folder, product.ProductOpenSource, false, nil)
 
-	assert.False(t, agg.anyScanError(false))
-	assert.True(t, agg.anyScanSucceeded(false))
+	snapshot := agg.StateSnapshot()
+	assert.False(t, snapshot.AnyScanErrorWorkingDirectory)
+	assert.True(t, snapshot.AnyScanSucceededWorkingDirectory)
 
 	testErr := errors.New("some error")
 	agg.SetScanDone(folder, product.ProductCode, false, testErr)
 
-	assert.True(t, agg.anyScanError(false))
+	snapshot = agg.StateSnapshot()
+	assert.True(t, snapshot.AnyScanErrorWorkingDirectory)
 }
 
 func TestScanStateAggregator_StateSnapshot(t *testing.T) {
@@ -277,9 +286,9 @@ func TestScanStateAggregator_OnlyEnabledProductsShouldBeCounted(t *testing.T) {
 	agg.SetScanState(folderPath, product.ProductOpenSource, true, newState)
 	agg.SetScanState(folderPath, product.ProductCode, true, newState)
 
-	assert.True(t, agg.allScansStarted(false))
-	assert.True(t, agg.anyScanInProgress(false))
 	snapshot := agg.StateSnapshot()
+	assert.True(t, snapshot.AllScansStartedWorkingDirectory)
+	assert.True(t, snapshot.AnyScanInProgressWorkingDirectory)
 	assert.Equal(t, snapshot.ScansInProgressCount, 4, "IaC won't be counted since it's disabled")
 }
 
@@ -312,7 +321,7 @@ func TestScanStateAggregator_StateSnapshot_ProductScanStates(t *testing.T) {
 	assert.False(t, iacPresent, "IaC should not be present in scan states (not started)")
 }
 
-func TestScanStateAggregator_ProductScanStates_NotStartedProductsExcluded(t *testing.T) {
+func TestScanStateAggregator_StateSnapshot_ProductScanStates_NotStartedProductsExcluded(t *testing.T) {
 	c := testutil.UnitTest(t)
 	c.SetSnykOpenBrowserActionsEnabled(true)
 	c.SetSnykCodeEnabled(true)

--- a/domain/scanstates/state_aggregator.go
+++ b/domain/scanstates/state_aggregator.go
@@ -1,5 +1,5 @@
 /*
- * © 2025 Snyk Limited
+ * © 2025-2026 Snyk Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,6 @@ type Aggregator interface {
 	SetScanState(folderPath types.FilePath, p product.Product, isReferenceScan bool, newState scanState)
 	SetScanDone(folderPath types.FilePath, p product.Product, isReferenceScan bool, scanErr error)
 	SetScanInProgress(folderPath types.FilePath, p product.Product, isReferenceScan bool)
-	allScansStarted(isReference bool) bool
-	anyScanInProgress(isReference bool) bool
-	anyScanSucceeded(isReference bool) bool
-	allScansSucceeded(isReference bool) bool
-	anyScanError(isReference bool) bool
 	SummaryEmitter() ScanStateChangeEmitter
 	StateSnapshot() StateSnapshot
 	GetScanErr(folderPath types.FilePath, p product.Product, isReferenceScan bool) error

--- a/domain/scanstates/summary_html.go
+++ b/domain/scanstates/summary_html.go
@@ -183,7 +183,7 @@ func (renderer *HtmlRenderer) isAutofixEnabledInAnyFolder() bool {
 	}
 
 	for _, folder := range renderer.c.Workspace().Folders() {
-		folderConfig := renderer.c.FolderConfig(folder.Path())
+		folderConfig := renderer.c.ImmutableFolderConfig(folder.Path())
 		if folderConfig != nil && folderConfig.SastSettings != nil && folderConfig.SastSettings.AutofixEnabled {
 			return true
 		}

--- a/domain/snyk/scanner/scanner.go
+++ b/domain/snyk/scanner/scanner.go
@@ -241,6 +241,7 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 		return
 	}
 
+	sc.scanStateAggregator.Init([]types.FilePath{workspaceFolderConfig.FolderPath})
 	sc.scanNotifier.SendInProgress(workspaceFolderConfig)
 	gitCheckoutHandler := vcs.NewCheckoutHandler(sc.c.Engine().GetConfiguration())
 
@@ -344,10 +345,10 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 		if gitCheckoutHandler.CleanupFunc() != nil {
 			logger.Debug().Msg("Calling cleanup func for base folder")
 			gitCheckoutHandler.CleanupFunc()()
-			logger.Debug().Msgf("All product scanners finished for %s", pathToScan)
-			sc.notifier.Send(types.InlineValueRefresh{})
-			sc.notifier.Send(types.CodeLensRefresh{})
 		}
+		logger.Debug().Msgf("All product scanners finished for %s", pathToScan)
+		sc.notifier.Send(types.InlineValueRefresh{})
+		sc.notifier.Send(types.CodeLensRefresh{})
 	}()
 }
 

--- a/domain/snyk/scanner/scanner.go
+++ b/domain/snyk/scanner/scanner.go
@@ -241,7 +241,6 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 		return
 	}
 
-	sc.scanStateAggregator.Init([]types.FilePath{workspaceFolderConfig.FolderPath})
 	sc.scanNotifier.SendInProgress(workspaceFolderConfig)
 	gitCheckoutHandler := vcs.NewCheckoutHandler(sc.c.Engine().GetConfiguration())
 

--- a/infrastructure/code/snyk_code_http_client.go
+++ b/infrastructure/code/snyk_code_http_client.go
@@ -67,7 +67,7 @@ func GetCodeApiUrlForFolder(c *config.Config, folder types.FilePath) (string, er
 		return "", fmt.Errorf("no folder specified when trying to determine Snyk Code API URL")
 	}
 
-	folderConfig, err := c.FolderConfigForSubPath(folder)
+	folderConfig, err := c.ImmutableFolderConfigForSubPath(folder)
 	if err != nil {
 		return "", err
 	}

--- a/infrastructure/configuration/template/config.html
+++ b/infrastructure/configuration/template/config.html
@@ -109,8 +109,7 @@
 
                         <div class="col-md-6">
                             <div class="form-group">
-                                <label>Issue View Options</label>
-                                <span data-toggle="tooltip" title="<p>Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions.</p><p>It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run.</p>">Show Ignored Issues</span>
+                                <label data-toggle="tooltip" title="<p>Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions.</p><p>It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run.</p>">Issue View Options</label>
                                 <div class="checkbox-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" name="issueViewOptions_openIssues" {{if .Settings.IssueViewOptions}}{{if .Settings.IssueViewOptions.OpenIssues}}checked{{end}}{{end}}>
@@ -119,6 +118,7 @@
                                     </label>
                                     <label class="checkbox-label">
                                         <input type="checkbox" name="issueViewOptions_ignoredIssues" {{if .Settings.IssueViewOptions}}{{if .Settings.IssueViewOptions.IgnoredIssues}}checked{{end}}{{end}}>
+                                        Show Ignored Issues
                                         <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="issueViewOptions_ignoredIssues"></span>
                                     </label>
                                 </div>

--- a/infrastructure/featureflag/featureflag.go
+++ b/infrastructure/featureflag/featureflag.go
@@ -226,7 +226,12 @@ func (s *serviceImpl) FlushCache() {
 }
 
 func (s *serviceImpl) GetFromFolderConfig(folderPath types.FilePath, flag string) bool {
-	folderConfig := s.c.ImmutableFolderConfig(folderPath)
+	folderConfig, _ := s.c.GetFolderConfigWithOptions(folderPath, storedconfig.GetFolderConfigOptions{
+		CreateIfNotExist:     false,
+		ReadOnly:             true,
+		EnrichFromGit:        false,
+		CreateMinimalFCOnErr: true,
+	})
 	return folderConfig.GetFeatureFlag(flag)
 }
 

--- a/infrastructure/featureflag/featureflag.go
+++ b/infrastructure/featureflag/featureflag.go
@@ -226,11 +226,7 @@ func (s *serviceImpl) FlushCache() {
 }
 
 func (s *serviceImpl) GetFromFolderConfig(folderPath types.FilePath, flag string) bool {
-	folderConfig, _ := s.c.GetFolderConfigWithOptions(folderPath, storedconfig.GetFolderConfigOptions{
-		CreateIfNotExist: true,
-		ReadOnly:         true,
-		EnrichFromGit:    false,
-	})
+	folderConfig := s.c.ImmutableFolderConfig(folderPath)
 	return folderConfig.GetFeatureFlag(flag)
 }
 

--- a/infrastructure/featureflag/featureflag.go
+++ b/infrastructure/featureflag/featureflag.go
@@ -227,10 +227,9 @@ func (s *serviceImpl) FlushCache() {
 
 func (s *serviceImpl) GetFromFolderConfig(folderPath types.FilePath, flag string) bool {
 	folderConfig, _ := s.c.GetFolderConfigWithOptions(folderPath, storedconfig.GetFolderConfigOptions{
-		CreateIfNotExist:     false,
-		ReadOnly:             true,
-		EnrichFromGit:        false,
-		CreateMinimalFCOnErr: true,
+		CreateIfNotExist: true,
+		ReadOnly:         true,
+		EnrichFromGit:    false,
 	})
 	return folderConfig.GetFeatureFlag(flag)
 }

--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -338,7 +338,7 @@ func (cliScanner *CLIScanner) legacyScan(ctx context.Context, pathToScan types.F
 
 func (cliScanner *CLIScanner) updateArgs(workDir types.FilePath, commandLineArgs []string, folderConfig *types.FolderConfig) ([]string, gotenv.Env) {
 	if folderConfig == nil {
-		folderConfig = cliScanner.config.FolderConfig(workDir)
+		folderConfig = cliScanner.config.ImmutableFolderConfig(workDir)
 	}
 	folderConfigArgs := folderConfig.AdditionalParameters
 

--- a/internal/storedconfig/stored_config.go
+++ b/internal/storedconfig/stored_config.go
@@ -37,6 +37,8 @@ type GetFolderConfigOptions struct {
 	ReadOnly bool
 	// EnrichFromGit enriches the folder config with Git branch information.
 	EnrichFromGit bool
+	// CreateMinimalFCOnErr returns a basic FolderConfig initialized with the path instead of nil if an error occurs.
+	CreateMinimalFCOnErr bool
 }
 
 // GetFolderConfigWithOptions retrieves folder config from storage with specified behaviors
@@ -45,6 +47,10 @@ func GetFolderConfigWithOptions(conf configuration.Configuration, path types.Fil
 
 	folderConfig, err := folderConfigFromStorage(conf, path, &l, opts.CreateIfNotExist)
 	if err != nil {
+		if opts.CreateMinimalFCOnErr {
+			l.Err(err).Msg("error retrieving folder config from storage, returning minimal fallback")
+			return &types.FolderConfig{FolderPath: path}, err
+		}
 		return nil, err
 	}
 
@@ -59,10 +65,10 @@ func GetFolderConfigWithOptions(conf configuration.Configuration, path types.Fil
 	}
 
 	// Update storage since we may have changed values like normalizing the path, enriching from git, etc., but skip if read-only mode.
-	if !opts.ReadOnly {
+	if !opts.ReadOnly && folderConfig != nil {
 		err = UpdateFolderConfig(conf, folderConfig, &l)
 		if err != nil {
-			return nil, err
+			return folderConfig, err
 		}
 	}
 

--- a/internal/storedconfig/stored_config.go
+++ b/internal/storedconfig/stored_config.go
@@ -28,7 +28,8 @@ import (
 
 // GetFolderConfigOptions controls the behavior of folder config retrieval
 type GetFolderConfigOptions struct {
-	// CreateIfNotExist creates a new folder config if one doesn't exist.
+	// CreateIfNotExist creates a new folder config if one doesn't exist,
+	// even on errors, but error will still be returned.
 	// When ReadOnly=false: creates and saves to storage.
 	// When ReadOnly=true: creates in-memory but doesn't save.
 	CreateIfNotExist bool
@@ -37,8 +38,6 @@ type GetFolderConfigOptions struct {
 	ReadOnly bool
 	// EnrichFromGit enriches the folder config with Git branch information.
 	EnrichFromGit bool
-	// CreateMinimalFCOnErr returns a basic FolderConfig initialized with the path instead of nil if an error occurs.
-	CreateMinimalFCOnErr bool
 }
 
 // GetFolderConfigWithOptions retrieves folder config from storage with specified behaviors
@@ -47,11 +46,11 @@ func GetFolderConfigWithOptions(conf configuration.Configuration, path types.Fil
 
 	folderConfig, err := folderConfigFromStorage(conf, path, &l, opts.CreateIfNotExist)
 	if err != nil {
-		if opts.CreateMinimalFCOnErr {
-			l.Err(err).Msg("error retrieving folder config from storage, returning minimal fallback")
-			return &types.FolderConfig{FolderPath: path}, err
+		if folderConfig == nil && opts.CreateIfNotExist {
+			l.Err(err).Msg("error retrieving folder config from storage, returning new minimal fallback as well")
+			folderConfig = &types.FolderConfig{FolderPath: path}
 		}
-		return nil, err
+		return folderConfig, err
 	}
 
 	// If folder config doesn't exist and we're not creating, return nil
@@ -70,6 +69,12 @@ func GetFolderConfigWithOptions(conf configuration.Configuration, path types.Fil
 		if err != nil {
 			return folderConfig, err
 		}
+	}
+
+	// As a sanity check to prevent panics, should never be needed.
+	if folderConfig == nil && opts.CreateIfNotExist {
+		l.Debug().Msg("fetched folder config from storage was nil")
+		folderConfig = &types.FolderConfig{FolderPath: path}
 	}
 
 	return folderConfig, nil

--- a/internal/types/config_resolver.go
+++ b/internal/types/config_resolver.go
@@ -606,47 +606,28 @@ func (r *ConfigResolver) isSettingEnabledForFolder(_ ImmutableFolderConfig, _ st
 	return fallback()
 }
 
-func (r *ConfigResolver) FilterSeverityForFolder(folderConfig ImmutableFolderConfig) SeverityFilter {
+func (r *ConfigResolver) FilterSeverityForFolder(_ ImmutableFolderConfig) SeverityFilter {
 	if r.c == nil {
 		return SeverityFilter{}
 	}
-	val, source := r.GetValue(SettingEnabledSeverities, folderConfig)
-	if source != ConfigSourceDefault {
-		if filter, ok := val.(*SeverityFilter); ok && filter != nil {
-			return *filter
-		}
-	}
+
 	return r.c.FilterSeverity()
 }
 
-func (r *ConfigResolver) RiskScoreThresholdForFolder(folderConfig ImmutableFolderConfig) int {
+func (r *ConfigResolver) RiskScoreThresholdForFolder(_ ImmutableFolderConfig) int {
 	if r.c == nil {
 		return 0
 	}
-	val, source := r.GetValue(SettingRiskScoreThreshold, folderConfig)
-	if source != ConfigSourceDefault {
-		if threshold, ok := val.(int); ok {
-			return threshold
-		}
-	}
+
 	return r.c.RiskScoreThreshold()
 }
 
-func (r *ConfigResolver) IssueViewOptionsForFolder(folderConfig ImmutableFolderConfig) IssueViewOptions {
+func (r *ConfigResolver) IssueViewOptionsForFolder(_ ImmutableFolderConfig) IssueViewOptions {
 	if r.c == nil {
 		return IssueViewOptions{}
 	}
 	result := r.c.IssueViewOptions()
-	if val, source := r.GetValue(SettingIssueViewOpenIssues, folderConfig); source != ConfigSourceDefault {
-		if open, ok := val.(bool); ok {
-			result.OpenIssues = open
-		}
-	}
-	if val, source := r.GetValue(SettingIssueViewIgnoredIssues, folderConfig); source != ConfigSourceDefault {
-		if ignored, ok := val.(bool); ok {
-			result.IgnoredIssues = ignored
-		}
-	}
+
 	return result
 }
 


### PR DESCRIPTION
### Description

Fetch FCs less in the scan aggregator.
Removed internal helpers from the interface and test `StateSnapshot()`.
Only getting "immutable" folder configs in more places.
Stop enriching from Git when immutable FC.
This will help increase performance.
Also ensure scan summary always is updated at end of scans.

### Checklist

- [x] Tests added and all succeed
 - Just adapted to work with the new way.
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
