### PR TITLE
perf(oss): reduce conversion allocations [IDE-1940]

### DIFF
--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -36,21 +36,32 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
-func toIssue(engine workflow.Engine, configResolver types.ConfigResolverInterface, workDir types.FilePath, affectedFilePath types.FilePath, issue ossIssue, scanResult *scanResult, issueDepNode *ast.Node, learnService learn.Service, ep error_reporting.ErrorReporter, format string, folderConfig *types.FolderConfig) *snyk.Issue {
+// vulnIndicesByID maps each vulnerability id to indices into scanResult.Vulnerabilities (scan order).
+func vulnIndicesByID(res *scanResult) map[string][]int {
+	if res == nil || len(res.Vulnerabilities) == 0 {
+		return nil
+	}
+	out := make(map[string][]int)
+	for i := range res.Vulnerabilities {
+		id := res.Vulnerabilities[i].Id
+		out[id] = append(out[id], i)
+	}
+	return out
+}
+
+func toIssue(engine workflow.Engine, configResolver types.ConfigResolverInterface, workDir types.FilePath, affectedFilePath types.FilePath, issue ossIssue, scanResult *scanResult, sameIDIndices []int, issueDepNode *ast.Node, learnService learn.Service, ep error_reporting.ErrorReporter, format string, folderConfig *types.FolderConfig) *snyk.Issue {
 	rangeFromNode := getRangeFromNode(issueDepNode)
 
-	// find all issues with the same id
-	matchingIssues := []snyk.OssIssueData{}
-	for _, otherIssue := range scanResult.Vulnerabilities {
-		if otherIssue.Id == issue.Id {
-			matchingIssues = append(matchingIssues, otherIssue.toAdditionalData(
-				engine,
-				scanResult,
-				[]snyk.OssIssueData{},
-				affectedFilePath,
-				rangeFromNode,
-			))
-		}
+	matchingIssues := make([]snyk.OssIssueData, 0, len(sameIDIndices))
+	for _, idx := range sameIDIndices {
+		otherIssue := &scanResult.Vulnerabilities[idx]
+		matchingIssues = append(matchingIssues, otherIssue.toAdditionalData(
+			engine,
+			scanResult,
+			[]snyk.OssIssueData{},
+			affectedFilePath,
+			rangeFromNode,
+		))
 	}
 
 	additionalData := issue.toAdditionalData(engine, scanResult, matchingIssues, affectedFilePath, rangeFromNode)
@@ -175,6 +186,7 @@ func convertScanResultToIssues(engine workflow.Engine, configResolver types.Conf
 	var issues []types.Issue
 
 	duplicateCheckMap := map[string]bool{}
+	byID := vulnIndicesByID(res)
 
 	for _, ossLegacyIssue := range res.Vulnerabilities {
 		if ossLegacyIssue.IsIgnored {
@@ -187,7 +199,8 @@ func convertScanResultToIssues(engine workflow.Engine, configResolver types.Conf
 			continue
 		}
 		node := getDependencyNode(&logger, targetFilePath, ossLegacyIssue.PackageManager, ossLegacyIssue.From, fileContent)
-		snykIssue := toIssue(engine, configResolver, workDir, targetFilePath, ossLegacyIssue, res, node, learnService, ep, format, folderConfig)
+		sameID := byID[ossLegacyIssue.Id]
+		snykIssue := toIssue(engine, configResolver, workDir, targetFilePath, ossLegacyIssue, res, sameID, node, learnService, ep, format, folderConfig)
 		packageIssueCacheMutex.Lock()
 		packageIssueCache[packageKey] = append(packageIssueCache[packageKey], snykIssue)
 		packageIssueCacheMutex.Unlock()

--- a/infrastructure/oss/issue_test.go
+++ b/infrastructure/oss/issue_test.go
@@ -1,0 +1,119 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+func TestVulnIndicesByID_GroupsIndicesInScanOrder(t *testing.T) {
+	res := &scanResult{
+		Vulnerabilities: []ossIssue{
+			{Id: "A", PackageName: "p1"},
+			{Id: "B", PackageName: "p2"},
+			{Id: "A", PackageName: "p3"},
+		},
+	}
+	got := vulnIndicesByID(res)
+	require.Len(t, got, 2)
+	assert.Equal(t, []int{0, 2}, got["A"])
+	assert.Equal(t, []int{1}, got["B"])
+}
+
+func TestVulnIndicesByID_NilOrEmpty(t *testing.T) {
+	assert.Nil(t, vulnIndicesByID(nil))
+	assert.Nil(t, vulnIndicesByID(&scanResult{}))
+}
+
+func TestConvertScanResultToIssues_SameIdMultiplePackages_MatchingIssuesIncludesAllSameId(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	issueID := "SNYK-DUP-1"
+	scanResult := &scanResult{
+		ProjectName: "test-project",
+		Vulnerabilities: []ossIssue{
+			{
+				Id:             issueID,
+				Name:           "n1",
+				Title:          "t1",
+				Severity:       "high",
+				PackageName:    "pkg-a",
+				Version:        "1.0.0",
+				PackageManager: "npm",
+				From:           []string{"lodash@4.17.4"},
+			},
+			{
+				Id:             issueID,
+				Name:           "n2",
+				Title:          "t2",
+				Severity:       "high",
+				PackageName:    "pkg-b",
+				Version:        "2.0.0",
+				PackageManager: "npm",
+				From:           []string{"lodash@4.17.4"},
+			},
+			{
+				Id:             issueID,
+				Name:           "n3",
+				Title:          "t3",
+				Severity:       "high",
+				PackageName:    "pkg-c",
+				Version:        "3.0.0",
+				PackageManager: "npm",
+				From:           []string{"lodash@4.17.4"},
+			},
+		},
+	}
+
+	workDir := types.FilePath("/test/workdir")
+	targetFilePath := types.FilePath("/test/workdir/package.json")
+	fileContent := []byte(`{"dependencies":{"lodash":"4.17.4"}}`)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	learnService := mock_learn.NewMockService(ctrl)
+	learnService.EXPECT().
+		GetLesson(gomock.Any(), issueID, gomock.Any(), gomock.Any(), types.DependencyVulnerability).
+		Return(&learn.Lesson{Url: "https://learn.snyk.io/lesson/test"}, nil).
+		AnyTimes()
+
+	errorReporter := error_reporting.NewTestErrorReporter(engine)
+	packageIssueCache := make(map[string][]types.Issue)
+	configResolver := testutil.DefaultConfigResolver(engine)
+
+	issues := convertScanResultToIssues(engine, configResolver, scanResult, workDir, targetFilePath, fileContent, learnService, errorReporter, packageIssueCache, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingFormat)), nil)
+
+	require.Len(t, issues, 3)
+	for _, i := range issues {
+		si, ok := i.(*snyk.Issue)
+		require.True(t, ok)
+		ad, ok := si.AdditionalData.(snyk.OssIssueData)
+		require.True(t, ok)
+		assert.Len(t, ad.MatchingIssues, 3, "each issue should list all three same-id vulns as matching")
+	}
+}

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -113,7 +113,7 @@ func Test_toIssue_LearnParameterConversion(t *testing.T) {
 		learnService: getLearnMock(t),
 	}
 	contentRoot := types.FilePath("/path/to/issue")
-	issue := toIssue(engine, defaultResolver(t, engine), contentRoot, types.FilePath("testPath"), sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingFormat)), nil)
+	issue := toIssue(engine, defaultResolver(t, engine), contentRoot, types.FilePath("testPath"), sampleOssIssue, &scanResult{}, nil, nonEmptyNode(), scanner.learnService, scanner.errorReporter, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingFormat)), nil)
 
 	assert.Equal(t, sampleOssIssue.Id, issue.ID)
 	assert.Equal(t, sampleOssIssue.Identifiers.CWE, issue.CWEs)
