### PR TITLE
debug: --debug + 2m timeout for Test_SmokeScanUnmanaged (do not merge)

### DIFF
--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1415,7 +1415,7 @@ func Test_SmokeScanUnmanaged(t *testing.T) {
 	// directly to storage before initialization triggers the scan.
 	engineConfig := engine.GetConfiguration()
 	fp := string(types.PathKey(cloneTargetDir))
-	engineConfig.Set(configresolver.UserFolderKey(fp, types.SettingAdditionalParameters), &configresolver.LocalConfigField{Value: []string{"--unmanaged"}, Changed: true})
+	engineConfig.Set(configresolver.UserFolderKey(fp, types.SettingAdditionalParameters), &configresolver.LocalConfigField{Value: []string{"--unmanaged", "--debug"}, Changed: true})
 
 	ensureInitialized(t, engine, tokenService, loc, initParams, nil)
 
@@ -1427,7 +1427,7 @@ func Test_SmokeScanUnmanaged(t *testing.T) {
 	require.Eventually(t, func() bool {
 		issueList = getIssueListFromPublishDiagnosticsNotification(t, jsonRPCRecorder, product.ProductOpenSource, cloneTargetDir)
 		return len(issueList) > 10
-	}, maxIntegTestDuration, time.Millisecond,
+	}, 2*time.Minute, time.Millisecond,
 		"publishDiagnostics did not report more than 10 unmanaged OSS issues for folder %s", cloneTargetDir)
 }
 


### PR DESCRIPTION
## Summary
- Investigation branch — **not for merge**
- Adds `--debug` to the CLI args in `Test_SmokeScanUnmanaged` so the unmanaged scan dumps hash upload + match counts on CI
- Cuts the inner `Eventually` from `maxIntegTestDuration` (15m) to `2m` so this test fails fast instead of holding the integ-test slot

## Why
`Test_SmokeScanUnmanaged` has been flaking on `integration-tests (macos-latest)`. CLI scan completes cleanly with `found 0 issues` against a known-vulnerable pinned fixture (`cpp-goof@259ea516a4ec`). With `--debug` we can see whether the CLI sent zero file hashes (LS/proxy issue) or the backend returned zero matches (service issue).

## Test plan
- [ ] CI runs Test_SmokeScanUnmanaged on macOS
- [ ] On failure, inspect CI log for `--debug` output around the unmanaged hash upload
- [ ] Compare against a passing run (ubuntu/windows) to confirm what differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)