### PR TITLE
fix(auth): flush pre-init OAuth token to new storage in SetupStorage [IDE-2026]

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -696,10 +696,28 @@ func getAsOauthToken(token string, logger *zerolog.Logger) (*oauth2.Token, error
 }
 
 func SetupStorage(conf configuration.Configuration, s storage.StorageWithCallbacks, logger *zerolog.Logger) {
+	// Capture any OAuth token that was refreshed before this storage was mounted.
+	// A background API call (e.g. feature-flag poll) can trigger a GAF token refresh
+	// before initializeHandler installs ls-config.json, storing the new token in viper
+	// memory only — it is never written to ls-config.json. After SetStorage below,
+	// GAF's syncTokenRefresh will lock and read ls-config.json; if that file still holds
+	// the previous-session token, Refresh overwrites the fresh viper value, fires the
+	// bridge with the stale token, then attempts a second refresh with an already-consumed
+	// refresh token — failing with "invalid_grant". Writing the fresh value to the new
+	// file first prevents that second attempt.
+	preInitOAuthToken := conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN)
+
 	conf.SetStorage(s)
 	conf.PersistInStorage(folderconfig.ConfigMainKey)
 	conf.PersistInStorage(auth.CONFIG_KEY_OAUTH_TOKEN)
 	conf.PersistInStorage(configuration.AUTHENTICATION_TOKEN)
+
+	if preInitOAuthToken != "" {
+		if err := s.Set(auth.CONFIG_KEY_OAUTH_TOKEN, preInitOAuthToken); err != nil {
+			logger.Warn().Err(err).Msg("failed to flush pre-init OAuth token to storage; " +
+				"a stale token may be read on the next sync")
+		}
+	}
 
 	err := s.Refresh(conf, folderconfig.ConfigMainKey)
 	if err != nil {

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/snyk/snyk-ls/infrastructure/cli/cli_constants"
+	"github.com/snyk/snyk-ls/internal/storage"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/util"
 )
@@ -909,4 +910,97 @@ func Test_ParseOAuthToken(t *testing.T) {
 		_, err := ParseOAuthToken("", &logger)
 		assert.Error(t, err)
 	})
+}
+
+// TestSetupStorage_FlushesPreInitOAuthTokenToNewStorage verifies that a token refreshed
+// before initializeHandler mounts ls-config.json (stored in viper memory only) is flushed
+// to the new backing file by SetupStorage. Without this flush, GAF's syncTokenRefresh reads
+// the stale file value, fires the bridge with it, and then attempts a second HTTP refresh
+// using the already-consumed refresh token — failing with "invalid_grant".
+func TestSetupStorage_FlushesPreInitOAuthTokenToNewStorage(t *testing.T) {
+	freshToken := `{"access_token":"fresh-at","refresh_token":"fresh-rt","token_type":"bearer","expiry":"2030-01-01T00:00:00Z"}`
+	staleToken := `{"access_token":"stale-at","refresh_token":"stale-rt","token_type":"bearer","expiry":"2020-01-01T00:00:00Z"}`
+
+	makeStaleStorage := func(t *testing.T) (storage.StorageWithCallbacks, string) {
+		t.Helper()
+		storageFile := filepath.Join(t.TempDir(), "ls-config.json")
+		s, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+		require.NoError(t, err)
+		require.NoError(t, s.Set(auth.CONFIG_KEY_OAUTH_TOKEN, staleToken))
+		return s, storageFile
+	}
+
+	assertFileHasFreshToken := func(t *testing.T, s storage.StorageWithCallbacks) {
+		t.Helper()
+		fileConf := configuration.NewWithOpts()
+		require.NoError(t, s.Refresh(fileConf, auth.CONFIG_KEY_OAUTH_TOKEN))
+		assert.Equal(t, freshToken, fileConf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN),
+			"storage file must contain the fresh pre-init token so syncTokenRefresh cannot load a stale value and trigger a second refresh")
+	}
+
+	t.Run("GetToken empty: file updated before s.Refresh overwrites memory", func(t *testing.T) {
+		// Arrange: fresh token in viper memory (pre-init refresh, no storage yet)
+		engine, _ := initEngineForConfigTest(t)
+		conf := engine.GetConfiguration()
+		logger := zerolog.Nop()
+		conf.Set(auth.CONFIG_KEY_OAUTH_TOKEN, freshToken)
+
+		_, storageFile := makeStaleStorage(t)
+		s, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+		require.NoError(t, err)
+
+		// Act
+		SetupStorage(conf, s, &logger)
+
+		// Assert: in-memory value is preserved (not overwritten by s.Refresh)
+		assert.Equal(t, freshToken, conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN),
+			"pre-init fresh token must survive SetupStorage's s.Refresh call unchanged")
+		// Assert: file has fresh token so syncTokenRefresh reads fresh on next API call
+		assertFileHasFreshToken(t, s)
+	})
+
+	t.Run("GetToken non-empty: file still updated even when s.Refresh is skipped", func(t *testing.T) {
+		// Arrange: canonical token already set (previous session), fresh OAuth token in memory
+		engine, _ := initEngineForConfigTest(t)
+		conf := engine.GetConfiguration()
+		logger := zerolog.Nop()
+
+		// Make GetToken(conf) return non-empty so SetupStorage skips s.Refresh for the token
+		conf.Set(configresolver.UserGlobalKey(types.SettingToken), "prev-session-canonical-token")
+		conf.Set(auth.CONFIG_KEY_OAUTH_TOKEN, freshToken)
+
+		_, storageFile := makeStaleStorage(t)
+		s, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+		require.NoError(t, err)
+
+		// Act
+		SetupStorage(conf, s, &logger)
+
+		// Assert: file has fresh token (syncTokenRefresh will read this file directly)
+		assertFileHasFreshToken(t, s)
+	})
+}
+
+// TestSetupStorage_EmptyPreInitToken_LoadsFromFile verifies that when no pre-init refresh
+// occurred (auth.CONFIG_KEY_OAUTH_TOKEN is empty in memory), SetupStorage loads the token
+// from the file as usual — the normal first-start or expired-and-restarted case.
+func TestSetupStorage_EmptyPreInitToken_LoadsFromFile(t *testing.T) {
+	engine, _ := initEngineForConfigTest(t)
+	conf := engine.GetConfiguration()
+	logger := zerolog.Nop()
+
+	// No pre-init token in memory
+	require.Empty(t, conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN))
+
+	existingToken := `{"access_token":"existing-at","refresh_token":"existing-rt","token_type":"bearer","expiry":"2030-01-01T00:00:00Z"}`
+	storageFile := filepath.Join(t.TempDir(), "ls-config.json")
+	s, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+	require.NoError(t, err)
+	require.NoError(t, s.Set(auth.CONFIG_KEY_OAUTH_TOKEN, existingToken))
+
+	SetupStorage(conf, s, &logger)
+
+	// The existing token from the file must be loaded into memory (normal path)
+	assert.Equal(t, existingToken, conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN),
+		"when no pre-init token exists, SetupStorage must load the token from the file")
 }


