### PR TITLE
fix(autofix): increase `GetAutofixDiffs` timeout to 4 mins

### DIFF
--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -70,8 +70,8 @@ func (sc *Scanner) GetAutofixDiffs(ctx context.Context, baseDir types.FilePath, 
 	// ticker sends a trigger every second to its channel
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	// timeoutTimer sends a trigger after 2 minutes to its channel
-	timeoutTimer := time.NewTimer(2 * time.Minute)
+	// timeoutTimer sends a trigger after 4 minutes to its channel
+	timeoutTimer := time.NewTimer(4 * time.Minute)
 	defer timeoutTimer.Stop()
 	for {
 		select {


### PR DESCRIPTION
### Description

The Autofix service is transitioning to an agentic LLM approach, which introduces increased latency during fix generation. We observed that some test requests were timing out on the client side even though the fixes were generated successfully on the Autofix backend. 

While we are actively working on improving the generation latency, we would like to increase the autofix polling timeout in `GetAutofixDiffs` from **2 minutes to 4 minutes**. This gives the agentic Autofix requests sufficient time to complete and return the generated diffs.


### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
