### PR TITLE
perf(oss): stream CLI scan output [IDE-1940]

### DIFF
--- a/infrastructure/oss/converter.go
+++ b/infrastructure/oss/converter.go
@@ -18,10 +18,12 @@
 package oss
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -82,19 +84,18 @@ func ProcessScanResults(ctx context.Context, scanOutput any, errorReporter error
 		return nil, nil
 	}
 
-	scanResults, err := UnmarshallOssJson(scanOutputBytes)
-	if err != nil {
-		errorReporter.CaptureErrorAndReportAsIssue(filePath, err)
-		return nil, nil
-	}
-
-	for _, scanResult := range scanResults {
-		targetFilePath := getAbsTargetFilePath(&logger, scanResult.Path, scanResult.DisplayTargetFile, workDir, filePath)
+	streamErr := StreamOssJson(bytes.NewReader(scanOutputBytes), func(sr *scanResult) error {
+		targetFilePath := getAbsTargetFilePath(&logger, sr.Path, sr.DisplayTargetFile, workDir, filePath)
 
 		fileContent := getFileContent(targetFilePath, readFiles, logger)
 
-		issues := convertScanResultToIssues(engine, configResolver, &scanResult, workDir, targetFilePath, fileContent, learnService, errorReporter, packageIssueCache, format, folderConfig)
+		issues := convertScanResultToIssues(engine, configResolver, sr, workDir, targetFilePath, fileContent, learnService, errorReporter, packageIssueCache, format, folderConfig)
 		allIssues = append(allIssues, issues...)
+		return nil
+	})
+	if streamErr != nil {
+		errorReporter.CaptureErrorAndReportAsIssue(filePath, streamErr)
+		return nil, nil
 	}
 
 	return allIssues, nil
@@ -109,6 +110,58 @@ func getFileContent(targetFilePath types.FilePath, readFiles bool, logger zerolo
 		return fc
 	}
 	return []byte{}
+}
+
+// StreamOssJson decodes the OSS CLI JSON from r, invoking yield once per scanResult.
+//
+// The array form ([{...}, {...}]) is consumed element-by-element via json.Decoder so
+// that only one *scanResult is resident at a time (IDE-1940). The single-object form
+// ({...}) is supported for parity with UnmarshallOssJson: yield is invoked once.
+//
+// Contract: yield MUST NOT retain *sr across calls. StreamOssJson may reuse the
+// underlying scanResult pointer between iterations; any fields the caller needs
+// after yield returns must be copied out by the caller.
+//
+// Returns the first error encountered (from r, from the decoder, or from yield).
+func StreamOssJson(r io.Reader, yield func(sr *scanResult) error) error {
+	dec := json.NewDecoder(r)
+	tok, err := dec.Token()
+	if err != nil {
+		return errors.Join(err, fmt.Errorf("couldn't read OSS CLI response opening token"))
+	}
+	delim, _ := tok.(json.Delim)
+	switch delim {
+	case '[':
+		for dec.More() {
+			sr := &scanResult{}
+			if decErr := dec.Decode(sr); decErr != nil {
+				return errors.Join(decErr, fmt.Errorf("couldn't decode OSS CLI scanResult element"))
+			}
+			if yieldErr := yield(sr); yieldErr != nil {
+				return yieldErr
+			}
+		}
+		// Consume closing ']' so the stream is fully drained; ignore error after the loop.
+		_, _ = dec.Token()
+		return nil
+	case '{':
+		// We've already consumed the opening '{'. Rebuild the full body by prepending
+		// it to dec.Buffered() (bytes read but not yet consumed) and any remaining
+		// bytes from r, then unmarshal as a single scanResult. Single-object mode is
+		// not the hot path, so correctness trumps streaming here.
+		var buf bytes.Buffer
+		buf.WriteByte('{')
+		if _, copyErr := io.Copy(&buf, io.MultiReader(dec.Buffered(), r)); copyErr != nil {
+			return errors.Join(copyErr, fmt.Errorf("couldn't read single-object OSS CLI response"))
+		}
+		sr := &scanResult{}
+		if unmErr := json.Unmarshal(buf.Bytes(), sr); unmErr != nil {
+			return errors.Join(unmErr, fmt.Errorf("couldn't unmarshal single-object OSS CLI response"))
+		}
+		return yield(sr)
+	default:
+		return fmt.Errorf("unexpected OSS CLI response opening token: %v", tok)
+	}
 }
 
 // UnmarshallOssJson is a standalone version of CLIScanner.unmarshallOssJson

