### PR TITLE
fix(server): preserve unchanged issue view options on partial payloads [IDE-1946]

### DIFF
--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -620,7 +620,7 @@ func applyIssueViewOptions(conf configuration.Configuration, engine workflow.Eng
 		return
 	}
 
-	ivo := &types.IssueViewOptions{}
+	ivo := config.GetIssueViewOptions(conf)
 	if v, ok := settingBool(settings, types.SettingIssueViewOpenIssues); ok {
 		ivo.OpenIssues = v
 	}
@@ -629,7 +629,7 @@ func applyIssueViewOptions(conf configuration.Configuration, engine workflow.Eng
 	}
 
 	oldValue := config.GetIssueViewOptions(conf)
-	modified := config.SetIssueViewOptionsOnConfig(conf, ivo, logger)
+	modified := config.SetIssueViewOptionsOnConfig(conf, &ivo, logger)
 	if !modified {
 		return
 	}
@@ -637,7 +637,7 @@ func applyIssueViewOptions(conf configuration.Configuration, engine workflow.Eng
 	propagations[types.SettingIssueViewIgnoredIssues] = ivo.IgnoredIssues
 	sendDiagnosticsForNewSettings(conf, logger)
 	if conf.GetBool(types.SettingIsLspInitialized) {
-		analytics.SendAnalyticsForFields(conf, engine, logger, "issueViewOptions", &oldValue, ivo, triggerSource, map[string]func(*types.IssueViewOptions) any{
+		analytics.SendAnalyticsForFields(conf, engine, logger, "issueViewOptions", &oldValue, &ivo, triggerSource, map[string]func(*types.IssueViewOptions) any{
 			"OpenIssues":    func(s *types.IssueViewOptions) any { return s.OpenIssues },
 			"IgnoredIssues": func(s *types.IssueViewOptions) any { return s.IgnoredIssues },
 		}, configResolver)

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -1664,3 +1664,116 @@ func Test_hasFilterChangesInLspConfig(t *testing.T) {
 		})
 	}
 }
+
+// IDE-1946: applyIssueViewOptions must seed from current config so partial payloads
+// (one flag Changed=true, the other Changed=false) preserve the unchanged flag.
+
+// seedIssueViewOptions writes the issue view options directly to conf and asserts
+// they are observable, so the test's precondition is unambiguous regardless of
+// any test-harness-provided defaults.
+func seedIssueViewOptions(t *testing.T, conf configuration.Configuration, opts types.IssueViewOptions) {
+	t.Helper()
+	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewOpenIssues), opts.OpenIssues)
+	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewIgnoredIssues), opts.IgnoredIssues)
+	require.Equal(t, opts, config.GetIssueViewOptions(conf), "test seed must be observable via GetIssueViewOptions")
+}
+
+func TestApplyIssueViewOptions_PreservesOpenWhenOnlyIgnoredChanged(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})
+
+	UpdateSettings(conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+		types.SettingIssueViewOpenIssues:    {Value: true, Changed: false},
+		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
+	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+
+	actual := config.GetIssueViewOptions(conf)
+	assert.True(t, actual.OpenIssues, "OpenIssues must be preserved as true when only Ignored is Changed")
+	assert.True(t, actual.IgnoredIssues, "IgnoredIssues must be updated to true")
+}
+
+func TestApplyIssueViewOptions_PreservesIgnoredWhenOnlyOpenChanged(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: true})
+
+	UpdateSettings(conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+		types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
+		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: false},
+	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+
+	actual := config.GetIssueViewOptions(conf)
+	assert.False(t, actual.OpenIssues, "OpenIssues must be updated to false")
+	assert.True(t, actual.IgnoredIssues, "IgnoredIssues must be preserved as true when only Open is Changed")
+}
+
+func TestApplyIssueViewOptions_BothChangedWritesBoth(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})
+
+	UpdateSettings(conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+		types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
+		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
+	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+
+	actual := config.GetIssueViewOptions(conf)
+	assert.False(t, actual.OpenIssues)
+	assert.True(t, actual.IgnoredIssues)
+}
+
+func TestApplyIssueViewOptions_NeitherPresentIsNoOp(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	seed := types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false}
+	seedIssueViewOptions(t, conf, seed)
+
+	UpdateSettings(conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+
+	assert.Equal(t, seed, config.GetIssueViewOptions(conf))
+}
+
+func TestApplyIssueViewOptions_NeitherChangedIsNoOp(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	seed := types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false}
+	seedIssueViewOptions(t, conf, seed)
+
+	UpdateSettings(conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+		types.SettingIssueViewOpenIssues:    {Value: false, Changed: false},
+		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: false},
+	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+
+	assert.Equal(t, seed, config.GetIssueViewOptions(conf))
+}
+
+func TestApplyIssueViewOptions_EmitsAnalyticsOnlyForActuallyChangedFields(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	logger := engine.GetLogger()
+
+	// Seed: Open=true, Ignored=false. Only Ignored toggles to true.
+	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})
+
+	propagations := map[string]any{}
+	applyIssueViewOptions(conf, engine, logger, map[string]*types.ConfigSetting{
+		types.SettingIssueViewOpenIssues:    {Value: true, Changed: false},
+		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
+	}, analytics.TriggerSourceTest, propagations, testutil.DefaultConfigResolver(engine))
+
+	// Config: OpenIssues unchanged at true; IgnoredIssues toggled to true.
+	actual := config.GetIssueViewOptions(conf)
+	assert.True(t, actual.OpenIssues, "OpenIssues must remain true (its Changed=false; bug would silently set it to false)")
+	assert.True(t, actual.IgnoredIssues, "IgnoredIssues must be true")
+
+	// Propagations carry both keys with their final correct values, so downstream
+	// consumers (LSP push) see a consistent snapshot of the issue view state.
+	assert.Equal(t, true, propagations[types.SettingIssueViewOpenIssues], "propagations must reflect the preserved Open value (true), not the buggy zero value")
+	assert.Equal(t, true, propagations[types.SettingIssueViewIgnoredIssues])
+}

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -1684,8 +1684,11 @@ func TestApplyIssueViewOptions_PreservesOpenWhenOnlyIgnoredChanged(t *testing.T)
 
 	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})
 
