### PR TITLE
test(server): stabilize Test_SmokeScanUnmanaged on Linux CI [IDE-2025]

### DIFF
--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1393,14 +1393,21 @@ func Test_SmokeScanUnmanaged(t *testing.T) {
 	loc, jsonRPCRecorder := setupServer(t, engine, tokenService)
 	// OSS-only: unmanaged scan is an OSS-specific path (--unmanaged for C/C++ repos).
 	enableOnlyProducts(t, engine, product.ProductOpenSource)
+	// When scan net-new is on, FilterAndPublishDiagnostics keeps only IsNew issues; enrichment/baseline
+	// timing on CI (especially Linux /tmp layouts) can leave every OSS issue filtered out while the CLI
+	// scan still succeeds. This test asserts unmanaged finding volume, not net-new only.
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingScanNetNew), false)
 	cleanupChannels()
 	di.Init(engine, tokenService)
 
 	cloneTargetDir, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.CppGoof, "259ea516a4ec", engine.GetLogger(), false)
-	cloneTargetDirString := string(cloneTargetDir)
 	if err != nil {
 		t.Fatal(err, "Couldn't setup test repo")
 	}
+	if resolved, evalErr := filepath.EvalSymlinks(string(cloneTargetDir)); evalErr == nil {
+		cloneTargetDir = types.FilePath(resolved)
+	}
+	cloneTargetDirString := string(cloneTargetDir)
 
 	initParams := prepareInitParams(t, cloneTargetDir, engine)
 

--- a/infrastructure/cli/initializer_test.go
+++ b/infrastructure/cli/initializer_test.go
@@ -76,7 +76,7 @@ func Test_EnsureCliShouldFindOrDownloadCliAndAddPathToEnv(t *testing.T) {
 		tokenService.SetToken(conf, "dummy") // we don't want to authenticate
 	}
 	_ = initializer.Init(t.Context())
-	assert.NotEmpty(t, types.GetGlobalString(conf, types.SettingCliPath))
+	assert.NotEmpty(t, config.GetCliPath(conf))
 }
 
 func Test_EnsureCLIShouldRespectCliPathInEnv(t *testing.T) {


### PR DESCRIPTION
### Description

Single commit on `main` (`07983f09`): [IDE-2025](https://snyksec.atlassian.net/browse/IDE-2025).

**Test_SmokeScanUnmanaged** (`application/server/server_smoke_test.go`)

- Keep OSS-only setup via `enableOnlyProducts(..., ProductOpenSource)`.
- Disable `SettingScanNetNew` for this test so OSS diagnostics are not filtered to net-new only (reduces Linux CI / `/tmp` symlink timing flakes).
- Canonicalize the cloned repo path with `filepath.EvalSymlinks`.
- Fix repo setup error handling order; remove redundant folder `SettingAdditionalParameters` / `--unmanaged` persistence (default unmanaged path for this fixture is enough).

**Initializer integ test** (`infrastructure/cli/initializer_test.go`)

- After `Init`, assert `config.GetCliPath(conf)` is non-empty instead of `types.GetGlobalString(..., SettingCliPath)`, so the test passes when the CLI is resolved via the default install path (local pre-push / `make test`).

### Checklist

- [x] Tests added and all succeed (`INTEG_TESTS=1 make test` at `07983f09`)
- [x] Regenerated mocks, etc. (`make generate`) — not required
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing — N/A
- [ ] License file updated, if new 3rd-party dependency is introduced — N/A


[IDE-2025]: https://snyksec.atlassian.net/browse/IDE-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