### PR TITLE
feat: html settings styling for secrets [IDE-1833]

### DIFF
--- a/application/server/configuration_smoke_test.go
+++ b/application/server/configuration_smoke_test.go
@@ -147,11 +147,8 @@ func Test_SmokeConfigurationDialog(t *testing.T) {
 				assertFieldPresent(t, html, "orgSetByUser", "OrgSetByUser field")
 				assertFieldPresent(t, html, "preferredOrg", "PreferredOrg field")
 
-				// Scan command config fields (pre/post scan commands per product - in hidden section)
-				assertFieldPresent(t, html, "scanConfig_Snyk_Open_Source_preScanCommand", "ScanConfig OSS PreScanCommand field")
-				assertFieldPresent(t, html, "scanConfig_Snyk_Open_Source_postScanCommand", "ScanConfig OSS PostScanCommand field")
-				assertFieldPresent(t, html, "scanConfig_Snyk_Code_preScanCommand", "ScanConfig Code PreScanCommand field")
-				assertFieldPresent(t, html, "scanConfig_Snyk_IaC_preScanCommand", "ScanConfig IaC PreScanCommand field")
+				// Scan command config fields (pre/post scan commands per product) are behind the
+				// EnableLdxSyncConfig feature flag which is not yet enabled in production.
 			}
 		})
 