+	// Open's Value (false) intentionally contradicts its seeded value (true)
+	// while Changed=false. If Changed were ignored, OpenIssues would flip to
+	// false and the assertion below would fail.
 	UpdateSettings(conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
-		types.SettingIssueViewOpenIssues:    {Value: true, Changed: false},
+		types.SettingIssueViewOpenIssues:    {Value: false, Changed: false},
 		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
@@ -1700,9 +1703,12 @@ func TestApplyIssueViewOptions_PreservesIgnoredWhenOnlyOpenChanged(t *testing.T)
 
 	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: true})
 
+	// Ignored's Value (false) intentionally contradicts its seeded value (true)
+	// while Changed=false. If Changed were ignored, IgnoredIssues would flip to
+	// false and the assertion below would fail.
 	UpdateSettings(conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
-		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: false},
+		types.SettingIssueViewIgnoredIssues: {Value: false, Changed: false},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 	actual := config.GetIssueViewOptions(conf)
@@ -1777,9 +1783,13 @@ func TestApplyIssueViewOptions_PreservesAndPropagatesUnchangedFieldWithLspInitia
 	// Seed: Open=true, Ignored=false. Only Ignored toggles to true.
 	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})
 
+	// Open's Value (false) intentionally contradicts its seeded value (true)
+	// while Changed=false. If Changed were ignored, OpenIssues would flip to
+	// false and the OpenIssues assertions below (config + propagation) would
+	// fail.
 	propagations := map[string]any{}
 	applyIssueViewOptions(conf, engine, logger, map[string]*types.ConfigSetting{
-		types.SettingIssueViewOpenIssues:    {Value: true, Changed: false},
+		types.SettingIssueViewOpenIssues:    {Value: false, Changed: false},
 		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
 	}, analytics.TriggerSourceTest, propagations, testutil.DefaultConfigResolver(engine))
 

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -1726,7 +1726,12 @@ func TestApplyIssueViewOptions_BothChangedWritesBoth(t *testing.T) {
 	assert.True(t, actual.IgnoredIssues)
 }
 
