### PR TITLE
feat: folder config migration from legacy JSON to GAF keys [IDE-1905]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -700,6 +700,8 @@ func SetupStorage(conf configuration.Configuration, s storage.StorageWithCallbac
 		logger.Err(err).Msg("unable to load folderConfig")
 	}
 
+	folderconfig.MigrateFromLegacyConfig(conf, logger)
+
 	if GetToken(conf) == "" {
 		err = s.Refresh(conf, auth.CONFIG_KEY_OAUTH_TOKEN)
 		if err != nil {

--- a/internal/folderconfig/folder_config_test.go
+++ b/internal/folderconfig/folder_config_test.go
@@ -322,6 +322,65 @@ func Test_BatchUpdateFolderConfigs(t *testing.T) {
 	})
 }
 
+func Test_CopyFolderConfigValues_DoesNotPersistDstKeys(t *testing.T) {
+	conf, storageFile := SetupConfigurationWithStorage(t)
+
+	srcPath := types.FilePath(t.TempDir())
+	dstPath := types.FilePath(t.TempDir())
+
+	// Set source values (these get persisted)
+	types.SetFolderUserSetting(conf, srcPath, types.SettingBaseBranch, "main")
+	types.SetFolderUserSetting(conf, srcPath, types.SettingAdditionalParameters, []string{"-d"})
+	types.SetAutoDeterminedOrg(conf, srcPath, "org-uuid")
+
+	// Copy to destination (should NOT persist)
+	types.CopyFolderConfigValues(conf, srcPath, dstPath)
+
+	// Values should be accessible in memory
+	snap := types.ReadFolderConfigSnapshot(conf, dstPath)
+	assert.Equal(t, "main", snap.BaseBranch)
+	assert.Equal(t, []string{"-d"}, snap.AdditionalParameters)
+	assert.Equal(t, "org-uuid", snap.AutoDeterminedOrg)
+
+	// Storage file should NOT contain destination folder keys
+	data, err := os.ReadFile(storageFile)
+	require.NoError(t, err)
+	dstNormalized := string(types.PathKey(dstPath))
+	assert.NotContains(t, string(data), dstNormalized, "destination folder keys should not be persisted to storage")
+}
+
+func Test_CopyFolderConfigValues_CopiesAllSettings(t *testing.T) {
+	conf, _ := SetupConfigurationWithStorage(t)
+
+	srcPath := types.FilePath(t.TempDir())
+	dstPath := types.FilePath(t.TempDir())
+
+	// Set all user and metadata settings on source
+	types.SetFolderUserSetting(conf, srcPath, types.SettingBaseBranch, "develop")
+	types.SetFolderUserSetting(conf, srcPath, types.SettingReferenceBranch, "develop")
+	types.SetFolderUserSetting(conf, srcPath, types.SettingAdditionalParameters, []string{"--all-projects"})
+	types.SetFolderUserSetting(conf, srcPath, types.SettingAdditionalEnvironment, "FOO=bar")
+	types.SetFolderUserSetting(conf, srcPath, types.SettingReferenceFolder, "/ref/path")
+	types.SetFolderUserSetting(conf, srcPath, types.SettingScanCommandConfig, map[product.Product]types.ScanCommandConfig{
+		"Snyk Code": {PreScanCommand: "echo test"},
+	})
+	types.SetPreferredOrgAndOrgSetByUser(conf, srcPath, "my-org", true)
+	types.SetAutoDeterminedOrg(conf, srcPath, "auto-org")
+
+	// Copy
+	types.CopyFolderConfigValues(conf, srcPath, dstPath)
+
+	// Verify all values copied
+	snap := types.ReadFolderConfigSnapshot(conf, dstPath)
+	assert.Equal(t, "develop", snap.BaseBranch)
+	assert.Equal(t, []string{"--all-projects"}, snap.AdditionalParameters)
+	assert.Equal(t, "FOO=bar", snap.AdditionalEnv)
+	assert.Equal(t, types.FilePath("/ref/path"), snap.ReferenceFolderPath)
+	assert.Equal(t, "my-org", snap.PreferredOrg)
+	assert.True(t, snap.OrgSetByUser)
+	assert.Equal(t, "auto-org", snap.AutoDeterminedOrg)
+}
+
 // isFolderPersisted checks if any well-known config key exists for the folder (for test verification).
 func isFolderPersisted(conf configuration.Configuration, path types.FilePath) bool {
 	fp := string(types.PathKey(path))

--- a/internal/folderconfig/migration.go
+++ b/internal/folderconfig/migration.go
@@ -1,0 +1,101 @@
+/*
+ * © 2022-2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package folderconfig
+
+import (
+	"encoding/json"
+
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// legacyFolderConfig represents the old FolderConfig struct fields needed for migration.
+// Only fields that are migrated to individual GAF keys are included.
+type legacyFolderConfig struct {
+	BaseBranch           string         `json:"baseBranch"`
+	AdditionalParameters []string       `json:"additionalParameters,omitempty"`
+	AdditionalEnv        string         `json:"additionalEnv,omitempty"`
+	ReferenceFolderPath  types.FilePath `json:"referenceFolderPath,omitempty"`
+	PreferredOrg         string         `json:"preferredOrg"`
+	AutoDeterminedOrg    string         `json:"autoDeterminedOrg"`
+	OrgSetByUser         bool           `json:"orgSetByUser"`
+}
+
+// legacyStoredConfig represents the old StoredConfig wrapper for migration.
+type legacyStoredConfig struct {
+	FolderConfigs map[types.FilePath]*legacyFolderConfig `json:"folderConfigs"`
+}
+
+// MigrateFromLegacyConfig checks for old-format INTERNAL_LS_CONFIG data and migrates
+// each folder's settings to individual GAF prefix keys. After successful migration,
+// the old key is cleared to prevent re-migration.
+func MigrateFromLegacyConfig(conf configuration.Configuration, logger *zerolog.Logger) {
+	l := logger.With().Str("method", "MigrateFromLegacyConfig").Logger()
+
+	oldData := conf.GetString(ConfigMainKey)
+	if oldData == "" {
+		return
+	}
+
+	var sc legacyStoredConfig
+	if err := json.Unmarshal([]byte(oldData), &sc); err != nil {
+		l.Err(err).Msg("failed to parse legacy folder config, clearing key to prevent re-migration")
+		conf.Set(ConfigMainKey, "")
+		return
+	}
+
+	if len(sc.FolderConfigs) == 0 {
+		conf.Set(ConfigMainKey, "")
+		return
+	}
+
+	migratedCount := 0
+	for path, fc := range sc.FolderConfigs {
+		if fc == nil {
+			continue
+		}
+
+		normalizedPath := types.PathKey(path)
+
+		if fc.BaseBranch != "" {
+			types.SetFolderUserSetting(conf, normalizedPath, types.SettingBaseBranch, fc.BaseBranch)
+		}
+		if len(fc.AdditionalParameters) > 0 {
+			types.SetFolderUserSetting(conf, normalizedPath, types.SettingAdditionalParameters, fc.AdditionalParameters)
+		}
+		if fc.AdditionalEnv != "" {
+			types.SetFolderUserSetting(conf, normalizedPath, types.SettingAdditionalEnvironment, fc.AdditionalEnv)
+		}
+		if fc.ReferenceFolderPath != "" {
+			types.SetFolderUserSetting(conf, normalizedPath, types.SettingReferenceFolder, string(fc.ReferenceFolderPath))
+		}
+
+		// Always migrate org fields — orgSetByUser:false is a meaningful state
+		types.SetPreferredOrgAndOrgSetByUser(conf, normalizedPath, fc.PreferredOrg, fc.OrgSetByUser)
+
+		if fc.AutoDeterminedOrg != "" {
+			types.SetAutoDeterminedOrg(conf, normalizedPath, fc.AutoDeterminedOrg)
+		}
+
+		migratedCount++
+	}
+
+	conf.Set(ConfigMainKey, "")
+	l.Info().Int("folderCount", migratedCount).Msg("migrated legacy folder configs to individual GAF keys")
+}

--- a/internal/folderconfig/migration.go
+++ b/internal/folderconfig/migration.go
@@ -55,13 +55,13 @@ func MigrateFromLegacyConfig(conf configuration.Configuration, logger *zerolog.L
 
 	var sc legacyStoredConfig
 	if err := json.Unmarshal([]byte(oldData), &sc); err != nil {
-		l.Err(err).Msg("failed to parse legacy folder config, clearing key to prevent re-migration")
-		conf.Set(ConfigMainKey, "")
+		l.Debug().Err(err).Msg("failed to parse legacy folder config, clearing key to prevent re-migration")
+		conf.Unset(ConfigMainKey)
 		return
 	}
 
 	if len(sc.FolderConfigs) == 0 {
-		conf.Set(ConfigMainKey, "")
+		conf.Unset(ConfigMainKey)
 		return
 	}
 
@@ -96,6 +96,6 @@ func MigrateFromLegacyConfig(conf configuration.Configuration, logger *zerolog.L
 		migratedCount++
 	}
 
-	conf.Set(ConfigMainKey, "")
+	conf.Unset(ConfigMainKey)
 	l.Info().Int("folderCount", migratedCount).Msg("migrated legacy folder configs to individual GAF keys")
 }

--- a/internal/folderconfig/migration_test.go
+++ b/internal/folderconfig/migration_test.go
@@ -1,0 +1,145 @@
+/*
+ * © 2022-2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package folderconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+
+	"github.com/snyk/snyk-ls/internal/storage"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// runMigrationFromFixture copies the input fixture to a temp storage file, sets up
+// configuration + storage, refreshes INTERNAL_LS_CONFIG, runs migration, and
+// returns the configuration and path to the resulting storage file.
+func runMigrationFromFixture(t *testing.T, inputFixture string) (configuration.Configuration, string) {
+	t.Helper()
+	input, err := os.ReadFile(inputFixture)
+	require.NoError(t, err)
+
+	storageFile := filepath.Join(t.TempDir(), "ls-config-test")
+	require.NoError(t, os.WriteFile(storageFile, input, 0644))
+
+	conf := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	conf.PersistInStorage(ConfigMainKey)
+	s, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+	require.NoError(t, err)
+	conf.SetStorage(s)
+	require.NoError(t, s.Refresh(conf, ConfigMainKey))
+
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	MigrateFromLegacyConfig(conf, &logger)
+
+	return conf, storageFile
+}
+
+func Test_MigrateFromLegacyConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputFixture     string
+		expectedFixture  string
+	}{
+		{
+			name:            "single folder with all migrated fields",
+			inputFixture:    "testdata/migration_all_fields_input.json",
+			expectedFixture: "testdata/migration_all_fields_expected.json",
+		},
+		{
+			name:            "multiple folders with different settings",
+			inputFixture:    "testdata/migration_multiple_folders_input.json",
+			expectedFixture: "testdata/migration_multiple_folders_expected.json",
+		},
+		{
+			name:            "partial fields only migrates non-zero values",
+			inputFixture:    "testdata/migration_partial_fields_input.json",
+			expectedFixture: "testdata/migration_partial_fields_expected.json",
+		},
+		{
+			name:            "malformed JSON clears key without panic",
+			inputFixture:    "testdata/migration_malformed_input.json",
+			expectedFixture: "testdata/migration_malformed_expected.json",
+		},
+		{
+			name:            "preserves orgSetByUser false",
+			inputFixture:    "testdata/migration_org_set_by_user_false_input.json",
+			expectedFixture: "testdata/migration_org_set_by_user_false_expected.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, storageFile := runMigrationFromFixture(t, tt.inputFixture)
+
+			actual, err := os.ReadFile(storageFile)
+			require.NoError(t, err)
+			expected, err := os.ReadFile(tt.expectedFixture)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expected), string(actual))
+		})
+	}
+}
+
+func Test_MigrateFromLegacyConfig_NoOp_WhenEmpty(t *testing.T) {
+	t.Parallel()
+	storageFile := filepath.Join(t.TempDir(), "ls-config-test")
+	require.NoError(t, os.WriteFile(storageFile, []byte("{}"), 0644))
+
+	conf := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	conf.PersistInStorage(ConfigMainKey)
+	s, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+	require.NoError(t, err)
+	conf.SetStorage(s)
+
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	MigrateFromLegacyConfig(conf, &logger)
+
+	actual, err := os.ReadFile(storageFile)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(actual))
+}
+
+func Test_MigrateFromLegacyConfig_Idempotent(t *testing.T) {
+	t.Parallel()
+	conf, storageFile := runMigrationFromFixture(t,
+		"testdata/migration_partial_fields_input.json")
+
+	// Change a value after first migration
+	types.SetFolderUserSetting(conf, "/Users/test/partial", types.SettingBaseBranch, "develop")
+
+	// Run migration again — should be no-op since ConfigMainKey was cleared
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	MigrateFromLegacyConfig(conf, &logger)
+
+	// Value should be "develop" (not reverted to "main")
+	snap := types.ReadFolderConfigSnapshot(conf, "/Users/test/partial")
+	assert.Equal(t, "develop", snap.BaseBranch)
+
+	// Disk should reflect "develop" too
+	actual, err := os.ReadFile(storageFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(actual), `"develop"`)
+	assert.NotContains(t, string(actual), `"value":"main"`)
+}

--- a/internal/folderconfig/migration_test.go
+++ b/internal/folderconfig/migration_test.go
@@ -17,8 +17,10 @@
 package folderconfig
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -98,7 +100,7 @@ func Test_MigrateFromLegacyConfig(t *testing.T) {
 			require.NoError(t, err)
 			expected, err := os.ReadFile(tt.expectedFixture)
 			require.NoError(t, err)
-			assert.JSONEq(t, string(expected), string(actual))
+			assert.JSONEq(t, normalizeFixtureKeys(t, string(expected)), string(actual))
 		})
 	}
 }
@@ -143,4 +145,43 @@ func Test_MigrateFromLegacyConfig_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(actual), `"develop"`)
 	assert.NotContains(t, string(actual), `"value":"main"`)
+}
+
+// normalizeFixtureKeys parses expected JSON and applies PathKey to the path
+// portion of config keys so fixtures (which use forward slashes) match
+// platform-specific output on Windows where filepath.Clean converts to backslashes.
+func normalizeFixtureKeys(t *testing.T, jsonStr string) string {
+	t.Helper()
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &m))
+
+	normalized := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		normalized[normalizeFolderPathInKey(k)] = v
+	}
+	out, err := json.Marshal(normalized)
+	require.NoError(t, err)
+	return string(out)
+}
+
+// normalizeFolderPathInKey applies PathKey to the path segment inside config
+// keys like "user:folder:<path>:<name>" or "folder:<path>:<name>".
+func normalizeFolderPathInKey(key string) string {
+	const folderPrefix = "folder:"
+
+	idx := strings.Index(key, folderPrefix)
+	if idx < 0 {
+		return key
+	}
+
+	prefix := key[:idx+len(folderPrefix)]
+	rest := key[idx+len(folderPrefix):]
+	lastColon := strings.LastIndex(rest, ":")
+	if lastColon <= 0 {
+		return key
+	}
+
+	path := rest[:lastColon]
+	suffix := rest[lastColon:]
+	return prefix + string(types.PathKey(types.FilePath(path))) + suffix
 }

--- a/internal/folderconfig/migration_test.go
+++ b/internal/folderconfig/migration_test.go
@@ -56,10 +56,11 @@ func runMigrationFromFixture(t *testing.T, inputFixture string) (configuration.C
 }
 
 func Test_MigrateFromLegacyConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name             string
-		inputFixture     string
-		expectedFixture  string
+		name            string
+		inputFixture    string
+		expectedFixture string
 	}{
 		{
 			name:            "single folder with all migrated fields",

--- a/internal/folderconfig/testdata/migration_all_fields_expected.json
+++ b/internal/folderconfig/testdata/migration_all_fields_expected.json
@@ -1,5 +1,4 @@
 {
-  "INTERNAL_LS_CONFIG": "",
   "folder:/Users/test/snyk-goof:auto_determined_org": "a1b2c3d4-0000-0000-0000-000000000001",
   "user:folder:/Users/test/snyk-goof:additional_environment": {"changed": true, "value": "SNYK_CFG_ORG=my-org"},
   "user:folder:/Users/test/snyk-goof:additional_parameters": {"changed": true, "value": ["-d", "--all-projects"]},

--- a/internal/folderconfig/testdata/migration_all_fields_expected.json
+++ b/internal/folderconfig/testdata/migration_all_fields_expected.json
@@ -1,0 +1,10 @@
+{
+  "INTERNAL_LS_CONFIG": "",
+  "folder:/Users/test/snyk-goof:auto_determined_org": "a1b2c3d4-0000-0000-0000-000000000001",
+  "user:folder:/Users/test/snyk-goof:additional_environment": {"changed": true, "value": "SNYK_CFG_ORG=my-org"},
+  "user:folder:/Users/test/snyk-goof:additional_parameters": {"changed": true, "value": ["-d", "--all-projects"]},
+  "user:folder:/Users/test/snyk-goof:base_branch": {"changed": true, "value": "master"},
+  "user:folder:/Users/test/snyk-goof:org_set_by_user": {"changed": true, "value": true},
+  "user:folder:/Users/test/snyk-goof:preferred_org": {"changed": true, "value": "c27d1906-bb01-487b-95d7-f547afa4add8"},
+  "user:folder:/Users/test/snyk-goof:reference_folder": {"changed": true, "value": "/Users/test/snyk-goof-ref"}
+}

--- a/internal/folderconfig/testdata/migration_all_fields_input.json
+++ b/internal/folderconfig/testdata/migration_all_fields_input.json
@@ -1,0 +1,3 @@
+{
+  "INTERNAL_LS_CONFIG": "{\"folderConfigs\":{\"/Users/test/snyk-goof\":{\"folderPath\":\"/Users/test/snyk-goof\",\"baseBranch\":\"master\",\"localBranches\":[\"master\",\"develop\"],\"additionalParameters\":[\"-d\",\"--all-projects\"],\"additionalEnv\":\"SNYK_CFG_ORG=my-org\",\"referenceFolderPath\":\"/Users/test/snyk-goof-ref\",\"preferredOrg\":\"c27d1906-bb01-487b-95d7-f547afa4add8\",\"autoDeterminedOrg\":\"a1b2c3d4-0000-0000-0000-000000000001\",\"orgMigratedFromGlobalConfig\":true,\"orgSetByUser\":true,\"featureFlags\":{\"snykCodeConsistentIgnores\":true},\"sastSettings\":{\"sastEnabled\":true}}}}"
+}

--- a/internal/folderconfig/testdata/migration_malformed_expected.json
+++ b/internal/folderconfig/testdata/migration_malformed_expected.json
@@ -1,0 +1,3 @@
+{
+  "INTERNAL_LS_CONFIG": ""
+}

--- a/internal/folderconfig/testdata/migration_malformed_expected.json
+++ b/internal/folderconfig/testdata/migration_malformed_expected.json
@@ -1,3 +1,1 @@
-{
-  "INTERNAL_LS_CONFIG": ""
-}
+{}

--- a/internal/folderconfig/testdata/migration_malformed_input.json
+++ b/internal/folderconfig/testdata/migration_malformed_input.json
@@ -1,0 +1,3 @@
+{
+  "INTERNAL_LS_CONFIG": "not valid json{{"
+}

--- a/internal/folderconfig/testdata/migration_multiple_folders_expected.json
+++ b/internal/folderconfig/testdata/migration_multiple_folders_expected.json
@@ -1,0 +1,10 @@
+{
+  "INTERNAL_LS_CONFIG": "",
+  "folder:/Users/test/project-b:auto_determined_org": "org-b-uuid",
+  "user:folder:/Users/test/project-a:base_branch": {"changed": true, "value": "develop"},
+  "user:folder:/Users/test/project-a:org_set_by_user": {"changed": true, "value": true},
+  "user:folder:/Users/test/project-a:preferred_org": {"changed": true, "value": "org-a-uuid"},
+  "user:folder:/Users/test/project-b:additional_parameters": {"changed": true, "value": ["--severity-threshold=high"]},
+  "user:folder:/Users/test/project-b:org_set_by_user": {"changed": true, "value": false},
+  "user:folder:/Users/test/project-b:preferred_org": {"changed": true, "value": ""}
+}

--- a/internal/folderconfig/testdata/migration_multiple_folders_expected.json
+++ b/internal/folderconfig/testdata/migration_multiple_folders_expected.json
@@ -1,5 +1,4 @@
 {
-  "INTERNAL_LS_CONFIG": "",
   "folder:/Users/test/project-b:auto_determined_org": "org-b-uuid",
   "user:folder:/Users/test/project-a:base_branch": {"changed": true, "value": "develop"},
   "user:folder:/Users/test/project-a:org_set_by_user": {"changed": true, "value": true},

--- a/internal/folderconfig/testdata/migration_multiple_folders_input.json
+++ b/internal/folderconfig/testdata/migration_multiple_folders_input.json
@@ -1,0 +1,3 @@
+{
+  "INTERNAL_LS_CONFIG": "{\"folderConfigs\":{\"/Users/test/project-a\":{\"folderPath\":\"/Users/test/project-a\",\"baseBranch\":\"develop\",\"preferredOrg\":\"org-a-uuid\",\"orgSetByUser\":true,\"autoDeterminedOrg\":\"\",\"orgMigratedFromGlobalConfig\":true,\"featureFlags\":{}},\"/Users/test/project-b\":{\"folderPath\":\"/Users/test/project-b\",\"baseBranch\":\"\",\"additionalParameters\":[\"--severity-threshold=high\"],\"preferredOrg\":\"\",\"orgSetByUser\":false,\"autoDeterminedOrg\":\"org-b-uuid\",\"orgMigratedFromGlobalConfig\":true,\"featureFlags\":{}}}}"
+}

--- a/internal/folderconfig/testdata/migration_org_set_by_user_false_expected.json
+++ b/internal/folderconfig/testdata/migration_org_set_by_user_false_expected.json
@@ -1,5 +1,4 @@
 {
-  "INTERNAL_LS_CONFIG": "",
   "folder:/Users/test/auto-org:auto_determined_org": "auto-org-uuid",
   "user:folder:/Users/test/auto-org:org_set_by_user": {"changed": true, "value": false},
   "user:folder:/Users/test/auto-org:preferred_org": {"changed": true, "value": ""}

--- a/internal/folderconfig/testdata/migration_org_set_by_user_false_expected.json
+++ b/internal/folderconfig/testdata/migration_org_set_by_user_false_expected.json
@@ -1,0 +1,6 @@
+{
+  "INTERNAL_LS_CONFIG": "",
+  "folder:/Users/test/auto-org:auto_determined_org": "auto-org-uuid",
+  "user:folder:/Users/test/auto-org:org_set_by_user": {"changed": true, "value": false},
+  "user:folder:/Users/test/auto-org:preferred_org": {"changed": true, "value": ""}
+}

--- a/internal/folderconfig/testdata/migration_org_set_by_user_false_input.json
+++ b/internal/folderconfig/testdata/migration_org_set_by_user_false_input.json
@@ -1,0 +1,3 @@
+{
+  "INTERNAL_LS_CONFIG": "{\"folderConfigs\":{\"/Users/test/auto-org\":{\"folderPath\":\"/Users/test/auto-org\",\"baseBranch\":\"\",\"preferredOrg\":\"\",\"orgSetByUser\":false,\"autoDeterminedOrg\":\"auto-org-uuid\",\"orgMigratedFromGlobalConfig\":true,\"featureFlags\":{}}}}"
+}

--- a/internal/folderconfig/testdata/migration_partial_fields_expected.json
+++ b/internal/folderconfig/testdata/migration_partial_fields_expected.json
@@ -1,5 +1,4 @@
 {
-  "INTERNAL_LS_CONFIG": "",
   "user:folder:/Users/test/partial:base_branch": {"changed": true, "value": "main"},
   "user:folder:/Users/test/partial:org_set_by_user": {"changed": true, "value": true},
   "user:folder:/Users/test/partial:preferred_org": {"changed": true, "value": "my-org"}

--- a/internal/folderconfig/testdata/migration_partial_fields_expected.json
+++ b/internal/folderconfig/testdata/migration_partial_fields_expected.json
@@ -1,0 +1,6 @@
+{
+  "INTERNAL_LS_CONFIG": "",
+  "user:folder:/Users/test/partial:base_branch": {"changed": true, "value": "main"},
+  "user:folder:/Users/test/partial:org_set_by_user": {"changed": true, "value": true},
+  "user:folder:/Users/test/partial:preferred_org": {"changed": true, "value": "my-org"}
+}

--- a/internal/folderconfig/testdata/migration_partial_fields_input.json
+++ b/internal/folderconfig/testdata/migration_partial_fields_input.json
@@ -1,0 +1,3 @@
+{
+  "INTERNAL_LS_CONFIG": "{\"folderConfigs\":{\"/Users/test/partial\":{\"folderPath\":\"/Users/test/partial\",\"baseBranch\":\"main\",\"preferredOrg\":\"my-org\",\"orgSetByUser\":true,\"autoDeterminedOrg\":\"\",\"orgMigratedFromGlobalConfig\":true,\"featureFlags\":{}}}}"
+}

--- a/internal/types/folder_config_helpers.go
+++ b/internal/types/folder_config_helpers.go
@@ -191,7 +191,6 @@ func CopyFolderConfigValues(conf configuration.Configuration, srcPath, dstPath F
 	for _, name := range userSettings {
 		if v := conf.Get(configresolver.UserFolderKey(src, name)); v != nil {
 			key := configresolver.UserFolderKey(dst, name)
-			conf.PersistInStorage(key)
 			conf.Set(key, v)
 		}
 	}
@@ -200,7 +199,6 @@ func CopyFolderConfigValues(conf configuration.Configuration, srcPath, dstPath F
 	for _, name := range metaSettings {
 		if v := conf.Get(configresolver.FolderMetadataKey(src, name)); v != nil {
 			key := configresolver.FolderMetadataKey(dst, name)
-			conf.PersistInStorage(key)
 			conf.Set(key, v)
 		}
 	}


### PR DESCRIPTION
### Description

Migrates folder config from old single-JSON-blob format (`INTERNAL_LS_CONFIG`) to individual GAF prefix keys, and fixes temp folder config pollution from delta base scans.

**Problem 1 — Data loss on upgrade**: The refactoring in IDE-1786 changed folder config storage from a monolithic JSON string to individual GAF keys (`user:folder:<path>:<setting>`). Without migration, users upgrading lose `preferredOrg`, `orgSetByUser`, `additionalParameters`, `baseBranch`, and other folder settings. Worst case: scans silently run against the wrong org.

**Problem 2 — Config file pollution**: `CopyFolderConfigValues()` called `PersistInStorage()` for every key copied to temp delta scan directories, writing 500+ junk entries to the config file that are never cleaned up.

#### Changes

**Commit 1 — Fix temp folder pollution**
- Remove `PersistInStorage()` calls from `CopyFolderConfigValues()` in `folder_config_helpers.go`
- Copied values remain in-memory via `conf.Set()` for scan execution
- Add 2 tests verifying no persistence to disk + correct in-memory copy

**Commit 2 — Legacy config migration**
- New `internal/folderconfig/migration.go`: parses old `INTERNAL_LS_CONFIG` JSON, writes fields as individual GAF keys using existing helpers, clears old key
- Migrated fields: `baseBranch`, `additionalParameters`, `additionalEnv`, `referenceFolderPath`, `preferredOrg`, `orgSetByUser`, `autoDeterminedOrg`
- Not migrated (re-fetched or dead): `localBranches`, `featureFlags`, `sastSettings`, `scanCommandConfig`, `orgMigratedFromGlobalConfig`
- Runs once in `SetupStorage()` after `Refresh()` loads old data
- 7 tests: table-driven with `t.Parallel()`, using JSON fixture files (`testdata/*_input.json` → `*_expected.json`) for actual file-level comparison of storage before/after migration

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced