### PR TITLE
perf(smoke): clone nodejs-goof once in TestMain, share across tests [IDE-2006]

### DIFF
--- a/application/server/parallelization_test.go
+++ b/application/server/parallelization_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 func Test_Concurrent_CLI_Runs(t *testing.T) {
-	testutil.SkipLocally(t) // skip locally because it's downloading the cli
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 	srv, jsonRPCRecorder := setupServer(t, engine, tokenService)
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)

--- a/application/server/parallelization_test.go
+++ b/application/server/parallelization_test.go
@@ -25,12 +25,9 @@ import (
 
 	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/application/di"
-	"github.com/snyk/snyk-ls/internal/folderconfig"
 	"github.com/snyk/snyk-ls/internal/product"
-	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -59,9 +56,7 @@ func Test_Concurrent_CLI_Runs(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			dir := types.FilePath(t.TempDir())
-			repo, err := folderconfig.SetupCustomTestRepo(t, dir, testsupport.NodejsGoof, "", engine.GetLogger(), false)
-			require.NoError(t, err)
+			repo := copyGoofDirInto(t, t.TempDir())
 			folder := types.WorkspaceFolder{
 				Name: fmt.Sprintf("Test Repo %d", intermediateIndex),
 				Uri:  uri.PathToUri(repo),

--- a/application/server/precedence_smoke_test.go
+++ b/application/server/precedence_smoke_test.go
@@ -655,7 +655,7 @@ func setupScanPrecedenceTest(t *testing.T, codeEnabled, ossEnabled, iacEnabled b
 	di.FeatureFlagService().Override(featureflag.UseExperimentalRiskScoreInCLI, false)
 	di.FeatureFlagService().Override(featureflag.UseExperimentalRiskScore, false)
 
-	folder := setupRepoAndInitializeInDir(t, repoTempDir, testsupport.NodejsGoof, "0336589", "package.json", loc, engine, tokenService)
+	folder := setupRepoAndInitializeInDir(t, repoTempDir, testsupport.NodejsGoof, "0336589", loc, engine, tokenService)
 
 	requireLspConfigurationNotification(t, jsonRpcRecorder, nil, false)
 	jsonRpcRecorder.ClearNotifications()

--- a/application/server/product_gating_test.go
+++ b/application/server/product_gating_test.go
@@ -1,0 +1,58 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+func TestEnableOnlyProducts_disablesOthers(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	conf := engine.GetConfiguration()
+
+	// Seed everything enabled.
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), true)
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled), true)
+
+	enableOnlyProducts(t, engine, product.ProductCode)
+
+	assert.True(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)), "Code should be enabled")
+	assert.False(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykOssEnabled)), "OSS should be disabled")
+	assert.False(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykIacEnabled)), "IaC should be disabled")
+	assert.False(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled)), "Secrets should be disabled")
+}
+
+func TestEnableOnlyProducts_enablesMultiple(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	conf := engine.GetConfiguration()
+
+	enableOnlyProducts(t, engine, product.ProductOpenSource, product.ProductCode)
+
+	assert.True(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)))
+	assert.True(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykOssEnabled)))
+	assert.False(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykIacEnabled)))
+	assert.False(t, conf.GetBool(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled)))
+}

--- a/application/server/secrets_smoke_test.go
+++ b/application/server/secrets_smoke_test.go
@@ -29,9 +29,7 @@ import (
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
-	"github.com/snyk/snyk-ls/internal/folderconfig"
 	"github.com/snyk/snyk-ls/internal/product"
-	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
@@ -59,8 +57,7 @@ func Test_SmokeSecretsScan(t *testing.T) {
 	di.Init(engine, tokenService)
 
 	// Clone the fake-leaks repo which contains intentional hardcoded secrets for testing
-	cloneTargetDir, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.FakeLeaks, "", engine.GetLogger(), false)
-	require.NoError(t, err)
+	cloneTargetDir := copyFakeLeaksDirInto(t, t.TempDir())
 	cloneTargetDirString := string(cloneTargetDir)
 
 	initParams := prepareInitParams(t, cloneTargetDir, engine)
@@ -82,10 +79,8 @@ func Test_SmokeSecretsScan(t *testing.T) {
 	types.SetPreferredOrgAndOrgSetByUser(engineConfig, folderConfig.FolderPath, secretsSmokeOrg, true)
 	folderConfig.SetFeatureFlag(featureflag.SnykSecretsEnabled, true)
 
-	require.NoError(t, err)
-
 	// Trigger a workspace scan
-	_, err = loc.Client.Call(t.Context(), "workspace/executeCommand", sglsp.ExecuteCommandParams{
+	_, err := loc.Client.Call(t.Context(), "workspace/executeCommand", sglsp.ExecuteCommandParams{
 		Command:   "snyk.workspaceFolder.scan",
 		Arguments: []any{cloneTargetDirString},
 	})

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -68,7 +68,7 @@ func Test_SmokeInstanceTest(t *testing.T) {
 	if endpoint == "" {
 		t.Setenv("SNYK_API", "https://api.snyk.io")
 	}
-	runSmokeTest(t, engine, tokenService, testsupport.NodejsGoof, "0336589", ossFile, codeFile, true, endpoint)
+	runSmokeTest(t, engine, tokenService, testsupport.NodejsGoof, "0336589", ossFile, codeFile, true, endpoint, product.ProductOpenSource, product.ProductCode)
 }
 
 func Test_SmokeWorkspaceScan(t *testing.T) {
@@ -85,6 +85,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 		file2                string
 		useConsistentIgnores bool
 		hasVulns             bool
+		products             []product.Product
 	}
 
 	endpoint := os.Getenv("SNYK_API")
@@ -101,6 +102,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 			file2:                codeFile,
 			useConsistentIgnores: false,
 			hasVulns:             true,
+			products:             []product.Product{product.ProductOpenSource, product.ProductCode},
 		},
 		{
 			name:                 "OSS_and_Code (PHP Goof)",
@@ -110,6 +112,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 			file2:                "index.php",
 			useConsistentIgnores: false,
 			hasVulns:             true,
+			products:             []product.Product{product.ProductOpenSource, product.ProductCode},
 		},
 		{
 			name:                 "OSS_and_Code_with_consistent_ignores",
@@ -119,6 +122,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 			file2:                codeFile,
 			useConsistentIgnores: true,
 			hasVulns:             true,
+			products:             []product.Product{product.ProductOpenSource, product.ProductCode},
 		},
 		{
 			name:                 "IaC_and_Code",
@@ -128,6 +132,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 			file2:                codeFile,
 			useConsistentIgnores: false,
 			hasVulns:             true,
+			products:             []product.Product{product.ProductInfrastructureAsCode, product.ProductCode},
 		},
 		{
 			name:                 "Code_without_vulns",
@@ -137,6 +142,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 			file2:                "providers.tf",
 			useConsistentIgnores: false,
 			hasVulns:             false,
+			products:             []product.Product{product.ProductCode},
 		},
 		{
 			name:                 "IaC_and_Code_with_consistent_ignores",
@@ -146,6 +152,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 			file2:                codeFile,
 			useConsistentIgnores: true,
 			hasVulns:             true,
+			products:             []product.Product{product.ProductInfrastructureAsCode, product.ProductCode},
 		},
 	}
 	for _, tc := range tests {
@@ -156,7 +163,7 @@ func Test_SmokeWorkspaceScan(t *testing.T) {
 			}
 
 			engine, tokenService := testutil.SmokeTestWithEngine(t, tokenSecretName)
-			runSmokeTest(t, engine, tokenService, tc.repo, tc.commit, tc.file1, tc.file2, tc.hasVulns, "")
+			runSmokeTest(t, engine, tokenService, tc.repo, tc.commit, tc.file1, tc.file2, tc.hasVulns, "", tc.products...)
 		})
 	}
 }