--- a/application/server/configuration_smoke_test.go
+++ b/application/server/configuration_smoke_test.go
@@ -149,6 +149,7 @@ func Test_SmokeConfigurationDialog(t *testing.T) {
 
 				// Scan command config fields (pre/post scan commands per product) are behind the
 				// EnableLdxSyncConfig feature flag which is not yet enabled in production.
+				// Will be fixed by https://snyksec.atlassian.net/browse/IDE-1786
 			}
 		})
 

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -96,10 +96,10 @@ func TestConfigHtmlRenderer_GetConfigHtml(t *testing.T) {
 	assert.Contains(t, html, "Snyk Code")
 	assert.Contains(t, html, "Authentication Method")
 	assert.Contains(t, html, "oauth")
-	assert.Contains(t, html, "Scan Configuration")    // Section header
-	assert.Contains(t, html, "Filtering and Display") // Section header
-	assert.Contains(t, html, "Folder Settings")       // Section header
-	assert.Contains(t, html, "CLI Configuration")     // Section header
+	assert.Contains(t, html, "Scan Configuration") // Section header
+	assert.Contains(t, html, "Filters and Views")  // Section header
+	assert.Contains(t, html, "Trust Settings")     // Section header
+	assert.Contains(t, html, "CLI Configuration")  // Section header
 }
 
 func TestConfigHtmlRenderer_EclipseShowsProjectSettings(t *testing.T) {

--- a/infrastructure/configuration/template/config.html
+++ b/infrastructure/configuration/template/config.html
@@ -65,7 +65,7 @@
                     </div>
 
                     <div class="form-group half-width">
-                        <label for="organization"><span data-toggle="tooltip" title="<p>Specify the organization (ID or name) for Snyk to run scans against.</p><p>Organization selection follows this order:</p><ol><li>Project-specific settings (if configured)</li><li>This global setting (if the project-specific setting is empty)</li><li>Your web account's preferred organization (if both above are empty)</li></ol><p>Manual organization settings override automatic organization selection.</p>">Organization</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="organization"></span></label>
+                        <label for="organization"><span data-toggle="tooltip" title="<p>Specify the organization (ID or name) for Snyk to run scans against.</p><p>Organization selection follows this order:</p><ol><li>Project-specific settings (if configured)</li><li>This global setting (if the project-specific setting is empty)</li><li>Your web account's preferred organization (if both above are empty)</li></ol>">Organization</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="organization"></span></label>
                         <input type="text" id="organization" name="organization" value="{{.Settings.Organization}}" placeholder="Organization UUID or Slug">
                     </div>
                 </div>
@@ -110,6 +110,7 @@
                         <div class="col-md-6">
                             <div class="form-group">
                                 <label>Issue View Options</label>
+                                <span data-toggle="tooltip" title="<p>Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions.</p><p>It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run.</p>">Show Ignored Issues</span>
                                 <div class="checkbox-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" name="issueViewOptions_openIssues" {{if .Settings.IssueViewOptions}}{{if .Settings.IssueViewOptions.OpenIssues}}checked{{end}}{{end}}>
@@ -118,7 +119,6 @@
                                     </label>
                                     <label class="checkbox-label">
                                         <input type="checkbox" name="issueViewOptions_ignoredIssues" {{if .Settings.IssueViewOptions}}{{if .Settings.IssueViewOptions.IgnoredIssues}}checked{{end}}{{end}}>
-                                        <span data-toggle="tooltip" title="<p>Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions.</p><p>It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run.</p>">Show Ignored Issues</span>
                                         <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="issueViewOptions_ignoredIssues"></span>
                                     </label>
                                 </div>
@@ -209,7 +209,7 @@
                     </div>
 
                     <div class="form-group half-width">
-                        <label for="cliReleaseChannel"><span data-toggle="tooltip" title="Release channel for Snyk CLI downloads (Stable, Release Candidate or Preview)">CLI Release Channel</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliReleaseChannel"></span></label>
+                        <label for="cliReleaseChannel"><span data-toggle="tooltip" title="Release channel for Snyk CLI downloads">CLI Release Channel</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliReleaseChannel"></span></label>
                         <select id="cliReleaseChannel" name="cliReleaseChannel">
                             <option value="stable" {{if eq .CliReleaseChannel "stable"}}selected{{end}}>Stable</option>
                             <option value="rc" {{if eq .CliReleaseChannel "rc"}}selected{{end}}>Release Candidate</option>
@@ -218,7 +218,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="cliBaseDownloadURL"><span data-toggle="tooltip" title="<p>Base URL for downloading Snyk CLI binaries.</p><p>Default: <strong>https://downloads.snyk.io</strong></p><p>For FIPS-enabled CLIs (Windows/Linux only), use <strong>https://downloads.snyk.io/fips</strong></p>">CLI Download Base URL</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliBaseDownloadURL"></span></label>
+                        <label for="cliBaseDownloadURL"><span data-toggle="tooltip" title="<p>Base URL for downloading Snyk CLI binaries.</p><p>Default: <strong>https://downloads.snyk.io</strong></p><p>For FIPS-enabled CLIs (Windows/Linux only), use <code>https://downloads.snyk.io/fips</code></p>">CLI Download Base URL</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliBaseDownloadURL"></span></label>
                         <input type="text" id="cliBaseDownloadURL" name="cliBaseDownloadURL" value="{{.Settings.CliBaseDownloadURL}}" placeholder="https://downloads.snyk.io">
                     </div>
                 </div>
@@ -236,7 +236,7 @@
 
                     <div class="form-group">
                         <button class="collapsible-header text-start w-100 d-flex justify-content-between align-items-center p-0" type="button" data-toggle="collapse" data-target="#trustedFoldersSection" aria-expanded="false" aria-controls="trustedFoldersSection">
-                            <span><span data-toggle="tooltip" title="List of folders that are trusted for scanning. Type folder paths directly">Folder Paths</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="trustedFolders"></span></span>
+                            <span><span data-toggle="tooltip" title="List of folders that are trusted for scanning. Type folder paths directly">Trusted Folder Paths</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="trustedFolders"></span></span>
                             <span class="collapse-icon">▼</span>
                         </button>
                         <div class="collapse" id="trustedFoldersSection">

--- a/infrastructure/configuration/template/config.html
+++ b/infrastructure/configuration/template/config.html
@@ -31,7 +31,7 @@
                     </div>
 
                     <div class="form-group">
-                        <h3>Snyk Products</h3>
+                        <h3>Scanners</h3>
                         <div class="checkbox-group">
                             <label class="checkbox-label">
                                 <input type="checkbox" name="activateSnykOpenSource" {{if eq .Settings.ActivateSnykOpenSource "true"}}checked{{end}}>
@@ -45,7 +45,7 @@
                             </label>
                             <label class="checkbox-label">
                                 <input type="checkbox" name="activateSnykIac" {{if eq .Settings.ActivateSnykIac "true"}}checked{{end}}>
-                                <span data-toggle="tooltip" title="Find and fix your IaC misconfigurations">Snyk IaC</span>
+                                <span data-toggle="tooltip" title="Find and fix your IaC misconfigurations">Snyk Infrastructure as Code</span>
                                 <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="activateSnykIac"></span>
                             </label>
                             <label class="checkbox-label">
@@ -65,7 +65,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="organization"><span data-toggle="tooltip" title="DEPRECATED: This global organization setting is deprecated. Please use the {{.FolderLabel | toLower}}-specific organization settings in the {{.FolderLabel}} Settings section below for better control">Organization <span class="deprecated-label">⚠ Deprecated</span></span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="organization"></span></label>
+                        <label for="organization"><span data-toggle="tooltip" title="<p>Specify the organization (ID or name) for Snyk to run scans against.</p><p>Organization selection follows this order:</p><ol><li>Project-specific settings (if configured)</li><li>This global setting (if the project-specific setting is empty)</li><li>Your web account's preferred organization (if both above are empty)</li></ol><p>Manual organization settings override automatic organization selection.</p>">Organization</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="organization"></span></label>
                         <input type="text" id="organization" name="organization" value="{{.Settings.Organization}}" placeholder="Organization UUID or Slug">
                     </div>
                 </div>
@@ -74,7 +74,7 @@
             <div class="col-md-6">
                 <div class="section">
                     <div class="section-header">
-                        <h2>Filtering and Display</h2>
+                        <h2>Filters and Views</h2>
                         <button type="button" class="reset-section-btn" data-section="filteringDisplay" title="Reset this section to defaults">Reset</button>
                     </div>
 
@@ -127,24 +127,18 @@
                         </div>
                     </div>
 
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                <label for="riskScoreThreshold"><span data-toggle="tooltip" title="[Closed Beta] Minimum risk score to display issues. Valid range: 0 to 1000 (0 = show all issues)">[Closed Beta] Filter by Risk Score</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="riskScoreThreshold"></span></label>
-                                <input type="number" id="riskScoreThreshold" name="riskScoreThreshold" min="0" max="1000" value="{{if ne .Settings.RiskScoreThreshold nil}}{{.Settings.RiskScoreThreshold}}{{end}}" placeholder="0">
-                                <span id="riskScore-error" class="error-message hidden">Risk score must be between 0 and 1000</span>
-                            </div>
-                        </div>
+                    <div class="form-group">
+                        <label for="riskScoreThreshold"><span data-toggle="tooltip" title="[Closed Beta] Minimum risk score to display issues. Valid range: 0 to 1000 (0 = show all issues)">[Closed Beta] Filter by Risk Score</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="riskScoreThreshold"></span></label>
+                        <input type="number" id="riskScoreThreshold" name="riskScoreThreshold" min="0" max="1000" value="{{if ne .Settings.RiskScoreThreshold nil}}{{.Settings.RiskScoreThreshold}}{{end}}" placeholder="0">
+                        <span id="riskScore-error" class="error-message hidden">Risk score must be between 0 and 1000</span>
+                    </div>
 
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                <label for="enableDeltaFindings"><span data-toggle="tooltip" title="Specifies whether to see all issues or only net new issues. Net new issues option requires a Git repository, where it compares findings with those in the base branch">Delta Findings</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="enableDeltaFindings"></span></label>
-                                <select id="enableDeltaFindings" name="enableDeltaFindings">
-                                    <option value="false" {{if ne .Settings.EnableDeltaFindings "true"}}selected{{end}}>All Issues</option>
-                                    <option value="true" {{if eq .Settings.EnableDeltaFindings "true"}}selected{{end}}>Net New Issues</option>
-                                </select>
-                            </div>
-                        </div>
+                    <div class="form-group">
+                        <label for="enableDeltaFindings"><span data-toggle="tooltip" title="Specifies whether to see all issues or only net new issues. Net new issues option requires a Git repository, where it compares findings with those in the base branch">Delta Findings</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="enableDeltaFindings"></span></label>
+                        <select id="enableDeltaFindings" name="enableDeltaFindings">
+                            <option value="false" {{if ne .Settings.EnableDeltaFindings "true"}}selected{{end}}>All Issues</option>
+                            <option value="true" {{if eq .Settings.EnableDeltaFindings "true"}}selected{{end}}>Net New Issues</option>
+                        </select>
                     </div>
                 </div>
             </div>
@@ -160,15 +154,6 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="authenticationMethod"><span data-toggle="tooltip" title="Specifies whether to authenticate with OAuth2, PAT (Personal Access Token), or with an API token (Legacy). Note: OAuth2 authentication is recommended as it provides enhanced security">Authentication Method</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="authenticationMethod"></span></label>
-                        <select id="authenticationMethod" name="authenticationMethod">
-                            <option value="oauth" {{if eq .Settings.AuthenticationMethod "oauth"}}selected{{end}}>OAuth2 (Recommended)</option>
-                            <option value="pat" {{if eq .Settings.AuthenticationMethod "pat"}}selected{{end}}>Personal Access Token</option>
-                            <option value="token" {{if eq .Settings.AuthenticationMethod "token"}}selected{{end}}>API Token (Legacy)</option>
-                        </select>
-                    </div>
-
-                    <div class="form-group">
                         <label for="endpoint"><span data-toggle="tooltip" title="If you're using SSO with Snyk and OAuth2, this is automatically populated. For public regional instances, see Snyk documentation. For private instances, contact your team or account manager">Endpoint</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="endpoint"></span></label>
                         <input type="text" id="endpoint" name="endpoint" value="{{.Settings.Endpoint}}" placeholder="https://app.snyk.io/api">
                         <span id="endpoint-error" class="error-message hidden">Invalid Endpoint URL. Expected format: api.snyk.io, api.*.snyk.io or api.*.snykgov.io</span>
@@ -181,6 +166,15 @@
                             <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="insecure"></span>
                         </label>
                     </div>
+
+                  <div class="form-group">
+                    <label for="authenticationMethod"><span data-toggle="tooltip" title="Specifies whether to authenticate with OAuth2, PAT (Personal Access Token), or with an API token (Legacy). Note: OAuth2 authentication is recommended as it provides enhanced security">Authentication Method</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="authenticationMethod"></span></label>
+                    <select id="authenticationMethod" name="authenticationMethod">
+                      <option value="oauth" {{if eq .Settings.AuthenticationMethod "oauth"}}selected{{end}}>OAuth2 (Recommended)</option>
+                      <option value="pat" {{if eq .Settings.AuthenticationMethod "pat"}}selected{{end}}>Personal Access Token</option>
+                      <option value="token" {{if eq .Settings.AuthenticationMethod "token"}}selected{{end}}>API Token (Legacy)</option>
+                    </select>
+                  </div>
 
                     <div class="form-group">
                         <label for="token">Token <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="token"></span></label>
@@ -231,18 +225,18 @@
             </div>
         </div>
 
-        <!-- Permissions -->
+        <!-- Trust Settings -->
         <div class="row">
             <div class="col-md-12">
                 <div class="section">
                     <div class="section-header">
-                        <h2>Permissions</h2>
+                        <h2>Trust Settings</h2>
                         <button type="button" class="reset-section-btn" data-section="permissions" title="Reset this section to defaults">Reset</button>
                     </div>
 
                     <div class="form-group">
                         <button class="collapsible-header text-start w-100 d-flex justify-content-between align-items-center p-0" type="button" data-toggle="collapse" data-target="#trustedFoldersSection" aria-expanded="false" aria-controls="trustedFoldersSection">
-                            <span><span data-toggle="tooltip" title="List of folders that are trusted for scanning. Type folder paths directly">Trusted Folders</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="trustedFolders"></span></span>
+                            <span><span data-toggle="tooltip" title="List of folders that are trusted for scanning. Type folder paths directly">Folder Paths</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="trustedFolders"></span></span>
                             <span class="collapse-icon">▼</span>
                         </button>
                         <div class="collapse" id="trustedFoldersSection">

--- a/infrastructure/configuration/template/config.html
+++ b/infrastructure/configuration/template/config.html
@@ -40,7 +40,7 @@
                             </label>
                             <label class="checkbox-label">
                                 <input type="checkbox" name="activateSnykCode" {{if eq .Settings.ActivateSnykCode "true"}}checked{{end}}>
-                                <span data-toggle="tooltip" title="Find and fix security issues in your application code in real time. Note: Snyk Code must be enabled for your organization in Snyk settings">Snyk Code</span>
+                                <span data-toggle="tooltip" title="<p>Find and fix security issues in your application code in real time.</p><p><strong>Note:</strong> Snyk Code must be enabled for your organization in Snyk settings.</p>">Snyk Code</span>
                                 <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="activateSnykCode"></span>
                             </label>
                             <label class="checkbox-label">
@@ -118,7 +118,7 @@
                                     </label>
                                     <label class="checkbox-label">
                                         <input type="checkbox" name="issueViewOptions_ignoredIssues" {{if .Settings.IssueViewOptions}}{{if .Settings.IssueViewOptions.IgnoredIssues}}checked{{end}}{{end}}>
-                                        <span data-toggle="tooltip" title="Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions. It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run">Show Ignored Issues</span>
+                                        <span data-toggle="tooltip" title="<p>Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions.</p><p>It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run.</p>">Show Ignored Issues</span>
                                         <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="issueViewOptions_ignoredIssues"></span>
                                     </label>
                                 </div>
@@ -128,13 +128,13 @@
                     </div>
 
                     <div class="form-group half-width">
-                        <label for="riskScoreThreshold"><span data-toggle="tooltip" title="Minimum risk score to display issues. Valid range: 0 to 1000 (0 = show all issues)">Filter by Risk Score<span class="deprecated-label">Closed Beta</span></span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="riskScoreThreshold"></span></label>
+                        <label for="riskScoreThreshold"><span data-toggle="tooltip" title="<p>Minimum risk score to display issues.</p><p>Valid range: 0 to 1000 (0 = show all issues).</p>">Filter by Risk Score<span class="deprecated-label">Closed Beta</span></span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="riskScoreThreshold"></span></label>
                         <input type="number" id="riskScoreThreshold" name="riskScoreThreshold" min="0" max="1000" value="{{if ne .Settings.RiskScoreThreshold nil}}{{.Settings.RiskScoreThreshold}}{{end}}" placeholder="0">
                         <span id="riskScore-error" class="error-message hidden">Risk score must be between 0 and 1000</span>
                     </div>
 
                     <div class="form-group half-width">
-                        <label for="enableDeltaFindings"><span data-toggle="tooltip" title="Specifies whether to see all issues or only net new issues. Net new issues option requires a Git repository, where it compares findings with those in the base branch">Delta Findings</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="enableDeltaFindings"></span></label>
+                        <label for="enableDeltaFindings"><span data-toggle="tooltip" title="<p>Specifies whether to see all issues or only net new issues.</p><p>Net new issues requires a Git repository, where it compares findings with those in the base branch.</p>">Delta Findings</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="enableDeltaFindings"></span></label>
                         <select id="enableDeltaFindings" name="enableDeltaFindings">
                             <option value="false" {{if ne .Settings.EnableDeltaFindings "true"}}selected{{end}}>All Issues</option>
                             <option value="true" {{if eq .Settings.EnableDeltaFindings "true"}}selected{{end}}>Net New Issues</option>
@@ -154,7 +154,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="endpoint"><span data-toggle="tooltip" title="If you're using SSO with Snyk and OAuth2, this is automatically populated. For public regional instances, see Snyk documentation. For private instances, contact your team or account manager">Endpoint</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="endpoint"></span></label>
+                        <label for="endpoint"><span data-toggle="tooltip" title="<p>If you're using SSO with Snyk and OAuth2, this is automatically populated.</p><p>For public regional instances, see Snyk documentation. For private instances, contact your team or account manager.</p>">Endpoint</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="endpoint"></span></label>
                         <input type="text" id="endpoint" name="endpoint" value="{{.Settings.Endpoint}}" placeholder="https://app.snyk.io/api">
                         <span id="endpoint-error" class="error-message hidden">Invalid Endpoint URL. Expected format: api.snyk.io, api.*.snyk.io or api.*.snykgov.io</span>
                     </div>
@@ -168,7 +168,7 @@
                     </div>
 
                   <div class="form-group half-width">
-                    <label for="authenticationMethod"><span data-toggle="tooltip" title="Specifies whether to authenticate with OAuth2, PAT (Personal Access Token), or with an API token (Legacy). Note: OAuth2 authentication is recommended as it provides enhanced security">Authentication Method</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="authenticationMethod"></span></label>
+                    <label for="authenticationMethod"><span data-toggle="tooltip" title="<p>Specifies whether to authenticate with OAuth2, PAT (Personal Access Token), or with an API token (Legacy).</p><p><strong>Note:</strong> OAuth2 authentication is recommended as it provides enhanced security.</p>">Authentication Method</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="authenticationMethod"></span></label>
                     <select id="authenticationMethod" name="authenticationMethod">
                       <option value="oauth" {{if eq .Settings.AuthenticationMethod "oauth"}}selected{{end}}>OAuth2 (Recommended)</option>
                       <option value="pat" {{if eq .Settings.AuthenticationMethod "pat"}}selected{{end}}>Personal Access Token</option>
@@ -209,7 +209,7 @@
                     </div>
 
                     <div class="form-group half-width">
-                        <label for="cliReleaseChannel"><span data-toggle="tooltip" title="Release channel for Snyk CLI downloads (stable, preview, or rc)">CLI Release Channel</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliReleaseChannel"></span></label>
+                        <label for="cliReleaseChannel"><span data-toggle="tooltip" title="Release channel for Snyk CLI downloads (Stable, Release Candidate or Preview)">CLI Release Channel</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliReleaseChannel"></span></label>
                         <select id="cliReleaseChannel" name="cliReleaseChannel">
                             <option value="stable" {{if eq .CliReleaseChannel "stable"}}selected{{end}}>Stable</option>
                             <option value="rc" {{if eq .CliReleaseChannel "rc"}}selected{{end}}>Release Candidate</option>
@@ -218,7 +218,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="cliBaseDownloadURL"><span data-toggle="tooltip" title="Base URL for downloading Snyk CLI binaries. The default is https://downloads.snyk.io. For FIPS-enabled CLIs (Windows/Linux only), use https://downloads.snyk.io/fips">CLI Download Base URL</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliBaseDownloadURL"></span></label>
+                        <label for="cliBaseDownloadURL"><span data-toggle="tooltip" title="<p>Base URL for downloading Snyk CLI binaries.</p><p>Default: <strong>https://downloads.snyk.io</strong></p><p>For FIPS-enabled CLIs (Windows/Linux only), use <strong>https://downloads.snyk.io/fips</strong></p>">CLI Download Base URL</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliBaseDownloadURL"></span></label>
                         <input type="text" id="cliBaseDownloadURL" name="cliBaseDownloadURL" value="{{.Settings.CliBaseDownloadURL}}" placeholder="https://downloads.snyk.io">
                     </div>
                 </div>
@@ -274,14 +274,6 @@
                 <input type="hidden" name="folder_{{$index}}_folderPath" value="{{$folder.FolderPath}}">
                 <div class="collapse folder-content" id="folder-{{$index}}">
 
-                <div class="form-group">
-                    <label class="checkbox-label">
-                        <input type="checkbox" id="folder_{{$index}}_autoOrg" data-index="{{$index}}" {{if not $folder.OrgSetByUser}}checked{{end}}>
-                        <span data-toggle="tooltip" title="When enabled, Snyk will automatically select the most appropriate organization for your project using context found in your repository. If disabled, you can manually specify the organization">Auto Select Organization</span>
-                    </label>
-                    <input type="hidden" name="folder_{{$index}}_orgSetByUser" id="folder_{{$index}}_orgSetByUser" value="{{if $folder.OrgSetByUser}}true{{else}}false{{end}}">
-                </div>
-
                 <div class="form-group half-width">
                     <label for="folder_{{$index}}_preferredOrg"><span data-toggle="tooltip" title="Specify the organization (ID or name) for this folder. If auto-select is enabled, this will show the automatically determined organization (read-only)">Organization</span></label>
                     <input type="text" id="folder_{{$index}}_preferredOrg" name="folder_{{$index}}_preferredOrg" value="{{if $folder.OrgSetByUser}}{{$folder.PreferredOrg}}{{else}}{{$folder.AutoDeterminedOrg}}{{end}}" data-preferred-org="{{$folder.PreferredOrg}}" data-auto-org="{{$folder.AutoDeterminedOrg}}" placeholder="Organization UUID or Slug" {{if not $folder.OrgSetByUser}}readonly{{end}}>
@@ -289,16 +281,25 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="folder_{{$index}}_additionalParameters"><span data-toggle="tooltip" title="Parameters to pass to Snyk CLI for this folder's scans. Space-separated arguments (e.g., --severity-threshold=high --debug)">Additional CLI Parameters</span></label>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="folder_{{$index}}_autoOrg" data-index="{{$index}}" {{if not $folder.OrgSetByUser}}checked{{end}}>
+                        <span data-toggle="tooltip" title="<p>When enabled, Snyk will automatically select the most appropriate organization for your project using context found in your repository.</p><p>If disabled, you can manually specify the organization.</p>">Auto Select Organization</span>
+                    </label>
+                    <input type="hidden" name="folder_{{$index}}_orgSetByUser" id="folder_{{$index}}_orgSetByUser" value="{{if $folder.OrgSetByUser}}true{{else}}false{{end}}">
+                </div>
+
+                <div class="form-group">
+                    <label for="folder_{{$index}}_additionalParameters"><span data-toggle="tooltip" title="<p>Parameters to pass to Snyk CLI for this folder's scans (space-separated).</p><p>Example: <code>--severity-threshold=high --debug</code></p>">Additional CLI Parameters</span></label>
                     <input type="text" id="folder_{{$index}}_additionalParameters" name="folder_{{$index}}_additionalParameters" value="{{range $p := $folder.AdditionalParameters}}{{$p}} {{end}}" placeholder="--severity-threshold=high">
                 </div>
 
                 <div class="form-group">
-                    <label for="folder_{{$index}}_additionalEnv"><span data-toggle="tooltip" title="Environment variables for this folder. Format: VAR1=value1;VAR2=value2">Additional Environment Variables</span></label>
+                    <label for="folder_{{$index}}_additionalEnv"><span data-toggle="tooltip" title="<p>Environment variables for this folder.</p><p>Format: <code>VAR1=value1;VAR2=value2</code></p>">Additional Environment Variables</span></label>
                     <input type="text" id="folder_{{$index}}_additionalEnv" name="folder_{{$index}}_additionalEnv" value="{{$folder.AdditionalEnv}}" placeholder="VAR1=value1;VAR2=value2">
                     <div id="folder_{{$index}}_additionalEnv-error" class="error-message hidden">Invalid format. Use: VAR1=value1;VAR2=value2</div>
                 </div>
 
+                {{if $.EnableLdxSyncConfig}}
                 <div class="form-group">
                     <button class="collapsible-header text-start w-100 d-flex justify-content-between align-items-center p-0" type="button" data-toggle="collapse" data-target="#folder-{{$index}}-prescan" aria-expanded="false" aria-controls="folder-{{$index}}-prescan">
                         <span data-toggle="tooltip" title="Configure commands to run before/after scans for each product. Commands run in the folder context.">Pre/Post Scan Commands</span>
@@ -389,6 +390,7 @@
                         </div>
                     </div>
                 </div>
+                {{end}}
 
                 {{if and $folder.EffectiveConfig $.EnableLdxSyncConfig}}
                 <div class="form-group">

--- a/infrastructure/configuration/template/config.html
+++ b/infrastructure/configuration/template/config.html
@@ -56,7 +56,7 @@
                         </div>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group half-width">
                         <label for="scanningMode"><span data-toggle="tooltip" title="Choose whether to run Snyk Code scans in the background (auto), or only when you run the Rescan command (manual)">Scanning Mode</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="scanningMode"></span></label>
                         <select id="scanningMode" name="scanningMode">
                             <option value="auto" {{if eq .Settings.ScanningMode "auto"}}selected{{end}}>Auto</option>
@@ -64,7 +64,7 @@
                         </select>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group half-width">
                         <label for="organization"><span data-toggle="tooltip" title="<p>Specify the organization (ID or name) for Snyk to run scans against.</p><p>Organization selection follows this order:</p><ol><li>Project-specific settings (if configured)</li><li>This global setting (if the project-specific setting is empty)</li><li>Your web account's preferred organization (if both above are empty)</li></ol><p>Manual organization settings override automatic organization selection.</p>">Organization</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="organization"></span></label>
                         <input type="text" id="organization" name="organization" value="{{.Settings.Organization}}" placeholder="Organization UUID or Slug">
                     </div>
@@ -109,7 +109,7 @@
 
                         <div class="col-md-6">
                             <div class="form-group">
-                                <label><span data-toggle="tooltip" title="Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions. It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run">Issue View Options</span></label>
+                                <label>Issue View Options</label>
                                 <div class="checkbox-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" name="issueViewOptions_openIssues" {{if .Settings.IssueViewOptions}}{{if .Settings.IssueViewOptions.OpenIssues}}checked{{end}}{{end}}>
@@ -118,7 +118,7 @@
                                     </label>
                                     <label class="checkbox-label">
                                         <input type="checkbox" name="issueViewOptions_ignoredIssues" {{if .Settings.IssueViewOptions}}{{if .Settings.IssueViewOptions.IgnoredIssues}}checked{{end}}{{end}}>
-                                        Show Ignored Issues
+                                        <span data-toggle="tooltip" title="Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions. It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run">Show Ignored Issues</span>
                                         <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="issueViewOptions_ignoredIssues"></span>
                                     </label>
                                 </div>
@@ -127,13 +127,13 @@
                         </div>
                     </div>
 
-                    <div class="form-group">
-                        <label for="riskScoreThreshold"><span data-toggle="tooltip" title="[Closed Beta] Minimum risk score to display issues. Valid range: 0 to 1000 (0 = show all issues)">[Closed Beta] Filter by Risk Score</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="riskScoreThreshold"></span></label>
+                    <div class="form-group half-width">
+                        <label for="riskScoreThreshold"><span data-toggle="tooltip" title="Minimum risk score to display issues. Valid range: 0 to 1000 (0 = show all issues)">Filter by Risk Score<span class="deprecated-label">Closed Beta</span></span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="riskScoreThreshold"></span></label>
                         <input type="number" id="riskScoreThreshold" name="riskScoreThreshold" min="0" max="1000" value="{{if ne .Settings.RiskScoreThreshold nil}}{{.Settings.RiskScoreThreshold}}{{end}}" placeholder="0">
                         <span id="riskScore-error" class="error-message hidden">Risk score must be between 0 and 1000</span>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group half-width">
                         <label for="enableDeltaFindings"><span data-toggle="tooltip" title="Specifies whether to see all issues or only net new issues. Net new issues option requires a Git repository, where it compares findings with those in the base branch">Delta Findings</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="enableDeltaFindings"></span></label>
                         <select id="enableDeltaFindings" name="enableDeltaFindings">
                             <option value="false" {{if ne .Settings.EnableDeltaFindings "true"}}selected{{end}}>All Issues</option>
@@ -159,7 +159,7 @@
                         <span id="endpoint-error" class="error-message hidden">Invalid Endpoint URL. Expected format: api.snyk.io, api.*.snyk.io or api.*.snykgov.io</span>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group half-width">
                         <label class="checkbox-label">
                             <input type="checkbox" name="insecure" {{if eq .Settings.Insecure "true"}}checked{{end}}>
                             <span data-toggle="tooltip" title="If enabled, the plugin will ignore SSL certificate errors. Use this when connecting to self-signed or internal CA servers.">Insecure (Skip SSL Verification)</span>
@@ -167,7 +167,7 @@
                         </label>
                     </div>
 
-                  <div class="form-group">
+                  <div class="form-group half-width">
                     <label for="authenticationMethod"><span data-toggle="tooltip" title="Specifies whether to authenticate with OAuth2, PAT (Personal Access Token), or with an API token (Legacy). Note: OAuth2 authentication is recommended as it provides enhanced security">Authentication Method</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="authenticationMethod"></span></label>
                     <select id="authenticationMethod" name="authenticationMethod">
                       <option value="oauth" {{if eq .Settings.AuthenticationMethod "oauth"}}selected{{end}}>OAuth2 (Recommended)</option>
@@ -179,7 +179,7 @@
                     <div class="form-group">
                         <label for="token">Token <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="token"></span></label>
                         <div class="button-group">
-                            <input type="password" id="token" name="token" value="{{.Settings.Token}}" placeholder="Snyk API Token">
+                            <input type="password" id="token" name="token" value="{{.Settings.Token}}" placeholder="Snyk API Token" class="half-width">
                             <button type="button" id="authenticate-btn">Authenticate</button>
                             <button type="button" id="logout-btn" class="secondary">Logout</button>
                         </div>
@@ -200,7 +200,7 @@
                         <input type="text" id="cliPath" name="cliPath" value="{{.Settings.CliPath}}" placeholder="/path/to/snyk-cli">
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group half-width">
                         <label class="checkbox-label">
                             <input type="checkbox" name="manageBinariesAutomatically" {{if eq .Settings.ManageBinariesAutomatically "true"}}checked{{end}}>
                             <span data-toggle="tooltip" title="Automatically download and manage Snyk CLI binaries">Manage Binaries Automatically</span>
@@ -208,7 +208,7 @@
                         </label>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group half-width">
                         <label for="cliReleaseChannel"><span data-toggle="tooltip" title="Release channel for Snyk CLI downloads (stable, preview, or rc)">CLI Release Channel</span> <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="cliReleaseChannel"></span></label>
                         <select id="cliReleaseChannel" name="cliReleaseChannel">
                             <option value="stable" {{if eq .CliReleaseChannel "stable"}}selected{{end}}>Stable</option>
@@ -282,7 +282,7 @@
                     <input type="hidden" name="folder_{{$index}}_orgSetByUser" id="folder_{{$index}}_orgSetByUser" value="{{if $folder.OrgSetByUser}}true{{else}}false{{end}}">
                 </div>
 
-                <div class="form-group">
+                <div class="form-group half-width">
                     <label for="folder_{{$index}}_preferredOrg"><span data-toggle="tooltip" title="Specify the organization (ID or name) for this folder. If auto-select is enabled, this will show the automatically determined organization (read-only)">Organization</span></label>
                     <input type="text" id="folder_{{$index}}_preferredOrg" name="folder_{{$index}}_preferredOrg" value="{{if $folder.OrgSetByUser}}{{$folder.PreferredOrg}}{{else}}{{$folder.AutoDeterminedOrg}}{{end}}" data-preferred-org="{{$folder.PreferredOrg}}" data-auto-org="{{$folder.AutoDeterminedOrg}}" placeholder="Organization UUID or Slug" {{if not $folder.OrgSetByUser}}readonly{{end}}>
                     <input type="hidden" name="folder_{{$index}}_autoDeterminedOrg" value="{{$folder.AutoDeterminedOrg}}">

--- a/infrastructure/configuration/template/js/ui/reset-handler.js
+++ b/infrastructure/configuration/template/js/ui/reset-handler.js
@@ -167,10 +167,10 @@
 	function formatSectionName(section) {
 		var names = {
 			scanConfiguration: "Scan Configuration",
-			filteringDisplay: "Filtering and Display",
+			filteringDisplay: "Filters and Views",
 			authentication: "Authentication",
 			cliConfiguration: "CLI Configuration",
-			permissions: "Permissions"
+			permissions: "Trust Settings"
 		};
 		return names[section] || section;
 	}

--- a/infrastructure/configuration/template/js/ui/tooltips.js
+++ b/infrastructure/configuration/template/js/ui/tooltips.js
@@ -12,7 +12,8 @@
 			$('[data-toggle="tooltip"]').tooltip({
 				placement: 'top',
 				boundary: 'window',
-				trigger: 'hover'
+				trigger: 'hover',
+				html: true
 			});
 		}
 	};

