### PR TITLE
fix(auth): don't log env vars at info level when running CLI commands [IDE-2030]

### DIFF
--- a/infrastructure/authentication/cli_provider.go
+++ b/infrastructure/authentication/cli_provider.go
@@ -201,7 +201,7 @@ func (a *CliAuthenticationProvider) buildCLICmd(ctx context.Context, args ...str
 	cmd := exec.CommandContext(ctx, cliPath, args...)
 	cmd.Env = cli.AppendCliEnvironmentVariables(a.engine, a.configResolver, os.Environ(), false)
 
-	a.engine.GetLogger().Info().Str("command", cmd.String()).Interface("env", cmd.Env).Msg("running Snyk CLI command")
+	a.engine.GetLogger().Info().Str("command", cmd.String()).Msg("running Snyk CLI command")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
- Env vars were logged at INFO level when running CLI commands in `CliAuthenticationProvider`, exposing potentially sensitive values (tokens, secrets) in logs
- Removed the `env=` field from the info-level log line in `infrastructure/authentication/cli_provider.go`
- Trace-level env logging in `infrastructure/cli/cli.go` is unaffected (developer-only, not visible in production)

## Test plan
- [ ] Verify no `env=` field appears in logs when running CLI auth commands at INFO level
- [ ] CI passes