### PR TITLE
chore(ldx-sync): update ldx_sync client to 2026-05-07 [IDE-1881]

### DIFF
--- a/domain/ide/command/ldx_sync_service_test.go
+++ b/domain/ide/command/ldx_sync_service_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/go-application-framework/pkg/apiclients/ldx_sync_config"
-	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/ldx_sync_config/ldx_sync/2024-10-15"
+	v20260507 "github.com/snyk/go-application-framework/pkg/apiclients/ldx_sync_config/ldx_sync/2026-05-07"
 	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
@@ -49,7 +49,7 @@ func defaultResolver(engine workflow.Engine) types.ConfigResolverInterface {
 
 // createLdxSyncResultWithOrg is a helper to create a LdxSyncConfigResult with an org ID for tests
 func createLdxSyncResultWithOrg(orgId string) ldx_sync_config.LdxSyncConfigResult {
-	orgs := []v20241015.Organization{
+	orgs := []v20260507.Organization{
 		{
 			Id:                   orgId,
 			Name:                 "Test Org",
@@ -62,26 +62,26 @@ func createLdxSyncResultWithOrg(orgId string) ldx_sync_config.LdxSyncConfigResul
 	configId := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 
 	return ldx_sync_config.LdxSyncConfigResult{
-		Config: &v20241015.UserConfigResponse{
+		Config: &v20260507.UserConfigResponse{
 			Data: struct {
 				Attributes struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				} `json:"attributes"`
 				Id   uuid.UUID                            `json:"id"`
-				Type v20241015.UserConfigResponseDataType `json:"type"`
+				Type v20260507.UserConfigResponseDataType `json:"type"`
 			}{
 				Attributes: struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				}{
 					Organizations: &orgs,
 				},
@@ -496,7 +496,7 @@ func Test_RefreshConfigFromLdxSync_PreservesNonLockedOverrides(t *testing.T) {
 
 // createLdxSyncResultWithLockedField creates a LdxSyncConfigResult with a locked field
 func createLdxSyncResultWithLockedField(orgId string, lockedFieldName string) ldx_sync_config.LdxSyncConfigResult {
-	orgs := []v20241015.Organization{
+	orgs := []v20260507.Organization{
 		{
 			Id:                   orgId,
 			Name:                 "Test Org",
@@ -507,10 +507,10 @@ func createLdxSyncResultWithLockedField(orgId string, lockedFieldName string) ld
 	}
 
 	// Create settings with a locked field using the correct API field names
-	settings := map[string]v20241015.SettingMetadata{
+	settings := map[string]v20260507.SettingMetadata{
 		lockedFieldName: {
 			Locked: util.Ptr(true),
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Value:  []string{"low", "medium", "high", "critical"},
 		},
 	}
@@ -518,26 +518,26 @@ func createLdxSyncResultWithLockedField(orgId string, lockedFieldName string) ld
 	configId := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 
 	return ldx_sync_config.LdxSyncConfigResult{
-		Config: &v20241015.UserConfigResponse{
+		Config: &v20260507.UserConfigResponse{
 			Data: struct {
 				Attributes struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				} `json:"attributes"`
 				Id   uuid.UUID                            `json:"id"`
-				Type v20241015.UserConfigResponseDataType `json:"type"`
+				Type v20260507.UserConfigResponseDataType `json:"type"`
 			}{
 				Attributes: struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				}{
 					Organizations: &orgs,
 					Settings:      &settings,
@@ -552,13 +552,13 @@ func createLdxSyncResultWithLockedField(orgId string, lockedFieldName string) ld
 
 // createLdxSyncResultWithOrgSettings creates a result with org-scope product_code_enabled setting
 func createLdxSyncResultWithOrgSettings(orgId string, products []string) ldx_sync_config.LdxSyncConfigResult {
-	settings := map[string]v20241015.SettingMetadata{}
+	settings := map[string]v20260507.SettingMetadata{}
 	for _, p := range products {
 		switch p {
 		case "code":
-			settings["product_code_enabled"] = v20241015.SettingMetadata{
+			settings["product_code_enabled"] = v20260507.SettingMetadata{
 				Locked: util.Ptr(true),
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 				Value:  true,
 			}
 		}
@@ -568,18 +568,18 @@ func createLdxSyncResultWithOrgSettings(orgId string, products []string) ldx_syn
 
 // createLdxSyncResultWithMachineSettings creates a result with machine-scope settings
 func createLdxSyncResultWithMachineSettings(orgId string, cliReleaseChannel string) ldx_sync_config.LdxSyncConfigResult {
-	settings := map[string]v20241015.SettingMetadata{
+	settings := map[string]v20260507.SettingMetadata{
 		"cli_release_channel": {
 			Locked: util.Ptr(true),
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Value:  cliReleaseChannel,
 		},
 	}
 	return createLdxSyncResultWithSettings(orgId, settings, "00000000-0000-0000-0000-000000000003")
 }
 
-func createLdxSyncResultWithSettings(orgId string, settings map[string]v20241015.SettingMetadata, configIdStr string) ldx_sync_config.LdxSyncConfigResult {
-	orgs := []v20241015.Organization{
+func createLdxSyncResultWithSettings(orgId string, settings map[string]v20260507.SettingMetadata, configIdStr string) ldx_sync_config.LdxSyncConfigResult {
+	orgs := []v20260507.Organization{
 		{
 			Id:                   orgId,
 			Name:                 "Test Org",
@@ -590,26 +590,26 @@ func createLdxSyncResultWithSettings(orgId string, settings map[string]v20241015
 	}
 	configId := uuid.MustParse(configIdStr)
 	return ldx_sync_config.LdxSyncConfigResult{
-		Config: &v20241015.UserConfigResponse{
+		Config: &v20260507.UserConfigResponse{
 			Data: struct {
 				Attributes struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				} `json:"attributes"`
 				Id   uuid.UUID                            `json:"id"`
-				Type v20241015.UserConfigResponseDataType `json:"type"`
+				Type v20260507.UserConfigResponseDataType `json:"type"`
 			}{
 				Attributes: struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				}{
 					Organizations: &orgs,
 					Settings:      &settings,
@@ -716,9 +716,9 @@ func Test_RefreshConfigFromLdxSync_NoNotificationWhenNoChanges(t *testing.T) {
 
 // createLdxSyncResultWithFolderSettings creates a LdxSyncConfigResult with folder-specific settings
 // The folderSettingsURL is the normalized URL key in the FolderSettings map (as the backend would return)
-func createLdxSyncResultWithFolderSettings(orgId string, folderSettingsURL string, folderSettings map[string]v20241015.SettingMetadata, remoteUrl string) ldx_sync_config.LdxSyncConfigResult {
+func createLdxSyncResultWithFolderSettings(orgId string, folderSettingsURL string, folderSettings map[string]v20260507.SettingMetadata, remoteUrl string) ldx_sync_config.LdxSyncConfigResult {
 	result := createLdxSyncResultWithOrg(orgId)
-	fs := map[string]map[string]v20241015.SettingMetadata{
+	fs := map[string]map[string]v20260507.SettingMetadata{
 		folderSettingsURL: folderSettings,
 	}
 	result.Config.Data.Attributes.FolderSettings = &fs
@@ -737,10 +737,10 @@ func Test_RefreshConfigFromLdxSync_WritesFolderSettings(t *testing.T) {
 
 	orgId := "test-org-folder-settings"
 	normalizedURL := "https://github.com/snyk/test-repo"
-	folderSettings := map[string]v20241015.SettingMetadata{
+	folderSettings := map[string]v20260507.SettingMetadata{
 		"issue_view_open_issues": {
 			Value:  true,
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Locked: util.Ptr(true),
 		},
 	}
@@ -777,15 +777,15 @@ func Test_RefreshConfigFromLdxSync_FolderSettingsWithURLNormalization(t *testing
 	orgId := "test-org-url-norm"
 	normalizedURL := "https://github.com/snyk/test-repo"
 	rawSSHURL := "git@github.com:snyk/test-repo.git"
-	folderSettings := map[string]v20241015.SettingMetadata{
+	folderSettings := map[string]v20260507.SettingMetadata{
 		"issue_view_open_issues": {
 			Value:  true,
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Locked: util.Ptr(false),
 		},
 		"issue_view_ignored_issues": {
 			Value:  false,
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Locked: util.Ptr(true),
 		},
 	}
@@ -830,10 +830,10 @@ func Test_RefreshConfigFromLdxSync_FolderSettingsNoRemoteUrl(t *testing.T) {
 
 	orgId := "test-org-no-remote"
 	normalizedURL := "https://github.com/snyk/test-repo"
-	folderSettings := map[string]v20241015.SettingMetadata{
+	folderSettings := map[string]v20260507.SettingMetadata{
 		"issue_view_open_issues": {
 			Value:  true,
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 		},
 	}
 
@@ -874,15 +874,15 @@ func Test_RefreshConfigFromLdxSync_LegacyMigration_PreservesExistingConfig(t *te
 
 	orgId := "legacy-org-id"
 	// LDX-Sync returns NON-locked machine settings — should not overwrite existing user values
-	settings := map[string]v20241015.SettingMetadata{
-		string(v20241015.AutomaticDownload): {
+	settings := map[string]v20260507.SettingMetadata{
+		string(v20260507.AutomaticDownload): {
 			Locked: util.Ptr(false),
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Value:  false,
 		},
-		string(v20241015.CliReleaseChannel): {
+		string(v20260507.CliReleaseChannel): {
 			Locked: util.Ptr(false),
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Value:  "preview",
 		},
 	}
@@ -917,15 +917,15 @@ func Test_RefreshConfigFromLdxSync_FirstRunDefaults_PopulatesConfig(t *testing.T
 	// No prior config set — fresh install scenario.
 	// Use real LDX-Sync machine settings: automatic_download (bool), cli_release_channel (string).
 	orgId := "fresh-org-id"
-	settings := map[string]v20241015.SettingMetadata{
-		string(v20241015.AutomaticDownload): {
+	settings := map[string]v20260507.SettingMetadata{
+		string(v20260507.AutomaticDownload): {
 			Locked: util.Ptr(false),
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Value:  true,
 		},
-		string(v20241015.CliReleaseChannel): {
+		string(v20260507.CliReleaseChannel): {
 			Locked: util.Ptr(false),
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Value:  "stable",
 		},
 	}
@@ -977,9 +977,9 @@ func Test_RefreshConfigFromLdxSync_BypassAttempt_LockedSettingRevertedOnSync(t *
 	orgId := "bypass-org"
 	// LDX-Sync returns locked per-flag settings — user overrides must be cleared
 	result := createLdxSyncResultWithLockedField(orgId, types.GetLDXSyncKey(types.SettingSeverityFilterCritical))
-	(*result.Config.Data.Attributes.Settings)[types.GetLDXSyncKey(types.SettingSnykCodeEnabled)] = v20241015.SettingMetadata{
+	(*result.Config.Data.Attributes.Settings)[types.GetLDXSyncKey(types.SettingSnykCodeEnabled)] = v20260507.SettingMetadata{
 		Locked: util.Ptr(true),
-		Origin: v20241015.SettingMetadataOriginOrg,
+		Origin: v20260507.SettingMetadataOriginOrg,
 		Value:  true,
 	}
 
@@ -1190,26 +1190,26 @@ func Test_RefreshConfigFromLdxSync_InvalidConfig_EmptyAttributesHandledGracefull
 	// Result with Config but nil Organizations and nil Settings
 	configId := uuid.MustParse("00000000-0000-0000-0000-000000000099")
 	emptyResult := ldx_sync_config.LdxSyncConfigResult{
-		Config: &v20241015.UserConfigResponse{
+		Config: &v20260507.UserConfigResponse{
 			Data: struct {
 				Attributes struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				} `json:"attributes"`
 				Id   uuid.UUID                            `json:"id"`
-				Type v20241015.UserConfigResponseDataType `json:"type"`
+				Type v20260507.UserConfigResponseDataType `json:"type"`
 			}{
 				Attributes: struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				}{
 					Organizations: nil,
 					Settings:      nil,
@@ -1249,28 +1249,28 @@ func Test_RefreshConfigFromLdxSync_NoMapping_FallsBackToGlobalOrg(t *testing.T) 
 
 	// API returns a result with NO organizations (project not tracked)
 	configId := uuid.MustParse("00000000-0000-0000-0000-000000000012")
-	emptyOrgs := []v20241015.Organization{}
+	emptyOrgs := []v20260507.Organization{}
 	noMappingResult := ldx_sync_config.LdxSyncConfigResult{
-		Config: &v20241015.UserConfigResponse{
+		Config: &v20260507.UserConfigResponse{
 			Data: struct {
 				Attributes struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				} `json:"attributes"`
 				Id   uuid.UUID                            `json:"id"`
-				Type v20241015.UserConfigResponseDataType `json:"type"`
+				Type v20260507.UserConfigResponseDataType `json:"type"`
 			}{
 				Attributes: struct {
 					CreatedAt      *time.Time                                       `json:"created_at,omitempty"`
-					FolderSettings *map[string]map[string]v20241015.SettingMetadata `json:"folder_settings,omitempty"`
+					FolderSettings *map[string]map[string]v20260507.SettingMetadata `json:"folder_settings,omitempty"`
 					LastModifiedAt *time.Time                                       `json:"last_modified_at,omitempty"`
-					Organizations  *[]v20241015.Organization                        `json:"organizations,omitempty"`
-					Scope          *v20241015.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
-					Settings       *map[string]v20241015.SettingMetadata            `json:"settings,omitempty"`
+					Organizations  *[]v20260507.Organization                        `json:"organizations,omitempty"`
+					Scope          *v20260507.UserConfigResponseDataAttributesScope `json:"scope,omitempty"`
+					Settings       *map[string]v20260507.SettingMetadata            `json:"settings,omitempty"`
 				}{
 					Organizations: &emptyOrgs,
 				},
@@ -1325,10 +1325,10 @@ func Test_RefreshConfigFromLdxSync_FolderSettingsLockedClearsOverrides(t *testin
 
 	orgId := "test-org-folder-locked"
 	normalizedURL := "https://github.com/snyk/test-repo"
-	folderSettings := map[string]v20241015.SettingMetadata{
+	folderSettings := map[string]v20260507.SettingMetadata{
 		"issue_view_open_issues": {
 			Value:  false,
-			Origin: v20241015.SettingMetadataOriginOrg,
+			Origin: v20260507.SettingMetadataOriginOrg,
 			Locked: util.Ptr(true),
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-//replace github.com/snyk/go-application-framework => ../go-application-framework
+replace github.com/snyk/go-application-framework => ../go-application-framework
 
 //replace github.com/snyk/code-client-go => ../code-client-go
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/snyk/cli-extension-secrets v0.0.0-20260305092220-defe1129df99
 	github.com/snyk/code-client-go v1.26.1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
-	github.com/snyk/go-application-framework v0.0.0-20260506111235-cca3157b9435
+	github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf
 	github.com/snyk/studio-mcp v1.6.1
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.10
@@ -141,7 +141,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/snyk/go-application-framework => ../go-application-framework
+//replace github.com/snyk/go-application-framework => ../go-application-framework
 
 //replace github.com/snyk/code-client-go => ../code-client-go
 

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h1:MumWzLKiIFhZEk/wP71S/zv2cceygDb3+KNXGBb1hC0=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20260506111235-cca3157b9435 h1:R6tOMqc6GyC8ncoTT+eO6I38qs9/SxgPi9AEYoIEubQ=
-github.com/snyk/go-application-framework v0.0.0-20260506111235-cca3157b9435/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
+github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf h1:PPIXGApRw2m806/hL7crqbsLs8vppnr0DzEZAGNYsnk=
+github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/studio-mcp v1.6.1 h1:rk+3eZDt9hVcdnmCzvK78qzuBzbxAHBf862ABc38t+I=

--- a/internal/types/ldx_sync_adapter.go
+++ b/internal/types/ldx_sync_adapter.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 
 	"github.com/rs/zerolog/log"
-	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/ldx_sync_config/ldx_sync/2024-10-15"
+	v20260507 "github.com/snyk/go-application-framework/pkg/apiclients/ldx_sync_config/ldx_sync/2026-05-07"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 	gafgit "github.com/snyk/go-application-framework/pkg/utils/git"
@@ -71,7 +71,7 @@ var ldxSyncSettingKeyMap = map[string]string{
 // ConvertLDXSyncResponseToOrgConfig converts a UserConfigResponse to our LDXSyncOrgConfig format.
 // Only extracts folder-scoped settings (not machine-scoped).
 // fm is used to determine setting scope from GAF annotations.
-func ConvertLDXSyncResponseToOrgConfig(orgId string, response *v20241015.UserConfigResponse, fm workflow.ConfigurationOptionsMetaData) *LDXSyncOrgConfig {
+func ConvertLDXSyncResponseToOrgConfig(orgId string, response *v20260507.UserConfigResponse, fm workflow.ConfigurationOptionsMetaData) *LDXSyncOrgConfig {
 	if response == nil {
 		return nil
 	}
@@ -97,7 +97,7 @@ func ConvertLDXSyncResponseToOrgConfig(orgId string, response *v20241015.UserCon
 
 // ExtractMachineSettings extracts machine-scoped settings from a UserConfigResponse.
 // fm is used to determine setting scope from GAF annotations.
-func ExtractMachineSettings(response *v20241015.UserConfigResponse, fm workflow.ConfigurationOptionsMetaData) map[string]*LDXSyncField {
+func ExtractMachineSettings(response *v20260507.UserConfigResponse, fm workflow.ConfigurationOptionsMetaData) map[string]*LDXSyncField {
 	if response == nil || response.Data.Attributes.Settings == nil {
 		return nil
 	}
@@ -123,7 +123,7 @@ func ExtractMachineSettings(response *v20241015.UserConfigResponse, fm workflow.
 // ExtractFolderSettings extracts folder-specific settings from a UserConfigResponse for the given remote URL
 // These settings should be stored per-folder, NOT merged into the org config cache
 // Returns nil if no folder-specific settings are found
-func ExtractFolderSettings(response *v20241015.UserConfigResponse, remoteUrl string) map[string]*LDXSyncField {
+func ExtractFolderSettings(response *v20260507.UserConfigResponse, remoteUrl string) map[string]*LDXSyncField {
 	if response == nil || response.Data.Attributes.FolderSettings == nil || remoteUrl == "" {
 		return nil
 	}
@@ -135,7 +135,7 @@ func ExtractFolderSettings(response *v20241015.UserConfigResponse, remoteUrl str
 	}
 	sort.Strings(keys)
 
-	index := make(map[string]map[string]v20241015.SettingMetadata)
+	index := make(map[string]map[string]v20260507.SettingMetadata)
 	collisionLogged := false
 	for _, apiKey := range keys {
 		settings := fs[apiKey]
@@ -255,7 +255,7 @@ func WriteFolderConfigToConfiguration(conf configuration.Configuration, orgId st
 }
 
 // ExtractOrgIdFromResponse extracts the preferred organization ID from a UserConfigResponse
-func ExtractOrgIdFromResponse(response *v20241015.UserConfigResponse) string {
+func ExtractOrgIdFromResponse(response *v20260507.UserConfigResponse) string {
 	if response == nil || response.Data.Attributes.Organizations == nil {
 		return ""
 	}

--- a/internal/types/ldx_sync_adapter_test.go
+++ b/internal/types/ldx_sync_adapter_test.go
@@ -19,7 +19,7 @@ package types
 import (
 	"testing"
 
-	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/ldx_sync_config/ldx_sync/2024-10-15"
+	v20260507 "github.com/snyk/go-application-framework/pkg/apiclients/ldx_sync_config/ldx_sync/2026-05-07"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -45,17 +45,17 @@ func TestConvertLDXSyncResponseToOrgConfig(t *testing.T) {
 	})
 
 	t.Run("converts settings with metadata", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Settings = &map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Settings = &map[string]v20260507.SettingMetadata{
 			"risk_score_threshold": {
 				Value:  500,
 				Locked: util.Ptr(true),
-				Origin: v20241015.SettingMetadataOriginGroup,
+				Origin: v20260507.SettingMetadataOriginGroup,
 			},
 			"scan_automatic": {
 				Value:  true,
 				Locked: util.Ptr(false),
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 		}
 
@@ -80,11 +80,11 @@ func TestConvertLDXSyncResponseToOrgConfig(t *testing.T) {
 	})
 
 	t.Run("handles nil locked pointers", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Settings = &map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Settings = &map[string]v20260507.SettingMetadata{
 			"scan_net_new": {
 				Value:  true,
-				Origin: v20241015.SettingMetadataOriginUser,
+				Origin: v20260507.SettingMetadataOriginUser,
 			},
 		}
 
@@ -96,11 +96,11 @@ func TestConvertLDXSyncResponseToOrgConfig(t *testing.T) {
 	})
 
 	t.Run("ignores unknown settings", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Settings = &map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Settings = &map[string]v20260507.SettingMetadata{
 			"unknown_setting": {
 				Value:  "test",
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 		}
 
@@ -114,12 +114,12 @@ func TestConvertLDXSyncResponseToOrgConfig(t *testing.T) {
 func TestExtractFolderSettings(t *testing.T) {
 	t.Run("extracts folder-specific settings", func(t *testing.T) {
 		locked := true
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.FolderSettings = &map[string]map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.FolderSettings = &map[string]map[string]v20260507.SettingMetadata{
 			"git@github.com:snyk/test-repo.git": {
 				"scan_automatic": {
 					Value:  false,
-					Origin: v20241015.SettingMetadataOriginOrg,
+					Origin: v20260507.SettingMetadataOriginOrg,
 					Locked: &locked,
 				},
 			},
@@ -135,12 +135,12 @@ func TestExtractFolderSettings(t *testing.T) {
 	})
 
 	t.Run("returns nil for missing remote URL", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.FolderSettings = &map[string]map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.FolderSettings = &map[string]map[string]v20260507.SettingMetadata{
 			"git@github.com:snyk/test-repo.git": {
 				"reference_branch": {
 					Value:  "develop",
-					Origin: v20241015.SettingMetadataOriginOrg,
+					Origin: v20260507.SettingMetadataOriginOrg,
 				},
 			},
 		}
@@ -155,12 +155,12 @@ func TestExtractFolderSettings(t *testing.T) {
 	})
 
 	t.Run("returns nil for empty remote URL", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.FolderSettings = &map[string]map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.FolderSettings = &map[string]map[string]v20260507.SettingMetadata{
 			"git@github.com:snyk/test-repo.git": {
 				"reference_branch": {
 					Value:  "develop",
-					Origin: v20241015.SettingMetadataOriginOrg,
+					Origin: v20260507.SettingMetadataOriginOrg,
 				},
 			},
 		}
@@ -170,7 +170,7 @@ func TestExtractFolderSettings(t *testing.T) {
 	})
 
 	t.Run("returns nil for nil folder settings", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
+		response := &v20260507.UserConfigResponse{}
 		result := ExtractFolderSettings(response, "git@github.com:snyk/test-repo.git")
 		assert.Nil(t, result)
 	})
@@ -178,12 +178,12 @@ func TestExtractFolderSettings(t *testing.T) {
 	t.Run("matches folder settings when API key is normalized HTTPS and remoteUrl is raw SSH", func(t *testing.T) {
 		locked := true
 		normalizedURL := "https://github.com/snyk/test-repo"
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.FolderSettings = &map[string]map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.FolderSettings = &map[string]map[string]v20260507.SettingMetadata{
 			normalizedURL: {
 				"issue_view_open_issues": {
 					Value:  true,
-					Origin: v20241015.SettingMetadataOriginOrg,
+					Origin: v20260507.SettingMetadataOriginOrg,
 					Locked: &locked,
 				},
 			},
@@ -200,12 +200,12 @@ func TestExtractFolderSettings(t *testing.T) {
 
 	t.Run("matches folder settings when API key is normalized HTTPS and remoteUrl is raw HTTPS with credentials", func(t *testing.T) {
 		normalizedURL := "https://github.com/snyk/test-repo"
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.FolderSettings = &map[string]map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.FolderSettings = &map[string]map[string]v20260507.SettingMetadata{
 			normalizedURL: {
 				"issue_view_ignored_issues": {
 					Value:  false,
-					Origin: v20241015.SettingMetadataOriginOrg,
+					Origin: v20260507.SettingMetadataOriginOrg,
 				},
 			},
 		}
@@ -219,18 +219,18 @@ func TestExtractFolderSettings(t *testing.T) {
 	})
 
 	t.Run("when two API keys normalize to the same URL, last sorted key wins", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.FolderSettings = &map[string]map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.FolderSettings = &map[string]map[string]v20260507.SettingMetadata{
 			"git@github.com:snyk/test-repo.git": {
 				"scan_automatic": {
 					Value:  false,
-					Origin: v20241015.SettingMetadataOriginOrg,
+					Origin: v20260507.SettingMetadataOriginOrg,
 				},
 			},
 			"https://github.com/snyk/test-repo": {
 				"scan_automatic": {
 					Value:  true,
-					Origin: v20241015.SettingMetadataOriginOrg,
+					Origin: v20260507.SettingMetadataOriginOrg,
 				},
 			},
 		}
@@ -247,18 +247,18 @@ func TestExtractMachineSettings(t *testing.T) {
 	fm := adapterTestFm(t)
 	t.Run("extracts machine-scope settings only", func(t *testing.T) {
 		locked := true
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Settings = &map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Settings = &map[string]v20260507.SettingMetadata{
 			// Machine-scope setting
 			"cli_release_channel": {
 				Value:  "stable",
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 				Locked: &locked,
 			},
 			// Org-scope setting (should be excluded)
 			"scan_automatic": {
 				Value:  true,
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 		}
 
@@ -282,18 +282,18 @@ func TestExtractMachineSettings(t *testing.T) {
 	})
 
 	t.Run("returns nil for nil settings", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
+		response := &v20260507.UserConfigResponse{}
 		result := ExtractMachineSettings(response, fm)
 		assert.Nil(t, result)
 	})
 
 	t.Run("returns nil when no machine-scope settings present", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Settings = &map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Settings = &map[string]v20260507.SettingMetadata{
 			// Only org-scope setting
 			"scan_automatic": {
 				Value:  true,
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 		}
 
@@ -303,29 +303,29 @@ func TestExtractMachineSettings(t *testing.T) {
 
 	// TODO - This test can be deleted once the changes done in IDE-1920 for the CB are reverted.
 	t.Run("ignores removed settings and accepts valid ones", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Settings = &map[string]v20241015.SettingMetadata{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Settings = &map[string]v20260507.SettingMetadata{
 			// Removed settings (commented out in ldxSyncSettingKeyMap)
 			"proxy_no_proxy": {
 				Value:  "localhost,127.0.0.1",
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 			"api_endpoint": {
 				Value:  "https://api.evil.com",
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 			"authentication_method": {
 				Value:  "token",
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 			"cwe_ids": {
 				Value:  "123,456",
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 			// Valid machine-scope setting
 			"cli_release_channel": {
 				Value:  "stable",
-				Origin: v20241015.SettingMetadataOriginOrg,
+				Origin: v20260507.SettingMetadataOriginOrg,
 			},
 		}
 
@@ -359,14 +359,14 @@ func TestExtractOrgIdFromResponse(t *testing.T) {
 	})
 
 	t.Run("returns empty for nil organizations", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
+		response := &v20260507.UserConfigResponse{}
 		result := ExtractOrgIdFromResponse(response)
 		assert.Empty(t, result)
 	})
 
 	t.Run("returns preferred organization", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Organizations = &[]v20241015.Organization{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Organizations = &[]v20260507.Organization{
 			{Id: "org1", Name: "Org 1", Slug: "org1", IsDefault: util.Ptr(true)},
 			{Id: "org2", Name: "Org 2", Slug: "org2", PreferredByAlgorithm: util.Ptr(true)},
 		}
@@ -376,8 +376,8 @@ func TestExtractOrgIdFromResponse(t *testing.T) {
 	})
 
 	t.Run("falls back to default organization", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Organizations = &[]v20241015.Organization{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Organizations = &[]v20260507.Organization{
 			{Id: "org1", Name: "Org 1", Slug: "org1", IsDefault: util.Ptr(true)},
 			{Id: "org2", Name: "Org 2", Slug: "org2"},
 		}
@@ -387,8 +387,8 @@ func TestExtractOrgIdFromResponse(t *testing.T) {
 	})
 
 	t.Run("falls back to first organization", func(t *testing.T) {
-		response := &v20241015.UserConfigResponse{}
-		response.Data.Attributes.Organizations = &[]v20241015.Organization{
+		response := &v20260507.UserConfigResponse{}
+		response.Data.Attributes.Organizations = &[]v20260507.Organization{
 			{Id: "org1", Name: "Org 1", Slug: "org1"},
 			{Id: "org2", Name: "Org 2", Slug: "org2"},
 		}


### PR DESCRIPTION
## Summary

- Updates all snyk-ls imports of the GAF ldx_sync generated client from version `2024-10-15` (package `v20241015`) to `2026-05-07` (package `v20260507`)
- Enables the `replace` directive in `go.mod` pointing to the local `go-application-framework` checkout while GAF PR #603 is not yet merged
- No adapter logic changes required — `UserConfigResponse`, `SettingMetadata`, and `Organization` types are structurally identical between versions

## Files changed

- `internal/types/ldx_sync_adapter.go` — import alias + all type references
- `internal/types/ldx_sync_adapter_test.go` — import alias + all type references
- `domain/ide/command/ldx_sync_service_test.go` — import alias + all type references
- `go.mod` — enabled local replace for go-application-framework

## Depends on

GAF PR: https://github.com/snyk/go-application-framework/pull/603 (the `replace` directive should be commented out again once that PR merges and a new GAF release is cut)

## Test plan

- [x] `go build ./...` passes with no errors
- [x] `go vet ./internal/types/... ./domain/ide/command/...` passes cleanly
- [ ] CI unit tests pass