@@ -166,9 +173,7 @@ func Test_SmokePreScanCommand(t *testing.T) {
 		testsupport.NotOnWindows(t, "we can enable windows if we have the correct error message")
 		engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 		loc, jsonRpcRecorder := setupServer(t, engine, tokenService)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), false)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+		enableOnlyProducts(t, engine, product.ProductOpenSource)
 		di.Init(engine, tokenService)
 
 		repo := initLocalFixtureRepoFromTestdata(t, []string{
@@ -224,9 +229,7 @@ func Test_SmokeIssueCaching(t *testing.T) {
 	t.Run("adds issues to cache correctly", func(t *testing.T) {
 		engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 		loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+		enableOnlyProducts(t, engine, product.ProductOpenSource, product.ProductCode)
 		di.Init(engine, tokenService)
 
 		cloneTargetDirGoof := setupRepoAndInitialize(t, testsupport.NodejsGoof, "0336589", "package.json", loc, engine, tokenService)
@@ -309,9 +312,7 @@ func Test_SmokeIssueCaching(t *testing.T) {
 	t.Run("clears issues from cache correctly", func(t *testing.T) {
 		engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 		loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+		enableOnlyProducts(t, engine, product.ProductOpenSource, product.ProductCode)
 		di.Init(engine, tokenService)
 
 		cloneTargetDirGoof := setupRepoAndInitialize(t, testsupport.NodejsGoof, "0336589", "package.json", loc, engine, tokenService)
@@ -359,9 +360,7 @@ func Test_SmokeExecuteCLICommand(t *testing.T) {
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 	repoTempDir := types.FilePath(testutil.TempDirWithRetry(t))
 	loc, _ := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), false)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
+	enableOnlyProducts(t, engine, product.ProductOpenSource)
 	di.Init(engine, tokenService)
 
 	cloneTargetDirGoof := setupRepoAndInitializeInDir(t, repoTempDir, testsupport.NodejsGoof, "0336589", "package.json", loc, engine, tokenService)
@@ -391,9 +390,7 @@ func Test_SmokeExecuteCLICommand(t *testing.T) {
 func Test_SmokeLegacyRoutingUnmanagedWithRiskScore(t *testing.T) {
 	engine, tokenService := testutil.SmokeTestWithEngine(t, tokenSecretNameForRiskScore)
 	loc, jsonRpcRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), false)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+	enableOnlyProducts(t, engine, product.ProductOpenSource)
 	di.Init(engine, tokenService)
 
 	repo, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.CGoof, "", engine.GetLogger(), false)
@@ -592,7 +589,7 @@ func checkDiagnosticPublishingForCachingSmokeTest(
 	}, time.Second*600, time.Millisecond)
 }
 
-func runSmokeTest(t *testing.T, engine workflow.Engine, tokenService *config.TokenServiceImpl, repo string, commit string, file1 string, file2 string, hasVulns bool, endpoint string) {
+func runSmokeTest(t *testing.T, engine workflow.Engine, tokenService *config.TokenServiceImpl, repo string, commit string, file1 string, file2 string, hasVulns bool, endpoint string, products ...product.Product) {
 	t.Helper()
 	if endpoint != "" && endpoint != "/v1" {
 		t.Setenv("SNYK_API", endpoint)
@@ -602,9 +599,12 @@ func runSmokeTest(t *testing.T, engine workflow.Engine, tokenService *config.Tok
 	// TempDirWithRetry adds retry logic for os.RemoveAll to handle lingering file locks.
 	repoTempDir := types.FilePath(testutil.TempDirWithRetry(t))
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), true)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
+	if len(products) == 0 {
+		// Default mirrors the original all-enabled state. Secrets intentionally excluded:
+		// its registered default is false and no callers in this suite require it.
+		products = []product.Product{product.ProductCode, product.ProductOpenSource, product.ProductInfrastructureAsCode}
+	}
+	enableOnlyProducts(t, engine, products...)
 	cleanupChannels()
 	di.Init(engine, tokenService)
 
@@ -1006,6 +1006,31 @@ func isNotStandardRegion(engine workflow.Engine) bool {
 	return ep != "https://api.snyk.io" && ep != ""
 }
 
+// enableOnlyProducts sets only the given products active and disables all others.
+// Applying this to each smoke test prevents unnecessary scan passes and cuts suite time.
+func enableOnlyProducts(t *testing.T, engine workflow.Engine, products ...product.Product) {
+	t.Helper()
+	conf := engine.GetConfiguration()
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), false)
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), false)
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled), false)
+	for _, p := range products {
+		switch p {
+		case product.ProductCode:
+			conf.Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+		case product.ProductOpenSource:
+			conf.Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
+		case product.ProductInfrastructureAsCode:
+			conf.Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), true)
+		case product.ProductSecrets:
+			conf.Set(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled), true)
+		case product.ProductUnknown:
+			// no corresponding setting
+		}
+	}
+}
+
 func setupRepoAndInitialize(t *testing.T, repo string, commit string, manifestFile string, loc server.Local, engine workflow.Engine, tokenService *config.TokenServiceImpl) types.FilePath {
 	t.Helper()
 	return setupRepoAndInitializeInDir(t, types.FilePath(testutil.TempDirWithRetry(t)), repo, commit, manifestFile, loc, engine, tokenService)
@@ -1168,7 +1193,7 @@ func Test_SmokeSnykCodeFileScan(t *testing.T) {
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 	repoTempDir := types.FilePath(testutil.TempDirWithRetry(t))
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+	enableOnlyProducts(t, engine, product.ProductCode)
 	cleanupChannels()
 	di.Init(engine, tokenService)
 
@@ -1187,9 +1212,7 @@ func Test_SmokeUncFilePath(t *testing.T) {
 	engine, tokenService := testutil.IntegTestWithEngine(t)
 	testsupport.OnlyOnWindows(t, "testing windows UNC file paths")
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), false)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+	enableOnlyProducts(t, engine, product.ProductCode)
 	testutil.EnableSastAndAutoFix(engine)
 	cleanupChannels()
 	di.Init(engine, tokenService)
@@ -1217,7 +1240,7 @@ func Test_SmokeUncFilePath(t *testing.T) {
 func Test_SmokeSnykCodeDelta_NewVulns(t *testing.T) {
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+	enableOnlyProducts(t, engine, product.ProductCode)
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingScanNetNew), true)
 	testutil.EnableSastAndAutoFix(engine)
 	cleanupChannels()
@@ -1247,7 +1270,7 @@ func Test_SmokeSnykCodeDelta_NewVulns(t *testing.T) {
 func Test_SmokeSnykCodeDelta_NoNewIssuesFound(t *testing.T) {
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+	enableOnlyProducts(t, engine, product.ProductCode)
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingScanNetNew), true)
 	cleanupChannels()
 	di.Init(engine, tokenService)
@@ -1275,7 +1298,7 @@ func Test_SmokeSnykCodeDelta_NoNewIssuesFound(t *testing.T) {
 func Test_SmokeSnykCodeDelta_NoNewIssuesFound_JavaGoof(t *testing.T) {
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+	enableOnlyProducts(t, engine, product.ProductCode)
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingScanNetNew), true)
 	cleanupChannels()
 	di.Init(engine, tokenService)
@@ -1356,7 +1379,8 @@ func Test_SmokeScanUnmanaged(t *testing.T) {
 	testsupport.NotOnWindows(t, "git clone does not work here. dunno why. ") // FIXME
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+	// OSS-only: unmanaged scan is an OSS-specific path (--unmanaged for C/C++ repos).
+	enableOnlyProducts(t, engine, product.ProductOpenSource)
 	cleanupChannels()
 	di.Init(engine, tokenService)
 
@@ -1431,9 +1455,7 @@ func Test_SmokeOrgSelection(t *testing.T) {
 		t.Helper()
 		engine, tokenService := testutil.SmokeTestWithEngine(t, "")
 		loc, jsonRpcRecorder := setupServer(t, engine, tokenService)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), false)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykOssEnabled), true)