@@ -158,7 +158,7 @@ func Test_toIssue_CodeActions(t *testing.T) {
 			sampleOssIssue.UpgradePath = []any{"false", test.packageName}
 			contentRoot := types.FilePath("/path/to/issue")
 
-			issue := toIssue(engine, defaultResolver(t, engine), contentRoot, types.FilePath("testPath"), sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingFormat)), nil)
+			issue := toIssue(engine, defaultResolver(t, engine), contentRoot, types.FilePath("testPath"), sampleOssIssue, &scanResult{}, nil, nonEmptyNode(), scanner.learnService, scanner.errorReporter, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingFormat)), nil)
 
 			assert.Equal(t, sampleOssIssue.Id, issue.ID)
 			assert.Equal(t, flashy+test.expectedUpgrade, issue.CodeActions[0].GetTitle())
@@ -189,7 +189,7 @@ func Test_toIssue_CodeActions_WithoutFix(t *testing.T) {
 	sampleOssIssue.UpgradePath = []any{"*"}
 	contentRoot := types.FilePath("/path/to/issue")
 
-	issue := toIssue(engine, defaultResolver(t, engine), contentRoot, types.FilePath("testPath"), sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingFormat)), nil)
+	issue := toIssue(engine, defaultResolver(t, engine), contentRoot, types.FilePath("testPath"), sampleOssIssue, &scanResult{}, nil, nonEmptyNode(), scanner.learnService, scanner.errorReporter, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingFormat)), nil)
 
 	assert.Equal(t, sampleOssIssue.Id, issue.ID)
 	assert.Equal(t, 2, len(issue.CodeActions))

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gomarkdown/markdown"
@@ -240,7 +241,36 @@ func (i *ossIssue) GetRemediation() string {
 	return "No remediation advice available"
 }
 
