### PR TITLE
feat(featureflag): evaluate enable-ldx-sync-ide-settings via Feature Flag Gateway

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/envvars"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"
 	connectivityworkflow "github.com/snyk/go-application-framework/pkg/local_workflows/connectivity_check_extension"
 	ignoreworkflow "github.com/snyk/go-application-framework/pkg/local_workflows/ignore_workflow"
 	frameworkLogging "github.com/snyk/go-application-framework/pkg/logging"
@@ -297,6 +298,7 @@ func newConfig(engine workflow.Engine, opts ...ConfigOption) *Config {
 	gafConfig := c.engine.GetConfiguration()
 	gafConfig.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, configuration.ImmutableDefaultValueFunction(true))
 	gafConfig.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
+	registerFFGBackedFeatureFlags(c.engine)
 	gafConfig.Set("configfile", c.configFile)
 	c.deviceId = c.determineDeviceId()
 	c.addDefaults()
@@ -338,6 +340,12 @@ func initWorkFlowEngine(c *Config) {
 		rti := runtimeinfo.New(runtimeinfo.WithName("snyk-ls"), runtimeinfo.WithVersion(Version))
 		c.engine.SetRuntimeInfo(rti)
 	}
+}
+
+func registerFFGBackedFeatureFlags(engine workflow.Engine) {
+	config_utils.AddFeatureFlagsToConfig(engine, map[string]string{
+		cli_constants.GAFConfigKeyEnableLdxSyncIdeSettings: cli_constants.FeatureFlagEnableLdxSyncIdeSettings,
+	})
 }
 
 func initWorkflows(c *Config) error {

--- a/infrastructure/cli/cli_constants/constants.go
+++ b/infrastructure/cli/cli_constants/constants.go
@@ -21,4 +21,9 @@ const (
 	EXECUTION_MODE_KEY              string = "execution-mode"
 	EXECUTION_MODE_VALUE_EXTENSION  string = "extension"
 	EXECUTION_MODE_VALUE_STANDALONE string = "standalone"
+
+	// FeatureFlagEnableLdxSyncIdeSettings is the Flipt release flag key (ide namespace), evaluated via Feature Flag Gateway.
+	FeatureFlagEnableLdxSyncIdeSettings = "enable-ldx-sync-ide-settings"
+	// GAFConfigKeyEnableLdxSyncIdeSettings is the GAF configuration key registered by AddFeatureFlagsToConfig for that FFG flag.
+	GAFConfigKeyEnableLdxSyncIdeSettings = "internal_enable_ldx_sync_ide_settings"
 )

--- a/infrastructure/featureflag/featureflag.go
+++ b/infrastructure/featureflag/featureflag.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/local_workflows/ignore_workflow"
 
 	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/infrastructure/cli/cli_constants"
 	"github.com/snyk/snyk-ls/internal/storedconfig"
 	"github.com/snyk/snyk-ls/internal/types"
 )
@@ -44,6 +45,9 @@ const (
 	SnykSecretsEnabled            string = "isSecretsEnabled"
 )
 
+// EnableLdxSyncIdeSettings is the FFG/Flipt release flag key (ide namespace) for LDX Sync-backed IDE settings.
+const EnableLdxSyncIdeSettings = cli_constants.FeatureFlagEnableLdxSyncIdeSettings
+
 var Flags = []string{
 	SnykCodeConsistentIgnores,
 	SnykCodeInlineIgnore,
@@ -52,6 +56,7 @@ var Flags = []string{
 	UseExperimentalRiskScore,
 	UseOsTest,
 	SnykSecretsEnabled,
+	EnableLdxSyncIdeSettings,
 }
 
 func UseOsTestWorkflow(folderConfig types.ImmutableFolderConfig) bool {
@@ -85,6 +90,9 @@ func (p *externalCallsProvider) getIgnoreApprovalEnabled(org string) (bool, erro
 func (p *externalCallsProvider) getFeatureFlag(flag string, org string) (bool, error) {
 	conf := p.c.Engine().GetConfiguration().Clone()
 	conf.Set(configuration.ORGANIZATION, org)
+	if flag == cli_constants.FeatureFlagEnableLdxSyncIdeSettings {
+		return conf.GetBoolWithError(cli_constants.GAFConfigKeyEnableLdxSyncIdeSettings)
+	}
 	return config_utils.GetFeatureFlagValue(flag, conf, p.c.Engine().GetNetworkAccess().GetHttpClient())
 }
 


### PR DESCRIPTION
### Description

Evaluates the Flipt release flag `enable-ldx-sync-ide-settings` (ide namespace) through GAF `config_utils.AddFeatureFlagsToConfig` and the Feature Flag Gateway (`{API_URL}/hidden/...`), instead of the legacy Registry `GetFeatureFlagValue` path.

- Registers `internal_enable_ldx_sync_ide_settings` → `enable-ldx-sync-ide-settings` on the GAF engine from `newConfig` (standalone and extension).
- Adds the flag to `featureflag.Flags` so `PopulateFolderConfig` still batches it into folder feature flags.
- Resolves it via `GetBoolWithError` on the internal GAF key for FFG-backed evaluation.

### How to use

After folder feature flags have been populated (e.g. after `featureFlagService.PopulateFolderConfig` or equivalent flows):

```go
if featureFlagService.GetFromFolderConfig(folderPath, featureflag.EnableLdxSyncIdeSettings) {
    // use LDX Sync for IDE settings
}
```

`featureflag.EnableLdxSyncIdeSettings` matches the Flipt key; ensure org context is set on the GAF configuration so FFG can evaluate for the organization.

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
