### PR TITLE
fix: align notifier and progress channel sizing [IDE-1979]

### DIFF
--- a/application/server/notification.go
+++ b/application/server/notification.go
@@ -44,7 +44,6 @@ func createProgressListener(progressChannel chan types.ProgressParams, server ty
 		case <-progressStopChan:
 			continue
 		default:
-			break
 		}
 		break
 	}
@@ -87,11 +86,13 @@ func disposeProgressListener() {
 func registerNotifier(conf configuration.Configuration, logger *zerolog.Logger, srv types.Server) {
 	l := logger.With().Str("method", "registerNotifier").Logger()
 	callbackFunction := func(params any) {
-		l.Debug().Msg("waiting for lsp initialization to be finished...")
-		for !conf.GetBool(types.SettingIsLspInitialized) {
-			time.Sleep(time.Millisecond)
+		if !conf.GetBool(types.SettingIsLspInitialized) {
+			l.Debug().Msg("waiting for lsp initialization to be finished...")
+			for !conf.GetBool(types.SettingIsLspInitialized) {
+				time.Sleep(time.Millisecond)
+			}
+			l.Debug().Msg("lsp initialization finished.")
 		}
-		l.Debug().Msg("lsp initialization finished.")
 
 		switch params := params.(type) {
 		case types.GetSdk:

--- a/internal/notification/notifier.go
+++ b/internal/notification/notifier.go
@@ -25,8 +25,8 @@ type Notifier interface {
 
 func NewNotifier() Notifier {
 	return &notifierImpl{
-		channel:     make(chan any, 100),
-		stopChannel: make(chan any, 100),
+		channel:     make(chan any, 1000),
+		stopChannel: make(chan any, 1000),
 	}
 }
 

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -32,7 +32,7 @@ import (
 
 var trackersMutex sync.RWMutex
 var trackers = make(map[types.ProgressToken]*Tracker)
-var ToServerProgressChannel = make(chan types.ProgressParams, 100000)
+var ToServerProgressChannel = make(chan types.ProgressParams, 1000)
 var _ ui.ProgressBar = (*Tracker)(nil)
 
 type Tracker struct {


### PR DESCRIPTION
### **User description**
### Description

Targets **base:** `refactor/IDE-1786_folder-config-refactoring` (stacked PR for [IDE-1979](https://snyksec.atlassian.net/browse/IDE-1979)).

- **Notifier buffers:** `internal/notification/notifier.go` — raise `channel` and `stopChannel` capacity from **100 → 1000** to absorb bursts without blocking senders as often.
- **Progress channel:** `internal/progress/progress.go` — set `ToServerProgressChannel` buffer to **1000** (was 100000) so progress traffic is bounded consistently with notifier sizing.
- **LSP init wait:** `application/server/notification.go` — only spin on `SettingIsLspInitialized` when it is still false; emit the “finished” log after the wait loop, not when already initialized.
- **Progress listener:** remove a redundant `break` in the `select` used while draining the progress channel during listener setup.

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced


[IDE-1979]: https://snyksec.atlassian.net/browse/IDE-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement


___

### **Description**
- Increased notifier channel buffer sizes from 100 to 1000.

- Aligned progress channel buffer size to 1000 for consistent traffic.

- Improved LSP initialization wait logic for efficiency.

- Cleaned up progress listener loop for better handling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  NotifierChannel["Notifier Channel Buffers (100 -> 1000)"]
  ProgressChannel["Progress Channel Buffer (100000 -> 1000)"]
  LSPInitWait["LSP Initialization Wait Logic"]
  ProgressListener["Progress Listener Cleanup"]
  Alignment["Channel Sizing Alignment"]
  SystemStability["Improved System Stability & Responsiveness"]

  NotifierChannel -- "Increase capacity" --> Alignment
  ProgressChannel -- "Align capacity" --> Alignment
  Alignment -- "Absorb bursts" --> SystemStability
  LSPInitWait -- "Optimize wait" --> SystemStability
  ProgressListener -- "Refine loop" --> SystemStability
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notification.go</strong><dd><code>Refine LSP initialization wait and progress listener cleanup</code></dd></summary>
<hr>

application/server/notification.go

<ul><li>Removed a redundant <code>break</code> statement in the progress listener cleanup <br>loop.<br> <li> Added a conditional check before waiting for LSP initialization.<br> <li> Improved logging message timing for LSP initialization completion.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1238/changes#diff-3ac97f07d29586cd80b9c63b5ac84fa3c0c029c0786ad485ae98d5d143cdaa53">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>notifier.go</strong><dd><code>Increase notifier channel buffer sizes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/notification/notifier.go

<ul><li>Increased the buffer capacity of <code>channel</code> from 100 to 1000.<br> <li> Increased the buffer capacity of <code>stopChannel</code> from 100 to 1000.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1238/changes#diff-06687aa0e8a299a44a7e4dc8218f0b5ca197158a3a72c0072031890e80ddecda">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>progress.go</strong><dd><code>Adjust progress channel buffer size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/progress/progress.go

<ul><li>Decreased the buffer capacity of <code>ToServerProgressChannel</code> from 100000 <br>to 1000.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1238/changes#diff-66d4349586a1dea4bd4de639d9a4a0439f4e011ca6b4f8667b1852baef6cf7c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

