### PR TITLE
fix: make test less flaky

### DIFF
--- a/application/server/parallelization_test.go
+++ b/application/server/parallelization_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"fmt"
 	"os"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -43,8 +44,12 @@ func Test_Concurrent_CLI_Runs(t *testing.T) {
 	lspClient := srv.Client
 
 	// create clones and make them workspace folders
-	type scanParamsTuple map[product.Product]bool
-	successfulScans := map[types.FilePath]scanParamsTuple{}
+	type scanStatus struct {
+		status types.ScanStatus
+		error  string
+	}
+	scanStatuses := map[types.FilePath]map[product.Product]scanStatus{}
+	scanStatusesMu := sync.Mutex{}
 
 	var workspaceFolders []types.WorkspaceFolder
 	wg := sync.WaitGroup{}
@@ -62,11 +67,16 @@ func Test_Concurrent_CLI_Runs(t *testing.T) {
 			}
 			mu.Lock()
 			workspaceFolders = append(workspaceFolders, folder)
-			successfulScans[repo] = scanParamsTuple{}
+			scanStatuses[repo] = map[product.Product]scanStatus{}
 			mu.Unlock()
 		}()
 	}
 	wg.Wait()
+
+	// Sort workspaceFolders to ensure deterministic order
+	sort.Slice(workspaceFolders, func(i, j int) bool {
+		return workspaceFolders[i].Name < workspaceFolders[j].Name
+	})
 
 	setUniqueCliPath(t, engine)
 
@@ -97,6 +107,10 @@ func Test_Concurrent_CLI_Runs(t *testing.T) {
 	// check if all scan params were sent
 	assert.Eventuallyf(t, func() bool {
 		notificationsByMethod := jsonRPCRecorder.FindNotificationsByMethod("$/snyk.scan")
+		scanStatusesMu.Lock()
+		defer scanStatusesMu.Unlock()
+
+		// Track scan statuses for diagnostics
 		for _, notification := range notificationsByMethod {
 			var scanParams types.SnykScanParams
 			err := notification.UnmarshalParams(&scanParams)
@@ -104,15 +118,49 @@ func Test_Concurrent_CLI_Runs(t *testing.T) {
 				continue
 			}
 
-			if scanParams.Status == types.Success {
-				successfulScans[scanParams.FolderPath][product.ToProduct(scanParams.Product)] = true
+			p := product.ToProduct(scanParams.Product)
+			if _, exists := scanStatuses[scanParams.FolderPath]; !exists {
+				continue
+			}
+
+			// Update status for this folder/product combination
+			scanStatuses[scanParams.FolderPath][p] = scanStatus{
+				status: scanParams.Status,
+				error:  "",
+			}
+			if scanParams.PresentableError != nil {
+				scanStatuses[scanParams.FolderPath][p] = scanStatus{
+					status: scanParams.Status,
+					error:  scanParams.PresentableError.ErrorMessage,
+				}
 			}
 		}
 
+		// Check for errors and log diagnostics
+		for folderPath, productStatuses := range scanStatuses {
+			for p, status := range productStatuses {
+				if status.status == types.ErrorStatus {
+					t.Logf("Scan error for folder %s product %s: %s", folderPath, p.ToProductCodename(), status.error)
+				}
+			}
+		}
+
+		// Count successful scans
+		ossEnabled := engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykOssEnabled))
+		iacEnabled := engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykIacEnabled))
 		received := 0
-		for _, tuple := range successfulScans {
-			if tuple[product.ProductOpenSource] == engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykOssEnabled)) && tuple[product.ProductInfrastructureAsCode] == engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykIacEnabled)) {
+		for folderPath, productStatuses := range scanStatuses {
+			ossSuccess := productStatuses[product.ProductOpenSource].status == types.Success
+			iacSuccess := productStatuses[product.ProductInfrastructureAsCode].status == types.Success
+			if ossSuccess == ossEnabled && iacSuccess == iacEnabled {
 				received++
+			} else {
+				// Log why this folder didn't match
+				t.Logf("Folder %s: OSS success=%v (expected=%v), IAC success=%v (expected=%v)",
+					folderPath, ossSuccess, ossEnabled, iacSuccess, iacEnabled)
+				for p, status := range productStatuses {
+					t.Logf("  Product %s: status=%s, error=%s", p.ToProductCodename(), status.status, status.error)
+				}
 			}
 		}
 		return received == len(workspaceFolders)

--- a/application/server/parallelization_test.go
+++ b/application/server/parallelization_test.go
@@ -49,7 +49,6 @@ func Test_Concurrent_CLI_Runs(t *testing.T) {
 		error  string
 	}
 	scanStatuses := map[types.FilePath]map[product.Product]scanStatus{}
-	scanStatusesMu := sync.Mutex{}
 
 	var workspaceFolders []types.WorkspaceFolder
 	wg := sync.WaitGroup{}
@@ -107,8 +106,6 @@ func Test_Concurrent_CLI_Runs(t *testing.T) {
 	// check if all scan params were sent
 	assert.Eventuallyf(t, func() bool {
 		notificationsByMethod := jsonRPCRecorder.FindNotificationsByMethod("$/snyk.scan")
-		scanStatusesMu.Lock()
-		defer scanStatusesMu.Unlock()
 
 		// Track scan statuses for diagnostics
 		for _, notification := range notificationsByMethod {


### PR DESCRIPTION
### **User description**
### Description

The parallelization test is flaky. This is an attempt to fix it.

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactor test to track scan status and errors.

- Add diagnostic logging for failure analysis.

- Ensure deterministic test execution order.

- Resolve data races in test logic.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parallelization_test.go</strong><dd><code>Enhance concurrent CLI runs test diagnostics and stability.</code></dd></summary>
<hr>

application/server/parallelization_test.go

<ul><li>Replaced <code>successfulScans</code> map with <code>scanStatuses</code> for detailed tracking <br>of scan outcomes.<br> <li> Introduced comprehensive diagnostic logging for scan statuses and <br>associated errors.<br> <li> Ensured deterministic test execution by sorting <code>workspaceFolders</code>.<br> <li> Enhanced assertions to verify scan success/failure against expected <br>configurations.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1259/changes#diff-dfb264976fa1c23451dc8d19b018920487af818f524aa24ea49211bd8b6326e9">+52/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