--- a/infrastructure/oss/converter_test.go
+++ b/infrastructure/oss/converter_test.go
@@ -1,0 +1,168 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const threeElementArrayJSON = `[
+  {
+    "projectName": "proj-a",
+    "packageManager": "npm",
+    "path": "/tmp/a",
+    "displayTargetFile": "a/package.json",
+    "vulnerabilities": [
+      {"id": "SNYK-A-1", "name": "pkg-a", "title": "t-a", "severity": "high"}
+    ]
+  },
+  {
+    "projectName": "proj-b",
+    "packageManager": "maven",
+    "path": "/tmp/b",
+    "displayTargetFile": "b/pom.xml",
+    "vulnerabilities": [
+      {"id": "SNYK-B-1", "name": "pkg-b", "title": "t-b", "severity": "medium"},
+      {"id": "SNYK-B-2", "name": "pkg-b", "title": "t-b-2", "severity": "low"}
+    ]
+  },
+  {
+    "projectName": "proj-c",
+    "packageManager": "gomodules",
+    "path": "/tmp/c",
+    "displayTargetFile": "c/go.mod",
+    "vulnerabilities": []
+  }
+]`
+
+const singleObjectJSON = `{
+  "projectName": "solo",
+  "packageManager": "pip",
+  "path": "/tmp/solo",
+  "displayTargetFile": "solo/requirements.txt",
+  "vulnerabilities": [
+    {"id": "SNYK-SOLO-1", "name": "pkg-solo", "title": "t-solo", "severity": "critical"}
+  ]
+}`
+
+func TestStreamOssJson_ArrayForm_YieldsEachElement(t *testing.T) {
+	var got []scanResult
+	err := StreamOssJson(strings.NewReader(threeElementArrayJSON), func(sr *scanResult) error {
+		// copy out (the contract says yield must not retain *sr across calls)
+		got = append(got, *sr)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	assert.Equal(t, "proj-a", got[0].ProjectName)
+	assert.Equal(t, "npm", got[0].PackageManager)
+	assert.Equal(t, "a/package.json", got[0].DisplayTargetFile)
+	require.Len(t, got[0].Vulnerabilities, 1)
+	assert.Equal(t, "SNYK-A-1", got[0].Vulnerabilities[0].Id)
+
+	assert.Equal(t, "proj-b", got[1].ProjectName)
+	assert.Equal(t, "maven", got[1].PackageManager)
+	require.Len(t, got[1].Vulnerabilities, 2)
+	assert.Equal(t, "SNYK-B-1", got[1].Vulnerabilities[0].Id)
+	assert.Equal(t, "SNYK-B-2", got[1].Vulnerabilities[1].Id)
+
+	assert.Equal(t, "proj-c", got[2].ProjectName)
+	assert.Equal(t, "gomodules", got[2].PackageManager)
+	assert.Empty(t, got[2].Vulnerabilities)
+}
+
+func TestStreamOssJson_SingleObjectForm_YieldsOnce(t *testing.T) {
+	calls := 0
+	var got scanResult
+	err := StreamOssJson(strings.NewReader(singleObjectJSON), func(sr *scanResult) error {
+		calls++
+		got = *sr
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "solo", got.ProjectName)
+	assert.Equal(t, "pip", got.PackageManager)
+	assert.Equal(t, "solo/requirements.txt", got.DisplayTargetFile)
+	require.Len(t, got.Vulnerabilities, 1)
+	assert.Equal(t, "SNYK-SOLO-1", got.Vulnerabilities[0].Id)
+}
+
+func TestStreamOssJson_YieldErrorShortCircuits(t *testing.T) {
+	yieldErr := errors.New("stop here")
+	calls := 0
+	err := StreamOssJson(strings.NewReader(threeElementArrayJSON), func(sr *scanResult) error {
+		calls++
+		if calls == 2 {
+			return yieldErr
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, yieldErr)
+	assert.Equal(t, 2, calls, "yield must not be invoked after returning an error")
+}
+
+func TestStreamOssJson_MalformedJSON_ReturnsError(t *testing.T) {
+	truncated := `[{"projectName":"a"},`
+	calls := 0
+	err := StreamOssJson(strings.NewReader(truncated), func(sr *scanResult) error {
+		calls++
+		return nil
+	})
+	require.Error(t, err)
+}
+
+func TestStreamOssJson_EmptyArray_YieldsZeroTimes(t *testing.T) {
+	calls := 0
+	err := StreamOssJson(strings.NewReader(`[]`), func(sr *scanResult) error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, calls)
+}
+
+func TestStreamOssJson_ParityWithUnmarshallOssJson(t *testing.T) {
+	expected, err := UnmarshallOssJson([]byte(threeElementArrayJSON))
+	require.NoError(t, err)
+	require.Len(t, expected, 3)
+
+	var streamed []scanResult
+	err = StreamOssJson(strings.NewReader(threeElementArrayJSON), func(sr *scanResult) error {
+		streamed = append(streamed, *sr)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, streamed, len(expected))
+
+	for i := range expected {
+		assert.Equal(t, expected[i].ProjectName, streamed[i].ProjectName, "index %d", i)
+		assert.Equal(t, expected[i].PackageManager, streamed[i].PackageManager, "index %d", i)
+		assert.Equal(t, expected[i].Path, streamed[i].Path, "index %d", i)
+		assert.Equal(t, expected[i].DisplayTargetFile, streamed[i].DisplayTargetFile, "index %d", i)
+		require.Equal(t, len(expected[i].Vulnerabilities), len(streamed[i].Vulnerabilities), "index %d", i)
+		if len(expected[i].Vulnerabilities) > 0 {
+			assert.Equal(t, expected[i].Vulnerabilities[0].Id, streamed[i].Vulnerabilities[0].Id, "index %d", i)
+		}
+	}
+}


### PR DESCRIPTION
### **User description**
### Description

Streams OSS CLI scan output element-by-element instead of unmarshalling the full CLI JSON payload into memory before conversion.

This is split PR 3 from `performance/IDE-1940_optimize-memory-footprint`. It is temporarily stacked on PR #1250 so the pre-push/test-hook stabilizers from the fixture harness PR are present; after PR #1250 lands this PR can be retargeted to `main`.

### Split Context

```mermaid
flowchart LR
  main[origin/main] --> pr1["PR #1250: test fixture + megaproject harness"]
  pr1 --> pr2["PR #1251: Code SARIF streaming"]
  pr1 --> pr3["PR #1253: OSS CLI streaming"]
  main --> pr4["PR TBD: OSS conversion caches"]
  main --> pr5["PR TBD: IssueCache index + memory backend"]
  pr5 --> pr6["PR TBD: Bolt backend + scanner integration"]
  pr6 --> pr7["PR TBD: Workspace/product cache clearing"]
  main --> pr8["PR TBD: Small hotpath optimizations"]
  main --> pr9["PR TBD: Perf docs + profiling history"]
```

### Scope

- Adds streamed decoding for OSS CLI JSON arrays so each scan result can be processed and released before decoding the next.
- Preserves single-object OSS JSON handling and the existing `UnmarshallOssJson` compatibility path.
- Adds parity and error-path tests for streamed OSS conversion.

### Verification

- `go test -count=1 -v ./infrastructure/oss` (`build/pr3_focused_oss_tests.log`)
- `make lint` (`build/pr3_make_lint.log`)
- Pre-push hook: `lint-fix` and unit tests passed during `git push --set-upstream origin perf/IDE-1940-oss-cli-streaming`

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced


___

### **PR Type**
enhancement, tests


___

### **Description**
- Stream OSS CLI JSON output for memory efficiency.

- Process scan results element-by-element.

- Introduce comprehensive test suite for streaming.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pr1("PR #1250: test fixture + megaproject harness")
  pr3("PR #1253: OSS CLI streaming")
  pr1 --> pr3
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter.go</strong><dd><code>Implement streaming for OSS CLI JSON output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/converter.go

<ul><li>Replaced bulk JSON unmarshalling with a streaming approach for OSS CLI <br>scan results.<br> <li> Introduced <code>StreamOssJson</code> to process JSON element-by-element, reducing <br>memory footprint.<br> <li> Enhanced <code>ProcessScanResults</code> to utilize the new streaming function.<br> <li> Maintained compatibility with the previous <code>UnmarshallOssJson</code> for <br>existing use cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1253/changes#diff-40fc8cb002a21205554b0456118cb66cf2a286eb851a28c759c4eca5722ea1da">+62/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter_test.go</strong><dd><code>Add tests for OSS CLI JSON streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/converter_test.go

<ul><li>Added a new test file for OSS CLI JSON streaming functionality.<br> <li> Created tests for array, single-object, empty array, and malformed <br>JSON inputs.<br> <li> Implemented tests to verify error propagation and parity with the <br>legacy unmarshalling method.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1253/changes#diff-7fde69594c4434380be94e02f1270c543cd0964a5c1d234b7d49780362f4868b">+168/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

