### PR TITLE
test(server): wait for unmanaged OSS diagnostics in smoke test

### DIFF
--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1369,9 +1369,13 @@ func Test_SmokeScanUnmanaged(t *testing.T) {
 	waitForScan(t, cloneTargetDirString, engine)
 	checkForScanParams(t, jsonRPCRecorder, cloneTargetDirString, product.ProductOpenSource)
 
-	issueList := getIssueListFromPublishDiagnosticsNotification(t, jsonRPCRecorder, product.ProductOpenSource, cloneTargetDir)
-
-	assert.Greater(t, len(issueList), 10, "More than 10 unmanaged issues expected")
+	// Diagnostics can arrive after $/snyk.scan reports Success (same pattern as checkOnlyOneQuickFixCodeAction).
+	var issueList []types.ScanIssue
+	require.Eventually(t, func() bool {
+		issueList = getIssueListFromPublishDiagnosticsNotification(t, jsonRPCRecorder, product.ProductOpenSource, cloneTargetDir)
+		return len(issueList) > 10
+	}, maxIntegTestDuration, time.Millisecond,
+		"publishDiagnostics did not report more than 10 unmanaged OSS issues for folder %s", cloneTargetDir)
 }
 
 // requireLspFolderConfigNotification checks that a $/snyk.configuration notification


### PR DESCRIPTION
publishDiagnostics can arrive after $/snyk.scan reports Success. Use require.Eventually with maxIntegTestDuration so Test_SmokeScanUnmanaged does not flake when diagnostics lag behind the scan notification.

### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