-func TestApplyIssueViewOptions_NeitherPresentIsNoOp(t *testing.T) {
+// TestApplyIssueViewOptions_EmptySettingsMapIsNoOp exercises the outer
+// processConfigSettings guard (`if len(settings) == 0 { return }`) and
+// therefore never enters applyIssueViewOptions. The inner
+// `!openPresent && !ignoredPresent` guard is covered by
+// TestApplyIssueViewOptions_NeitherChangedIsNoOp below.
+func TestApplyIssueViewOptions_EmptySettingsMapIsNoOp(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
@@ -1753,10 +1758,21 @@ func TestApplyIssueViewOptions_NeitherChangedIsNoOp(t *testing.T) {
 	assert.Equal(t, seed, config.GetIssueViewOptions(conf))
 }
 
-func TestApplyIssueViewOptions_EmitsAnalyticsOnlyForActuallyChangedFields(t *testing.T) {
+// TestApplyIssueViewOptions_PreservesAndPropagatesUnchangedFieldWithLspInitialized
+// drives the post-LSP-init branch (`if conf.GetBool(types.SettingIsLspInitialized)`)
+// of applyIssueViewOptions, which calls analytics.SendAnalyticsForFields. That
+// helper iterates field mappings and only emits a SendConfigChangedAnalytics
+// event when oldVal != newVal — so combined with the seed-from-config fix,
+// only IgnoredIssues should be considered "changed" here. We assert on the
+// observable outcomes (resulting config + propagations); the per-field
+// emission filter itself is unit-tested in infrastructure/analytics. Without
+// LspInitialized=true the analytics branch is skipped entirely.
+func TestApplyIssueViewOptions_PreservesAndPropagatesUnchangedFieldWithLspInitialized(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	logger := engine.GetLogger()
+
+	conf.Set(types.SettingIsLspInitialized, true)
 
 	// Seed: Open=true, Ignored=false. Only Ignored toggles to true.
 	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})


### PR DESCRIPTION
### **User description**
## Summary

Fixes a bug in `applyIssueViewOptions` where a partial `workspace/didChangeConfiguration` payload would silently overwrite the unchanged issue view flag with its zero value, causing the IntelliJ plugin's tree view to empty when toggling 'Show Ignored Issues'.

## Root cause

`applyIssueViewOptions` built a fresh zero-value `types.IssueViewOptions{}` and overlaid only the field whose `Changed=true`, then unconditionally wrote both `issue_view_open_issues` and `issue_view_ignored_issues` to the config. When the IDE sent only one flag with `Changed=true` (and the other with `Changed=false`), the unchanged flag was silently overwritten with `false`.

## Fix

Seed `ivo` from the current config (`config.GetIssueViewOptions(conf)`), mirroring the existing `extractSeverityFilterFromSettings` pattern, so the per-field gating in `settingBool`/`settingPresent` correctly preserves the flag whose `Changed=false`. Combined with `analytics.SendAnalyticsForFields`'s existing per-field `oldVal != newVal` filter, this also emits exactly one analytics event per actually-toggled flag.

## Commits

1. **`dea22436`** — production fix in `application/server/configuration.go` + 6 unit tests (Gherkin acceptance criteria).
2. **`0a77a8c9`** — QA follow-up (test-only):
   - Renamed `..._NeitherPresentIsNoOp` → `..._EmptySettingsMapIsNoOp` (the empty-map case exits early in `processConfigSettings`, never reaching the inner guard, which is already covered by `..._NeitherChangedIsNoOp`).
   - Renamed `..._EmitsAnalyticsOnlyForActuallyChangedFields` → `..._PreservesAndPropagatesUnchangedFieldWithLspInitialized` and set `SettingIsLspInitialized=true` so the analytics branch is actually exercised. Coverage of `applyIssueViewOptions` rises from 80.0% to **95.0%**.

## Test plan

- [x] 6 new unit tests pass — `go test ./application/server/ -run ApplyIssueViewOptions -v`
- [x] Full `application/server` package: `ok` (105s)
- [x] `make test` (unit + JS): all 127 packages pass on Node 20
- [x] `INTEG_TESTS=1 make test`: all 127 packages pass
- [x] `SMOKE_TESTS=1 make test`: passes locally except `Test_SmokePrecedence_OrgScope_UserFolderOverrideReflectedInNotification` which is **pre-existing** on the parent commit `c9b4a8b3` and requires the `SNYK_TOKEN_CONSISTENT_IGNORES` test-org token (set in CI) for LDX-Sync lock validation.
- [x] `make lint` clean, `go vet` clean.
- [x] `snyk_code_scan` on `application/server`: 0 issues. No dependency changes.

## Out of scope (follow-ups)

- The `propagations` map populated by these helpers is dead code in production today (no reader after `processConfigSettings`); its removal is already in flight on PR #1216.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes issue view options overwrite bug.

- Preserves unchanged flags from partial payloads.

- Improves configuration update logic.

- Adds comprehensive unit tests for validation.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.go</strong><dd><code>Preserve issue view options on partial configuration updates</code></dd></summary>
<hr>

application/server/configuration.go

<ul><li>Modified <code>applyIssueViewOptions</code> to initialize <code>types.IssueViewOptions</code> <br>from the current configuration using <code>config.GetIssueViewOptions(conf)</code>.<br> <li> This change prevents partial <code>workspace/didChangeConfiguration</code> payloads <br>from overwriting unchanged issue view flags with their zero values.<br> <li> Ensures that only explicitly changed fields are updated, preserving <br>the state of others.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1228/changes#diff-eb3fe6fd1956591838595b08979653ec23c0b0c16f5340e9e89a05c30e921607">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration_test.go</strong><dd><code>Add comprehensive tests for issue view options configuration</code></dd></summary>
<hr>

application/server/configuration_test.go

<ul><li>Introduced new unit tests to specifically verify the correct <br>preservation of issue view options when partial configuration updates <br>are received, covering scenarios where only one flag is changed.<br> <li> Added a helper function <code>seedIssueViewOptions</code> to facilitate setting and <br>verifying configuration states for tests.<br> <li> Added tests for edge cases like empty settings maps and no changed <br>fields.<br> <li> Refactored existing tests for better clarity and coverage, including <br>tests that trigger analytics paths.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1228/changes#diff-e141faafb3f0507956b85e92ac3b584c7c706bd96e7f428c7ef95d0d8b2df564">+129/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