### PR DESCRIPTION
## Summary

- Captures the in-memory `auth.CONFIG_KEY_OAUTH_TOKEN` before `SetupStorage` switches the conf's backing store to `ls-config.json`
- Writes it to the new file immediately, before `PersistInStorage`'s `s.Refresh` call or any bridge registration
- Prevents GAF's `syncTokenRefresh` from reading a stale previous-session token, firing the bridge with it, and then attempting a second HTTP refresh with an already-consumed refresh token

## Root cause

Before `initializeHandler` mounts `ls-config.json`, a background API call (e.g. feature-flag poll) can trigger an OAuth token refresh. The new token is stored in **viper memory only** — no `ls-config.json` write occurs because no LS storage is mounted yet.

When `SetupStorage` installs `ls-config.json`, GAF's `syncTokenRefresh` (called on the next API request) locks and reads that file. If the file still holds the **previous-session token**, `storage.Refresh` calls `config.Set` with the stale value, which:
1. Overwrites the fresh viper token
2. Fires the OAuth bridge with the stale token (reverting the LS canonical token)
3. Attempts a second HTTP `POST /oauth2/token` with an already-consumed refresh token → **`invalid_grant`**

Snyk refresh tokens are single-use. This is why the failure manifests as a one-way door to logout.

The race is especially visible in IntelliJ because its JVM startup gives a larger window between `di.Init()` (where background services start) and the LSP `initialize` request.

## Diagrams

See `docs/diagrams/IDE-2026_oauth_refresh_race.mmd` (before) and `IDE-2026_oauth_refresh_fixed.mmd` (after).

## Stack

```mermaid
flowchart LR
  main --> pr1["fix/IDE-2026 ← you are here"]
```

Single-PR fix. No stacking required (112 changed lines).

## Test plan

- [x] `TestSetupStorage_FlushesPreInitOAuthTokenToNewStorage` — two subtests covering `GetToken==""` (s.Refresh path) and `GetToken!=""` (skipped-Refresh path); both verify the file is updated with the fresh token
- [x] `TestSetupStorage_EmptyPreInitToken_LoadsFromFile` — verifies the normal first-start path is unchanged
- [x] `go test ./application/config/... ./infrastructure/authentication/... ./internal/storage/...` — all green
- [x] `make lint` — 0 issues
- [x] Verification agent — no Critical / Should Fix findings

## Related

- Depends on / follows: #1252 (IDE-1900 — previous partial fix: storage bridge + credential serialisation)
- Part of IDE-2026