--- a/infrastructure/configuration/template/js/ui/tooltips.js
+++ b/infrastructure/configuration/template/js/ui/tooltips.js
@@ -10,8 +10,8 @@
 		if (typeof $ !== "undefined" && $.fn && $.fn.tooltip) {
 			// All elements with data-toggle="tooltip" (spans inside labels, checkboxes, and buttons)
 			$('[data-toggle="tooltip"]').tooltip({
-				placement: 'top',
-				boundary: 'window',
+				placement: 'auto',
+				boundary: 'viewport',
 				trigger: 'hover',
 				html: true
 			});

--- a/infrastructure/configuration/template/styles.css
+++ b/infrastructure/configuration/template/styles.css
@@ -58,6 +58,9 @@
     --scrollbar-width: 10px;
     --scrollbar-border-radius: 5px;
     --max-form-width: 1400px;
+
+    /* Breakpoints (cannot use CSS custom properties in @media queries per spec)
+       768px = Bootstrap "md" breakpoint */
 }
 
 body {
@@ -117,6 +120,7 @@ form > .section {
     margin-right: 0;
 }
 
+/* Bootstrap md breakpoint (768px). Note that we cannot use CSS custom properties in @media queries per spec */
 @media (min-width: 768px) {
     .col-md-6 {
         padding-left: 10px !important;
@@ -135,6 +139,7 @@ form > .section {
     }
 }
 
+/* Below Bootstrap md breakpoint (768px - 1). Note that we cannot use CSS custom properties in @media queries per spec  */
 @media (max-width: 767px) {
     .col-md-6,
     .col-md-12 {
@@ -217,6 +222,7 @@ h3 {
     min-height: 0;
 }
 
+/* Bootstrap md breakpoint (768px). Note that we cannot use CSS custom properties in @media queries per spec  */
 @media (min-width: 768px) {
     .half-width {
         max-width: 50%;

--- a/infrastructure/configuration/template/styles.css
+++ b/infrastructure/configuration/template/styles.css
@@ -209,12 +209,17 @@ h3 {
 /* - - - Form Elements - - - */
 .form-group {
     margin-bottom: var(--form-group-margin);
-    flex-grow: 1;
-    flex-shrink: 1;
+    flex-grow: 0;
+    flex-shrink: 0;
     flex-basis: auto;
     display: flex;
     flex-direction: column;
     min-height: 0;
+}
+
+.section > .row,
+.section-header + .form-group {
+    flex: 1 1 auto;
 }
 
 .checkbox-group {
@@ -278,6 +283,16 @@ textarea {
     box-sizing: border-box;
     font-family: inherit;
     font-size: inherit;
+}
+
+select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    padding-right: 28px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23cccccc' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
 }
 
 /* IE11 placeholder support */

--- a/infrastructure/configuration/template/styles.css
+++ b/infrastructure/configuration/template/styles.css
@@ -544,9 +544,17 @@ button.secondary[disabled] {
     color: var(--text-color);
     border: 1px solid var(--border-color);
     font-size: var(--small-font-size);
-    max-width: 300px;
+    max-width: 400px;
     text-align: left;
     padding: 8px 12px;
+}
+
+.tooltip .tooltip-inner code {
+    font-family: var(--editor-font-family);
+    font-size: var(--tiny-font-size);
+    background-color: var(--background-color);
+    padding: 1px 4px;
+    border-radius: var(--border-radius-small);
 }
 
 .tooltip.bs-tooltip-top .arrow::before,

--- a/infrastructure/configuration/template/styles.css
+++ b/infrastructure/configuration/template/styles.css
@@ -217,6 +217,12 @@ h3 {
     min-height: 0;
 }
 
+@media (min-width: 768px) {
+    .half-width {
+        max-width: 50%;
+    }
+}
+
 .section > .row,
 .section-header + .form-group {
     flex: 1 1 auto;
@@ -434,6 +440,10 @@ button.secondary[disabled] {
     margin-right: 10px;
 }
 
+.button-group input.half-width {
+    flex: 0 1 50%;
+}
+
 .button-group button {
     flex-shrink: 0;
     margin-right: 10px;
@@ -504,6 +514,24 @@ button.secondary[disabled] {
 /* - - - Tooltips - - - */
 [data-toggle="tooltip"] {
     cursor: help;
+}
+
+[data-toggle="tooltip"]::after {
+    content: "";
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    margin-left: 4px;
+    vertical-align: text-bottom;
+    background-color: var(--disabled-foreground);
+    opacity: 0.7;
+    cursor: help;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z'/%3E%3C/svg%3E");
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
 }
 
 .tooltip {

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -380,6 +380,39 @@
       return window.__modified__;
     };
 
+    // Reposition tooltip popups to stay within the viewport
+    function repositionTooltip(trigger) {
+      var popup = trigger.querySelector('.tooltip-popup');
+      if (!popup) return;
+
+      // Reset to default positioning before measuring
+      popup.style.left = '50%';
+      popup.style.transform = 'translateX(-50%)';
+      popup.style.bottom = 'calc(100% + 8px)';
+      popup.style.top = '';
+
+      var rect = popup.getBoundingClientRect();
+
+      // Flip below if clipped at top
+      if (rect.top < 0) {
+        popup.style.bottom = '';
+        popup.style.top = 'calc(100% + 8px)';
+        rect = popup.getBoundingClientRect();
+      }
+
+      // Nudge horizontally if clipped on the right
+      if (rect.right > window.innerWidth) {
+        var overflowRight = rect.right - window.innerWidth + 8;
+        popup.style.left = 'calc(50% - ' + overflowRight + 'px)';
+      }
+
+      // Nudge horizontally if clipped on the left
+      if (rect.left < 0) {
+        var overflowLeft = -rect.left + 8;
+        popup.style.left = 'calc(50% + ' + overflowLeft + 'px)';
+      }
+    }
+
     window.addEventListener('load', function() {
       var form = get('configForm');
       if (!form) return;
@@ -401,6 +434,14 @@
       for (var j = 0; j < selects.length; j++) {
         // Selects: use change event
         selects[j].addEventListener('change', markDirtyAndSave);
+      }
+
+      // Attach tooltip repositioning on hover
+      var tooltipTriggers = document.querySelectorAll('[data-toggle="tooltip"]');
+      for (var k = 0; k < tooltipTriggers.length; k++) {
+        tooltipTriggers[k].addEventListener('mouseenter', function() {
+          repositionTooltip(this);
+        });
       }
     });
   })();

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -20,40 +20,49 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Snyk Settings</title>
   <style nonce="ideNonce">
+    /* Variables - matching main config dialog (infrastructure/configuration/template/styles.css) */
     :root {
-      /* Spacing - fixed values that don't need theme adaptation */
+      /* Spacing */
       --container-padding: 20px;
       --section-padding: 15px;
       --input-padding: 8px;
       --form-group-margin: 15px;
       --section-margin: 30px;
       --checkbox-gap: 8px;
-      --label-margin-bottom: 5px;
 
-      /* Border radius - fixed values */
-      --border-radius: 4px;
-      --border-radius-small: 2px;
-
-      /* Layout - fixed values */
-      --max-form-width: 1400px;
-
-      /* Typography - fixed values */
-      --h1-font-size: 24px;
-      --h2-font-size: 18px;
-      --base-font-size: 13px;
+      /* Typography */
+      --default-font: var(--vscode-font-family, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif);
+      --editor-font-family: var(--vscode-editor-font-family, 'Monaco', 'Courier New', monospace);
+      --base-font-size: var(--vscode-font-size, 13px);
       --small-font-size: 12px;
       --tiny-font-size: 11px;
+      --h1-font-size: 24px;
+      --h2-font-size: 18px;
 
-      /* Badge styling - fixed values matching Bootstrap */
-      --badge-background-color: #6c757d;
-      --badge-color: #fff;
-      --badge-padding: 2px 6px;
+      /* Colors - Map to vscode theme variables with fallbacks */
+      --background-color: var(--vscode-editor-background, #1e1e1e);
+      --text-color: var(--vscode-foreground, #cccccc);
+      --input-foreground: var(--vscode-input-foreground, #cccccc);
+      --editor-foreground: var(--vscode-editor-foreground, #ffffff);
+      --disabled-foreground: var(--vscode-disabledForeground, #808080);
+      --error-foreground: var(--vscode-errorForeground, #f48771);
 
-      /* Tooltip styling - fixed values */
-      --tooltip-background-color: #000;
-      --tooltip-color: #fff;
+      /* Backgrounds */
+      --input-background: var(--vscode-input-background, #3c3c3c);
+      --section-background: var(--vscode-editor-inactiveSelectionBackground, #2a2d2e);
+
+      /* Borders */
+      --input-border: var(--vscode-input-border, #454545);
+      --border-color: var(--vscode-panel-border, #454545);
+      --focus-border: var(--vscode-focusBorder, #007acc);
+
+      /* Other */
+      --border-radius: 4px;
+      --border-radius-small: 2px;
+      --max-form-width: 1400px;
     }
 
+    /* Base */
     body {
       font-family: var(--default-font);
       font-size: var(--base-font-size);
@@ -61,17 +70,20 @@
       background-color: var(--background-color);
       padding: var(--container-padding);
       margin: 0;
+      accent-color: var(--focus-border);
     }
 
+    /* Layout */
     form {
       max-width: var(--max-form-width);
       margin: 0 auto;
     }
 
+    /* Typography */
     h1 {
       font-size: var(--h1-font-size);
       margin-bottom: var(--container-padding);
-      color: var(--text-color);
+      color: var(--editor-foreground);
       max-width: var(--max-form-width);
       margin-left: auto;
       margin-right: auto;
@@ -81,33 +93,45 @@
       font-size: var(--h2-font-size);
       margin-top: 0;
       margin-bottom: var(--section-padding);
-      color: var(--text-color);
+      color: var(--editor-foreground);
       border-bottom: 1px solid var(--border-color);
-      padding-bottom: var(--checkbox-gap);
+      padding-bottom: 8px;
       flex-shrink: 0;
     }
 
+    /* Sections */
     .section {
       margin-bottom: var(--section-margin);
       padding: var(--section-padding);
-      background-color: var(--section-background-color);
+      background-color: var(--section-background);
       border-radius: var(--border-radius);
       display: flex;
       flex-direction: column;
+      min-height: 0;
     }
 
+    /* Form Elements */
     .form-group {
       margin-bottom: var(--form-group-margin);
-      flex-grow: 1;
+      flex-grow: 0;
+      flex-shrink: 0;
+      flex-basis: auto;
       display: flex;
       flex-direction: column;
+      min-height: 0;
+    }
+
+    @media (min-width: 768px) {
+      .half-width {
+        max-width: 50%;
+      }
     }
 
     label {
       display: block;
-      margin-bottom: var(--label-margin-bottom);
+      margin-bottom: 5px;
       font-weight: 600;
-      color: var(--text-color);
+      color: var(--input-foreground);
     }
 
     .checkbox-label {
@@ -115,6 +139,11 @@
       align-items: center;
       font-weight: normal;
       cursor: pointer;
+      margin-bottom: 8px;
+    }
+
+    .checkbox-label:last-child {
+      margin-bottom: 0;
     }
 
     .checkbox-label input[type="checkbox"] {
@@ -125,25 +154,42 @@
     select {
       width: 100%;
       padding: var(--input-padding);
-      background-color: var(--input-background-color);
-      color: var(--text-color);
-      border: 1px solid var(--border-color);
+      background-color: var(--input-background);
+      color: var(--input-foreground);
+      border: 1px solid var(--input-border);
       border-radius: var(--border-radius-small);
       box-sizing: border-box;
       font-family: inherit;
       font-size: inherit;
     }
 
+    select {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      padding-right: 28px;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23cccccc' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 8px center;
+    }
+
+    input::placeholder {
+      color: var(--disabled-foreground);
+      opacity: 0.6;
+      font-style: italic;
+    }
+
     input:focus,
     select:focus {
-      outline: 1px solid var(--focus-color);
+      outline: 1px solid var(--focus-border);
       outline-offset: -1px;
     }
 
+    /* Info Message */
     .info-message {
       padding: var(--section-padding);
-      background-color: var(--section-background-color);
-      border: 1px solid var(--focus-color);
+      background-color: var(--section-background);
+      border: 1px solid var(--focus-border);
       border-radius: var(--border-radius);
       margin-bottom: var(--container-padding);
       max-width: var(--max-form-width);
@@ -152,121 +198,125 @@
     }
 
     a {
-      color: var(--link-color);
+      color: var(--focus-border);
     }
 
-    /* Bootstrap badge base styles */
-    .badge {
-      --bs-badge-padding-x: 0.65em;
-      --bs-badge-padding-y: 0.35em;
-      --bs-badge-font-size: 0.75em;
-      --bs-badge-font-weight: 700;
-      --bs-badge-border-radius: 0.375rem;
-      display: inline-block;
-      padding: var(--bs-badge-padding-y) var(--bs-badge-padding-x);
-      font-size: var(--bs-badge-font-size);
-      font-weight: var(--bs-badge-font-weight);
-      line-height: 1;
-      color: var(--badge-color);
-      text-align: center;
-      white-space: nowrap;
-      vertical-align: baseline;
-      border-radius: var(--bs-badge-border-radius);
-    }
-
-    .bg-secondary {
-      background-color: var(--badge-background-color) !important;
-    }
-
-    /* Tooltip overrides to match LS HTML */
-    .badge.bg-secondary[data-bs-toggle="tooltip"] {
-      margin-left: var(--checkbox-gap);
-      vertical-align: middle;
+    /* Tooltips */
+    [data-toggle="tooltip"] {
       cursor: help;
-      font-size: var(--tiny-font-size);
-      padding: var(--badge-padding);
       position: relative;
     }
 
-    .badge.bg-secondary[data-bs-toggle="tooltip"]:hover::after {
-      content: attr(title);
+    [data-toggle="tooltip"]::after {
+      content: "";
+      display: inline-block;
+      width: 14px;
+      height: 14px;
+      margin-left: 4px;
+      vertical-align: text-bottom;
+      background-color: var(--disabled-foreground);
+      opacity: 0.7;
+      cursor: help;
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z'/%3E%3C/svg%3E");
+      -webkit-mask-size: contain;
+      mask-size: contain;
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
+    }
+
+    .tooltip-popup {
+      display: none;
       position: absolute;
+      bottom: calc(100% + 8px);
       left: 50%;
       transform: translateX(-50%);
-      bottom: 100%;
-      margin-bottom: var(--checkbox-gap);
-      padding: var(--checkbox-gap) var(--small-font-size);
-      background-color: var(--tooltip-background-color);
-      color: var(--tooltip-color);
+      padding: 8px 12px;
+      background-color: var(--input-background);
+      color: var(--text-color);
+      border: 1px solid var(--border-color);
       border-radius: var(--border-radius);
       font-size: var(--small-font-size);
       font-weight: normal;
       white-space: normal;
-      width: 250px;
-      max-width: 300px;
+      max-width: 400px;
+      min-width: 200px;
+      width: max-content;
       z-index: 1000;
       box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+      text-align: left;
+      line-height: 1.4;
     }
 
-    .badge.bg-secondary[data-bs-toggle="tooltip"]:hover::before {
-      content: '';
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      bottom: 100%;
-      margin-bottom: var(--border-radius-small);
-      border: 6px solid transparent;
-      border-top-color: var(--tooltip-background-color);
+    .tooltip-popup p {
+      margin: 0 0 1rem 0;
+    }
+
+    .tooltip-popup p:last-child {
+      margin-bottom: 0;
+    }
+
+    .tooltip-popup code {
+      font-family: var(--editor-font-family);
+      font-size: var(--tiny-font-size);
+      background-color: var(--background-color);
+      padding: 1px 4px;
+      border-radius: var(--border-radius-small);
+    }
+
+    [data-toggle="tooltip"]:hover .tooltip-popup {
+      display: block;
     }
   </style>
 </head>
 <body>
 <h1>Snyk Settings</h1>
 
-<div class="info-message">
-  <strong>Note:</strong> The Snyk CLI is not yet available. Configure the executable settings below to download and set up the CLI.
-  <br><br>
-  <strong>Limited settings mode:</strong> Only CLI download settings are currently available. Once the CLI is downloaded,
-  additional options will appear including authentication, scan types, severity filters, and organization settings.
-</div>
-
 <form id="configForm">
+<div class="info-message">
+  <strong>Note:</strong> The Snyk CLI is not yet available. Configure the settings below to download and set up the CLI.
+  <br><br>
+  <strong>Limited settings mode:</strong> Only Authentication and CLI Configuration settings are currently available. Once the CLI is downloaded,
+  additional sections will appear including Scan Configuration, Filters and Views, Trust Settings, and Folder Settings.
+</div>
+  <div class="section">
+    <h2>Authentication</h2>
+
+    <div class="form-group half-width">
+      <label class="checkbox-label">
+        <input type="checkbox" name="insecure" id="insecure" {{INSECURE_CHECKED}}>
+        <span data-toggle="tooltip">Insecure (Skip SSL Verification)<span class="tooltip-popup">If enabled, the plugin will ignore SSL certificate errors. Use this when connecting to self-signed or internal CA servers.</span></span>
+      </label>
+    </div>
+  </div>
+
   <div class="section">
     <h2>CLI Configuration</h2>
 
     <div class="form-group">
-      <label class="checkbox-label">
-        <input type="checkbox" name="manageBinariesAutomatically" id="manageBinariesAutomatically" {{MANAGE_BINARIES_CHECKED}}>
-        Manage Binaries Automatically
-        <span class="badge bg-secondary" data-bs-toggle="tooltip" title="Automatically download and manage Snyk CLI binaries">?</span>
-      </label>
-    </div>
-
-    <div class="form-group">
-      <label for="cliBaseDownloadURL">CLI Download Base URL <span class="badge bg-secondary" data-bs-toggle="tooltip" title="Base URL for downloading Snyk CLI binaries. The default is https://downloads.snyk.io. For FIPS-enabled CLIs (Windows/Linux only), use https://downloads.snyk.io/fips">?</span></label>
-      <input type="text" id="cliBaseDownloadURL" name="cliBaseDownloadURL" value="{{CLI_BASE_DOWNLOAD_URL}}" placeholder="https://downloads.snyk.io">
-    </div>
-
-    <div class="form-group">
-      <label class="checkbox-label">
-        <input type="checkbox" name="insecure" id="insecure" {{INSECURE_CHECKED}}>
-        Insecure (Skip SSL Verification)
-        <span class="badge bg-secondary" data-bs-toggle="tooltip" title="If enabled, the plugin will ignore SSL certificate errors. Use this when connecting to self-signed or internal CA servers.">?</span>
-      </label>
-    </div>
-
-    <div class="form-group">
-      <label for="cliPath">CLI Path <span class="badge bg-secondary" data-bs-toggle="tooltip" title="Path to Snyk CLI executable">?</span></label>
+      <label for="cliPath"><span data-toggle="tooltip">CLI Path<span class="tooltip-popup">Path to Snyk CLI executable</span></span></label>
       <input type="text" id="cliPath" name="cliPath" value="{{CLI_PATH}}" placeholder="/path/to/snyk-cli">
     </div>
 
-    <div class="form-group">
-      <label for="cliReleaseChannel">CLI Release Channel <span class="badge bg-secondary" data-bs-toggle="tooltip" title="Release channel for Snyk CLI downloads (stable, preview, or rc)">?</span></label>
+    <div class="form-group half-width">
+      <label class="checkbox-label">
+        <input type="checkbox" name="manageBinariesAutomatically" id="manageBinariesAutomatically" {{MANAGE_BINARIES_CHECKED}}>
+        <span data-toggle="tooltip">Manage Binaries Automatically<span class="tooltip-popup">Automatically download and manage Snyk CLI binaries</span></span>
+      </label>
+    </div>
+
+    <div class="form-group half-width">
+      <label for="cliReleaseChannel"><span data-toggle="tooltip">CLI Release Channel<span class="tooltip-popup">Release channel for Snyk CLI downloads (Stable, Release Candidate or Preview)</span></span></label>
       <select id="cliReleaseChannel" name="cliReleaseChannel">
         <option value="stable" {{CHANNEL_STABLE_SELECTED}}>Stable</option>
         <option value="rc" {{CHANNEL_RC_SELECTED}}>Release Candidate</option>
         <option value="preview" {{CHANNEL_PREVIEW_SELECTED}}>Preview</option>
       </select>
+    </div>
+
+    <div class="form-group">
+      <label for="cliBaseDownloadURL"><span data-toggle="tooltip">CLI Download Base URL<span class="tooltip-popup"><p>Base URL for downloading Snyk CLI binaries.</p><p>Default: <strong>https://downloads.snyk.io</strong></p><p>For FIPS-enabled CLIs (Windows/Linux only), use <strong>https://downloads.snyk.io/fips</strong></p></span></span></label>
+      <input type="text" id="cliBaseDownloadURL" name="cliBaseDownloadURL" value="{{CLI_BASE_DOWNLOAD_URL}}" placeholder="https://downloads.snyk.io">
     </div>
   </div>
 </form>


### PR DESCRIPTION
### Description

Implemented feedback from design review:

- Updated layout of settings to align fields
- Dropdown chevrons are now padded
- Section titles updated
- Tooltips are now indicated by info icons
- Fallback settings page uses the same styling/fields as the main page

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
