### PR TITLE
fix(treeview): use ErrorConfig suffix for HTML product scan errors

### DIFF
--- a/domain/ide/treeview/tree_builder.go
+++ b/domain/ide/treeview/tree_builder.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/types"
 )
@@ -254,7 +255,7 @@ func (b *TreeBuilder) buildProductNodes(fd FolderData) []TreeNode {
 				desc = "- " + productDescription(p, totalIssues, stats.severityCounts) + " (scanning...)"
 			}
 		} else if scanError != "" {
-			desc = "- (scan failed)"
+			desc = productScanErrorDescription(scanError)
 		} else if scanRegistered {
 			desc = "- " + productDescription(p, totalIssues, stats.severityCounts)
 		}
@@ -766,4 +767,13 @@ func issuePriority(issue types.Issue) int {
 	}
 
 	return severityWeight*1_000_000 + score
+}
+
+// productScanErrorDescription matches scan_notifier SendError: errors listed in utils.ErrorConfig use
+// TreeRootSuffix as the inline HTML tree description; unknown errors keep "- (scan failed)".
+func productScanErrorDescription(scanError string) string {
+	if meta, ok := utils.ErrorConfig[scanError]; ok && meta.TreeRootSuffix != "" {
+		return "- " + meta.TreeRootSuffix
+	}
+	return "- (scan failed)"
 }

--- a/domain/ide/treeview/tree_builder_test.go
+++ b/domain/ide/treeview/tree_builder_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -1159,8 +1160,39 @@ func TestBuildTree_ProductNode_ScanError_ShowsErrorSuffix(t *testing.T) {
 
 	ossNode := findChildByProduct(data.Nodes, product.ProductOpenSource)
 	require.NotNil(t, ossNode)
-	assert.Contains(t, ossNode.Description, "(scan failed)", "errored product node should show scan failed suffix")
+	assert.Equal(t, "- (scan failed)", ossNode.Description, "unknown scan errors should use generic scan failed suffix")
 	assert.Equal(t, "dependency graph failed", ossNode.ErrorMessage, "product node should carry the full error message")
+}
+
+func TestBuildTree_ProductNode_ScanError_UsesErrorCatalogTreeSuffix(t *testing.T) {
+	cases := []struct {
+		errMsg     string
+		wantInDesc string
+	}{
+		{utils.ErrSnykCodeNotEnabled, "(disabled at Snyk)"},
+		{utils.ErrNoReferenceBranch, "(no reference branch)"},
+		{utils.ErrNoRepo, "(repository not found)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.errMsg, func(t *testing.T) {
+			builder := newBuilderWithCompletedScans()
+			builder.SetProductScanErrors(map[types.FilePath]map[product.Product]string{
+				"/project": {product.ProductOpenSource: tc.errMsg},
+			})
+
+			data := builder.BuildTreeFromFolderData([]FolderData{{
+				FolderPath: "/project", FolderName: "project",
+				SupportedIssueTypes: map[product.FilterableIssueType]bool{product.FilterableIssueTypeOpenSource: true},
+				AllIssues:           nil, FilteredIssues: nil,
+			}})
+
+			ossNode := findChildByProduct(data.Nodes, product.ProductOpenSource)
+			require.NotNil(t, ossNode)
+			assert.Contains(t, ossNode.Description, tc.wantInDesc)
+			assert.NotContains(t, ossNode.Description, "(scan failed)", "catalogued errors should not use generic scan failed label")
+			assert.Equal(t, tc.errMsg, ossNode.ErrorMessage)
+		})
+	}
 }
 
 func TestBuildTree_ProductNode_ScanError_NoIssueChildren(t *testing.T) {


### PR DESCRIPTION
Product nodes with scan errors used a hardcoded "- (scan failed)" description while $\/snyk\/scan already maps the same message keys via utils.ErrorConfig TreeRootSuffix. Align the server-rendered tree inline label with that catalog, keeping the full message on ErrorMessage / data-error-message for overlays.

Tests cover catalogued errors on main and unknown errors still use the generic suffix.

### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