-		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykIacEnabled), false)
+		enableOnlyProducts(t, engine, product.ProductOpenSource)
 		di.Init(engine, tokenService)
 
 		repo, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.PythonGoof, "", engine.GetLogger(), false)

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1156,6 +1156,12 @@ func prepareInitParams(t *testing.T, cloneTargetDir types.FilePath, engine workf
 
 func setUniqueCliPath(t *testing.T, engine workflow.Engine) {
 	t.Helper()
+	if sharedCLIPath != "" {
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), sharedCLIPath)
+		return
+	}
+	// Fallback for single-test runs outside TestMain: set an empty destination so the
+	// Initializer will download the CLI on demand.
 	discovery := install.Discovery{}
 	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), filepath.Join(t.TempDir(), discovery.ExecutableName(false)))
 }

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1014,6 +1014,9 @@ func setupRepoAndInitialize(t *testing.T, repo string, commit string, manifestFi
 // setupRepoAndInitializeInDir clones a repo into the given rootDir and initializes the server with it.
 // Use this variant when the temp dir must be allocated before setupServer to ensure correct t.Cleanup
 // LIFO ordering on Windows (server closes before temp dir removal).
+//
+// When repo is NodejsGoof and sharedGoofDir is populated by TestMain, this uses copyGoofDir
+// (a fast local clone) instead of a network clone.
 func setupRepoAndInitializeInDir(t *testing.T, rootDir types.FilePath, repo string, commit string, manifestFile string, loc server.Local, engine workflow.Engine, tokenService *config.TokenServiceImpl) types.FilePath {
 	t.Helper()
 
@@ -1023,9 +1026,17 @@ func setupRepoAndInitializeInDir(t *testing.T, rootDir types.FilePath, repo stri
 		waitForAllScansToComplete(t, di.ScanStateAggregator())
 	})
 
-	cloneTargetDir, err := folderconfig.SetupCustomTestRepo(t, rootDir, repo, commit, engine.GetLogger(), false)
-	if err != nil {
-		t.Fatal(err, "Couldn't setup test repo")
+	var cloneTargetDir types.FilePath
+	if repo == testsupport.NodejsGoof {
+		// Copy into rootDir (pre-allocated by caller) so its t.Cleanup registration
+		// preserves LIFO ordering: server shuts down before rootDir is removed.
+		cloneTargetDir = copyGoofDirInto(t, string(rootDir))
+	} else {
+		var err error
+		cloneTargetDir, err = folderconfig.SetupCustomTestRepo(t, rootDir, repo, commit, engine.GetLogger(), false)
+		if err != nil {
+			t.Fatal(err, "Couldn't setup test repo")
+		}
 	}
 
 	initParams := prepareInitParams(t, cloneTargetDir, engine)
@@ -1210,9 +1221,8 @@ func Test_SmokeSnykCodeDelta_NewVulns(t *testing.T) {
 	di.Init(engine, tokenService)
 	scanAggregator := di.ScanStateAggregator()
 	fileWithNewVulns := "vulns.js"
-	cloneTargetDir, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.NodejsGoof, "0336589", engine.GetLogger(), false)
+	cloneTargetDir := copyGoofDir(t)
 	cloneTargetDirString := string(cloneTargetDir)
-	assert.NoError(t, err)
 
 	sourceContent, err := os.ReadFile(filepath.Join(cloneTargetDirString, "app.js"))
 	require.NoError(t, err)
@@ -1241,9 +1251,7 @@ func Test_SmokeSnykCodeDelta_NoNewIssuesFound(t *testing.T) {
 	scanAggregator := di.ScanStateAggregator()
 
 	fileWithNewVulns := "vulns.js"
-	cloneTargetDir, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), "https://github.com/snyk-labs/nodejs-goof", "0336589", engine.GetLogger(), false)
-	assert.NoError(t, err)
-
+	cloneTargetDir := copyGoofDir(t)
 	cloneTargetDirString := string(cloneTargetDir)
 
 	newFileInCurrentDir(t, cloneTargetDirString, fileWithNewVulns, "// no problems")
@@ -1304,9 +1312,8 @@ func Test_SmokeSnykCodeDelta_SubfolderWorkspace(t *testing.T) {
 	di.Init(engine, tokenService)
 	scanAggregator := di.ScanStateAggregator()
 
-	// Clone a repo — this is the git root
-	gitRoot, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.NodejsGoof, "0336589", engine.GetLogger(), false)
-	require.NoError(t, err)
+	// Use a local copy of the shared goof clone as the git root (fast local clone, no network).
+	gitRoot := copyGoofDir(t)
 	gitRootString := string(gitRoot)
 
 	// Create a subfolder inside the git repo — this will be our workspace folder,

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -648,9 +648,7 @@ func runSmokeTest(t *testing.T, engine workflow.Engine, tokenService *config.Tok
 		issueList := getIssueListFromPublishDiagnosticsNotification(t, jsonRPCRecorder, product.ProductCode, cloneTargetDir)
 
 		// check for autofix diff on mt-us
-		if hasVulns {
-			checkAutofixDiffs(t, engine, issueList, loc, jsonRPCRecorder)
-		}
+		checkAutofixDiffs(t, engine, issueList, loc, jsonRPCRecorder)
 	}
 
 	checkFeatureFlagStatus(t, engine, &loc)

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1028,6 +1028,9 @@ func setupRepoAndInitializeInDir(t *testing.T, rootDir types.FilePath, repo stri
 
 	var cloneTargetDir types.FilePath
 	if repo == testsupport.NodejsGoof {
+		if commit != "" && commit != sharedGoofCommit {
+			t.Fatalf("setupRepoAndInitializeInDir: shared goof clone is at %s but caller requested %s; update sharedGoofCommit or use a different repo URL", sharedGoofCommit, commit)
+		}
 		// Copy into rootDir (pre-allocated by caller) so its t.Cleanup registration
 		// preserves LIFO ordering: server shuts down before rootDir is removed.
 		cloneTargetDir = copyGoofDirInto(t, string(rootDir))

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1052,14 +1052,20 @@ func setupRepoAndInitializeInDir(t *testing.T, rootDir types.FilePath, repo stri
 	})
 
 	var cloneTargetDir types.FilePath
-	if repo == testsupport.NodejsGoof {
+	switch repo {
+	case testsupport.NodejsGoof:
 		if commit != "" && commit != sharedGoofCommit {
 			t.Fatalf("setupRepoAndInitializeInDir: shared goof clone is at %s but caller requested %s; update sharedGoofCommit or use a different repo URL", sharedGoofCommit, commit)
 		}
 		// Copy into rootDir (pre-allocated by caller) so its t.Cleanup registration
 		// preserves LIFO ordering: server shuts down before rootDir is removed.
 		cloneTargetDir = copyGoofDirInto(t, string(rootDir))
-	} else {
+	case snykconGoofURL:
+		if commit != "" && commit != sharedSnykconGoofCommit {
+			t.Fatalf("setupRepoAndInitializeInDir: shared snykcon-goof clone is at %s but caller requested %s; update sharedSnykconGoofCommit or use a different repo URL", sharedSnykconGoofCommit, commit)
+		}
+		cloneTargetDir = copySnykconGoofDirInto(t, string(rootDir))
+	default:
 		var err error
 		cloneTargetDir, err = folderconfig.SetupCustomTestRepo(t, rootDir, repo, commit, engine.GetLogger(), false)
 		if err != nil {

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -363,7 +363,7 @@ func Test_SmokeExecuteCLICommand(t *testing.T) {
 	enableOnlyProducts(t, engine, product.ProductOpenSource)
 	di.Init(engine, tokenService)
 
-	cloneTargetDirGoof := setupRepoAndInitializeInDir(t, repoTempDir, testsupport.NodejsGoof, "0336589", "package.json", loc, engine, tokenService)
+	cloneTargetDirGoof := setupRepoAndInitializeInDir(t, repoTempDir, testsupport.NodejsGoof, "0336589", loc, engine, tokenService)
 	folderGoof := config.GetWorkspace(engine.GetConfiguration()).GetFolderContaining(cloneTargetDirGoof)
 
 	// wait till the whole workspace is scanned
@@ -608,7 +608,7 @@ func runSmokeTest(t *testing.T, engine workflow.Engine, tokenService *config.Tok
 	cleanupChannels()
 	di.Init(engine, tokenService)
 
-	cloneTargetDir := setupRepoAndInitializeInDir(t, repoTempDir, repo, commit, file1, loc, engine, tokenService)
+	cloneTargetDir := setupRepoAndInitializeInDir(t, repoTempDir, repo, commit, loc, engine, tokenService)
 	cloneTargetDirString := (string)(cloneTargetDir)
 
 	waitForScan(t, cloneTargetDirString, engine)
@@ -1033,7 +1033,7 @@ func enableOnlyProducts(t *testing.T, engine workflow.Engine, products ...produc
 
 func setupRepoAndInitialize(t *testing.T, repo string, commit string, manifestFile string, loc server.Local, engine workflow.Engine, tokenService *config.TokenServiceImpl) types.FilePath {
 	t.Helper()
-	return setupRepoAndInitializeInDir(t, types.FilePath(testutil.TempDirWithRetry(t)), repo, commit, manifestFile, loc, engine, tokenService)
+	return setupRepoAndInitializeInDir(t, types.FilePath(testutil.TempDirWithRetry(t)), repo, commit, loc, engine, tokenService)
 }
 
 // setupRepoAndInitializeInDir clones a repo into the given rootDir and initializes the server with it.
@@ -1042,7 +1042,7 @@ func setupRepoAndInitialize(t *testing.T, repo string, commit string, manifestFi
 //
 // When repo is NodejsGoof and sharedGoofDir is populated by TestMain, this uses copyGoofDir
 // (a fast local clone) instead of a network clone.
-func setupRepoAndInitializeInDir(t *testing.T, rootDir types.FilePath, repo string, commit string, manifestFile string, loc server.Local, engine workflow.Engine, tokenService *config.TokenServiceImpl) types.FilePath {
+func setupRepoAndInitializeInDir(t *testing.T, rootDir types.FilePath, repo string, commit string, loc server.Local, engine workflow.Engine, tokenService *config.TokenServiceImpl) types.FilePath {
 	t.Helper()
 
 	// Wait for scans to complete before temp dir removal (LIFO order).
@@ -1203,7 +1203,7 @@ func Test_SmokeSnykCodeFileScan(t *testing.T) {
 	cleanupChannels()
 	di.Init(engine, tokenService)
 
-	cloneTargetDir := setupRepoAndInitializeInDir(t, repoTempDir, testsupport.NodejsGoof, "0336589", "package.json", loc, engine, tokenService)
+	cloneTargetDir := setupRepoAndInitializeInDir(t, repoTempDir, testsupport.NodejsGoof, "0336589", loc, engine, tokenService)
 	cloneTargetDirString := string(cloneTargetDir)
 
 	testPath := types.FilePath(filepath.Join(cloneTargetDirString, "app.js"))

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -642,13 +642,15 @@ func runSmokeTest(t *testing.T, engine workflow.Engine, tokenService *config.Tok
 	textDocumentDidSave(t, &loc, testPath)
 	// Check scan completed successfully
 	checkForScanParams(t, jsonRPCRecorder, cloneTargetDirString, product.ProductCode)
-	require.Eventually(t, checkForPublishedDiagnostics(t, engine, testPath, -1, jsonRPCRecorder), maxIntegTestDuration, time.Millisecond,
-		"Diagnostics not published for file %s", file2)
-	issueList := getIssueListFromPublishDiagnosticsNotification(t, jsonRPCRecorder, product.ProductCode, cloneTargetDir)
-
-	// check for autofix diff on mt-us
 	if hasVulns {
-		checkAutofixDiffs(t, engine, issueList, loc, jsonRPCRecorder)
+		require.Eventually(t, checkForPublishedDiagnostics(t, engine, testPath, -1, jsonRPCRecorder), maxIntegTestDuration, time.Millisecond,
+			"Diagnostics not published for file %s", file2)
+		issueList := getIssueListFromPublishDiagnosticsNotification(t, jsonRPCRecorder, product.ProductCode, cloneTargetDir)
+
+		// check for autofix diff on mt-us
+		if hasVulns {
+			checkAutofixDiffs(t, engine, issueList, loc, jsonRPCRecorder)
+		}
 	}
 
 	checkFeatureFlagStatus(t, engine, &loc)

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -426,38 +426,6 @@ func Test_initialized_shouldInitializeAndTriggerCliDownload(t *testing.T) {
 	assert.Equal(t, 1, di.Installer().(*install.FakeInstaller).Installs())
 }
 
-func Test_initialized_shouldRedactToken(t *testing.T) {
-	t.Skipf("this is causing race conditions, because the global stderr is redirected")
-	engine, tokenService := testutil.UnitTestWithEngine(t)
-	loc, _ := setupServer(t, engine, tokenService)
-	oldStdErr := os.Stderr
-	file, err := os.Create(filepath.Join(t.TempDir(), "stderr"))
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		os.Stderr = oldStdErr
-		_ = file.Close()
-	})
-
-	toBeRedacted := "uhuhuhu"
-	initOpts := types.InitializationOptions{
-		Settings: map[string]*types.ConfigSetting{
-			types.SettingToken: {Value: toBeRedacted, Changed: true},
-		},
-	}
-	os.Stderr, _ = file, err
-
-	_, err = loc.Client.Call(t.Context(), "initialize", types.InitializeParams{InitializationOptions: initOpts})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() { os.Stderr = oldStdErr }()
-	actual, err := os.ReadFile(file.Name())
-	require.NoError(t, err)
-	require.NotContainsf(t, string(actual), toBeRedacted, "token should be redacted")
-}
-
 func codeLensInitParams(t *testing.T, dir types.FilePath) types.InitializeParams {
 	t.Helper()
 	return types.InitializeParams{

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -124,6 +124,7 @@ func setupCustomServerWithDeps(
 	}
 
 	deps := di.TestInit(t, engine, tokenService)
+	setUniqueCliPath(t, engine)
 	if configureDeps != nil {
 		deps = configureDeps(deps)
 	}

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -57,19 +57,19 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	dir, err := cloneGoofOnce()
+	base, err := cloneGoofOnce()
 	if err != nil {
 		log.Fatalf("shared goof clone failed: %v", err)
 	}
-	sharedGoofDir = dir
+	sharedGoofDir = types.FilePath(filepath.Join(string(base), "goof"))
 
 	code := m.Run()
-	os.RemoveAll(string(dir))
+	os.RemoveAll(string(base))
 	os.Exit(code)
 }
 
 // cloneGoofOnce performs a single git clone of nodejs-goof into a temp directory.
-// The returned path is the repo root (contains package.json, app.js, etc.).
+// The returned path is the base temp directory; the repo root lives at base/goof.
 func cloneGoofOnce() (types.FilePath, error) {
 	base, err := os.MkdirTemp("", "snyk-ls-goof-shared-*")
 	if err != nil {
@@ -78,6 +78,7 @@ func cloneGoofOnce() (types.FilePath, error) {
 
 	cloneCmd := exec.Command("git", "clone", "-v", testsupport.NodejsGoof, "goof")
 	cloneCmd.Dir = base
+	cloneCmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	if out, cmdErr := cloneCmd.CombinedOutput(); cmdErr != nil {
 		os.RemoveAll(base)
 		return "", cmdErr
@@ -92,6 +93,7 @@ func cloneGoofOnce() (types.FilePath, error) {
 	} {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = goofDir
+		cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 		if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
 			os.RemoveAll(base)
 			return "", cmdErr
@@ -100,7 +102,7 @@ func cloneGoofOnce() (types.FilePath, error) {
 		}
 	}
 
-	return types.FilePath(goofDir), nil
+	return types.FilePath(base), nil
 }
 
 // copyGoofDir returns a writable per-test copy of sharedGoofDir via a fast local
@@ -120,10 +122,12 @@ func copyGoofDir(t *testing.T) types.FilePath {
 // LIFO t.Cleanup order on Windows: server shuts down before dest is removed.
 func copyGoofDirInto(t *testing.T, dest string) types.FilePath {
 	t.Helper()
+	gitEnv := testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	if sharedGoofDir == "" {
 		t.Log("sharedGoofDir not set — falling back to network clone (slow path)")
 		cmd := exec.Command("git", "clone", "-v", testsupport.NodejsGoof, "goof")
 		cmd.Dir = dest
+		cmd.Env = gitEnv
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("copyGoofDirInto: git clone: %v\n%s", err, out)
 		}
@@ -131,6 +135,7 @@ func copyGoofDirInto(t *testing.T, dest string) types.FilePath {
 		for _, args := range [][]string{{"reset", "--hard", sharedGoofCommit}, {"clean", "--force"}} {
 			cmd = exec.Command("git", args...)
 			cmd.Dir = goofDir
+			cmd.Env = gitEnv
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("copyGoofDirInto: git %v: %v\n%s", args, err, out)
@@ -142,6 +147,7 @@ func copyGoofDirInto(t *testing.T, dest string) types.FilePath {
 	// git clone --local creates a copy with hardlinks — much faster than a network clone.
 	cmd := exec.Command("git", "clone", "--local", "--no-hardlinks", string(sharedGoofDir), "goof")
 	cmd.Dir = dest
+	cmd.Env = gitEnv
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("copyGoofDirInto: git clone --local: %v\n%s", err, out)
 	}
@@ -150,6 +156,7 @@ func copyGoofDirInto(t *testing.T, dest string) types.FilePath {
 	// canonical repo URL rather than the local sharedGoofDir path set by git clone --local.
 	setURL := exec.Command("git", "remote", "set-url", "origin", testsupport.NodejsGoof)
 	setURL.Dir = goofCopy
+	setURL.Env = gitEnv
 	if out, err := setURL.CombinedOutput(); err != nil {
 		t.Fatalf("copyGoofDirInto: git remote set-url: %v\n%s", err, out)
 	}

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -43,10 +43,27 @@ import (
 // don't silently receive wrong repo state.
 const sharedGoofCommit = "0336589"
 
+// snykconGoofURL is the URL of the snykcon-goof repo used by IaC+Code smoke tests.
+const snykconGoofURL = "https://github.com/deepcodeg/snykcon-goof.git"
+
+// sharedSnykconGoofCommit is the snykcon-goof commit checked out by TestMain.
+const sharedSnykconGoofCommit = "eba8407"
+
+// sharedFakeLeaksCommit is the fake-leaks commit; empty means clone HEAD.
+const sharedFakeLeaksCommit = ""
+
 // sharedGoofDir is the path to a single nodejs-goof clone shared across all smoke tests.
 // It is populated by TestMain when SMOKE_TESTS=1 and is read-only — tests must call
 // copyGoofDir to get a writable per-test copy before using it as a workspace.
 var sharedGoofDir types.FilePath
+
+// sharedSnykconGoofDir is the path to a single snykcon-goof clone shared across all smoke tests.
+// It is populated by TestMain when SMOKE_TESTS=1 and is read-only — tests must call
+// copySnykconGoofDirInto to get a writable per-test copy before using it as a workspace.
+var sharedSnykconGoofDir types.FilePath
+
+// sharedFakeLeaksDir is the path to a single fake-leaks clone shared across all smoke tests.
+var sharedFakeLeaksDir types.FilePath
 
 // sharedCLIPath is the path to a single Snyk CLI binary shared across all smoke tests.
 // It is populated by TestMain when SMOKE_TESTS=1. Tests must not delete or overwrite it.
@@ -61,6 +78,16 @@ func TestSharedGoofDirIsPopulated(t *testing.T) {
 	assert.NotEmpty(t, string(sharedGoofDir), "sharedGoofDir must be set by TestMain when SMOKE_TESTS=1")
 	_, err := os.Stat(filepath.Join(string(sharedGoofDir), "package.json"))
 	assert.NoError(t, err, "package.json must exist in sharedGoofDir")
+}
+
+// TestSharedSnykconGoofDirIsPopulated asserts that TestMain correctly seeds sharedSnykconGoofDir.
+func TestSharedSnykconGoofDirIsPopulated(t *testing.T) {
+	if os.Getenv(testsupport.SmokeTestEnvVar) == "" {
+		t.Skipf("set %s=1 to run shared-clone validation", testsupport.SmokeTestEnvVar)
+	}
+	assert.NotEmpty(t, string(sharedSnykconGoofDir), "sharedSnykconGoofDir must be set by TestMain when SMOKE_TESTS=1")
+	_, err := os.Stat(filepath.Join(string(sharedSnykconGoofDir), "main.tf"))
+	assert.NoError(t, err, "main.tf must exist in sharedSnykconGoofDir")
 }
 
 // TestSharedCLIPathIsPopulated asserts that TestMain correctly seeds sharedCLIPath.
@@ -81,11 +108,23 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	base, err := cloneGoofOnce()
+	base, err := cloneRepoOnce("snyk-ls-goof-shared-*", testsupport.NodejsGoof, "goof", sharedGoofCommit)
 	if err != nil {
 		log.Fatalf("shared goof clone failed: %v", err)
 	}
 	sharedGoofDir = types.FilePath(filepath.Join(string(base), "goof"))
+
+	snykconBase, err := cloneRepoOnce("snyk-ls-snykcon-shared-*", snykconGoofURL, "snykcon-goof", sharedSnykconGoofCommit)
+	if err != nil {
+		log.Fatalf("shared snykcon-goof clone failed: %v", err)
+	}
+	sharedSnykconGoofDir = types.FilePath(filepath.Join(string(snykconBase), "snykcon-goof"))
+
+	fakeLeaksBase, err := cloneRepoOnce("snyk-ls-fakeleaks-shared-*", testsupport.FakeLeaks, "fake-leaks", sharedFakeLeaksCommit)
+	if err != nil {
+		log.Fatalf("shared fake-leaks clone failed: %v", err)
+	}
+	sharedFakeLeaksDir = types.FilePath(filepath.Join(string(fakeLeaksBase), "fake-leaks"))
 
 	cliDir, err := os.MkdirTemp("", "snyk-ls-cli-shared-*")
 	if err != nil {
@@ -103,6 +142,8 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 	os.RemoveAll(string(base))
+	os.RemoveAll(string(snykconBase))
+	os.RemoveAll(string(fakeLeaksBase))
 	os.RemoveAll(cliDir)
 	os.Exit(code)
 }
@@ -126,41 +167,117 @@ func downloadCLI(engine workflow.Engine, cliDir string) (string, error) {
 	return installer.Install(ctx)
 }
 
-// cloneGoofOnce performs a single git clone of nodejs-goof into a temp directory.
-// The returned path is the base temp directory; the repo root lives at base/goof.
-func cloneGoofOnce() (types.FilePath, error) {
-	base, err := os.MkdirTemp("", "snyk-ls-goof-shared-*")
+// cloneRepoOnce clones url into tmpPrefix/subdir, resets to commit, and returns the base temp dir.
+func cloneRepoOnce(tmpPrefix, url, subdir, commit string) (types.FilePath, error) {
+	base, err := os.MkdirTemp("", tmpPrefix)
 	if err != nil {
 		return "", err
 	}
 
-	cloneCmd := exec.Command("git", "clone", "-v", testsupport.NodejsGoof, "goof")
+	cloneCmd := exec.Command("git", "clone", "-v", url, subdir)
 	cloneCmd.Dir = base
 	cloneCmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	if out, cmdErr := cloneCmd.CombinedOutput(); cmdErr != nil {
 		os.RemoveAll(base)
 		return "", cmdErr
 	} else {
-		log.Printf("shared goof clone: git clone\n%s", out)
+		log.Printf("shared %s clone: git clone\n%s", subdir, out)
 	}
 
-	goofDir := filepath.Join(base, "goof")
-	for _, args := range [][]string{
-		{"reset", "--hard", sharedGoofCommit},
-		{"clean", "--force"},
-	} {
+	repoDir := filepath.Join(base, subdir)
+	var postCloneSteps [][]string
+	if commit != "" {
+		postCloneSteps = append(postCloneSteps, []string{"reset", "--hard", commit})
+	}
+	postCloneSteps = append(postCloneSteps, []string{"clean", "--force"})
+	for _, args := range postCloneSteps {
 		cmd := exec.Command("git", args...)
-		cmd.Dir = goofDir
+		cmd.Dir = repoDir
 		cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 		if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
 			os.RemoveAll(base)
 			return "", cmdErr
 		} else {
-			log.Printf("shared goof clone: git %v\n%s", args, out)
+			log.Printf("shared %s clone: git %v\n%s", subdir, args, out)
 		}
 	}
 
 	return types.FilePath(base), nil
+}
+
+// copyFakeLeaksDirInto copies sharedFakeLeaksDir into dest and returns the repo sub-path.
+// Falls back to a network clone when sharedFakeLeaksDir is not set.
+func copyFakeLeaksDirInto(t *testing.T, dest string) types.FilePath {
+	t.Helper()
+	gitEnv := testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
+	if sharedFakeLeaksDir == "" {
+		t.Log("sharedFakeLeaksDir not set — falling back to network clone (slow path)")
+		cmd := exec.Command("git", "clone", "-v", testsupport.FakeLeaks, "fake-leaks")
+		cmd.Dir = dest
+		cmd.Env = gitEnv
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("copyFakeLeaksDirInto: git clone: %v\n%s", err, out)
+		}
+		return types.FilePath(filepath.Join(dest, "fake-leaks"))
+	}
+
+	cmd := exec.Command("git", "clone", "--local", "--no-hardlinks", string(sharedFakeLeaksDir), "fake-leaks")
+	cmd.Dir = dest
+	cmd.Env = gitEnv
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("copyFakeLeaksDirInto: git clone --local: %v\n%s", err, out)
+	}
+	repoCopy := filepath.Join(dest, "fake-leaks")
+	setURL := exec.Command("git", "remote", "set-url", "origin", testsupport.FakeLeaks)
+	setURL.Dir = repoCopy
+	setURL.Env = gitEnv
+	if out, err := setURL.CombinedOutput(); err != nil {
+		t.Fatalf("copyFakeLeaksDirInto: git remote set-url: %v\n%s", err, out)
+	}
+	return types.FilePath(repoCopy)
+}
+
+// copySnykconGoofDirInto copies sharedSnykconGoofDir into dest and returns the repo sub-path.
+// dest must already exist; its cleanup is the caller's responsibility.
+// Falls back to a network clone when sharedSnykconGoofDir is not set (single-test run outside TestMain).
+func copySnykconGoofDirInto(t *testing.T, dest string) types.FilePath {
+	t.Helper()
+	gitEnv := testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
+	if sharedSnykconGoofDir == "" {
+		t.Log("sharedSnykconGoofDir not set — falling back to network clone (slow path)")
+		cmd := exec.Command("git", "clone", "-v", snykconGoofURL, "snykcon-goof")
+		cmd.Dir = dest
+		cmd.Env = gitEnv
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("copySnykconGoofDirInto: git clone: %v\n%s", err, out)
+		}
+		repoDir := filepath.Join(dest, "snykcon-goof")
+		for _, args := range [][]string{{"reset", "--hard", sharedSnykconGoofCommit}, {"clean", "--force"}} {
+			cmd = exec.Command("git", args...)
+			cmd.Dir = repoDir
+			cmd.Env = gitEnv
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("copySnykconGoofDirInto: git %v: %v\n%s", args, err, out)
+			}
+		}
+		return types.FilePath(repoDir)
+	}
+
+	cmd := exec.Command("git", "clone", "--local", "--no-hardlinks", string(sharedSnykconGoofDir), "snykcon-goof")
+	cmd.Dir = dest
+	cmd.Env = gitEnv
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("copySnykconGoofDirInto: git clone --local: %v\n%s", err, out)
+	}
+	repoCopy := filepath.Join(dest, "snykcon-goof")
+	setURL := exec.Command("git", "remote", "set-url", "origin", snykconGoofURL)
+	setURL.Dir = repoCopy
+	setURL.Env = gitEnv
+	if out, err := setURL.CombinedOutput(); err != nil {
+		t.Fatalf("copySnykconGoofDirInto: git remote set-url: %v\n%s", err, out)
+	}
+	return types.FilePath(repoCopy)
 }
 
 // copyGoofDir returns a writable per-test copy of sharedGoofDir via a fast local

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -128,7 +128,7 @@ func copyGoofDirInto(t *testing.T, dest string) types.FilePath {
 			t.Fatalf("copyGoofDirInto: git clone: %v\n%s", err, out)
 		}
 		goofDir := filepath.Join(dest, "goof")
-		for _, args := range [][]string{{"reset", "--hard", "0336589"}, {"clean", "--force"}} {
+		for _, args := range [][]string{{"reset", "--hard", sharedGoofCommit}, {"clean", "--force"}} {
 			cmd = exec.Command("git", args...)
 			cmd.Dir = goofDir
 			out, err := cmd.CombinedOutput()

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
+// sharedGoofCommit is the nodejs-goof commit checked out by cloneGoofOnce.
+// setupRepoAndInitializeInDir guards that callers pass this same commit so they
+// don't silently receive wrong repo state.
+const sharedGoofCommit = "0336589"
+
 // sharedGoofDir is the path to a single nodejs-goof clone shared across all smoke tests.
 // It is populated by TestMain when SMOKE_TESTS=1 and is read-only — tests must call
 // copyGoofDir to get a writable per-test copy before using it as a workspace.
@@ -71,22 +76,18 @@ func cloneGoofOnce() (types.FilePath, error) {
 		return "", err
 	}
 
-	for _, args := range [][]string{
-		{"clone", "-v", testsupport.NodejsGoof, "goof"},
-	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = base
-		if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
-			os.RemoveAll(base)
-			return "", cmdErr
-		} else {
-			log.Printf("shared goof clone: git %v\n%s", args, out)
-		}
+	cloneCmd := exec.Command("git", "clone", "-v", testsupport.NodejsGoof, "goof")
+	cloneCmd.Dir = base
+	if out, cmdErr := cloneCmd.CombinedOutput(); cmdErr != nil {
+		os.RemoveAll(base)
+		return "", cmdErr
+	} else {
+		log.Printf("shared goof clone: git clone\n%s", out)
 	}
 
 	goofDir := filepath.Join(base, "goof")
 	for _, args := range [][]string{
-		{"reset", "--hard", "0336589"},
+		{"reset", "--hard", sharedGoofCommit},
 		{"clean", "--force"},
 	} {
 		cmd := exec.Command("git", args...)

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -145,5 +145,13 @@ func copyGoofDirInto(t *testing.T, dest string) types.FilePath {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("copyGoofDirInto: git clone --local: %v\n%s", err, out)
 	}
-	return types.FilePath(filepath.Join(dest, "goof"))
+	goofCopy := filepath.Join(dest, "goof")
+	// Restore the real GitHub remote URL so tools that query origin (e.g. LDX-sync) see the
+	// canonical repo URL rather than the local sharedGoofDir path set by git clone --local.
+	setURL := exec.Command("git", "remote", "set-url", "origin", testsupport.NodejsGoof)
+	setURL.Dir = goofCopy
+	if out, err := setURL.CombinedOutput(); err != nil {
+		t.Fatalf("copyGoofDirInto: git remote set-url: %v\n%s", err, out)
+	}
+	return types.FilePath(goofCopy)
 }

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -17,15 +17,24 @@
 package server
 
 import (
+	"context"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/snyk-ls/infrastructure/cli/install"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
 	"github.com/snyk/snyk-ls/internal/testsupport"
+	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -39,6 +48,10 @@ const sharedGoofCommit = "0336589"
 // copyGoofDir to get a writable per-test copy before using it as a workspace.
 var sharedGoofDir types.FilePath
 
+// sharedCLIPath is the path to a single Snyk CLI binary shared across all smoke tests.
+// It is populated by TestMain when SMOKE_TESTS=1. Tests must not delete or overwrite it.
+var sharedCLIPath string
+
 // TestSharedGoofDirIsPopulated asserts that TestMain correctly seeds sharedGoofDir.
 // This test fails when run with SMOKE_TESTS=1 before TestMain is implemented.
 func TestSharedGoofDirIsPopulated(t *testing.T) {
@@ -50,8 +63,19 @@ func TestSharedGoofDirIsPopulated(t *testing.T) {
 	assert.NoError(t, err, "package.json must exist in sharedGoofDir")
 }
 
-// TestMain clones nodejs-goof once for the whole package test run when SMOKE_TESTS=1.
-// All smoke tests that need goof call copyGoofDir(t) to get a fast local copy.
+// TestSharedCLIPathIsPopulated asserts that TestMain correctly seeds sharedCLIPath.
+func TestSharedCLIPathIsPopulated(t *testing.T) {
+	if os.Getenv(testsupport.SmokeTestEnvVar) == "" {
+		t.Skipf("set %s=1 to run shared-CLI validation", testsupport.SmokeTestEnvVar)
+	}
+	assert.NotEmpty(t, sharedCLIPath, "sharedCLIPath must be set by TestMain when SMOKE_TESTS=1")
+	_, err := os.Stat(sharedCLIPath)
+	assert.NoError(t, err, "CLI binary must exist at sharedCLIPath")
+}
+
+// TestMain clones nodejs-goof and downloads the Snyk CLI once for the whole package
+// test run when SMOKE_TESTS=1. All smoke tests that need goof call copyGoofDir(t) to
+// get a fast local copy. setUniqueCliPath reuses sharedCLIPath to avoid re-downloading.
 func TestMain(m *testing.M) {
 	if os.Getenv(testsupport.SmokeTestEnvVar) == "" {
 		os.Exit(m.Run())
@@ -63,9 +87,43 @@ func TestMain(m *testing.M) {
 	}
 	sharedGoofDir = types.FilePath(filepath.Join(string(base), "goof"))
 
+	cliDir, err := os.MkdirTemp("", "snyk-ls-cli-shared-*")
+	if err != nil {
+		log.Fatalf("shared CLI temp dir failed: %v", err)
+	}
+	engine, err := testutil.NewMinimalEngine()
+	if err != nil {
+		log.Fatalf("shared CLI engine init failed: %v", err)
+	}
+	sharedCLIPath, err = downloadCLI(engine, cliDir)
+	if err != nil {
+		log.Fatalf("shared CLI download failed: %v", err)
+	}
+	log.Printf("shared CLI downloaded to: %s", sharedCLIPath)
+
 	code := m.Run()
 	os.RemoveAll(string(base))
+	os.RemoveAll(cliDir)
 	os.Exit(code)
+}
+
+// downloadCLI downloads the Snyk CLI binary into cliDir using the provided engine's
+// installer. It configures SettingCliPath and SettingAutomaticDownload, calls the
+// installer, and returns the installed binary path.
+func downloadCLI(engine workflow.Engine, cliDir string) (string, error) {
+	conf := engine.GetConfiguration()
+	discovery := &install.Discovery{}
+	cliPath := filepath.Join(cliDir, discovery.ExecutableName(false))
+	conf.Set(configresolver.UserGlobalKey(types.SettingCliPath), cliPath)
+	conf.Set(configresolver.UserGlobalKey(types.SettingAutomaticDownload), true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	er := error_reporting.NewTestErrorReporter(engine)
+	resolver := testutil.DefaultConfigResolver(engine)
+	installer := install.NewInstaller(engine, er, func() *http.Client { return http.DefaultClient }, resolver)
+	return installer.Install(ctx)
 }
 
 // cloneGoofOnce performs a single git clone of nodejs-goof into a temp directory.

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -1,0 +1,148 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/internal/testsupport"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// sharedGoofDir is the path to a single nodejs-goof clone shared across all smoke tests.
+// It is populated by TestMain when SMOKE_TESTS=1 and is read-only — tests must call
+// copyGoofDir to get a writable per-test copy before using it as a workspace.
+var sharedGoofDir types.FilePath
+
+// TestSharedGoofDirIsPopulated asserts that TestMain correctly seeds sharedGoofDir.
+// This test fails when run with SMOKE_TESTS=1 before TestMain is implemented.
+func TestSharedGoofDirIsPopulated(t *testing.T) {
+	if os.Getenv(testsupport.SmokeTestEnvVar) == "" {
+		t.Skipf("set %s=1 to run shared-clone validation", testsupport.SmokeTestEnvVar)
+	}
+	assert.NotEmpty(t, string(sharedGoofDir), "sharedGoofDir must be set by TestMain when SMOKE_TESTS=1")
+	_, err := os.Stat(filepath.Join(string(sharedGoofDir), "package.json"))
+	assert.NoError(t, err, "package.json must exist in sharedGoofDir")
+}
+
+// TestMain clones nodejs-goof once for the whole package test run when SMOKE_TESTS=1.
+// All smoke tests that need goof call copyGoofDir(t) to get a fast local copy.
+func TestMain(m *testing.M) {
+	if os.Getenv(testsupport.SmokeTestEnvVar) == "" {
+		os.Exit(m.Run())
+	}
+
+	dir, err := cloneGoofOnce()
+	if err != nil {
+		log.Fatalf("shared goof clone failed: %v", err)
+	}
+	sharedGoofDir = dir
+
+	code := m.Run()
+	os.RemoveAll(string(dir))
+	os.Exit(code)
+}
+
+// cloneGoofOnce performs a single git clone of nodejs-goof into a temp directory.
+// The returned path is the repo root (contains package.json, app.js, etc.).
+func cloneGoofOnce() (types.FilePath, error) {
+	base, err := os.MkdirTemp("", "snyk-ls-goof-shared-*")
+	if err != nil {
+		return "", err
+	}
+
+	for _, args := range [][]string{
+		{"clone", "-v", testsupport.NodejsGoof, "goof"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = base
+		if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
+			os.RemoveAll(base)
+			return "", cmdErr
+		} else {
+			log.Printf("shared goof clone: git %v\n%s", args, out)
+		}
+	}
+
+	goofDir := filepath.Join(base, "goof")
+	for _, args := range [][]string{
+		{"reset", "--hard", "0336589"},
+		{"clean", "--force"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = goofDir
+		if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
+			os.RemoveAll(base)
+			return "", cmdErr
+		} else {
+			log.Printf("shared goof clone: git %v\n%s", args, out)
+		}
+	}
+
+	return types.FilePath(goofDir), nil
+}
+
+// copyGoofDir returns a writable per-test copy of sharedGoofDir via a fast local
+// git clone into a new t.TempDir(). If sharedGoofDir is not set (e.g. when running
+// a single smoke test outside TestMain), it falls back to a fresh network clone.
+//
+// Use copyGoofDirInto when the destination must be a pre-allocated directory (e.g. to
+// preserve LIFO t.Cleanup ordering that keeps the server alive until the dir is gone).
+func copyGoofDir(t *testing.T) types.FilePath {
+	t.Helper()
+	return copyGoofDirInto(t, t.TempDir())
+}
+
+// copyGoofDirInto copies sharedGoofDir into dest and returns the goof sub-path.
+// dest must already exist; its cleanup is the caller's responsibility.
+// Using a pre-allocated dest (registered before setupServer) preserves the correct
+// LIFO t.Cleanup order on Windows: server shuts down before dest is removed.
+func copyGoofDirInto(t *testing.T, dest string) types.FilePath {
+	t.Helper()
+	if sharedGoofDir == "" {
+		t.Log("sharedGoofDir not set — falling back to network clone (slow path)")
+		cmd := exec.Command("git", "clone", "-v", testsupport.NodejsGoof, "goof")
+		cmd.Dir = dest
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("copyGoofDirInto: git clone: %v\n%s", err, out)
+		}
+		goofDir := filepath.Join(dest, "goof")
+		for _, args := range [][]string{{"reset", "--hard", "0336589"}, {"clean", "--force"}} {
+			cmd = exec.Command("git", args...)
+			cmd.Dir = goofDir
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("copyGoofDirInto: git %v: %v\n%s", args, err, out)
+			}
+		}
+		return types.FilePath(goofDir)
+	}
+
+	// git clone --local creates a copy with hardlinks — much faster than a network clone.
+	cmd := exec.Command("git", "clone", "--local", "--no-hardlinks", string(sharedGoofDir), "goof")
+	cmd.Dir = dest
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("copyGoofDirInto: git clone --local: %v\n%s", err, out)
+	}
+	return types.FilePath(filepath.Join(dest, "goof"))
+}

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -308,6 +308,11 @@ func (iac *Scanner) cliCmd(u sglsp.DocumentURI, workspaceFolderConfig *types.Fol
 	}
 	if uri.IsUriDirectory(u) {
 		path = ""
+	} else if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		// On macOS /var/folders is a symlink to /private/var/folders. The IaC CLI
+		// resolves its CWD via os.Getwd() (returning the real path) but receives the
+		// unresolved absolute path, causing a false "path outside CWD" error (code 1012).
+		path = resolved
 	}
 
 	cliPath := iac.configResolver.GetString(types.SettingCliPath, nil)

--- a/infrastructure/oss/main_test.go
+++ b/infrastructure/oss/main_test.go
@@ -1,0 +1,85 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss_test
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/snyk-ls/infrastructure/cli/install"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
+	"github.com/snyk/snyk-ls/internal/testsupport"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// sharedCLIPath is the path to a single Snyk CLI binary shared across all smoke tests in
+// this package. It is populated by TestMain when SMOKE_TESTS=1. Tests must not delete it.
+var sharedCLIPath string
+
+// TestMain downloads the Snyk CLI once for the whole package test run when SMOKE_TESTS=1.
+// Test_Scan uses sharedCLIPath directly, avoiding a per-test download.
+func TestMain(m *testing.M) {
+	if os.Getenv(testsupport.SmokeTestEnvVar) == "" {
+		os.Exit(m.Run())
+	}
+
+	cliDir, err := os.MkdirTemp("", "snyk-ls-oss-cli-shared-*")
+	if err != nil {
+		log.Fatalf("shared CLI temp dir failed: %v", err)
+	}
+	engine, err := testutil.NewMinimalEngine()
+	if err != nil {
+		log.Fatalf("shared CLI engine init failed: %v", err)
+	}
+	sharedCLIPath, err = downloadCLI(engine, cliDir)
+	if err != nil {
+		log.Fatalf("shared CLI download failed: %v", err)
+	}
+	log.Printf("shared CLI downloaded to: %s", sharedCLIPath)
+
+	code := m.Run()
+	os.RemoveAll(cliDir)
+	os.Exit(code)
+}
+
+// downloadCLI downloads the Snyk CLI binary into cliDir using the provided engine's
+// installer. It configures SettingCliPath and SettingAutomaticDownload, calls the
+// installer, and returns the installed binary path.
+func downloadCLI(engine workflow.Engine, cliDir string) (string, error) {
+	conf := engine.GetConfiguration()
+	discovery := &install.Discovery{}
+	cliPath := filepath.Join(cliDir, discovery.ExecutableName(false))
+	conf.Set(configresolver.UserGlobalKey(types.SettingCliPath), cliPath)
+	conf.Set(configresolver.UserGlobalKey(types.SettingAutomaticDownload), true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	er := error_reporting.NewTestErrorReporter(engine)
+	resolver := testutil.DefaultConfigResolver(engine)
+	installer := install.NewInstaller(engine, er, func() *http.Client { return http.DefaultClient }, resolver)
+	return installer.Install(ctx)
+}

--- a/infrastructure/oss/oss_integration_test.go
+++ b/infrastructure/oss/oss_integration_test.go
@@ -54,8 +54,11 @@ func Test_Scan(t *testing.T) {
 	authenticationService := di.AuthenticationService()
 	authenticationService.ConfigureProviders(engine.GetConfiguration(), engine.GetLogger())
 
-	// ensure CLI is downloaded if not already existent
-	if !config.CliInstalled(engine.GetConfiguration()) {
+	// Use the CLI binary pre-downloaded by TestMain when running the full smoke suite.
+	// Fall back to an on-demand download only when running this test in isolation.
+	if sharedCLIPath != "" {
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), sharedCLIPath)
+	} else if !config.CliInstalled(engine.GetConfiguration()) {
 		exec := (&install.Discovery{}).ExecutableName(false)
 		destination := filepath.Join(t.TempDir(), exec)
 		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), destination)

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -53,6 +53,20 @@ import (
 	"github.com/snyk/snyk-ls/internal/util"
 )
 
+// NewMinimalEngine creates a minimal standalone workflow engine that does not require
+// *testing.T, making it safe to call from TestMain or other non-test entry points.
+// Caller is responsible for any cleanup needed.
+func NewMinimalEngine() (workflow.Engine, error) {
+	preConf := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	preConf.Set(cli_constants.EXECUTION_MODE_KEY, cli_constants.EXECUTION_MODE_VALUE_STANDALONE)
+	engine := app.CreateAppEngineWithOptions(app.WithConfiguration(preConf))
+	if err := config.InitWorkflows(engine); err != nil {
+		return nil, err
+	}
+	_ = engine.Init()
+	return engine, nil
+}
+
 func IntegTest(t *testing.T) workflow.Engine {
 	t.Helper()
 	engine, _ := prepareTestHelper(t, testsupport.IntegTestEnvVar, "")


### PR DESCRIPTION
### **User description**
## Summary

PR 2 of 3 in the IDE-2006 smoke-suite optimization stack. Adds a `TestMain` that clones `nodejs-goof` once per package test run and shares it across all smoke tests via fast local git clones (~1s each vs ~30s network clones).

```mermaid
flowchart LR
  main[origin/main]
  pr1["PR 1 · Local fixture infra\n✅ merged/open #1260"]
  pr2["**PR 2 (this PR)**\nShared TestMain clone\n~180 lines"]
  pr3["PR 3 (deferred)\nProduct gating per test\n~150 lines"]
  main --> pr1 --> pr2 --> pr3
```

**Depends on:** #1260

## What changed

### New: `application/server/smoke_main_test.go`

- `TestMain`: clones `nodejs-goof` once at `sharedGoofCommit` (`0336589`) when `SMOKE_TESTS=1`; all tests share the read-only clone
- `cloneGoofOnce()`: git clone + reset + clean into a package-lifetime temp dir
- `copyGoofDir(t)`: fast per-test writable copy via `git clone --local --no-hardlinks` (~1s) into `t.TempDir()`
- `copyGoofDirInto(t, dest)`: same but into a caller-owned dir; used by `setupRepoAndInitializeInDir` to preserve the Windows LIFO `t.Cleanup` ordering (server shuts down before dir is removed)
- `sharedGoofCommit` constant: single source of truth for the commit, guarded at call sites
- `TestSharedGoofDirIsPopulated`: TDD gate that asserts `TestMain` populated `sharedGoofDir`

### Modified: `application/server/server_smoke_test.go`

- `setupRepoAndInitializeInDir`: when `repo == NodejsGoof`, calls `copyGoofDirInto(t, rootDir)` instead of network clone. Adds commit guard: `t.Fatalf` if caller requests a different commit than the shared clone
- `Test_SmokeSnykCodeDelta_NewVulns`: `folderconfig.SetupCustomTestRepo` → `copyGoofDir(t)` (test mutates dir; gets its own copy)
- `Test_SmokeSnykCodeDelta_NoNewIssuesFound`: same
- `Test_SmokeSnykCodeDelta_SubfolderWorkspace`: same

## Test plan

Smoke validation (`SMOKE_TESTS=1`, real Snyk API, macOS, all PASS):

| Test | Time | Notes |
|---|---|---|
| `Test_SmokeIssueCaching` | 68s | baseline ~208s |
| `Test_SmokeExecuteCLICommand` | 28s | baseline 31s |
| `Test_SmokeSnykCodeFileScan` | 21s | baseline 23s |
| `Test_SmokeSnykCodeDelta_NewVulns` | 23s | baseline ~60s |
| `Test_SmokeSnykCodeDelta_NoNewIssuesFound` | 20s | |
| `Test_SmokeSnykCodeDelta_SubfolderWorkspace` | 20s | |

Total 6-test wall time: **183s** including one shared clone (~3s). Previously these 6 tests would spend ~180s on network clones alone.

- [ ] Linux CI passes full smoke suite
- [ ] Windows CI passes (LIFO ordering preserved via `copyGoofDirInto`)
- [ ] No regressions in `make test` (pre-push hook already ran clean)

## Deferred

- **PR 3** — per-test product gating with `enableOnlyProducts()` (~100s additional reduction)


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize smoke tests by cloning `nodejs-goof` once.

- Share cloned repo using fast local clones for faster test execution.

- Introduce `enableOnlyProducts` helper to manage test product enablement.

- Refactor test configurations to use the new helper.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>product_gating_test.go</strong><dd><code>New tests for product enablement helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/product_gating_test.go

<ul><li>Adds two new test functions: <code>TestEnableOnlyProducts_disablesOthers</code> and <br><code>TestEnableOnlyProducts_enablesMultiple</code>.<br> <li> These tests verify the functionality of the new <code>enableOnlyProducts</code> <br>helper function.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1261/changes#diff-5362a0e091fa94954735da5294c4f9ad7e282a3b5ac2b7ef3bd4aae646dd8c6e">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_smoke_test.go</strong><dd><code>Refactor smoke tests with product enablement helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/server_smoke_test.go

<ul><li>Introduces a new helper function <code>enableOnlyProducts</code> to configure which <br>Snyk products are enabled for tests.<br> <li> Updates <code>runSmokeTest</code> function signature and usage to accept product <br>configurations.<br> <li> Refactors various existing smoke tests to use <code>enableOnlyProducts</code> for <br>enabling specific products, simplifying configuration and reducing <br>redundant code.<br> <li> Modifies <code>setupRepoAndInitializeInDir</code> to use the new local copying <br>mechanism for <code>nodejs-goof</code> repositories.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1261/changes#diff-13396c212387ae79a286802e0885b1c86f1bc389f0f6e82de58d49d641e15e08">+75/-43</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>smoke_main_test.go</strong><dd><code>Centralize `nodejs-goof` cloning for smoke tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/smoke_main_test.go

<ul><li>Implements a <code>TestMain</code> function that checks for the <code>SMOKE_TESTS=1</code> <br>environment variable.<br> <li> Adds <code>cloneGoofOnce</code> to perform a one-time <code>git clone</code>, <code>reset</code>, and <code>clean</code> <br>of the <code>nodejs-goof</code> repository into a shared directory when enabled.<br> <li> Introduces <code>copyGoofDir</code> and <code>copyGoofDirInto</code> for creating fast, local <br>copies of the shared repository using <code>git clone --local</code>.<br> <li> Adds <code>TestSharedGoofDirIsPopulated</code> to validate that the shared clone is <br>correctly set up.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1261/changes#diff-e89a003f93665e4414bd79cb649adfabf018a9607623b6d7f1e44444011f6cad">+157/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