-func GetExtendedMessage(configResolver types.ConfigResolverInterface, engine workflow.Engine, id, title, description, severity, packageName string, cves, cwes, fixedIn []string, folderConfig *types.FolderConfig) string {
+// extendedMessageCache memoizes GetExtendedMessage for identical vulnerability rows (megaproject-scale OSS scans).
+var extendedMessageCache sync.Map // key: extendedMessageCacheKey, value: string
+
+type extendedMessageCacheKey struct {
+	formatKey   string
+	id          string
+	title       string
+	description string
+	severity    string
+	packageName string
+	cves        string
+	cwes        string
+	fixedIn     string
+}
+
+func joinIdentifierParts(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func extendedMessageFormatKey(configResolver types.ConfigResolverInterface, folderConfig *types.FolderConfig) string {
+	if configResolver != nil && configResolver.GetString(types.SettingFormat, folderConfig) == config.FormatHtml {
+		return "html"
+	}
+	return "md"
+}
+
+func buildExtendedMessage(configResolver types.ConfigResolverInterface, engine workflow.Engine, id, title, description, severity, packageName string, cves, cwes, fixedIn []string, folderConfig *types.FolderConfig) string {
 	if configResolver != nil && configResolver.GetString(types.SettingFormat, folderConfig) == config.FormatHtml {
 		title = string(markdown.ToHTML([]byte(title), nil, nil))
 		description = string(markdown.ToHTML([]byte(description), nil, nil))
@@ -259,6 +289,33 @@ func GetExtendedMessage(configResolver types.ConfigResolverInterface, engine wor
 		packageName,
 		summary,
 		description)
+}
+
+func GetExtendedMessage(configResolver types.ConfigResolverInterface, engine workflow.Engine, id, title, description, severity, packageName string, cves, cwes, fixedIn []string, folderConfig *types.FolderConfig) string {
+	key := extendedMessageCacheKey{
+		formatKey:   extendedMessageFormatKey(configResolver, folderConfig),
+		id:          id,
+		title:       title,
+		description: description,
+		severity:    severity,
+		packageName: packageName,
+		cves:        joinIdentifierParts(cves),
+		cwes:        joinIdentifierParts(cwes),
+		fixedIn:     joinIdentifierParts(fixedIn),
+	}
+	if v, ok := extendedMessageCache.Load(key); ok {
+		s, ok := v.(string)
+		if ok {
+			return s
+		}
+	}
+	msg := buildExtendedMessage(configResolver, engine, id, title, description, severity, packageName, cves, cwes, fixedIn, folderConfig)
+	actual, _ := extendedMessageCache.LoadOrStore(key, msg)
+	s, ok := actual.(string)
+	if ok {
+		return s
+	}
+	return msg
 }
 
 func createCveLink(cves []string) string {

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -185,7 +185,10 @@ func (i *ossIssue) getLessonURL() string {
 }
 
 func (i *ossIssue) toReferences(engine workflow.Engine) []types.Reference {
-	var references []types.Reference
+	if len(i.References) == 0 {
+		return nil
+	}
+	references := make([]types.Reference, 0, len(i.References))
 	for _, ref := range i.References {
 		references = append(references, ref.toReference(engine))
 	}
@@ -193,7 +196,7 @@ func (i *ossIssue) toReferences(engine workflow.Engine) []types.Reference {
 }
 
 func (r reference) toReference(engine workflow.Engine) types.Reference {
-	u, err := url.Parse(string(r.Url))
+	u, err := urlParseCachedCopy(string(r.Url))
 	if err != nil {
 		engine.GetLogger().Err(err).Msg("Unable to parse reference url: " + string(r.Url))
 	}
@@ -331,7 +334,7 @@ func createIssueUrlMarkdown(engine workflow.Engine, vulnID string) string {
 }
 
 func CreateIssueURL(engine workflow.Engine, vulnID string) *url.URL {
-	parse, err := url.Parse("https://snyk.io/vuln/" + vulnID)
+	parse, err := urlParseCachedCopy("https://snyk.io/vuln/" + vulnID)
 	if err != nil {
 		engine.GetLogger().Err(err).Msg("Unable to create issue link for issue:" + vulnID)
 	}

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -244,8 +244,56 @@ func (i *ossIssue) GetRemediation() string {
 	return "No remediation advice available"
 }
 
-// extendedMessageCache memoizes GetExtendedMessage for identical vulnerability rows (megaproject-scale OSS scans).
-var extendedMessageCache sync.Map // key: extendedMessageCacheKey, value: string
+const maxExtendedMessageCacheEntries = 4096
+
+// extendedMessageCache memoizes GetExtendedMessage for identical vulnerability rows while keeping
+// a hard cap so long-lived language-server sessions do not retain scan-derived text indefinitely.
+var extendedMessageCache = newBoundedExtendedMessageCache(maxExtendedMessageCacheEntries)
+
+type boundedExtendedMessageCache struct {
+	mu     sync.RWMutex
+	max    int
+	values map[extendedMessageCacheKey]string
+}
+
+func newBoundedExtendedMessageCache(limit int) *boundedExtendedMessageCache {
+	return &boundedExtendedMessageCache{
+		max:    limit,
+		values: make(map[extendedMessageCacheKey]string),
+	}
+}
+
+func (c *boundedExtendedMessageCache) load(key extendedMessageCacheKey) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v, ok := c.values[key]
+	return v, ok
+}
+
+func (c *boundedExtendedMessageCache) loadOrStore(key extendedMessageCacheKey, value string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.values[key]; ok {
+		return existing
+	}
+	if len(c.values) >= c.max {
+		return value
+	}
+	c.values[key] = value
+	return value
+}
+
+func (c *boundedExtendedMessageCache) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.values)
+}
+
+func (c *boundedExtendedMessageCache) resetForTests() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values = make(map[extendedMessageCacheKey]string)
+}
 
 type extendedMessageCacheKey struct {
 	formatKey   string
@@ -306,19 +354,11 @@ func GetExtendedMessage(configResolver types.ConfigResolverInterface, engine wor
 		cwes:        joinIdentifierParts(cwes),
 		fixedIn:     joinIdentifierParts(fixedIn),
 	}
-	if v, ok := extendedMessageCache.Load(key); ok {
-		s, ok := v.(string)
-		if ok {
-			return s
-		}
-	}
-	msg := buildExtendedMessage(configResolver, engine, id, title, description, severity, packageName, cves, cwes, fixedIn, folderConfig)
-	actual, _ := extendedMessageCache.LoadOrStore(key, msg)
-	s, ok := actual.(string)
-	if ok {
+	if s, ok := extendedMessageCache.load(key); ok {
 		return s
 	}
-	return msg
+	msg := buildExtendedMessage(configResolver, engine, id, title, description, severity, packageName, cves, cwes, fixedIn, folderConfig)
+	return extendedMessageCache.loadOrStore(key, msg)
 }
 
 func createCveLink(cves []string) string {

--- a/infrastructure/oss/types_extended_message_test.go
+++ b/infrastructure/oss/types_extended_message_test.go
@@ -1,0 +1,108 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+func TestGetExtendedMessage_memoizationMatchesDirectBuild(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingFormat), config.FormatMd)
+	issue := sampleIssue()
+	resolver := defaultResolver(t, engine)
+	want := buildExtendedMessage(
+		resolver, engine,
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+		nil,
+	)
+	got := GetExtendedMessage(
+		resolver, engine,
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+		nil,
+	)
+	require.Equal(t, want, got)
+	gotAgain := GetExtendedMessage(
+		resolver, engine,
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+		nil,
+	)
+	assert.Equal(t, want, gotAgain)
+}
+
+func TestGetExtendedMessage_differentPackageNameNotDeduped(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingFormat), config.FormatMd)
+	issue := sampleIssue()
+	resolver := defaultResolver(t, engine)
+	a := GetExtendedMessage(
+		resolver, engine,
+		issue.Id, issue.Title, issue.Description, issue.Severity, "pkg-a",
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+		nil,
+	)
+	b := GetExtendedMessage(
+		resolver, engine,
+		issue.Id, issue.Title, issue.Description, issue.Severity, "pkg-b",
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+		nil,
+	)
+	require.NotEqual(t, a, b)
+	assert.Contains(t, a, "pkg-a")
+	assert.Contains(t, b, "pkg-b")
+}
+
+func TestGetExtendedMessage_concurrentSameArgs(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingFormat), config.FormatMd)
+	issue := sampleIssue()
+	resolver := defaultResolver(t, engine)
+	first := GetExtendedMessage(
+		resolver, engine,
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+		nil,
+	)
+	const workers = 64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			g := GetExtendedMessage(
+				resolver, engine,
+				issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+				issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+				nil,
+			)
+			assert.Equal(t, first, g)
+		}()
+	}
+	wg.Wait()
+}

