### PR TITLE
perf(code): stream SARIF conversion [IDE-1940]

### DIFF
--- a/infrastructure/code/conversion.go
+++ b/infrastructure/code/conversion.go
@@ -18,6 +18,7 @@ package code
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog"
@@ -32,20 +33,40 @@ import (
 // This is a simplified version for use by MCP and other tools that need conversion without full scanner
 // basePath is the absolute path where the scan was run (optional - if empty, paths remain relative)
 func ConvertSARIFJSONToIssues(engine workflow.Engine, logger *zerolog.Logger, hoverVerbosity int, sarifJSON []byte, basePath string) ([]types.Issue, error) {
+	var head sarifDocumentHead
+	if err := json.Unmarshal(sarifJSON, &head); err != nil {
+		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", err)
+	}
+	if len(head.Runs) == 0 {
+		return nil, nil
+	}
+	run := codeClientSarif.Run{
+		Tool:       head.Runs[0].Tool,
+		Properties: head.Runs[0].Properties,
+		Results:    nil,
+	}
 	var sarifResponse codeClientSarif.SarifResponse
+	sarifResponse.Sarif.Schema = head.Schema
+	sarifResponse.Sarif.Version = head.Version
+	sarifResponse.Sarif.Runs = []codeClientSarif.Run{run}
 
-	err := json.Unmarshal(sarifJSON, &sarifResponse.Sarif)
+	converter := SarifConverter{sarif: sarifResponse, logger: logger, hoverVerbosity: hoverVerbosity, engine: engine}
+	ruleLink := createRuleLink()
+	baseDir := types.FilePath(basePath)
+
+	var issues []types.Issue
+	var errs error
+	err := streamFirstRunResults(sarifJSON, func(res codeClientSarif.Result) error {
+		var err2 error
+		issues, err2 = converter.appendIssuesForResult(run, res, baseDir, ruleLink, issues)
+		errs = errors.Join(errs, err2)
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", err)
 	}
-
-	converter := SarifConverter{sarif: sarifResponse, logger: logger, hoverVerbosity: hoverVerbosity, engine: engine}
-
-	// Convert with provided base path (or empty for relative paths)
-	issues, err := converter.toIssues(types.FilePath(basePath))
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert SARIF to issues: %w", err)
+	if errs != nil {
+		return nil, fmt.Errorf("failed to convert SARIF to issues: %w", errs)
 	}
-
 	return issues, nil
 }

--- a/infrastructure/code/conversion.go
+++ b/infrastructure/code/conversion.go
@@ -74,7 +74,7 @@ func ConvertSARIFJSONToIssues(engine workflow.Engine, logger *zerolog.Logger, ho
 		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", streamErr)
 	}
 	if conversionErrs != nil {
-		return nil, fmt.Errorf("failed to convert SARIF to issues: %w", conversionErrs)
+		return issues, fmt.Errorf("failed to convert SARIF to issues: %w", conversionErrs)
 	}
 	return issues, nil
 }

--- a/infrastructure/code/conversion.go
+++ b/infrastructure/code/conversion.go
@@ -55,14 +55,14 @@ func ConvertSARIFJSONToIssues(engine workflow.Engine, logger *zerolog.Logger, ho
 	baseDir := types.FilePath(basePath)
 
 	var issues []types.Issue
-	var errs error
-	err := streamFirstRunResults(sarifJSON, func(res codeClientSarif.Result) error {
-		var err2 error
-		issues, err2 = converter.appendIssuesForResult(run, res, baseDir, ruleLink, issues)
-		errs = errors.Join(errs, err2)
+	var conversionErrs error
+	streamErr := streamFirstRunResults(sarifJSON, func(res codeClientSarif.Result) error {
+		var appendErr error
+		issues, appendErr = converter.appendIssuesForResult(run, res, baseDir, ruleLink, issues)
+		conversionErrs = errors.Join(conversionErrs, appendErr)
 		return nil
 	})
-	if errors.Is(err, errDuplicateSARIFStreamingKey) {
+	if errors.Is(streamErr, errDuplicateSARIFStreamingKey) {
 		var full codeClientSarif.SarifResponse
 		if unmarshalErr := json.Unmarshal(sarifJSON, &full.Sarif); unmarshalErr != nil {
 			return nil, fmt.Errorf("failed to parse SARIF JSON: %w", unmarshalErr)
@@ -70,11 +70,11 @@ func ConvertSARIFJSONToIssues(engine workflow.Engine, logger *zerolog.Logger, ho
 		fullConverter := SarifConverter{sarif: full, logger: logger, hoverVerbosity: hoverVerbosity, engine: engine}
 		return fullConverter.toIssues(baseDir)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", err)
+	if streamErr != nil {
+		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", streamErr)
 	}
-	if errs != nil {
-		return nil, fmt.Errorf("failed to convert SARIF to issues: %w", errs)
+	if conversionErrs != nil {
+		return nil, fmt.Errorf("failed to convert SARIF to issues: %w", conversionErrs)
 	}
 	return issues, nil
 }

--- a/infrastructure/code/conversion.go
+++ b/infrastructure/code/conversion.go
@@ -62,6 +62,14 @@ func ConvertSARIFJSONToIssues(engine workflow.Engine, logger *zerolog.Logger, ho
 		errs = errors.Join(errs, err2)
 		return nil
 	})
+	if errors.Is(err, errDuplicateSARIFStreamingKey) {
+		var full codeClientSarif.SarifResponse
+		if unmarshalErr := json.Unmarshal(sarifJSON, &full.Sarif); unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to parse SARIF JSON: %w", unmarshalErr)
+		}
+		fullConverter := SarifConverter{sarif: full, logger: logger, hoverVerbosity: hoverVerbosity, engine: engine}
+		return fullConverter.toIssues(baseDir)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", err)
 	}

--- a/infrastructure/code/conversion_stream.go
+++ b/infrastructure/code/conversion_stream.go
@@ -1,0 +1,159 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	codeClientSarif "github.com/snyk/code-client-go/sarif"
+)
+
+// sarifRunHead is the first run object without results so json.Unmarshal skips the large results array.
+type sarifRunHead struct {
+	Tool       codeClientSarif.Tool          `json:"tool"`
+	Properties codeClientSarif.RunProperties `json:"properties"`
+}
+
+type sarifDocumentHead struct {
+	Schema  string         `json:"$schema"`
+	Version string         `json:"version"`
+	Runs    []sarifRunHead `json:"runs"`
+}
+
+func isDelim(tok json.Token, want json.Delim) bool {
+	d, ok := tok.(json.Delim)
+	return ok && d == want
+}
+
+// streamFirstRunResults walks sarifJSON (inner Sarif document) and decodes each result in runs[0].results.
+func streamFirstRunResults(sarifJSON []byte, handle func(codeClientSarif.Result) error) error {
+	dec := json.NewDecoder(bytes.NewReader(sarifJSON))
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if !isDelim(tok, '{') {
+		return fmt.Errorf("expected top-level JSON object")
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("expected object key string")
+		}
+		if key != "runs" {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+			continue
+		}
+		return consumeRunsArrayResults(dec, handle)
+	}
+	return nil
+}
+
+func consumeRunsArrayResults(dec *json.Decoder, handle func(codeClientSarif.Result) error) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if !isDelim(tok, '[') {
+		return fmt.Errorf("runs: expected JSON array")
+	}
+	tok, err = dec.Token()
+	if err != nil {
+		return err
+	}
+	if isDelim(tok, ']') {
+		return nil
+	}
+	if !isDelim(tok, '{') {
+		return fmt.Errorf("runs: expected run object")
+	}
+	if err := consumeRunObjectResults(dec, handle); err != nil {
+		return err
+	}
+	return finishRunsArrayAfterFirstRun(dec)
+}
+
+func consumeRunObjectResults(dec *json.Decoder, handle func(codeClientSarif.Result) error) error {
+	for {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if isDelim(keyTok, '}') {
+			return nil
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("runs[0]: expected object key string")
+		}
+		switch key {
+		case "results":
+			if err := decodeResultsArray(dec, handle); err != nil {
+				return err
+			}
+		default:
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func finishRunsArrayAfterFirstRun(dec *json.Decoder) error {
+	for dec.More() {
+		var skipRun json.RawMessage
+		if err := dec.Decode(&skipRun); err != nil {
+			return err
+		}
+	}
+	_, err := dec.Token()
+	return err
+}
+
+func skipJSONValue(dec *json.Decoder) error {
+	var skip json.RawMessage
+	return dec.Decode(&skip)
+}
+
+func decodeResultsArray(dec *json.Decoder, handle func(codeClientSarif.Result) error) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if !isDelim(tok, '[') {
+		return fmt.Errorf("results: expected JSON array")
+	}
+	for dec.More() {
+		var res codeClientSarif.Result
+		if decErr := dec.Decode(&res); decErr != nil {
+			return decErr
+		}
+		if hErr := handle(res); hErr != nil {
+			return hErr
+		}
+	}
+	_, err = dec.Token()
+	return err
+}

--- a/infrastructure/code/conversion_stream.go
+++ b/infrastructure/code/conversion_stream.go
@@ -27,7 +27,10 @@ import (
 
 var errDuplicateSARIFStreamingKey = errors.New("duplicate SARIF key requires full unmarshal")
 
-// sarifRunHead is the first run object without results so json.Unmarshal skips the large results array.
+// sarifRunHead holds only the non-results fields of a SARIF run object.
+// When json.Unmarshal decodes a []sarifRunHead, it still reads every byte of the
+// document (including the results arrays) but never allocates codeClientSarif.Result
+// objects, so peak allocation is much lower than a full SarifResponse unmarshal.
 type sarifRunHead struct {
 	Tool       codeClientSarif.Tool          `json:"tool"`
 	Properties codeClientSarif.RunProperties `json:"properties"`

--- a/infrastructure/code/conversion_stream.go
+++ b/infrastructure/code/conversion_stream.go
@@ -19,10 +19,13 @@ package code
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	codeClientSarif "github.com/snyk/code-client-go/sarif"
 )
+
+var errDuplicateSARIFStreamingKey = errors.New("duplicate SARIF key requires full unmarshal")
 
 // sarifRunHead is the first run object without results so json.Unmarshal skips the large results array.
 type sarifRunHead struct {
@@ -51,6 +54,7 @@ func streamFirstRunResults(sarifJSON []byte, handle func(codeClientSarif.Result)
 	if !isDelim(tok, '{') {
 		return fmt.Errorf("expected top-level JSON object")
 	}
+	seenRuns := false
 	for dec.More() {
 		keyTok, err := dec.Token()
 		if err != nil {
@@ -66,7 +70,13 @@ func streamFirstRunResults(sarifJSON []byte, handle func(codeClientSarif.Result)
 			}
 			continue
 		}
-		return consumeRunsArrayResults(dec, handle)
+		if seenRuns {
+			return errDuplicateSARIFStreamingKey
+		}
+		seenRuns = true
+		if err := consumeRunsArrayResults(dec, handle); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -96,6 +106,7 @@ func consumeRunsArrayResults(dec *json.Decoder, handle func(codeClientSarif.Resu
 }
 
 func consumeRunObjectResults(dec *json.Decoder, handle func(codeClientSarif.Result) error) error {
+	seenResults := false
 	for {
 		keyTok, err := dec.Token()
 		if err != nil {
@@ -110,6 +121,10 @@ func consumeRunObjectResults(dec *json.Decoder, handle func(codeClientSarif.Resu
 		}
 		switch key {
 		case "results":
+			if seenResults {
+				return errDuplicateSARIFStreamingKey
+			}
+			seenResults = true
 			if err := decodeResultsArray(dec, handle); err != nil {
 				return err
 			}

--- a/infrastructure/code/conversion_test.go
+++ b/infrastructure/code/conversion_test.go
@@ -1,0 +1,199 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	codeClientSarif "github.com/snyk/code-client-go/sarif"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// minimal inner SARIF document (MCP path) with two security results for streaming vs full-unmarshal parity.
+const conversionTestInnerSarif = `{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SnykCode",
+          "semanticVersion": "1.0.0",
+          "version": "1.0.0",
+          "rules": [
+            {
+              "id": "java/TestRule",
+              "name": "TestRule",
+              "shortDescription": { "text": "Test rule" },
+              "defaultConfiguration": { "level": "warning" },
+              "help": { "markdown": "help-md", "text": "help" },
+              "properties": {
+                "tags": ["java"],
+                "categories": ["Security"],
+                "cwe": ["CWE-1"]
+              }
+            }
+          ]
+        }
+      },
+      "properties": {},
+      "results": [
+        {
+          "ruleId": "java/TestRule",
+          "level": "warning",
+          "message": { "text": "first finding" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/a.java" },
+                "region": { "startLine": 10, "endLine": 10, "startColumn": 1, "endColumn": 5 }
+              }
+            }
+          ],
+          "fingerprints": { "0": "", "1": "fp-a", "identity": "id-a" }
+        },
+        {
+          "ruleId": "java/TestRule",
+          "level": "warning",
+          "message": { "text": "second finding" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/b.java" },
+                "region": { "startLine": 20, "endLine": 20, "startColumn": 2, "endColumn": 6 }
+              }
+            }
+          ],
+          "fingerprints": { "0": "", "1": "fp-b", "identity": "id-b" }
+        }
+      ]
+    }
+  ]
+}`
+
+func issueSortKey(i types.Issue) string {
+	return string(i.GetAffectedFilePath()) + "\x00" + i.GetID() + "\x00" + i.GetMessage()
+}
+
+func sortIssuesForCompare(issues []types.Issue) []types.Issue {
+	out := append([]types.Issue(nil), issues...)
+	sort.Slice(out, func(a, b int) bool {
+		return issueSortKey(out[a]) < issueSortKey(out[b])
+	})
+	return out
+}
+
+func assertIssueSlicesEqual(t *testing.T, want, got []types.Issue) {
+	t.Helper()
+	require.Equal(t, len(want), len(got))
+	sw := sortIssuesForCompare(want)
+	sg := sortIssuesForCompare(got)
+	for i := range sw {
+		w := sw[i]
+		g := sg[i]
+		require.Equal(t, w.GetID(), g.GetID())
+		require.Equal(t, w.GetMessage(), g.GetMessage())
+		require.Equal(t, w.GetAffectedFilePath(), g.GetAffectedFilePath())
+		require.Equal(t, w.GetRange(), g.GetRange())
+		require.Equal(t, w.GetSeverity(), g.GetSeverity())
+		require.Equal(t, w.GetFingerprint(), g.GetFingerprint())
+		require.Equal(t, w.GetGlobalIdentity(), g.GetGlobalIdentity())
+	}
+}
+
+// TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal checks streaming decode matches json.Unmarshal + toIssues.
+func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal(t *testing.T) {
+	t.Parallel()
+	engine, _ := testutil.SmokeTestWithEngine(t, "")
+	logger := zerolog.Nop()
+	hover := 0
+	basePath := ""
+
+	var full codeClientSarif.SarifResponse
+	require.NoError(t, json.Unmarshal([]byte(conversionTestInnerSarif), &full.Sarif))
+	conv := SarifConverter{sarif: full, logger: &logger, hoverVerbosity: hover, engine: engine}
+	want, err := conv.toIssues(types.FilePath(basePath))
+	require.NoError(t, err)
+
+	got, err := ConvertSARIFJSONToIssues(engine, &logger, hover, []byte(conversionTestInnerSarif), basePath)
+	require.NoError(t, err)
+	assertIssueSlicesEqual(t, want, got)
+}
+
+func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal_EmptyRuns(t *testing.T) {
+	t.Parallel()
+	engine, _ := testutil.SmokeTestWithEngine(t, "")
+	logger := zerolog.Nop()
+	inner := `{"$schema":"https://example/sarif.json","version":"2.1.0","runs":[]}`
+	var full codeClientSarif.SarifResponse
+	require.NoError(t, json.Unmarshal([]byte(inner), &full.Sarif))
+	conv := SarifConverter{sarif: full, logger: &logger, hoverVerbosity: 0, engine: engine}
+	want, err := conv.toIssues("")
+	require.NoError(t, err)
+	got, err := ConvertSARIFJSONToIssues(engine, &logger, 0, []byte(inner), "")
+	require.NoError(t, err)
+	require.Equal(t, len(want), len(got))
+}
+
+func TestConvertSARIFJSONToIssues_MalformedResultsArray(t *testing.T) {
+	t.Parallel()
+	engine, _ := testutil.SmokeTestWithEngine(t, "")
+	logger := zerolog.Nop()
+	// Valid first result, invalid second element in results array.
+	sarif := `{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SnykCode",
+          "rules": [
+            {
+              "id": "r1",
+              "name": "r1",
+              "shortDescription": { "text": "r" },
+              "defaultConfiguration": { "level": "warning" },
+              "help": { "markdown": "", "text": "" },
+              "properties": { "categories": ["Security"], "tags": [] }
+            }
+          ]
+        }
+      },
+      "properties": {},
+      "results": [
+        {
+          "ruleId": "r1",
+          "level": "warning",
+          "message": { "text": "ok" },
+          "locations": [],
+          "fingerprints": {}
+        },
+        not_valid_json_token
+      ]
+    }
+  ]
+}`
+	_, err := ConvertSARIFJSONToIssues(engine, &logger, 0, []byte(sarif), "")
+	require.Error(t, err)
+}

--- a/infrastructure/code/conversion_test.go
+++ b/infrastructure/code/conversion_test.go
@@ -125,7 +125,7 @@ func assertIssueSlicesEqual(t *testing.T, want, got []types.Issue) {
 // TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal checks streaming decode matches json.Unmarshal + toIssues.
 func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal(t *testing.T) {
 	t.Parallel()
-	engine, _ := testutil.SmokeTestWithEngine(t, "")
+	engine := testutil.UnitTest(t)
 	logger := zerolog.Nop()
 	hover := 0
 	basePath := ""
@@ -143,7 +143,7 @@ func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal(t *testing.T) {
 
 func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal_EmptyRuns(t *testing.T) {
 	t.Parallel()
-	engine, _ := testutil.SmokeTestWithEngine(t, "")
+	engine := testutil.UnitTest(t)
 	logger := zerolog.Nop()
 	inner := `{"$schema":"https://example/sarif.json","version":"2.1.0","runs":[]}`
 	var full codeClientSarif.SarifResponse
@@ -158,7 +158,7 @@ func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal_EmptyRuns(t *testin
 
 func TestConvertSARIFJSONToIssues_MalformedResultsArray(t *testing.T) {
 	t.Parallel()
-	engine, _ := testutil.SmokeTestWithEngine(t, "")
+	engine := testutil.UnitTest(t)
 	logger := zerolog.Nop()
 	// Valid first result, invalid second element in results array.
 	sarif := `{
@@ -196,4 +196,84 @@ func TestConvertSARIFJSONToIssues_MalformedResultsArray(t *testing.T) {
 }`
 	_, err := ConvertSARIFJSONToIssues(engine, &logger, 0, []byte(sarif), "")
 	require.Error(t, err)
+}
+
+func TestConvertSARIFJSONToIssues_DuplicateRunsAndResultsMatchFullUnmarshal(t *testing.T) {
+	t.Parallel()
+	engine := testutil.UnitTest(t)
+	logger := zerolog.Nop()
+	inner := `{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "SnykCode", "rules": [] } },
+      "results": [
+        { "ruleId": "ignored/FirstRun", "message": { "text": "ignored first run" }, "locations": [], "fingerprints": {} }
+      ]
+    }
+  ],
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SnykCode",
+          "rules": [
+            {
+              "id": "java/DuplicateRule",
+              "name": "DuplicateRule",
+              "shortDescription": { "text": "Duplicate rule" },
+              "defaultConfiguration": { "level": "warning" },
+              "help": { "markdown": "help-md", "text": "help" },
+              "properties": { "categories": ["Security"], "tags": [] }
+            }
+          ]
+        }
+      },
+      "properties": {},
+      "results": [
+        {
+          "ruleId": "java/DuplicateRule",
+          "level": "warning",
+          "message": { "text": "ignored duplicate results" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/ignored.java" },
+                "region": { "startLine": 1, "endLine": 1, "startColumn": 1, "endColumn": 2 }
+              }
+            }
+          ],
+          "fingerprints": { "1": "ignored" }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "java/DuplicateRule",
+          "level": "warning",
+          "message": { "text": "last duplicate wins" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/last.java" },
+                "region": { "startLine": 7, "endLine": 7, "startColumn": 3, "endColumn": 9 }
+              }
+            }
+          ],
+          "fingerprints": { "1": "last-fp", "identity": "last-id" }
+        }
+      ]
+    }
+  ]
+}`
+
+	var full codeClientSarif.SarifResponse
+	require.NoError(t, json.Unmarshal([]byte(inner), &full.Sarif))
+	conv := SarifConverter{sarif: full, logger: &logger, hoverVerbosity: 0, engine: engine}
+	want, err := conv.toIssues("")
+	require.NoError(t, err)
+
+	got, err := ConvertSARIFJSONToIssues(engine, &logger, 0, []byte(inner), "")
+
+	require.NoError(t, err)
+	assertIssueSlicesEqual(t, want, got)
 }

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -304,130 +304,143 @@ func (s *SarifConverter) getRule(r codeClientSarif.Run, id string) codeClientSar
 	return codeClientSarif.Rule{}
 }
 
+func (s *SarifConverter) appendIssuesForResult(
+	r codeClientSarif.Run,
+	result codeClientSarif.Result,
+	baseDir types.FilePath,
+	ruleLink *url.URL,
+	issues []types.Issue,
+) ([]types.Issue, error) {
+	var errs error
+	for _, loc := range result.Locations {
+		// Response contains encoded relative paths that should be decoded and converted to absolute.
+		absPath, err := DecodePath(ToAbsolutePath(baseDir, types.FilePath(loc.PhysicalLocation.ArtifactLocation.URI)))
+		if err != nil {
+			s.logger.Error().
+				Err(err).
+				Msg("failed to convert URI to absolute path: base directory: " +
+					string(baseDir) +
+					", URI: " +
+					loc.PhysicalLocation.ArtifactLocation.URI)
+			errs = errors.Join(errs, err)
+			continue
+		}
+
+		position := loc.PhysicalLocation.Region
+		// NOTE: sarif uses 1-based location numbering, see
+		// https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Ref493492556
+		startLine := position.StartLine - 1
+		endLine := util.Max(position.EndLine-1, startLine)
+		startCol := position.StartColumn - 1
+		endCol := util.Max(position.EndColumn-1, 0)
+		myRange := types.Range{
+			Start: types.Position{
+				Line:      startLine,
+				Character: startCol,
+			},
+			End: types.Position{
+				Line:      endLine,
+				Character: endCol,
+			},
+		}
+
+		testRule := s.getRule(r, result.RuleID)
+
+		// only process security issues
+		isSecurityType := s.isSecurityIssue(testRule)
+		if !isSecurityType {
+			continue
+		}
+
+		message := s.getMessage(result, testRule)
+		formattedMessage := s.formattedMessageMarkdown(result, testRule, baseDir)
+
+		exampleCommits := s.getExampleCommits(testRule)
+		exampleFixes := make([]snyk.ExampleCommitFix, 0, len(exampleCommits))
+		for _, commit := range exampleCommits {
+			commitURL := commit.fix.CommitURL
+			commitFixLines := make([]snyk.CommitChangeLine, 0, len(commit.fix.Lines))
+			for _, line := range commit.fix.Lines {
+				commitFixLines = append(commitFixLines, snyk.CommitChangeLine{
+					Line:       line.Line,
+					LineNumber: line.LineNumber,
+					LineChange: line.LineChange})
+			}
+
+			exampleFixes = append(exampleFixes, snyk.ExampleCommitFix{
+				CommitURL: commitURL,
+				Lines:     commitFixLines,
+			})
+		}
+
+		markers, err := s.getMarkers(result, baseDir)
+		errs = errors.Join(errs, err)
+
+		key := util.GetIssueKey(result.RuleID, absPath, startLine, endLine, startCol, endCol)
+		title := testRule.ShortDescription.Text
+		if title == "" {
+			title = testRule.ID
+		}
+
+		additionalData := snyk.CodeIssueData{
+			Key:                key,
+			Title:              title,
+			Message:            result.Message.Text,
+			Rule:               testRule.Name,
+			RuleId:             testRule.ID,
+			RepoDatasetSize:    testRule.Properties.RepoDatasetSize,
+			ExampleCommitFixes: exampleFixes,
+			CWE:                testRule.Properties.Cwe,
+			Text:               testRule.Help.Markdown,
+			Markers:            markers,
+			Cols:               [2]int{startCol, endCol},
+			Rows:               [2]int{startLine, endLine},
+			IsSecurityType:     isSecurityType,
+			IsAutofixable:      result.Properties.IsAutofixable,
+			PriorityScore:      result.Properties.PriorityScore,
+			DataFlow:           s.getCodeFlow(result, baseDir),
+		}
+
+		d := &snyk.Issue{
+			ID:                  result.RuleID,
+			Range:               myRange,
+			Severity:            issueSeverity(result.Level),
+			Message:             message,
+			FormattedMessage:    formattedMessage,
+			IssueType:           types.CodeSecurityVulnerability,
+			ContentRoot:         baseDir,
+			AffectedFilePath:    types.FilePath(absPath),
+			Product:             product.ProductCode,
+			IssueDescriptionURL: ruleLink,
+			References:          s.getReferences(testRule),
+			AdditionalData:      additionalData,
+			CWEs:                testRule.Properties.Cwe,
+			FindingId:           result.Fingerprints.SnykAssetFindingV1,
+		}
+		d.SetFingerPrint(result.Fingerprints.Num1)
+		d.SetGlobalIdentity(result.Fingerprints.Identity)
+		isIgnored, ignoreDetails := GetIgnoreDetailsFromSuppressions(s.engine.GetLogger(), result.Suppressions)
+		d.IsIgnored = isIgnored
+		d.IgnoreDetails = ignoreDetails
+		d.AdditionalData = additionalData
+
+		issues = append(issues, d)
+	}
+	return issues, errs
+}
+
 func (s *SarifConverter) toIssues(baseDir types.FilePath) (issues []types.Issue, err error) {
 	runs := s.sarif.Sarif.Runs
 	if len(runs) == 0 {
 		return issues, nil
 	}
 	ruleLink := createRuleLink()
-
 	r := runs[0]
 	var errs error
 	for _, result := range r.Results {
-		for _, loc := range result.Locations {
-			// Response contains encoded relative paths that should be decoded and converted to absolute.
-			absPath, err := DecodePath(ToAbsolutePath(baseDir, types.FilePath(loc.PhysicalLocation.ArtifactLocation.URI)))
-			if err != nil {
-				s.logger.Error().
-					Err(err).
-					Msg("failed to convert URI to absolute path: base directory: " +
-						string(baseDir) +
-						", URI: " +
-						loc.PhysicalLocation.ArtifactLocation.URI)
-				errs = errors.Join(errs, err)
-				continue
-			}
-
-			position := loc.PhysicalLocation.Region
-			// NOTE: sarif uses 1-based location numbering, see
-			// https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Ref493492556
-			startLine := position.StartLine - 1
-			endLine := util.Max(position.EndLine-1, startLine)
-			startCol := position.StartColumn - 1
-			endCol := util.Max(position.EndColumn-1, 0)
-			myRange := types.Range{
-				Start: types.Position{
-					Line:      startLine,
-					Character: startCol,
-				},
-				End: types.Position{
-					Line:      endLine,
-					Character: endCol,
-				},
-			}
-
-			testRule := s.getRule(r, result.RuleID)
-
-			// only process security issues
-			isSecurityType := s.isSecurityIssue(testRule)
-			if !isSecurityType {
-				continue
-			}
-
-			message := s.getMessage(result, testRule)
-			formattedMessage := s.formattedMessageMarkdown(result, testRule, baseDir)
-
-			exampleCommits := s.getExampleCommits(testRule)
-			exampleFixes := make([]snyk.ExampleCommitFix, 0, len(exampleCommits))
-			for _, commit := range exampleCommits {
-				commitURL := commit.fix.CommitURL
-				commitFixLines := make([]snyk.CommitChangeLine, 0, len(commit.fix.Lines))
-				for _, line := range commit.fix.Lines {
-					commitFixLines = append(commitFixLines, snyk.CommitChangeLine{
-						Line:       line.Line,
-						LineNumber: line.LineNumber,
-						LineChange: line.LineChange})
-				}
-
-				exampleFixes = append(exampleFixes, snyk.ExampleCommitFix{
-					CommitURL: commitURL,
-					Lines:     commitFixLines,
-				})
-			}
-
-			markers, err := s.getMarkers(result, baseDir)
-			errs = errors.Join(errs, err)
-
-			key := util.GetIssueKey(result.RuleID, absPath, startLine, endLine, startCol, endCol)
-			title := testRule.ShortDescription.Text
-			if title == "" {
-				title = testRule.ID
-			}
-
-			additionalData := snyk.CodeIssueData{
-				Key:                key,
-				Title:              title,
-				Message:            result.Message.Text,
-				Rule:               testRule.Name,
-				RuleId:             testRule.ID,
-				RepoDatasetSize:    testRule.Properties.RepoDatasetSize,
-				ExampleCommitFixes: exampleFixes,
-				CWE:                testRule.Properties.Cwe,
-				Text:               testRule.Help.Markdown,
-				Markers:            markers,
-				Cols:               [2]int{startCol, endCol},
-				Rows:               [2]int{startLine, endLine},
-				IsSecurityType:     isSecurityType,
-				IsAutofixable:      result.Properties.IsAutofixable,
-				PriorityScore:      result.Properties.PriorityScore,
-				DataFlow:           s.getCodeFlow(result, baseDir),
-			}
-
-			d := &snyk.Issue{
-				ID:                  result.RuleID,
-				Range:               myRange,
-				Severity:            issueSeverity(result.Level),
-				Message:             message,
-				FormattedMessage:    formattedMessage,
-				IssueType:           types.CodeSecurityVulnerability,
-				ContentRoot:         baseDir,
-				AffectedFilePath:    types.FilePath(absPath),
-				Product:             product.ProductCode,
-				IssueDescriptionURL: ruleLink,
-				References:          s.getReferences(testRule),
-				AdditionalData:      additionalData,
-				CWEs:                testRule.Properties.Cwe,
-				FindingId:           result.Fingerprints.SnykAssetFindingV1,
-			}
-			d.SetFingerPrint(result.Fingerprints.Num1)
-			d.SetGlobalIdentity(result.Fingerprints.Identity)
-			isIgnored, ignoreDetails := GetIgnoreDetailsFromSuppressions(s.engine.GetLogger(), result.Suppressions)
-			d.IsIgnored = isIgnored
-			d.IgnoreDetails = ignoreDetails
-			d.AdditionalData = additionalData
-
-			issues = append(issues, d)
-		}
+		var err2 error
+		issues, err2 = s.appendIssuesForResult(r, result, baseDir, ruleLink, issues)
+		errs = errors.Join(errs, err2)
 	}
 	return issues, errs
 }

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -429,13 +429,14 @@ func (s *SarifConverter) appendIssuesForResult(
 	return issues, errs
 }
 
-func (s *SarifConverter) toIssues(baseDir types.FilePath) (issues []types.Issue, err error) {
+func (s *SarifConverter) toIssues(baseDir types.FilePath) ([]types.Issue, error) {
 	runs := s.sarif.Sarif.Runs
 	if len(runs) == 0 {
-		return issues, nil
+		return nil, nil
 	}
 	ruleLink := createRuleLink()
 	r := runs[0]
+	var issues []types.Issue
 	var errs error
 	for _, result := range r.Results {
 		var err2 error


### PR DESCRIPTION
### **User description**
### Description

Streams SARIF result decoding in the Snyk Code conversion path so large Code scan payloads do not require full result-array materialization before issue conversion.

This is split PR 2 from `performance/IDE-1940_optimize-memory-footprint`. It is temporarily stacked on PR #1250 so the pre-push/test-hook stabilizers from the fixture harness PR are present; after PR #1250 lands this PR can be retargeted to `main`.

### Split Context

```mermaid
flowchart LR
  main[origin/main] --> pr1["PR #1250: test fixture + megaproject harness"]
  pr1 --> pr2["PR #1251: Code SARIF streaming"]
  main --> pr3["PR TBD: OSS CLI streaming"]
  main --> pr4["PR TBD: OSS conversion caches"]
  main --> pr5["PR TBD: IssueCache index + memory backend"]
  pr5 --> pr6["PR TBD: Bolt backend + scanner integration"]
  pr6 --> pr7["PR TBD: Workspace/product cache clearing"]
  main --> pr8["PR TBD: Small hotpath optimizations"]
  main --> pr9["PR TBD: Perf docs + profiling history"]
```

### Scope

- Adds `conversion_stream.go` to token-walk `runs[0].results` with `json.Decoder`.
- Keeps streaming and full-unmarshal conversion behavior aligned through shared result append logic.
- Adds conversion tests for parity, empty runs, and malformed result handling.

### Verification

- `go test -count=1 -v ./infrastructure/code` (`build/pr2_focused_code_tests.log`)
- `make lint` (`build/pr2_make_lint.log`)
- Pre-push hook: `lint-fix` and unit tests passed during `git push --set-upstream origin perf/IDE-1940-code-sarif-streaming`

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduce streaming SARIF result decoding to reduce memory footprint.

- Implement new tests for streaming conversion parity and edge cases.

- Refactor conversion logic to support per-result processing.

- Fallback to full JSON unmarshalling when duplicate SARIF keys are encountered.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Full JSON Unmarshal] --> B{Process Results};
  B --> C(Convert to Issues);
  A --> D{Stream SARIF Decoding};
  D --> E{Process Results (one by one)};
  E --> F(Convert to Issues);
  G[New Test Cases] --> B;
  G --> D;
  H{Duplicate Keys Detected} --> A;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conversion.go</strong><dd><code>Refactor SARIF conversion for streaming and error handling</code></dd></summary>
<hr>

infrastructure/code/conversion.go

<ul><li>Refactor <code>ConvertSARIFJSONToIssues</code> to use streaming JSON decoding.<br> <li> Introduce a new method <code>appendIssuesForResult</code> for processing individual <br>SARIF results.<br> <li> Implement fallback logic to full JSON unmarshalling when duplicate <br>SARIF keys are encountered, to preserve encoding/json semantics.<br> <li> Enhance error handling by joining multiple conversion errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1251/changes#diff-cf02ee8aead14021f3336c6c9c4fe368ce974be4c41bc08bdaa2364326aede89">+38/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conversion_stream.go</strong><dd><code>Implement SARIF JSON streaming decoder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/code/conversion_stream.go

<ul><li>Add new file containing the core streaming logic for SARIF JSON.<br> <li> Implement <code>json.Decoder</code> based token-walking for efficient result <br>processing.<br> <li> Define <code>sarifRunHead</code> and <code>sarifDocumentHead</code> structs for partial parsing.<br> <li> Handle duplicate SARIF keys by returning <br><code>errDuplicateSARIFStreamingKey</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1251/changes#diff-02358a5e5905ef12f9be2122af2217e5ce895c1f07494ee3d40569a2922c8ef7">+177/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convert.go</strong><dd><code>Modularize SARIF conversion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/code/convert.go

<ul><li>Refactor <code>toIssues</code> method to delegate result processing to a new <br><code>appendIssuesForResult</code> method.<br> <li> This change modularizes the conversion logic, supporting the new <br>streaming approach.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1251/changes#diff-c487190192b10556a66dd6213400d3084215c69eb2c4f547285fe7b4ab61c0f4">+127/-113</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conversion_test.go</strong><dd><code>Add unit tests for SARIF streaming conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/code/conversion_test.go

<ul><li>Add new test file for SARIF conversion streaming functionality.<br> <li> Include tests to verify parity between streaming and full <br>unmarshalling.<br> <li> Add tests for empty runs, malformed results, and duplicate keys <br>fallback.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1251/changes#diff-6a35334a7e6bba7a5432e8a4e24f5779c42a87272b84ac7e49e2df3dabd7118c">+279/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

