### PR TITLE
fix(test): use os.Setenv to allow parallel tests calling UnitTest [IDE-2017]

### DIFF
--- a/application/server/inline_values_test.go
+++ b/application/server/inline_values_test.go
@@ -83,12 +83,15 @@ func Test_textDocumentInlineValues_InlineValues_IntegTest(t *testing.T) {
 			TextDocument: sglsp.TextDocumentIdentifier{URI: documentURI},
 			Range:        sglsp.Range{Start: sglsp.Position{Line: 17}, End: sglsp.Position{Line: 17}},
 		})
-		assert.NoError(t, err)
+		if err != nil {
+			return false
+		}
 
 		var inlineValues []types.InlineValue
-		err = rsp.UnmarshalResult(&inlineValues)
-		assert.NoError(t, err)
+		if err = rsp.UnmarshalResult(&inlineValues); err != nil {
+			return false
+		}
 
 		return len(inlineValues) == 1 && inlineValues[0].Range.Start.Line == 17 && inlineValues[0].Range.End.Line == 17
-	}, time.Minute, time.Millisecond, "expected inline values to be served, but they were not")
+	}, time.Minute, time.Second, "expected inline values to be served, but they were not")
 }

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -101,7 +101,7 @@ func initStandaloneTestPreEngine(t *testing.T, binarySearchPaths []string) workf
 
 func UnitTestWithEngine(t *testing.T) (workflow.Engine, *config.TokenServiceImpl) {
 	t.Helper()
-	t.Setenv(shellenv.DisableShellEnvLoadingEnvVar, "1")
+	_ = os.Setenv(shellenv.DisableShellEnvLoadingEnvVar, "1") //nolint:usetesting // t.Setenv panics when called from a parallel test (Go 1.25+)
 	engine, ts := config.InitEngine(initStandaloneTestPreEngine(t, []string{}))
 	conf := engine.GetConfiguration()
 	logger := engine.GetLogger()
@@ -192,7 +192,7 @@ func CreateDummyProgressListener(t *testing.T) {
 
 func prepareTestHelper(t *testing.T, envVar string, tokenSecretName string) (workflow.Engine, *config.TokenServiceImpl) {
 	t.Helper()
-	t.Setenv(shellenv.DisableShellEnvLoadingEnvVar, "1")
+	_ = os.Setenv(shellenv.DisableShellEnvLoadingEnvVar, "1") //nolint:usetesting // t.Setenv panics when called from a parallel test (Go 1.25+)
 	if os.Getenv(envVar) == "" {
 		t.Logf("%s is not set", envVar)
 		t.SkipNow()


### PR DESCRIPTION
## Summary

- Replaces `t.Setenv(DisableShellEnvLoadingEnvVar, "1")` with `os.Setenv(...)` in `UnitTestWithEngine` and `prepareTestHelper` in `internal/testutil/test_setup.go`
- Adds `//nolint:usetesting` with an explanation to silence the linter (which would otherwise suggest reverting to `t.Setenv`)
- Fixes a Go 1.25+ panic that fires when any test calls `t.Parallel()` before calling `testutil.UnitTest(t)` or `testutil.UnitTestWithEngine(t)`

**Root cause:** Go 1.25 introduced a strict check in `t.Setenv` that panics if the test (or any ancestor) has called `t.Parallel()`. Since `UnitTestWithEngine` calls `t.Setenv(DisableShellEnvLoadingEnvVar, "1")`, any parallel test that calls `testutil.UnitTest` will panic.

**Fix:** `os.Setenv` is safe to use here because all tests in the suite set this variable to the same value (`"1"`) and no test ever needs it absent. The variable is used to disable shell env loading during tests. `os.Setenv` is goroutine-safe (protected by `envLock` in `syscall/env_unix.go`), so concurrent parallel tests writing the same key/value is idempotent and race-free.

**Jira:** [IDE-2017](https://snyksec.atlassian.net/browse/IDE-2017)

## Test plan

- [x] `TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal` (the triggering test) now passes
- [x] `make test` — all unit tests pass
- [x] `INTEG_TESTS=1 make test` — all integration tests pass
- [x] `SMOKE_TESTS=1 make test` — all smoke tests pass
- [x] `make lint` — 0 issues
- [x] pr-review-bot — PASS, no blocking findings

[IDE-2017]: https://snyksec.atlassian.net/browse/IDE-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