--- a/infrastructure/oss/types_extended_message_test.go
+++ b/infrastructure/oss/types_extended_message_test.go
@@ -17,6 +17,7 @@
 package oss
 
 import (
+	"strconv"
 	"sync"
 	"testing"
 
@@ -30,6 +31,7 @@ import (
 )
 
 func TestGetExtendedMessage_memoizationMatchesDirectBuild(t *testing.T) {
+	extendedMessageCache.resetForTests()
 	engine := testutil.UnitTest(t)
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingFormat), config.FormatMd)
 	issue := sampleIssue()
@@ -57,6 +59,7 @@ func TestGetExtendedMessage_memoizationMatchesDirectBuild(t *testing.T) {
 }
 
 func TestGetExtendedMessage_differentPackageNameNotDeduped(t *testing.T) {
+	extendedMessageCache.resetForTests()
 	engine := testutil.UnitTest(t)
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingFormat), config.FormatMd)
 	issue := sampleIssue()
@@ -79,6 +82,7 @@ func TestGetExtendedMessage_differentPackageNameNotDeduped(t *testing.T) {
 }
 
 func TestGetExtendedMessage_concurrentSameArgs(t *testing.T) {
+	extendedMessageCache.resetForTests()
 	engine := testutil.UnitTest(t)
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingFormat), config.FormatMd)
 	issue := sampleIssue()
@@ -105,4 +109,23 @@ func TestGetExtendedMessage_concurrentSameArgs(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestGetExtendedMessage_cacheIsBounded(t *testing.T) {
+	extendedMessageCache.resetForTests()
+	engine := testutil.UnitTest(t)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingFormat), config.FormatMd)
+	issue := sampleIssue()
+	resolver := defaultResolver(t, engine)
+
+	for i := range maxExtendedMessageCacheEntries + 10 {
+		_ = GetExtendedMessage(
+			resolver, engine,
+			issue.Id+"-"+strconv.Itoa(i), issue.Title, issue.Description, issue.Severity, issue.PackageName,
+			issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+			nil,
+		)
+	}
+
+	assert.LessOrEqual(t, extendedMessageCache.len(), maxExtendedMessageCacheEntries)
 }

--- a/infrastructure/oss/unified_converter.go
+++ b/infrastructure/oss/unified_converter.go
@@ -521,23 +521,20 @@ func buildOssIssueData(
 
 // extractReferences extracts references from finding and vulnerability problem
 func extractReferences(problem *testapi.SnykVulnProblem) []types.Reference {
-	references := []types.Reference{} // Initialize as empty slice, not nil
-
-	// Extract references from vulnerability problem if available
-	if problem != nil && len(problem.References) > 0 {
-		for _, ref := range problem.References {
-			// Parse URL string to *url.URL
-			parsedURL, err := url.Parse(ref.Url)
-			if err != nil {
-				continue
-			}
-			references = append(references, types.Reference{
-				Title: ref.Title,
-				Url:   parsedURL,
-			})
-		}
+	if problem == nil || len(problem.References) == 0 {
+		return []types.Reference{}
 	}
-
+	references := make([]types.Reference, 0, len(problem.References))
+	for _, ref := range problem.References {
+		parsedURL, err := urlParseCachedCopy(ref.Url)
+		if err != nil {
+			continue
+		}
+		references = append(references, types.Reference{
+			Title: ref.Title,
+			Url:   parsedURL,
+		})
+	}
 	return references
 }
 
@@ -704,11 +701,10 @@ func extractLicense(finding *testapi.FindingData) string {
 
 // createIssueURL creates the Snyk issue description URL
 func createIssueURL(id string) *url.URL {
-	u, err := url.Parse(fmt.Sprintf("https://snyk.io/vuln/%s", id))
+	u, err := urlParseCachedCopy("https://snyk.io/vuln/" + id)
 	if err != nil {
 		return nil
 	}
-
 	return u
 }
 

--- a/infrastructure/oss/url_parse_cache.go
+++ b/infrastructure/oss/url_parse_cache.go
@@ -1,0 +1,45 @@
+/*
+ * © 2025-2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"net/url"
+	"sync"
+)
+
+// parsedURLStringCache stores one *url.URL per distinct raw URL string (megaproject-scale
+// OSS scans repeat the same advisory links across many findings).
+var parsedURLStringCache sync.Map // string -> *url.URL (canonical parsed value; not mutated after store)
+
+// urlParseCachedCopy parses raw once per distinct string and returns a shallow copy of *url.URL
+// so each consumer keeps an independent pointer (same semantics as calling url.Parse every time).
+func urlParseCachedCopy(raw string) (*url.URL, error) {
+	if v, ok := parsedURLStringCache.Load(raw); ok {
+		orig, ok := v.(*url.URL)
+		if ok {
+			c := *orig
+			return &c, nil
+		}
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	parsedURLStringCache.Store(raw, u)
+	c := *u
+	return &c, nil
+}

--- a/infrastructure/oss/url_parse_cache.go
+++ b/infrastructure/oss/url_parse_cache.go
@@ -21,25 +21,71 @@ import (
 	"sync"
 )
 
-// parsedURLStringCache stores one *url.URL per distinct raw URL string (megaproject-scale
-// OSS scans repeat the same advisory links across many findings).
-var parsedURLStringCache sync.Map // string -> *url.URL (canonical parsed value; not mutated after store)
+const maxParsedURLStringCacheEntries = 4096
+
+// parsedURLStringCache stores one *url.URL per distinct raw URL string while keeping
+// a hard cap so long-lived language-server sessions do not retain every unique URL.
+var parsedURLStringCache = newBoundedURLParseCache(maxParsedURLStringCacheEntries)
+
+type boundedURLParseCache struct {
+	mu     sync.RWMutex
+	max    int
+	values map[string]*url.URL
+}
+
+func newBoundedURLParseCache(limit int) *boundedURLParseCache {
+	return &boundedURLParseCache{
+		max:    limit,
+		values: make(map[string]*url.URL),
+	}
+}
+
+func (c *boundedURLParseCache) loadCopy(raw string) (*url.URL, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	orig, ok := c.values[raw]
+	if !ok {
+		return nil, false
+	}
+	copied := *orig
+	return &copied, true
+}
+
+func (c *boundedURLParseCache) storeCopy(raw string, parsed *url.URL) *url.URL {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.values[raw]; ok {
+		copied := *existing
+		return &copied
+	}
+	if len(c.values) < c.max {
+		c.values[raw] = parsed
+	}
+	copied := *parsed
+	return &copied
+}
+
+func (c *boundedURLParseCache) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.values)
+}
+
+func (c *boundedURLParseCache) resetForTests() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values = make(map[string]*url.URL)
+}
 
 // urlParseCachedCopy parses raw once per distinct string and returns a shallow copy of *url.URL
 // so each consumer keeps an independent pointer (same semantics as calling url.Parse every time).
 func urlParseCachedCopy(raw string) (*url.URL, error) {
-	if v, ok := parsedURLStringCache.Load(raw); ok {
-		orig, ok := v.(*url.URL)
-		if ok {
-			c := *orig
-			return &c, nil
-		}
+	if cached, ok := parsedURLStringCache.loadCopy(raw); ok {
+		return cached, nil
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
 		return nil, err
 	}
-	parsedURLStringCache.Store(raw, u)
-	c := *u
-	return &c, nil
+	return parsedURLStringCache.storeCopy(raw, u), nil
 }

--- a/infrastructure/oss/url_parse_cache_test.go
+++ b/infrastructure/oss/url_parse_cache_test.go
@@ -1,0 +1,51 @@
+/*
+ * © 2025 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+)
+
+func TestURLParseCachedCopy_sameRaw_distinctPointers_equalValue(t *testing.T) {
+	const raw = "https://example.com/path?q=1"
+	a, err := urlParseCachedCopy(raw)
+	require.NoError(t, err)
+	b, err := urlParseCachedCopy(raw)
+	require.NoError(t, err)
+	assert.Equal(t, a.String(), b.String())
+	assert.NotSame(t, a, b, "each call should return an independent pointer")
+}
+
+func TestURLParseCachedCopy_parseError(t *testing.T) {
+	_, err := urlParseCachedCopy("://invalid")
+	assert.Error(t, err)
+}
+
+func TestCreateIssueURL_usesCache_distinctPointers(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	u1 := CreateIssueURL(engine, "SNYK-JS-TEST")
+	u2 := CreateIssueURL(engine, "SNYK-JS-TEST")
+	require.NotNil(t, u1)
+	require.NotNil(t, u2)
+	assert.Equal(t, u1.String(), u2.String())
+	assert.NotSame(t, u1, u2)
+}

--- a/infrastructure/oss/url_parse_cache_test.go
+++ b/infrastructure/oss/url_parse_cache_test.go
@@ -17,6 +17,7 @@
 package oss
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ import (
 )
 
 func TestURLParseCachedCopy_sameRaw_distinctPointers_equalValue(t *testing.T) {
+	parsedURLStringCache.resetForTests()
 	const raw = "https://example.com/path?q=1"
 	a, err := urlParseCachedCopy(raw)
 	require.NoError(t, err)
@@ -41,6 +43,7 @@ func TestURLParseCachedCopy_parseError(t *testing.T) {
 }
 
 func TestCreateIssueURL_usesCache_distinctPointers(t *testing.T) {
+	parsedURLStringCache.resetForTests()
 	engine := testutil.UnitTest(t)
 	u1 := CreateIssueURL(engine, "SNYK-JS-TEST")
 	u2 := CreateIssueURL(engine, "SNYK-JS-TEST")
@@ -48,4 +51,15 @@ func TestCreateIssueURL_usesCache_distinctPointers(t *testing.T) {
 	require.NotNil(t, u2)
 	assert.Equal(t, u1.String(), u2.String())
 	assert.NotSame(t, u1, u2)
+}
+
+func TestURLParseCachedCopy_cacheIsBounded(t *testing.T) {
+	parsedURLStringCache.resetForTests()
+
+	for i := range maxParsedURLStringCacheEntries + 10 {
+		_, err := urlParseCachedCopy("https://example.com/path/" + strconv.Itoa(i))
+		require.NoError(t, err)
+	}
+
+	assert.LessOrEqual(t, parsedURLStringCache.len(), maxParsedURLStringCacheEntries)
 }


### PR DESCRIPTION
### **User description**
### Description

Reduces OSS conversion allocation pressure by indexing matching vulnerabilities, memoizing repeated extended messages, caching parsed URLs, and pre-sizing reference slices.

This is split PR 4 from `performance/IDE-1940_optimize-memory-footprint`. It is temporarily stacked on PR #1250 so the pre-push/test-hook stabilizers from the fixture harness PR are present; after PR #1250 lands this PR can be retargeted to `main`.

### Split Context

```mermaid
flowchart LR
  main[origin/main] --> pr1["PR #1250: test fixture + megaproject harness"]
  pr1 --> pr2["PR #1251: Code SARIF streaming"]
  pr1 --> pr3["PR #1253: OSS CLI streaming"]
  pr1 --> pr4["PR #1255: OSS conversion caches"]
  main --> pr5["PR TBD: IssueCache index + memory backend"]
  pr5 --> pr6["PR TBD: Bolt backend + scanner integration"]
  pr6 --> pr7["PR TBD: Workspace/product cache clearing"]
  main --> pr8["PR TBD: Small hotpath optimizations"]
  main --> pr9["PR TBD: Perf docs + profiling history"]
```

### Scope

- Indexes OSS vulnerabilities by ID before matching related issues.
- Memoizes repeated OSS extended-message rendering.
- Caches parsed URLs and pre-sizes OSS reference slices.
- Adds focused OSS tests for matching issue parity, memoized messages, and URL parse cache behavior.

### Verification

- `go test -count=1 -v ./infrastructure/oss` (`build/pr4_focused_oss_tests.log`)
- `make lint` (`build/pr4_make_lint.log`)
- Pre-push hook: `lint-fix` and unit tests passed during `git push --set-upstream origin perf/IDE-1940-oss-conversion-caches`

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [x] License file updated, if new 3rd-party dependency is introduced


___

### **PR Type**
Enhancement


___

### **Description**
- Index OSS vulnerabilities by ID for faster matching.

- Memoize extended message rendering for performance.

- Cache parsed URLs to reduce overhead.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>issue.go</strong><dd><code>Index vulnerabilities by ID for efficient matching.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-8a8ae474b46c292d5e918379849be57960c91e3168268e3f36d5b6fb3a2831ad">+27/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Implement memoization for extended messages and URL parsing.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-8453f08acb550d16749b285a7d53443bbf915c50af44a4002eb6a765e7c780a6">+64/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unified_converter.go</strong><dd><code>Integrate URL parsing cache for references and issue URLs.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-75cc7b3352e4a2f1077307fb167c6b96b9d1973c24f65b5dc762d396c566eb9a">+13/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>url_parse_cache.go</strong><dd><code>Introduce URL parsing cache mechanism.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-af8d91c2c73d984434a1c8e0e665c0cbc89790d3bdc1f46c31bdcafabb1d29da">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>issue_test.go</strong><dd><code>Add tests for vulnerability ID indexing and matching.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-9c9cc097d00032b18d40a7ffb96b1aa8b94b2af6a3c000a860f101bca1562d5f">+119/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>oss_test.go</strong><dd><code>Adjust tests for toIssue and URL creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-18d44a59ba6614f20ee4e2bb69fe6801a5c680206aaba162efda262707b87721">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types_extended_message_test.go</strong><dd><code>Test memoization of extended message generation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-73a9a879de4d144760cb363395d4d0ab128b09d8224b537e36d56360f5f81c7d">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>url_parse_cache_test.go</strong><dd><code>Test URL parsing cache functionality.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1255/changes#diff-d78aae8891bdb83de3ce1d7a04be14839f78bdef3a30052a71c2e784d2b534ff">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

