### PR TITLE
Backport fixes for rc/1.1305

### DIFF
--- a/application/config/config.go
+++ b/application/config/config.go
@@ -705,21 +705,31 @@ func (c *Config) SetToken(newTokenString string) {
 
 	newOAuthToken, oAuthErr := getAsOauthToken(newTokenString, c.logger)
 
-	if c.authenticationMethod == types.OAuthAuthentication && oAuthErr == nil &&
-		c.shouldUpdateOAuth2Token(oldTokenString, newTokenString) {
-		c.logger.Debug().Msg("put oauth2 token into GAF")
-		conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
-		conf.Set(auth.CONFIG_KEY_OAUTH_TOKEN, newTokenString)
+	// applied is the token that was actually written to GAF (or already there).
+	// If we skip the write below because the incoming token is stale, applied
+	// stays equal to the existing on-disk/in-memory token so the rest of this
+	// function does not overwrite c.token or notify listeners with the stale value.
+	applied := newTokenString
+
+	if c.authenticationMethod == types.OAuthAuthentication && oAuthErr == nil {
+		if c.shouldUpdateOAuth2Token(oldTokenString, newTokenString) {
+			c.logger.Debug().Msg("put oauth2 token into GAF")
+			conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
+			conf.Set(auth.CONFIG_KEY_OAUTH_TOKEN, newTokenString)
+		} else {
+			c.logger.Debug().Msg("rejected stale oauth2 token; keeping existing credentials")
+			applied = oldTokenString
+		}
 	} else if conf.GetString(configuration.AUTHENTICATION_TOKEN) != newTokenString {
 		c.logger.Debug().Msg("put api token or pat into GAF")
 		conf.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, false)
 		conf.Set(configuration.AUTHENTICATION_TOKEN, newTokenString) // We use the same config key for PATs and API Tokens.
 	}
 
-	// ensure scrubbing of new newTokenString
+	// ensure scrubbing of the token that was actually applied
 	if w, ok := c.scrubbingWriter.(frameworkLogging.ScrubbingLogWriter); ok {
-		if newTokenString != "" {
-			w.AddTerm(newTokenString, 0)
+		if applied != "" {
+			w.AddTerm(applied, 0)
 			if newOAuthToken != nil && newOAuthToken.AccessToken != "" {
 				w.AddTerm(newOAuthToken.AccessToken, 0)
 				w.AddTerm(newOAuthToken.RefreshToken, 0)
@@ -727,8 +737,8 @@ func (c *Config) SetToken(newTokenString string) {
 		}
 	}
 
-	c.token = newTokenString
-	c.notifyTokenChannelListeners(newTokenString, oldTokenString)
+	c.token = applied
+	c.notifyTokenChannelListeners(applied, oldTokenString)
 }
 
 func (c *Config) notifyTokenChannelListeners(newTokenString string, oldTokenString string) {
@@ -762,9 +772,9 @@ func (c *Config) shouldUpdateOAuth2Token(oldToken string, newToken string) bool 
 	}
 
 	isNewToken := oldToken != newToken
-	tokenExpiryIsNewer := oldOauthToken.Expiry.Before(newOauthToken.Expiry)
+	tokenExpiryIsSameOrNewer := !newOauthToken.Expiry.Before(oldOauthToken.Expiry)
 
-	return isNewToken && tokenExpiryIsNewer
+	return isNewToken && tokenExpiryIsSameOrNewer
 }
 
 func (c *Config) SetFormat(format string) {

--- a/application/config/config.go
+++ b/application/config/config.go
@@ -1258,11 +1258,29 @@ func (c *Config) SetStorage(s storage.StorageWithCallbacks) {
 	c.storage = s
 
 	conf := c.engine.GetConfiguration()
+	// Capture any OAuth token that was refreshed before this storage was mounted.
+	// A background API call (e.g. feature-flag poll) can trigger a GAF token refresh
+	// before initializeHandler installs ls-config.json, storing the new token in viper
+	// memory only — it is never written to ls-config.json. After SetStorage below,
+	// GAF's syncTokenRefresh will lock and read ls-config.json; if that file still holds
+	// the previous-session token, Refresh overwrites the fresh viper value, fires the
+	// bridge with the stale token, then attempts a second refresh with an already-consumed
+	// refresh token — failing with "invalid_grant". Writing the fresh value to the new
+	// file first prevents that second attempt.
+	preInitOAuthToken := conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN)
+
 	conf.SetStorage(s)
 	c.m.Unlock()
 	conf.PersistInStorage(storedconfig.ConfigMainKey)
 	conf.PersistInStorage(auth.CONFIG_KEY_OAUTH_TOKEN)
 	conf.PersistInStorage(configuration.AUTHENTICATION_TOKEN)
+
+	if preInitOAuthToken != "" {
+		if err := s.Set(auth.CONFIG_KEY_OAUTH_TOKEN, preInitOAuthToken); err != nil {
+			c.logger.Warn().Err(err).Msg("failed to flush pre-init OAuth token to storage; " +
+				"a stale token may be read on the next sync")
+		}
+	}
 
 	// now refresh from storage
 	err := s.Refresh(conf, storedconfig.ConfigMainKey)

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -392,12 +392,79 @@ func TestConfig_shouldUpdateOAuth2Token(t *testing.T) {
 
 		assert.True(t, c.shouldUpdateOAuth2Token(string(oldTokenBytes), string(newTokenBytes)))
 	})
+	t.Run("same expiry rotated refresh token -> true", func(t *testing.T) {
+		oldToken := token
+		oldToken.AccessToken = "old-access"
+		oldToken.RefreshToken = "old-refresh"
+		oldTokenBytes, err := json.Marshal(oldToken)
+		require.NoError(t, err)
+
+		rotatedToken := token
+		rotatedToken.AccessToken = "new-access"
+		rotatedToken.RefreshToken = "new-refresh"
+		rotatedTokenBytes, err := json.Marshal(rotatedToken)
+		require.NoError(t, err)
+
+		assert.True(t, c.shouldUpdateOAuth2Token(string(oldTokenBytes), string(rotatedTokenBytes)))
+	})
 	t.Run("old token not an oauth token, but new one is -> true", func(t *testing.T) {
 		assert.True(t, c.shouldUpdateOAuth2Token(uuid.NewString(), string(newTokenBytes)))
 	})
 	t.Run("new token not an oauth token -> false", func(t *testing.T) {
 		assert.False(t, c.shouldUpdateOAuth2Token(string(newTokenBytes), uuid.NewString()))
 	})
+}
+
+// Test_SetToken_RejectsStaleOAuth_DoesNotNotify verifies that when SetToken is
+// called with a stale OAuth token (older expiry than current), the in-memory
+// c.token is NOT overwritten and token-change channel listeners are NOT notified
+// with the stale value.
+func Test_SetToken_RejectsStaleOAuth_DoesNotNotify(t *testing.T) {
+	c := New(WithBinarySearchPaths([]string{}))
+	require.NoError(t, c.WaitForDefaultEnv(t.Context()))
+	c.SetAuthenticationMethod(types.OAuthAuthentication)
+
+	freshTokenBytes, err := json.Marshal(oauth2.Token{
+		AccessToken:  "fresh-access",
+		RefreshToken: "fresh-refresh",
+		Expiry:       time.Now().Add(2 * time.Hour),
+	})
+	require.NoError(t, err)
+	freshToken := string(freshTokenBytes)
+
+	// Register a channel before the fresh-token write so we can confirm the write
+	// fired a notification, then consume it to clear the slate.
+	freshChannel := c.TokenChangesChannel()
+	c.SetToken(freshToken)
+	select {
+	case <-freshChannel:
+		// expected: fresh token notification fired
+	case <-time.After(2 * time.Second):
+		t.Fatal("fresh token write did not fire channel notification")
+	}
+
+	require.Equal(t, freshToken, c.Token(), "fresh token should be the in-memory token")
+
+	// Register a new channel before attempting the stale write.
+	staleChannel := c.TokenChangesChannel()
+
+	staleTokenBytes, err := json.Marshal(oauth2.Token{
+		AccessToken:  "stale-access",
+		RefreshToken: "stale-refresh",
+		Expiry:       time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	c.SetToken(string(staleTokenBytes))
+
+	assert.Equal(t, freshToken, c.Token(), "stale OAuth token must NOT overwrite in-memory token")
+
+	select {
+	case newToken := <-staleChannel:
+		assert.Failf(t, "channel notified with stale token", "received: %v", newToken)
+	case <-time.After(100 * time.Millisecond):
+		// pass: no notification within timeout
+	}
 }
 
 func TestConfig_AuthenticationMethodMatchesToken(t *testing.T) {

--- a/application/config/config_test.go
+++ b/application/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"path/filepath"
 	"slices"
 	"testing"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/mocks"
 
 	"github.com/snyk/snyk-ls/infrastructure/cli/cli_constants"
+	"github.com/snyk/snyk-ls/internal/storage"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/util"
 )
@@ -465,6 +467,103 @@ func Test_SetToken_RejectsStaleOAuth_DoesNotNotify(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		// pass: no notification within timeout
 	}
+}
+
+// Test_SetStorage_FlushesPreInitOAuthTokenToNewStorage verifies that a token
+// refreshed before SetStorage mounts ls-config.json (stored in viper memory only)
+// is flushed to the new backing file. Without this flush, GAF's syncTokenRefresh
+// reads the stale file value, fires the bridge with it, and then attempts a second
+// HTTP refresh using the already-consumed refresh token — failing with
+// "invalid_grant". [IDE-2026]
+func Test_SetStorage_FlushesPreInitOAuthTokenToNewStorage(t *testing.T) {
+	freshToken := `{"access_token":"fresh-at","refresh_token":"fresh-rt","token_type":"bearer","expiry":"2030-01-01T00:00:00Z"}`
+	staleToken := `{"access_token":"stale-at","refresh_token":"stale-rt","token_type":"bearer","expiry":"2020-01-01T00:00:00Z"}`
+
+	makeStaleStorageFile := func(t *testing.T) string {
+		t.Helper()
+		storageFile := filepath.Join(t.TempDir(), "ls-config.json")
+		stalePrime, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+		require.NoError(t, err)
+		require.NoError(t, stalePrime.Set(auth.CONFIG_KEY_OAUTH_TOKEN, staleToken))
+		return storageFile
+	}
+
+	assertFileHasFreshToken := func(t *testing.T, s storage.StorageWithCallbacks) {
+		t.Helper()
+		fileConf := configuration.NewWithOpts()
+		require.NoError(t, s.Refresh(fileConf, auth.CONFIG_KEY_OAUTH_TOKEN))
+		assert.Equal(t, freshToken, fileConf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN),
+			"storage file must contain the fresh pre-init token so syncTokenRefresh cannot load a stale value and trigger a second refresh")
+	}
+
+	t.Run("EmptyToken true: file updated before s.Refresh overwrites memory", func(t *testing.T) {
+		// Fresh OAuth token in viper memory (pre-init refresh, no storage yet attached).
+		c := New(WithBinarySearchPaths([]string{}))
+		require.NoError(t, c.WaitForDefaultEnv(t.Context()))
+		conf := c.engine.GetConfiguration()
+		conf.Set(auth.CONFIG_KEY_OAUTH_TOKEN, freshToken)
+		require.True(t, c.EmptyToken(), "this subtest exercises the c.EmptyToken()==true branch where Refresh runs")
+
+		storageFile := makeStaleStorageFile(t)
+		freshStorage, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+		require.NoError(t, err)
+
+		c.SetStorage(freshStorage)
+
+		// In-memory value must be preserved (not overwritten by s.Refresh reading the stale file).
+		assert.Equal(t, freshToken, conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN),
+			"pre-init fresh token must survive SetStorage's s.Refresh call unchanged")
+		assertFileHasFreshToken(t, freshStorage)
+	})
+
+	t.Run("EmptyToken false: file still updated even when s.Refresh is skipped", func(t *testing.T) {
+		// Canonical token already set (previous session): c.NonEmptyToken()==true so
+		// SetStorage skips the conditional s.Refresh(conf, CONFIG_KEY_OAUTH_TOKEN)
+		// block. The unconditional s.Set flush must still write the fresh OAuth token
+		// to the file so syncTokenRefresh reads fresh on the next API call.
+		c := New(WithBinarySearchPaths([]string{}))
+		require.NoError(t, c.WaitForDefaultEnv(t.Context()))
+		c.SetToken("prev-session-canonical-token")
+		require.False(t, c.EmptyToken(), "this subtest exercises the c.EmptyToken()==false branch where Refresh is skipped")
+
+		conf := c.engine.GetConfiguration()
+		conf.Set(auth.CONFIG_KEY_OAUTH_TOKEN, freshToken)
+
+		storageFile := makeStaleStorageFile(t)
+		freshStorage, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+		require.NoError(t, err)
+
+		c.SetStorage(freshStorage)
+
+		assertFileHasFreshToken(t, freshStorage)
+	})
+}
+
+// Test_SetStorage_EmptyPreInitToken_LoadsFromFile verifies that when no
+// pre-init refresh occurred (auth.CONFIG_KEY_OAUTH_TOKEN is empty in memory),
+// SetStorage loads the token from the file as usual — the normal first-start
+// or expired-and-restarted case. [IDE-2026]
+func Test_SetStorage_EmptyPreInitToken_LoadsFromFile(t *testing.T) {
+	c := New(WithBinarySearchPaths([]string{}))
+	require.NoError(t, c.WaitForDefaultEnv(t.Context()))
+	conf := c.engine.GetConfiguration()
+
+	// No pre-init OAuth token in memory.
+	require.Empty(t, conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN))
+
+	existingToken := `{"access_token":"existing-at","refresh_token":"existing-rt","token_type":"bearer","expiry":"2030-01-01T00:00:00Z"}`
+	storageFile := filepath.Join(t.TempDir(), "ls-config.json")
+	prime, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+	require.NoError(t, err)
+	require.NoError(t, prime.Set(auth.CONFIG_KEY_OAUTH_TOKEN, existingToken))
+
+	s, err := storage.NewStorageWithCallbacks(storage.WithStorageFile(storageFile))
+	require.NoError(t, err)
+	c.SetStorage(s)
+
+	// The existing token from the file must be loaded into memory (normal path).
+	assert.Equal(t, existingToken, conf.GetString(auth.CONFIG_KEY_OAUTH_TOKEN),
+		"when no pre-init token exists, SetStorage must load the token from the file")
 }
 
 func TestConfig_AuthenticationMethodMatchesToken(t *testing.T) {

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -213,8 +213,8 @@ func writeSettings(c *config.Config, settings types.Settings, triggerSource anal
 	updateCliConfig(c, settings)
 	updateApiEndpoints(c, settings, triggerSource) // Must be called before token is set, as it may trigger a logout which clears the token.
 	updateCliBaseDownloadURL(c, settings, triggerSource)
-	updateToken(settings.Token) // Must be called before the Authentication method is set, as the latter checks the token.
-	updateAuthenticationMethod(c, settings, triggerSource)
+	updateAuthenticationMethod(c, settings, triggerSource) // Must be called before the token is set, so SetToken routes the token through the correct (OAuth vs API/PAT) branch.
+	updateToken(settings.Token)
 	updateEnvironment(c, settings)
 	updatePathFromSettings(c, settings)
 	updateErrorReporting(c, settings, triggerSource)

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -18,10 +18,12 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +35,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 
@@ -41,6 +44,7 @@ import (
 	mock_command "github.com/snyk/snyk-ls/domain/ide/command/mock"
 	"github.com/snyk/snyk-ls/domain/ide/workspace"
 	"github.com/snyk/snyk-ls/infrastructure/analytics"
+	storage2 "github.com/snyk/snyk-ls/internal/storage"
 	"github.com/snyk/snyk-ls/internal/storedconfig"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -493,6 +497,9 @@ func initTestRepo(t *testing.T, tempDir string) error {
 
 func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing.T) {
 	c := testutil.IntegTest(t)
+	if c.Token() == "" {
+		t.Skip("SNYK_TOKEN is required to resolve the user's preferred default org via /rest/self")
+	}
 
 	// Set to a specific org first
 	initialOrgId := "00000000-0000-0000-0000-000000000001"
@@ -514,6 +521,9 @@ func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing
 
 func Test_UpdateSettings_WhitespaceOrganizationResetsToDefault_Integration(t *testing.T) {
 	c := testutil.IntegTest(t)
+	if c.Token() == "" {
+		t.Skip("SNYK_TOKEN is required to resolve the user's preferred default org via /rest/self")
+	}
 
 	// Set to a specific org first
 	initialOrgId := "00000000-0000-0000-0000-000000000001"
@@ -848,6 +858,73 @@ func Test_updateFolderConfig_HandlesNilStoredConfig(t *testing.T) {
 	// Should not panic and should handle nil gracefully
 	updateFolderConfig(c, settings, logger, analytics.TriggerSourceTest)
 	// If we get here without panic, the nil check worked
+}
+
+// Test_InitializeSettings_PreservesRefreshedOAuthTokenWhenInitializeSendsStaleToken
+// reproduces the IDE-1900 scenario end-to-end against InitializeSettings: a fresh
+// OAuth token reaches the auth service first (e.g. via GAF refresh), then the IDE
+// sends a stale token through InitializationOptions. The stale token must NOT
+// overwrite the fresh one in memory and must NOT generate an IDE notification.
+func Test_InitializeSettings_PreservesRefreshedOAuthTokenWhenInitializeSendsStaleToken(t *testing.T) {
+	c := testutil.UnitTest(t)
+	di.TestInit(t)
+	c.SetAuthenticationMethod(types.OAuthAuthentication)
+
+	// ConfigureProviders during updateAuthenticationMethod calls Default() which
+	// registers a storage callback, so storage must be in place.
+	storageWithCallbacks, err := storage2.NewStorageWithCallbacks(storage2.WithStorageFile(filepath.Join(t.TempDir(), "testStorage")))
+	require.NoError(t, err)
+	c.SetStorage(storageWithCallbacks)
+
+	freshExpiry := time.Now().Add(2 * time.Hour)
+	staleExpiry := time.Now().Add(1 * time.Hour)
+	freshTokenBytes, err := json.Marshal(oauth2.Token{
+		AccessToken:  "fresh-access",
+		RefreshToken: "fresh-refresh",
+		TokenType:    "Bearer",
+		Expiry:       freshExpiry,
+	})
+	require.NoError(t, err)
+	freshToken := string(freshTokenBytes)
+
+	staleTokenBytes, err := json.Marshal(oauth2.Token{
+		AccessToken:  "stale-access",
+		RefreshToken: "stale-refresh",
+		TokenType:    "Bearer",
+		Expiry:       staleExpiry,
+	})
+	require.NoError(t, err)
+	staleToken := string(staleTokenBytes)
+
+	var authNotificationsMu sync.Mutex
+	var authNotifications []types.AuthenticationParams
+	di.Notifier().CreateListener(func(params any) {
+		if authParams, ok := params.(types.AuthenticationParams); ok {
+			authNotificationsMu.Lock()
+			defer authNotificationsMu.Unlock()
+			authNotifications = append(authNotifications, authParams)
+		}
+	})
+	t.Cleanup(func() { di.Notifier().DisposeListener() })
+
+	// Simulate the fresh token reaching the auth service first (e.g. via the OAuth
+	// storage bridge after a GAF refresh).
+	di.AuthenticationService().UpdateCredentials(freshToken, true, false)
+
+	// Now simulate the IDE sending a stale token via InitializationOptions.
+	InitializeSettings(c, types.Settings{
+		Token:                staleToken,
+		AuthenticationMethod: types.OAuthAuthentication,
+	})
+
+	assert.Equal(t, freshToken, c.Token(), "stale OAuth token from init MUST NOT overwrite the fresher in-memory token")
+
+	authNotificationsMu.Lock()
+	defer authNotificationsMu.Unlock()
+	require.NotEmpty(t, authNotifications, "fresh token UpdateCredentials should have produced at least one notification")
+	for _, params := range authNotifications {
+		assert.NotEqual(t, staleToken, params.Token, "no IDE notification should carry the stale token")
+	}
 }
 
 func Test_InitializeSettings(t *testing.T) {

--- a/application/server/notification/scan_notifier_test.go
+++ b/application/server/notification/scan_notifier_test.go
@@ -20,9 +20,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	notification2 "github.com/snyk/snyk-ls/application/server/notification"
 	"github.com/snyk/snyk-ls/domain/snyk/scanner"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
@@ -84,6 +86,51 @@ func Test_SendMessage(t *testing.T) {
 			assert.Fail(t, "Scan message was not sent")
 		})
 	}
+}
+
+func Test_SendError_NotAuthenticated_SuppressesNotification(t *testing.T) {
+	c := testutil.UnitTest(t)
+	mockNotifier := notification.NewMockNotifier()
+	scanNotifier, _ := notification2.NewScanNotifier(c, mockNotifier, nil)
+	folderPath := types.FilePath("/test/oss/folderPath")
+
+	scanNotifier.SendError(product.ProductOpenSource, folderPath, utils.MsgNotAuthenticatedNoScan)
+
+	requireMessageSent(t, mockNotifier)
+	for _, msg := range mockNotifier.SentMessages() {
+		scanParam := msg.(types.SnykScanParams)
+		assert.Equal(t, types.ErrorStatus, scanParam.Status)
+		assert.Equal(t, product.ProductOpenSource.ToProductCodename(), scanParam.Product)
+		assert.Equal(t, folderPath, scanParam.FolderPath)
+		require.NotNil(t, scanParam.PresentableError)
+		assert.False(t, scanParam.PresentableError.ShowNotification)
+		assert.Equal(t, "(not authenticated)", scanParam.PresentableError.TreeNodeSuffix)
+	}
+}
+
+func Test_SendError_ProductDisabledForFolder_SendsErrorStatus(t *testing.T) {
+	c := testutil.UnitTest(t)
+	mockNotifier := notification.NewMockNotifier()
+	scanNotifier, _ := notification2.NewScanNotifier(c, mockNotifier, nil)
+	folderPath := types.FilePath("/test/code/folderPath")
+
+	scanNotifier.SendError(product.ProductCode, folderPath, utils.ErrSnykCodeNotEnabledForFolder)
+
+	requireMessageSent(t, mockNotifier)
+	for _, msg := range mockNotifier.SentMessages() {
+		scanParam := msg.(types.SnykScanParams)
+		assert.Equal(t, types.ErrorStatus, scanParam.Status)
+		assert.Equal(t, product.ProductCode.ToProductCodename(), scanParam.Product)
+		assert.Equal(t, folderPath, scanParam.FolderPath)
+		require.NotNil(t, scanParam.PresentableError)
+		assert.False(t, scanParam.PresentableError.ShowNotification)
+		assert.Equal(t, "(disabled in workspace)", scanParam.PresentableError.TreeNodeSuffix)
+	}
+}
+
+func requireMessageSent(t *testing.T, notifier *notification.MockNotifier) {
+	t.Helper()
+	assert.NotEmpty(t, notifier.SentMessages(), "expected scan notification to be sent")
 }
 
 func Test_SendSuccess_SendsForAllEnabledProducts(t *testing.T) {

--- a/application/server/secrets_smoke_test.go
+++ b/application/server/secrets_smoke_test.go
@@ -17,6 +17,9 @@
 package server
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -24,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
@@ -37,8 +41,106 @@ import (
 const (
 	secretsSmokeTokenEnvVar = "SNYK_DEV_TOKEN"
 	secretsSmokeDefaultAPI  = "https://api.dev.snyk.io"
-	secretsSmokeOrg         = "a16eb5a4-7283-45e9-949f-84696bd22bda" // devex_ide org
+	secretsSmokeOrg         = "9cff56cd-57d1-49b8-9238-69ebfde7142f" // devex_ide org
 )
+
+// Test_SmokeSecretsScan_UnsupportedFileDoesNotError validates IDE-1953:
+// saving a binary (unsupported) file must not produce a "scan failed" error
+// notification. The secrets engine filters binary files out (SNYK-CLI-0008
+// NoSupportedFilesFound) which should be treated as success.
+func Test_SmokeSecretsScan_UnsupportedFileDoesNotError(t *testing.T) {
+	if len(os.Getenv("CI")) > 0 {
+		t.Skip("temporary skipped (still in CB)")
+	}
+
+	c := testutil.SmokeTest(t, "")
+
+	loc, jsonRPCRecorder := setupServer(t, c)
+	enableOnlySecrets(c)
+	cleanupChannels()
+	di.Init()
+
+	// Workspace contains only a binary file — the secrets file filter rejects it
+	// (returns SNYK-CLI-0008 / NoSupportedFilesFound), which should map to success, not error.
+	workspaceDir := t.TempDir()
+	binaryFile := filepath.Join(workspaceDir, "image.bin")
+	// PNG magic bytes — definitively non-text, will be rejected by TextFileOnlyFilter
+	require.NoError(t, os.WriteFile(binaryFile, []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}, 0600))
+
+	// The server only emits $/snyk.folderConfigs for git repos; init one so the
+	// folder is treated as a real workspace and we get a folderConfig notification.
+	gitCmds := [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "test"},
+		{"add", "image.bin"},
+		{"commit", "-m", "initial"},
+	}
+	for _, args := range gitCmds {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workspaceDir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	initParams := prepareInitParams(t, types.FilePath(workspaceDir), c)
+	initParams.ClientInfo.Name = "snyk-ls-secrets-smoke"
+	initParams.InitializationOptions.IntegrationName = "ls-secrets-smoke"
+	ensureInitialized(t, c, loc, initParams, nil)
+
+	// Wait for the server to register the folder before configuring it.
+	require.Eventually(t, func() bool {
+		notifications := jsonRPCRecorder.FindNotificationsByMethod("$/snyk.folderConfigs")
+		return receivedFolderConfigNotification(t, notifications, types.FilePath(workspaceDir))
+	}, time.Minute, 100*time.Millisecond, "did not receive folder config notification")
+
+	// Wire the pre-prod org and the secrets feature flag onto the folder.
+	folderConfig := c.FolderConfig(types.FilePath(workspaceDir))
+	require.NotNil(t, folderConfig)
+	folderConfig.PreferredOrg = secretsSmokeOrg
+	folderConfig.OrgSetByUser = true
+	if folderConfig.FeatureFlags == nil {
+		folderConfig.FeatureFlags = map[string]bool{}
+	}
+	folderConfig.FeatureFlags[featureflag.SnykSecretsEnabled] = true
+	require.NoError(t, c.UpdateFolderConfig(folderConfig))
+
+	_, err := loc.Client.Call(t.Context(), "workspace/executeCommand", sglsp.ExecuteCommandParams{
+		Command:   "snyk.workspaceFolder.scan",
+		Arguments: []any{workspaceDir},
+	})
+	require.NoError(t, err)
+
+	waitForScan(t, workspaceDir, c)
+
+	// Assert at least one $/snyk.scan notification for secrets was received, then verify none is ErrorStatus.
+	secretsProduct := product.ProductSecrets.ToProductCodename()
+	var scanParam types.SnykScanParams
+	require.Eventually(t, func() bool {
+		for _, n := range jsonRPCRecorder.FindNotificationsByMethod("$/snyk.scan") {
+			var p types.SnykScanParams
+			if err := n.UnmarshalParams(&p); err != nil {
+				continue
+			}
+			if p.Product == secretsProduct && p.FolderPath == types.FilePath(workspaceDir) && p.Status != types.InProgress {
+				scanParam = p
+				return true
+			}
+		}
+		return false
+	}, time.Minute, 100*time.Millisecond, "expected at least one completed $/snyk.scan notification for secrets product")
+
+	assert.NotEqual(t, types.ErrorStatus, scanParam.Status,
+		"secrets scan of an unsupported binary file must not produce an error notification")
+}
+
+func enableOnlySecrets(c *config.Config) {
+	c.SetSnykCodeEnabled(false)
+	c.SetSnykOssEnabled(false)
+	c.SetSnykIacEnabled(false)
+	c.SetSnykSecretsEnabled(true)
+	c.SetAutomaticScanning(false)
+}
 
 func Test_SmokeSecretsScan(t *testing.T) {
 	t.Skip("skipping secrets smoke test until secret scanner is deployed to prod")

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/ide/converter"
 	"github.com/snyk/snyk-ls/domain/ide/hover"
 	"github.com/snyk/snyk-ls/domain/ide/workspace"
+	"github.com/snyk/snyk-ls/infrastructure/authentication"
 	"github.com/snyk/snyk-ls/infrastructure/cli"
 	"github.com/snyk/snyk-ls/infrastructure/cli/cli_constants"
 	"github.com/snyk/snyk-ls/infrastructure/cli/install"
@@ -235,6 +236,10 @@ func initializeHandler(c *config.Config, srv *jrpc2.Server) handler.Func {
 		}
 
 		c.SetStorage(storage)
+
+		// Register the OAuth storage bridge before any pre-initialization API call so a
+		// rotated refresh token is reliably propagated to the IDE.
+		authentication.RegisterOAuthStorageBridge(storage, di.AuthenticationService())
 
 		addWorkspaceFolders(c, params)
 		di.LdxSyncService().RefreshConfigFromLdxSync(ctx, c, c.Workspace().Folders(), nil)

--- a/domain/ide/command/apply_auth_config.go
+++ b/domain/ide/command/apply_auth_config.go
@@ -30,8 +30,13 @@ import (
 // logs out and clears workspace. Returns true if endpoints changed.
 // Logout internally calls configureProviders, so no explicit ConfigureProviders call is needed.
 func ApplyEndpointChange(ctx context.Context, c *config.Config, authService authentication.AuthenticationService, endpoint string) bool {
+	oldEndpoint := c.Endpoint()
 	changed := c.UpdateApiEndpoints(endpoint)
 	if changed && c.IsLSPInitialized() {
+		c.Logger().Info().
+			Str("old_endpoint", oldEndpoint).
+			Str("new_endpoint", endpoint).
+			Msg("auth endpoint changed after LSP initialization; clearing credentials")
 		authService.Logout(ctx)
 		c.Workspace().Clear()
 	}
@@ -51,6 +56,10 @@ func ApplyAuthMethodChange(ctx context.Context, c *config.Config, authService au
 	}
 
 	previousMethod := c.AuthenticationMethod()
+	c.Logger().Info().
+		Str("old_auth_method", string(previousMethod)).
+		Str("new_auth_method", string(authMethod)).
+		Msg("auth method change requested")
 	c.SetAuthenticationMethod(authMethod)
 	authService.ConfigureProviders(c)
 

--- a/domain/ide/command/connectivity_check_test.go
+++ b/domain/ide/command/connectivity_check_test.go
@@ -109,6 +109,10 @@ func Test_connectivityCheckCommand_Execute_integration(t *testing.T) {
 	assert.Contains(t, responseStr, "Checking for proxy configuration")
 	assert.Contains(t, responseStr, "Testing connectivity to Snyk endpoints")
 	assert.Regexp(t, `api\.snyk\.io\s+OK \(HTTP 204\)`, responseStr)
-	assert.Contains(t, responseStr, "Authentication token is configured")
-	assert.Contains(t, responseStr, "Snyk Token and Organizations")
+	if c.Token() != "" {
+		assert.Contains(t, responseStr, "Authentication token is configured")
+		assert.Contains(t, responseStr, "Snyk Token and Organizations")
+	} else {
+		assert.NotContains(t, responseStr, "Snyk Token and Organizations")
+	}
 }

--- a/domain/ide/treeview/tree_builder.go
+++ b/domain/ide/treeview/tree_builder.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/types"
 )
@@ -250,7 +251,7 @@ func (b *TreeBuilder) buildProductNodes(fd FolderData) []TreeNode {
 				desc = "- " + productDescription(p, totalIssues, stats.severityCounts) + " (scanning...)"
 			}
 		} else if scanError != "" {
-			desc = "- (scan failed)"
+			desc = productScanErrorDescription(scanError)
 		} else if scanRegistered {
 			desc = "- " + productDescription(p, totalIssues, stats.severityCounts)
 		}
@@ -762,4 +763,13 @@ func issuePriority(issue types.Issue) int {
 	}
 
 	return severityWeight*1_000_000 + score
+}
+
+// productScanErrorDescription matches scan_notifier SendError: errors listed in utils.ErrorConfig use
+// TreeRootSuffix as the inline HTML tree description; unknown errors keep "- (scan failed)".
+func productScanErrorDescription(scanError string) string {
+	if meta, ok := utils.ErrorConfig[scanError]; ok && meta.TreeRootSuffix != "" {
+		return "- " + meta.TreeRootSuffix
+	}
+	return "- (scan failed)"
 }

--- a/domain/ide/treeview/tree_builder_test.go
+++ b/domain/ide/treeview/tree_builder_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -1159,8 +1160,39 @@ func TestBuildTree_ProductNode_ScanError_ShowsErrorSuffix(t *testing.T) {
 
 	ossNode := findChildByProduct(data.Nodes, product.ProductOpenSource)
 	require.NotNil(t, ossNode)
-	assert.Contains(t, ossNode.Description, "(scan failed)", "errored product node should show scan failed suffix")
+	assert.Equal(t, "- (scan failed)", ossNode.Description, "unknown scan errors should use generic scan failed suffix")
 	assert.Equal(t, "dependency graph failed", ossNode.ErrorMessage, "product node should carry the full error message")
+}
+
+func TestBuildTree_ProductNode_ScanError_UsesErrorCatalogTreeSuffix(t *testing.T) {
+	cases := []struct {
+		errMsg     string
+		wantInDesc string
+	}{
+		{utils.ErrSnykCodeNotEnabled, "(disabled at Snyk)"},
+		{utils.ErrNoReferenceBranch, "(no reference branch)"},
+		{utils.ErrNoRepo, "(repository not found)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.errMsg, func(t *testing.T) {
+			builder := newBuilderWithCompletedScans()
+			builder.SetProductScanErrors(map[types.FilePath]map[product.Product]string{
+				"/project": {product.ProductOpenSource: tc.errMsg},
+			})
+
+			data := builder.BuildTreeFromFolderData([]FolderData{{
+				FolderPath: "/project", FolderName: "project",
+				SupportedIssueTypes: map[product.FilterableIssueType]bool{product.FilterableIssueTypeOpenSource: true},
+				AllIssues:           nil, FilteredIssues: nil,
+			}})
+
+			ossNode := findChildByProduct(data.Nodes, product.ProductOpenSource)
+			require.NotNil(t, ossNode)
+			assert.Contains(t, ossNode.Description, tc.wantInDesc)
+			assert.NotContains(t, ossNode.Description, "(scan failed)", "catalogued errors should not use generic scan failed label")
+			assert.Equal(t, tc.errMsg, ossNode.ErrorMessage)
+		})
+	}
 }
 
 func TestBuildTree_ProductNode_ScanError_NoIssueChildren(t *testing.T) {

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/ide/hover"
 	"github.com/snyk/snyk-ls/infrastructure/analytics"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	noti "github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -371,6 +372,16 @@ func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 
 func (f *Folder) sendScanError(product product.Product, err error) {
 	f.scanNotifier.SendError(product, f.path, err.Error())
+
+	if utils.IsNonFailingScanError(err.Error()) {
+		f.c.Logger().Debug().
+			Err(err).
+			Str("method", "ProcessResults").
+			Str("product", string(product)).
+			Msg("product scan skipped with expected status")
+		return
+	}
+
 	f.c.Logger().Err(err).
 		Str("method", "ProcessResults").
 		Str("product", string(product)).

--- a/domain/ide/workspace/folder_test.go
+++ b/domain/ide/workspace/folder_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/snyk/persistence/mock_persistence"
 	"github.com/snyk/snyk-ls/domain/snyk/scanner"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	context2 "github.com/snyk/snyk-ls/internal/context"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
@@ -67,6 +68,22 @@ func Test_Scan_WhenNoIssues_shouldNotProcessResults(t *testing.T) {
 	f.ProcessResults(t.Context(), data)
 
 	assert.Equal(t, 0, hoverRecorder.Calls())
+}
+
+func Test_ProcessResults_nonFailingScanError_sendsScanErrorNotSuccess(t *testing.T) {
+	c := testutil.UnitTest(t)
+	notifier := notification.NewMockNotifier()
+	f, scanNotifier := NewMockFolderWithScanNotifier(c, notifier)
+	setupWorkspaceWithFolder(c, f, notifier)
+
+	f.ProcessResults(t.Context(), types.ScanData{
+		Product: product.ProductCode,
+		Err:     errors.New(utils.ErrSnykCodeNotEnabledForFolder),
+	})
+
+	assert.Len(t, scanNotifier.ErrorCalls(), 1, "SendError should run so IDE receives treeNodeSuffix metadata")
+	assert.Empty(t, scanNotifier.SuccessCalls(), "SendSuccess must not run for non-failing scan errors")
+	assert.Equal(t, 0, notifier.SendErrorDiagnosticCount(), "non-failing errors must not publish error diagnostics")
 }
 
 func Test_ProcessResults_whenDifferentPaths_AddsToCache(t *testing.T) {
@@ -846,6 +863,30 @@ func Test_processResults_ShouldSendError(t *testing.T) {
 	// Assert
 	assert.Empty(t, scanNotifier.SuccessCalls())
 	assert.Len(t, scanNotifier.ErrorCalls(), 1)
+}
+
+func Test_processResults_NonFailingError_sendsScanErrorWithoutDiagnostics(t *testing.T) {
+	// Arrange
+	c := testutil.UnitTest(t)
+
+	notifier := notification.NewMockNotifier()
+	f, scanNotifier := NewMockFolderWithScanNotifier(c, notifier)
+	setupWorkspaceWithFolder(c, f, notifier)
+
+	data := types.ScanData{
+		Product:           product.ProductOpenSource,
+		UpdateGlobalCache: true,
+		SendAnalytics:     true,
+		Err:               errors.New(utils.MsgNotAuthenticatedNoScan),
+	}
+
+	// Act
+	f.ProcessResults(t.Context(), data)
+
+	// Assert: IDE still gets $/snyk/scan error + presentableError (e.g. treeNodeSuffix); no success, no editor diagnostics
+	assert.Empty(t, scanNotifier.SuccessCalls())
+	assert.Len(t, scanNotifier.ErrorCalls(), 1)
+	assert.Equal(t, 0, notifier.SendErrorDiagnosticCount())
 }
 
 func Test_processResults_ShouldSendAnalyticsToAPI(t *testing.T) {

--- a/infrastructure/authentication/auth_configuration.go
+++ b/infrastructure/authentication/auth_configuration.go
@@ -63,11 +63,7 @@ func unsetOauthTokenConfig(c *config.Config) {
 func Default(c *config.Config, authenticationService AuthenticationService) AuthenticationProvider {
 	conf := c.Engine().GetConfiguration()
 	conf.Unset(configuration.AUTHENTICATION_TOKEN)
-	credentialsUpdateCallback := func(_ string, value any) {
-		// an empty struct marks an empty token, so we stay with empty string if the cast fails
-		newToken, _ := value.(string)
-		go authenticationService.updateCredentials(newToken, true, false)
-	}
+	credentialsUpdateCallback := newOAuthStorageBridgeCallback(authenticationService)
 
 	openBrowserFunc := func(url string) {
 		authenticationService.provider().setAuthUrl(url)
@@ -123,4 +119,29 @@ func NewOAuthProvider(
 func NewPatProvider(c *config.Config, openBrowserFunc func(string)) *PatAuthenticationProvider {
 	conf := c.Engine().GetConfiguration()
 	return newPatAuthenticationProvider(conf, openBrowserFunc, c.Logger())
+}
+
+// RegisterOAuthStorageBridge attaches a callback to the OAuth token storage key
+// so any write — including rotations performed by GAF during pre-initialization
+// API calls — is routed through the authentication service. This is the same
+// callback that Default() installs via NewOAuthProvider; the bridge exists so it
+// can be wired up in initializeHandler before the OAuth provider has been
+// constructed, ensuring an early GAF-driven refresh is not lost.
+func RegisterOAuthStorageBridge(s storage.StorageWithCallbacks, authenticationService AuthenticationService) {
+	if s == nil || authenticationService == nil {
+		return
+	}
+	s.RegisterCallback(auth.CONFIG_KEY_OAUTH_TOKEN, newOAuthStorageBridgeCallback(authenticationService))
+}
+
+// newOAuthStorageBridgeCallback is the single source of truth for the storage
+// callback that propagates a written/rotated OAuth token to the authentication
+// service. It queues the update for sequential processing to prevent race
+// conditions where older tokens overwrite newer ones during rapid rotations.
+func newOAuthStorageBridgeCallback(authenticationService AuthenticationService) storage.StorageCallbackFunc {
+	return func(_ string, value any) {
+		// an empty struct marks an empty token, so we stay with empty string if the cast fails
+		newToken, _ := value.(string)
+		authenticationService.queueCredentialUpdate(newToken, true, false)
+	}
 }

--- a/infrastructure/authentication/auth_configuration_test.go
+++ b/infrastructure/authentication/auth_configuration_test.go
@@ -21,13 +21,17 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
 	storage2 "github.com/snyk/snyk-ls/internal/storage"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -60,6 +64,120 @@ func Test_NewOAuthProvider_registersStorageCallback(t *testing.T) {
 	assert.Eventuallyf(t, func() bool {
 		return <-tokenReceived
 	}, 5*time.Second, 100*time.Millisecond, "token should have been received")
+}
+
+// Test_RegisterOAuthStorageBridge_PropagatesTokenToAuthService verifies that the
+// pre-init bridge wires GAF storage updates into the auth service even before the
+// OAuth provider is configured via Default().
+func Test_RegisterOAuthStorageBridge_PropagatesTokenToAuthService(t *testing.T) {
+	c := testutil.UnitTest(t)
+	c.SetAuthenticationMethod(types.OAuthAuthentication)
+	storageWithCallbacks, err := storage2.NewStorageWithCallbacks(storage2.WithStorageFile(filepath.Join(t.TempDir(), "testStorage")))
+	require.NoError(t, err)
+	c.SetStorage(storageWithCallbacks)
+
+	notifier := notification.NewNotifier()
+	authParamsChan := make(chan types.AuthenticationParams, 4)
+	notifier.CreateListener(func(params any) {
+		if authParams, ok := params.(types.AuthenticationParams); ok {
+			authParamsChan <- authParams
+		}
+	})
+	t.Cleanup(notifier.DisposeListener)
+
+	service := NewAuthenticationService(c, nil, error_reporting.NewTestErrorReporter(), notifier)
+	t.Cleanup(service.Shutdown)
+
+	// Register the bridge BEFORE Default() runs (mirrors initializeHandler order).
+	RegisterOAuthStorageBridge(storageWithCallbacks, service)
+
+	rotatedTokenBytes, err := json.Marshal(oauth2.Token{
+		AccessToken:  "rotated-access",
+		RefreshToken: "rotated-refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	rotatedToken := string(rotatedTokenBytes)
+
+	// Simulate GAF persisting a rotated OAuth token during a pre-init API call.
+	require.NoError(t, storageWithCallbacks.Set(auth.CONFIG_KEY_OAUTH_TOKEN, rotatedToken))
+
+	// Wait for the auth service to apply the rotated token.
+	require.Eventuallyf(t, func() bool {
+		return c.Token() == rotatedToken
+	}, 5*time.Second, 25*time.Millisecond, "rotated token must reach auth service via bridge")
+
+	// And the corresponding IDE notification must have been queued.
+	select {
+	case authParams := <-authParamsChan:
+		assert.Equal(t, rotatedToken, authParams.Token)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected IDE notification for rotated OAuth token via bridge")
+	}
+}
+
+// Test_RegisterOAuthStorageBridge_NoOpOnNilArgs verifies the defensive nil-guards
+// so initializeHandler can call this even before storage / auth service are ready.
+func Test_RegisterOAuthStorageBridge_NoOpOnNilArgs(t *testing.T) {
+	c := testutil.UnitTest(t)
+	storageWithCallbacks, err := storage2.NewStorageWithCallbacks(storage2.WithStorageFile(filepath.Join(t.TempDir(), "testStorage")))
+	require.NoError(t, err)
+	service := NewAuthenticationService(c, nil, error_reporting.NewTestErrorReporter(), notification.NewNotifier())
+	t.Cleanup(service.Shutdown)
+
+	// Should not panic with either nil
+	RegisterOAuthStorageBridge(nil, service)
+	RegisterOAuthStorageBridge(storageWithCallbacks, nil)
+}
+
+// Test_RegisterOAuthStorageBridge_SerializesRapidTokenRotations verifies that the
+// bridge's queued-update worker preserves order during rapid token rotations: the
+// final in-memory token must equal the last token written to storage.
+func Test_RegisterOAuthStorageBridge_SerializesRapidTokenRotations(t *testing.T) {
+	c := testutil.UnitTest(t)
+	c.SetAuthenticationMethod(types.OAuthAuthentication)
+	storageWithCallbacks, err := storage2.NewStorageWithCallbacks(storage2.WithStorageFile(filepath.Join(t.TempDir(), "testStorage")))
+	require.NoError(t, err)
+	c.SetStorage(storageWithCallbacks)
+
+	notifier := notification.NewNotifier()
+	authParamsChan := make(chan types.AuthenticationParams, 16)
+	notifier.CreateListener(func(params any) {
+		if authParams, ok := params.(types.AuthenticationParams); ok {
+			authParamsChan <- authParams
+		}
+	})
+	t.Cleanup(notifier.DisposeListener)
+
+	service := NewAuthenticationService(c, nil, error_reporting.NewTestErrorReporter(), notifier)
+	t.Cleanup(service.Shutdown)
+
+	RegisterOAuthStorageBridge(storageWithCallbacks, service)
+
+	// Build tokens with strictly increasing expiry so each newer one is accepted by
+	// shouldUpdateOAuth2Token (otherwise SetToken silently rejects out-of-order writes).
+	tokenJSONs := make([]string, 5)
+	base := time.Now().Add(time.Hour)
+	for i := range tokenJSONs {
+		tokenBytes, err := json.Marshal(oauth2.Token{
+			AccessToken:  "access",
+			RefreshToken: "refresh",
+			TokenType:    "Bearer",
+			Expiry:       base.Add(time.Duration(i) * time.Minute),
+		})
+		require.NoError(t, err)
+		tokenJSONs[i] = string(tokenBytes)
+	}
+
+	for _, tokenJSON := range tokenJSONs {
+		require.NoError(t, storageWithCallbacks.Set(auth.CONFIG_KEY_OAUTH_TOKEN, tokenJSON))
+	}
+
+	final := tokenJSONs[len(tokenJSONs)-1]
+	require.Eventuallyf(t, func() bool {
+		return c.Token() == final
+	}, 5*time.Second, 25*time.Millisecond, "final token in must equal last token written to storage")
 }
 
 func Test_NewOauthProvider_oauthProvider_created_with_injected_refreshMethod(t *testing.T) {

--- a/infrastructure/authentication/auth_service.go
+++ b/infrastructure/authentication/auth_service.go
@@ -60,4 +60,11 @@ type AuthenticationService interface {
 
 	// AuthURL retrieves the authentication URL
 	AuthURL(ctx context.Context) string
+
+	// queueCredentialUpdate queues a credential update for serialized processing by the
+	// internal worker. Used by the OAuth storage bridge to prevent rapid-rotation races.
+	queueCredentialUpdate(token string, sendNotification bool, updateApiUrl bool)
+
+	// Shutdown cleans up resources such as the credential update worker goroutine.
+	Shutdown()
 }

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -44,6 +44,15 @@ const ExpirationMsg = "Your authentication failed due to token expiration. Pleas
 const InvalidCredsMessage = "Your authentication credentials cannot be validated. Automatically clearing credentials. You need to re-authenticate to use Snyk."
 const MethodChangedMessage = "Your authentication method has changed. Please re-authenticate to continue using Snyk."
 
+// credentialUpdate represents a request to update credentials with synchronization.
+// Used by the OAuth storage bridge to serialize updates and prevent race conditions
+// where older tokens overwrite newer ones during rapid rotations.
+type credentialUpdate struct {
+	token            string
+	sendNotification bool
+	updateApiUrl     bool
+}
+
 type AuthenticationServiceImpl struct {
 	authProvider  AuthenticationProvider
 	errorReporter error_reporting.ErrorReporter
@@ -56,16 +65,68 @@ type AuthenticationServiceImpl struct {
 	m                           sync.RWMutex
 	previousAuthCtxCancelFunc   context.CancelFunc
 	previousAuthCtxCancelFuncMu sync.Mutex
+	// credentialUpdateChan serializes credential updates from the OAuth storage bridge
+	// so concurrent rotations cannot apply tokens out-of-order.
+	credentialUpdateChan chan credentialUpdate
+	// credentialUpdateCancel cancels the credential update worker on Shutdown.
+	credentialUpdateCancel context.CancelFunc
 }
 
 func NewAuthenticationService(c *config.Config, authProviders AuthenticationProvider, errorReporter error_reporting.ErrorReporter, notifier noti.Notifier) AuthenticationService {
 	cache := imcache.New[string, bool]()
-	return &AuthenticationServiceImpl{
-		authProvider:  authProviders,
-		errorReporter: errorReporter,
-		notifier:      notifier,
-		c:             c,
-		authCache:     cache,
+	updateChan := make(chan credentialUpdate, 100)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	service := &AuthenticationServiceImpl{
+		authProvider:           authProviders,
+		errorReporter:          errorReporter,
+		notifier:               notifier,
+		c:                      c,
+		authCache:              cache,
+		credentialUpdateChan:   updateChan,
+		credentialUpdateCancel: cancel,
+	}
+
+	// Start worker goroutine to process credential updates sequentially.
+	go service.credentialUpdateWorker(ctx)
+
+	return service
+}
+
+// credentialUpdateWorker processes credential updates sequentially from the channel.
+// This prevents race conditions where older tokens overwrite newer ones during rapid
+// rotations from the OAuth storage bridge.
+func (a *AuthenticationServiceImpl) credentialUpdateWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case update := <-a.credentialUpdateChan:
+			a.UpdateCredentials(update.token, update.sendNotification, update.updateApiUrl)
+		}
+	}
+}
+
+// queueCredentialUpdate queues a credential update for sequential processing by the
+// worker goroutine. Used by the OAuth storage bridge callback to serialize updates.
+func (a *AuthenticationServiceImpl) queueCredentialUpdate(token string, sendNotification bool, updateApiUrl bool) {
+	select {
+	case a.credentialUpdateChan <- credentialUpdate{
+		token:            token,
+		sendNotification: sendNotification,
+		updateApiUrl:     updateApiUrl,
+	}:
+	default:
+		a.c.Logger().Warn().
+			Str("method", "AuthenticationService.queueCredentialUpdate").
+			Msg("credential update channel full, dropping update")
+	}
+}
+
+// Shutdown cleans up the credential update worker goroutine. Safe to call multiple times.
+func (a *AuthenticationServiceImpl) Shutdown() {
+	if a.credentialUpdateCancel != nil {
+		a.credentialUpdateCancel()
 	}
 }
 
@@ -202,6 +263,15 @@ func (a *AuthenticationServiceImpl) updateCredentials(newToken string, sendNotif
 		// checks are performed - e.g. in IsAuthenticated or Authenticate which call the API to check for real
 		a.authCache.Remove(oldToken)
 		a.c.SetToken(newToken)
+		// SetToken silently rejects stale OAuth tokens (older expiry than current).
+		// If that happened, do not fire token-change listeners or send notifications
+		// with the stale value the caller passed in.
+		if a.c.Token() != newToken {
+			a.c.Logger().Debug().
+				Str("method", "AuthenticationService.updateCredentials").
+				Msg("auth credentials update skipped because token was not applied")
+			return
+		}
 	}
 
 	if sendNotification {
@@ -351,6 +421,13 @@ func shouldCauseLogout(err error, logger *zerolog.Logger) bool {
 	// string matching where we don't have explicit errors
 	default:
 		errMsg := err.Error()
+		// "authentication failed", "invalid_grant", and "token_inactive" only appear when
+		// the OAuth server explicitly rejected the credentials (e.g. invalid_grant on
+		// token refresh). This is a permanent failure and must trigger logout even when
+		// wrapped inside a url.Error transport chain.
+		if isPermanentOAuthRefreshError(errMsg) {
+			return true
+		}
 		switch {
 		case strings.Contains(errMsg, "oauth2"):
 			return true
@@ -368,6 +445,13 @@ func shouldCauseLogout(err error, logger *zerolog.Logger) bool {
 			return false
 		}
 	}
+}
+
+func isPermanentOAuthRefreshError(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	return strings.Contains(lower, "authentication failed") ||
+		strings.Contains(lower, "invalid_grant") ||
+		strings.Contains(lower, "token_inactive")
 }
 
 func (a *AuthenticationServiceImpl) handleEmptyUser(logger zerolog.Logger, isLegacyToken bool, invalidToken oauth2.Token) {

--- a/infrastructure/authentication/auth_service_impl_test.go
+++ b/infrastructure/authentication/auth_service_impl_test.go
@@ -278,6 +278,42 @@ func Test_UpdateCredentials(t *testing.T) {
 		service.UpdateCredentials(token, false, true)
 		assert.Empty(t, mockNotifier.SentMessages())
 	})
+
+	t.Run("Rejected stale OAuth token does not send notification", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+		c.SetAuthenticationMethod(types.OAuthAuthentication)
+		mockNotifier := notification.NewMockNotifier()
+		service := NewAuthenticationService(c, nil, error_reporting.NewTestErrorReporter(), mockNotifier)
+
+		freshTokenBytes, err := json.Marshal(oauth2.Token{
+			AccessToken:  "fresh-access",
+			RefreshToken: "fresh-refresh",
+			Expiry:       time.Now().Add(2 * time.Hour),
+		})
+		require.NoError(t, err)
+		freshToken := string(freshTokenBytes)
+		service.UpdateCredentials(freshToken, false, false)
+
+		// Drain notifications from the fresh-token write (should be none as
+		// sendNotification=false, but be defensive).
+		_ = mockNotifier.SentMessages()
+
+		// Reset notifier capture so the second call's notification (if any)
+		// is observable in isolation.
+		freshNotifierCount := len(mockNotifier.SentMessages())
+
+		staleTokenBytes, err := json.Marshal(oauth2.Token{
+			AccessToken:  "stale-access",
+			RefreshToken: "stale-refresh",
+			Expiry:       time.Now().Add(time.Hour),
+		})
+		require.NoError(t, err)
+		service.UpdateCredentials(string(staleTokenBytes), true, false)
+
+		assert.Equal(t, freshToken, c.Token(), "stale OAuth token must NOT overwrite the in-memory token")
+		assert.Equal(t, freshNotifierCount, len(mockNotifier.SentMessages()),
+			"updateCredentials must NOT send a notification when SetToken rejected the stale OAuth token")
+	})
 }
 
 func Test_Authenticate(t *testing.T) {
@@ -618,6 +654,32 @@ func TestGetApiUrl(t *testing.T) {
 			result := getPrioritizedApiUrl(tt.customUrl, tt.engineUrl)
 			assert.Equal(t, tt.expectedResult, result, "getApiUrl(%v, %v) = %v; want %v",
 				tt.customUrl, tt.engineUrl, result, tt.expectedResult)
+		})
+	}
+}
+
+// Test_isPermanentOAuthRefreshError verifies that OAuth permanent-failure error
+// strings (invalid_grant, token_inactive, "authentication failed") are detected
+// even when wrapped or in mixed case.
+func Test_isPermanentOAuthRefreshError(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"oauth2 invalid_grant", "oauth2: cannot fetch token: 400 Bad Request: invalid_grant", true},
+		{"token_inactive", "oauth2 token refresh failed: token_inactive", true},
+		{"authentication failed (lowercase)", "authentication failed", true},
+		{"AUTHENTICATION FAILED uppercase", "AUTHENTICATION FAILED", true},
+		{"wrapped in url.Error context", `Get "https://api.snyk.io/rest/self": Post "https://api.snyk.io/oauth2/token": oauth2: cannot fetch token: 400: invalid_grant`, true},
+		{"transient network error - no logout", "dial tcp: connection refused", false},
+		{"random error - no logout", "something unexpected happened", false},
+		{"empty string - no logout", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPermanentOAuthRefreshError(tc.msg))
 		})
 	}
 }

--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -69,8 +69,8 @@ func (sc *Scanner) GetAutofixDiffs(ctx context.Context, baseDir types.FilePath, 
 	// ticker sends a trigger every second to its channel
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	// timeoutTimer sends a trigger after 2 minutes to its channel
-	timeoutTimer := time.NewTimer(2 * time.Minute)
+	// timeoutTimer sends a trigger after 4 minutes to its channel
+	timeoutTimer := time.NewTimer(4 * time.Minute)
 	defer timeoutTimer.Stop()
 	for {
 		select {

--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -165,21 +165,24 @@ func (sc *Scanner) Scan(ctx context.Context, pathToScan types.FilePath, workspac
 
 	logger.Debug().Msg("Code scanner: starting scan")
 
+	if !sc.IsEnabledForFolder(workspaceFolderConfig) {
+		return nil, errors.New(utils.ErrSnykCodeNotEnabledForFolder)
+	}
+
 	if !sc.C.NonEmptyToken() {
-		logger.Info().Msg("not authenticated, not scanning")
-		return issues, err
+		logger.Info().Msg(utils.MsgNotAuthenticatedNoScan)
+		return nil, errors.New(utils.MsgNotAuthenticatedNoScan)
 	}
 
 	if workspaceFolderConfig.SastSettings == nil {
-		errMsg := "SAST settings not available"
-		logger.Error().Msg(errMsg)
-		return issues, errors.New(errMsg)
+		logger.Error().Msg(utils.ErrSastSettingsNotAvailable)
+		return nil, errors.New(utils.ErrSastSettingsNotAvailable)
 	}
 
 	sastResponse := workspaceFolderConfig.SastSettings
 
 	if !sastResponse.SastEnabled {
-		return issues, errors.New(utils.ErrSnykCodeNotEnabled)
+		return nil, errors.New(utils.ErrSnykCodeNotEnabled)
 	}
 
 	if isLocalEngineEnabled(sastResponse) {
@@ -283,7 +286,10 @@ func internalScan(ctx context.Context, sc *Scanner, folderPath types.FilePath, f
 
 	if t.IsCanceled() || ctx.Err() != nil {
 		progress.Cancel(t.GetToken())
-		return results, err
+		// Match OSS/IaC: cancellation returns an explicit empty slice (not the
+		// named-return zero value (nil, nil)) so callers and JSON/LSP
+		// consumers see an empty issue list rather than nil.
+		return []types.Issue{}, nil
 	}
 
 	codeConsistentIgnoresEnabled := sc.featureFlagService.GetFromFolderConfig(folderPath, featureflag.SnykCodeConsistentIgnores)

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -236,6 +236,9 @@ func Test_Scan(t *testing.T) {
 
 	t.Run("Shouldn't run if Sast is disabled", func(t *testing.T) {
 		c := testutil.UnitTest(t)
+		// Enable Code on the config so the IsEnabledForFolder guard passes
+		// (added in IDE-2002); this subtest exercises the downstream SastEnabled check.
+		c.SetSnykCodeEnabled(true)
 		ctrl := gomock.NewController(t)
 		mockEngine := mocks.NewMockEngine(ctrl)
 		mockConfig := mocks.NewMockConfiguration(ctrl)
@@ -282,6 +285,9 @@ func Test_Scan(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := testutil.UnitTest(t)
+			// Enable Code on the config so the IsEnabledForFolder guard passes
+			// (added in IDE-2002; resolver=nil falls back to c.IsSnykCodeEnabled).
+			c.SetSnykCodeEnabled(true)
 			snykApiMock := &snyk_api.FakeApiClient{CodeEnabled: true}
 			ctrl := gomock.NewController(t)
 			mockEngine := mocks.NewMockEngine(ctrl)

--- a/infrastructure/code/conversion.go
+++ b/infrastructure/code/conversion.go
@@ -18,6 +18,7 @@ package code
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog"
@@ -31,20 +32,48 @@ import (
 // This is a simplified version for use by MCP and other tools that need conversion without full scanner
 // basePath is the absolute path where the scan was run (optional - if empty, paths remain relative)
 func ConvertSARIFJSONToIssues(logger *zerolog.Logger, hoverVerbosity int, sarifJSON []byte, basePath string) ([]types.Issue, error) {
-	var sarifResponse codeClientSarif.SarifResponse
-
-	err := json.Unmarshal(sarifJSON, &sarifResponse.Sarif)
-	if err != nil {
+	var head sarifDocumentHead
+	if err := json.Unmarshal(sarifJSON, &head); err != nil {
 		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", err)
 	}
+	if len(head.Runs) == 0 {
+		return nil, nil
+	}
+	run := codeClientSarif.Run{
+		Tool:       head.Runs[0].Tool,
+		Properties: head.Runs[0].Properties,
+		Results:    nil,
+	}
+	var sarifResponse codeClientSarif.SarifResponse
+	sarifResponse.Sarif.Schema = head.Schema
+	sarifResponse.Sarif.Version = head.Version
+	sarifResponse.Sarif.Runs = []codeClientSarif.Run{run}
 
 	converter := SarifConverter{sarif: sarifResponse, logger: logger, hoverVerbosity: hoverVerbosity}
+	ruleLink := createRuleLink()
+	baseDir := types.FilePath(basePath)
 
-	// Convert with provided base path (or empty for relative paths)
-	issues, err := converter.toIssues(types.FilePath(basePath))
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert SARIF to issues: %w", err)
+	var issues []types.Issue
+	var conversionErrs error
+	streamErr := streamFirstRunResults(sarifJSON, func(res codeClientSarif.Result) error {
+		var appendErr error
+		issues, appendErr = converter.appendIssuesForResult(run, res, baseDir, ruleLink, issues)
+		conversionErrs = errors.Join(conversionErrs, appendErr)
+		return nil
+	})
+	if errors.Is(streamErr, errDuplicateSARIFStreamingKey) {
+		var full codeClientSarif.SarifResponse
+		if unmarshalErr := json.Unmarshal(sarifJSON, &full.Sarif); unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to parse SARIF JSON: %w", unmarshalErr)
+		}
+		fullConverter := SarifConverter{sarif: full, logger: logger, hoverVerbosity: hoverVerbosity}
+		return fullConverter.toIssues(baseDir)
 	}
-
+	if streamErr != nil {
+		return nil, fmt.Errorf("failed to parse SARIF JSON: %w", streamErr)
+	}
+	if conversionErrs != nil {
+		return issues, fmt.Errorf("failed to convert SARIF to issues: %w", conversionErrs)
+	}
 	return issues, nil
 }

--- a/infrastructure/code/conversion_stream.go
+++ b/infrastructure/code/conversion_stream.go
@@ -1,0 +1,177 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	codeClientSarif "github.com/snyk/code-client-go/sarif"
+)
+
+var errDuplicateSARIFStreamingKey = errors.New("duplicate SARIF key requires full unmarshal")
+
+// sarifRunHead holds only the non-results fields of a SARIF run object.
+// When json.Unmarshal decodes a []sarifRunHead, it still reads every byte of the
+// document (including the results arrays) but never allocates codeClientSarif.Result
+// objects, so peak allocation is much lower than a full SarifResponse unmarshal.
+type sarifRunHead struct {
+	Tool       codeClientSarif.Tool          `json:"tool"`
+	Properties codeClientSarif.RunProperties `json:"properties"`
+}
+
+type sarifDocumentHead struct {
+	Schema  string         `json:"$schema"`
+	Version string         `json:"version"`
+	Runs    []sarifRunHead `json:"runs"`
+}
+
+func isDelim(tok json.Token, want json.Delim) bool {
+	d, ok := tok.(json.Delim)
+	return ok && d == want
+}
+
+// streamFirstRunResults walks sarifJSON (inner Sarif document) and decodes each result in runs[0].results.
+func streamFirstRunResults(sarifJSON []byte, handle func(codeClientSarif.Result) error) error {
+	dec := json.NewDecoder(bytes.NewReader(sarifJSON))
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if !isDelim(tok, '{') {
+		return fmt.Errorf("expected top-level JSON object")
+	}
+	seenRuns := false
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("expected object key string")
+		}
+		if key != "runs" {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+			continue
+		}
+		if seenRuns {
+			return errDuplicateSARIFStreamingKey
+		}
+		seenRuns = true
+		if err := consumeRunsArrayResults(dec, handle); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func consumeRunsArrayResults(dec *json.Decoder, handle func(codeClientSarif.Result) error) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if !isDelim(tok, '[') {
+		return fmt.Errorf("runs: expected JSON array")
+	}
+	tok, err = dec.Token()
+	if err != nil {
+		return err
+	}
+	if isDelim(tok, ']') {
+		return nil
+	}
+	if !isDelim(tok, '{') {
+		return fmt.Errorf("runs: expected run object")
+	}
+	if err := consumeRunObjectResults(dec, handle); err != nil {
+		return err
+	}
+	return finishRunsArrayAfterFirstRun(dec)
+}
+
+func consumeRunObjectResults(dec *json.Decoder, handle func(codeClientSarif.Result) error) error {
+	seenResults := false
+	for {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if isDelim(keyTok, '}') {
+			return nil
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("runs[0]: expected object key string")
+		}
+		switch key {
+		case "results":
+			if seenResults {
+				return errDuplicateSARIFStreamingKey
+			}
+			seenResults = true
+			if err := decodeResultsArray(dec, handle); err != nil {
+				return err
+			}
+		default:
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func finishRunsArrayAfterFirstRun(dec *json.Decoder) error {
+	for dec.More() {
+		var skipRun json.RawMessage
+		if err := dec.Decode(&skipRun); err != nil {
+			return err
+		}
+	}
+	_, err := dec.Token()
+	return err
+}
+
+func skipJSONValue(dec *json.Decoder) error {
+	var skip json.RawMessage
+	return dec.Decode(&skip)
+}
+
+func decodeResultsArray(dec *json.Decoder, handle func(codeClientSarif.Result) error) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if !isDelim(tok, '[') {
+		return fmt.Errorf("results: expected JSON array")
+	}
+	for dec.More() {
+		var res codeClientSarif.Result
+		if decErr := dec.Decode(&res); decErr != nil {
+			return decErr
+		}
+		if hErr := handle(res); hErr != nil {
+			return hErr
+		}
+	}
+	_, err = dec.Token()
+	return err
+}

--- a/infrastructure/code/conversion_test.go
+++ b/infrastructure/code/conversion_test.go
@@ -1,0 +1,275 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	codeClientSarif "github.com/snyk/code-client-go/sarif"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// minimal inner SARIF document (MCP path) with two security results for streaming vs full-unmarshal parity.
+const conversionTestInnerSarif = `{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SnykCode",
+          "semanticVersion": "1.0.0",
+          "version": "1.0.0",
+          "rules": [
+            {
+              "id": "java/TestRule",
+              "name": "TestRule",
+              "shortDescription": { "text": "Test rule" },
+              "defaultConfiguration": { "level": "warning" },
+              "help": { "markdown": "help-md", "text": "help" },
+              "properties": {
+                "tags": ["java"],
+                "categories": ["Security"],
+                "cwe": ["CWE-1"]
+              }
+            }
+          ]
+        }
+      },
+      "properties": {},
+      "results": [
+        {
+          "ruleId": "java/TestRule",
+          "level": "warning",
+          "message": { "text": "first finding" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/a.java" },
+                "region": { "startLine": 10, "endLine": 10, "startColumn": 1, "endColumn": 5 }
+              }
+            }
+          ],
+          "fingerprints": { "0": "", "1": "fp-a", "identity": "id-a" }
+        },
+        {
+          "ruleId": "java/TestRule",
+          "level": "warning",
+          "message": { "text": "second finding" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/b.java" },
+                "region": { "startLine": 20, "endLine": 20, "startColumn": 2, "endColumn": 6 }
+              }
+            }
+          ],
+          "fingerprints": { "0": "", "1": "fp-b", "identity": "id-b" }
+        }
+      ]
+    }
+  ]
+}`
+
+func issueSortKey(i types.Issue) string {
+	return string(i.GetAffectedFilePath()) + "\x00" + i.GetID() + "\x00" + i.GetMessage()
+}
+
+func sortIssuesForCompare(issues []types.Issue) []types.Issue {
+	out := append([]types.Issue(nil), issues...)
+	sort.Slice(out, func(a, b int) bool {
+		return issueSortKey(out[a]) < issueSortKey(out[b])
+	})
+	return out
+}
+
+func assertIssueSlicesEqual(t *testing.T, want, got []types.Issue) {
+	t.Helper()
+	require.Equal(t, len(want), len(got))
+	sw := sortIssuesForCompare(want)
+	sg := sortIssuesForCompare(got)
+	for i := range sw {
+		w := sw[i]
+		g := sg[i]
+		require.Equal(t, w.GetID(), g.GetID())
+		require.Equal(t, w.GetMessage(), g.GetMessage())
+		require.Equal(t, w.GetAffectedFilePath(), g.GetAffectedFilePath())
+		require.Equal(t, w.GetRange(), g.GetRange())
+		require.Equal(t, w.GetSeverity(), g.GetSeverity())
+		require.Equal(t, w.GetFingerprint(), g.GetFingerprint())
+		require.Equal(t, w.GetGlobalIdentity(), g.GetGlobalIdentity())
+	}
+}
+
+// TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal checks streaming decode matches json.Unmarshal + toIssues.
+func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal(t *testing.T) {
+	testutil.UnitTest(t)
+	logger := zerolog.Nop()
+	hover := 0
+	basePath := ""
+
+	var full codeClientSarif.SarifResponse
+	require.NoError(t, json.Unmarshal([]byte(conversionTestInnerSarif), &full.Sarif))
+	conv := SarifConverter{sarif: full, logger: &logger, hoverVerbosity: hover}
+	want, err := conv.toIssues(types.FilePath(basePath))
+	require.NoError(t, err)
+
+	got, err := ConvertSARIFJSONToIssues(&logger, hover, []byte(conversionTestInnerSarif), basePath)
+	require.NoError(t, err)
+	assertIssueSlicesEqual(t, want, got)
+}
+
+func TestConvertSARIFJSONToIssues_StreamMatchesFullUnmarshal_EmptyRuns(t *testing.T) {
+	testutil.UnitTest(t)
+	logger := zerolog.Nop()
+	inner := `{"$schema":"https://example/sarif.json","version":"2.1.0","runs":[]}`
+	var full codeClientSarif.SarifResponse
+	require.NoError(t, json.Unmarshal([]byte(inner), &full.Sarif))
+	conv := SarifConverter{sarif: full, logger: &logger, hoverVerbosity: 0}
+	want, err := conv.toIssues("")
+	require.NoError(t, err)
+	got, err := ConvertSARIFJSONToIssues(&logger, 0, []byte(inner), "")
+	require.NoError(t, err)
+	require.Equal(t, len(want), len(got))
+}
+
+func TestConvertSARIFJSONToIssues_MalformedResultsArray(t *testing.T) {
+	testutil.UnitTest(t)
+	logger := zerolog.Nop()
+	// Valid first result, invalid second element in results array.
+	sarif := `{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SnykCode",
+          "rules": [
+            {
+              "id": "r1",
+              "name": "r1",
+              "shortDescription": { "text": "r" },
+              "defaultConfiguration": { "level": "warning" },
+              "help": { "markdown": "", "text": "" },
+              "properties": { "categories": ["Security"], "tags": [] }
+            }
+          ]
+        }
+      },
+      "properties": {},
+      "results": [
+        {
+          "ruleId": "r1",
+          "level": "warning",
+          "message": { "text": "ok" },
+          "locations": [],
+          "fingerprints": {}
+        },
+        not_valid_json_token
+      ]
+    }
+  ]
+}`
+	_, err := ConvertSARIFJSONToIssues(&logger, 0, []byte(sarif), "")
+	require.Error(t, err)
+}
+
+func TestConvertSARIFJSONToIssues_DuplicateRunsAndResultsMatchFullUnmarshal(t *testing.T) {
+	testutil.UnitTest(t)
+	logger := zerolog.Nop()
+	inner := `{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "SnykCode", "rules": [] } },
+      "results": [
+        { "ruleId": "ignored/FirstRun", "message": { "text": "ignored first run" }, "locations": [], "fingerprints": {} }
+      ]
+    }
+  ],
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SnykCode",
+          "rules": [
+            {
+              "id": "java/DuplicateRule",
+              "name": "DuplicateRule",
+              "shortDescription": { "text": "Duplicate rule" },
+              "defaultConfiguration": { "level": "warning" },
+              "help": { "markdown": "help-md", "text": "help" },
+              "properties": { "categories": ["Security"], "tags": [] }
+            }
+          ]
+        }
+      },
+      "properties": {},
+      "results": [
+        {
+          "ruleId": "java/DuplicateRule",
+          "level": "warning",
+          "message": { "text": "ignored duplicate results" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/ignored.java" },
+                "region": { "startLine": 1, "endLine": 1, "startColumn": 1, "endColumn": 2 }
+              }
+            }
+          ],
+          "fingerprints": { "1": "ignored" }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "java/DuplicateRule",
+          "level": "warning",
+          "message": { "text": "last duplicate wins" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///tmp/last.java" },
+                "region": { "startLine": 7, "endLine": 7, "startColumn": 3, "endColumn": 9 }
+              }
+            }
+          ],
+          "fingerprints": { "1": "last-fp", "identity": "last-id" }
+        }
+      ]
+    }
+  ]
+}`
+
+	var full codeClientSarif.SarifResponse
+	require.NoError(t, json.Unmarshal([]byte(inner), &full.Sarif))
+	conv := SarifConverter{sarif: full, logger: &logger, hoverVerbosity: 0}
+	want, err := conv.toIssues("")
+	require.NoError(t, err)
+
+	got, err := ConvertSARIFJSONToIssues(&logger, 0, []byte(inner), "")
+
+	require.NoError(t, err)
+	assertIssueSlicesEqual(t, want, got)
+}

--- a/infrastructure/code/convert.go
+++ b/infrastructure/code/convert.go
@@ -304,130 +304,144 @@ func (s *SarifConverter) getRule(r codeClientSarif.Run, id string) codeClientSar
 	return codeClientSarif.Rule{}
 }
 
-func (s *SarifConverter) toIssues(baseDir types.FilePath) (issues []types.Issue, err error) {
+func (s *SarifConverter) appendIssuesForResult(
+	r codeClientSarif.Run,
+	result codeClientSarif.Result,
+	baseDir types.FilePath,
+	ruleLink *url.URL,
+	issues []types.Issue,
+) ([]types.Issue, error) {
+	var errs error
+	for _, loc := range result.Locations {
+		// Response contains encoded relative paths that should be decoded and converted to absolute.
+		absPath, err := DecodePath(ToAbsolutePath(baseDir, types.FilePath(loc.PhysicalLocation.ArtifactLocation.URI)))
+		if err != nil {
+			s.logger.Error().
+				Err(err).
+				Msg("failed to convert URI to absolute path: base directory: " +
+					string(baseDir) +
+					", URI: " +
+					loc.PhysicalLocation.ArtifactLocation.URI)
+			errs = errors.Join(errs, err)
+			continue
+		}
+
+		position := loc.PhysicalLocation.Region
+		// NOTE: sarif uses 1-based location numbering, see
+		// https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Ref493492556
+		startLine := position.StartLine - 1
+		endLine := util.Max(position.EndLine-1, startLine)
+		startCol := position.StartColumn - 1
+		endCol := util.Max(position.EndColumn-1, 0)
+		myRange := types.Range{
+			Start: types.Position{
+				Line:      startLine,
+				Character: startCol,
+			},
+			End: types.Position{
+				Line:      endLine,
+				Character: endCol,
+			},
+		}
+
+		testRule := s.getRule(r, result.RuleID)
+
+		// only process security issues
+		isSecurityType := s.isSecurityIssue(testRule)
+		if !isSecurityType {
+			continue
+		}
+
+		message := s.getMessage(result, testRule)
+		formattedMessage := s.formattedMessageMarkdown(result, testRule, baseDir)
+
+		exampleCommits := s.getExampleCommits(testRule)
+		exampleFixes := make([]snyk.ExampleCommitFix, 0, len(exampleCommits))
+		for _, commit := range exampleCommits {
+			commitURL := commit.fix.CommitURL
+			commitFixLines := make([]snyk.CommitChangeLine, 0, len(commit.fix.Lines))
+			for _, line := range commit.fix.Lines {
+				commitFixLines = append(commitFixLines, snyk.CommitChangeLine{
+					Line:       line.Line,
+					LineNumber: line.LineNumber,
+					LineChange: line.LineChange})
+			}
+
+			exampleFixes = append(exampleFixes, snyk.ExampleCommitFix{
+				CommitURL: commitURL,
+				Lines:     commitFixLines,
+			})
+		}
+
+		markers, err := s.getMarkers(result, baseDir)
+		errs = errors.Join(errs, err)
+
+		key := util.GetIssueKey(result.RuleID, absPath, startLine, endLine, startCol, endCol)
+		title := testRule.ShortDescription.Text
+		if title == "" {
+			title = testRule.ID
+		}
+
+		additionalData := snyk.CodeIssueData{
+			Key:                key,
+			Title:              title,
+			Message:            result.Message.Text,
+			Rule:               testRule.Name,
+			RuleId:             testRule.ID,
+			RepoDatasetSize:    testRule.Properties.RepoDatasetSize,
+			ExampleCommitFixes: exampleFixes,
+			CWE:                testRule.Properties.Cwe,
+			Text:               testRule.Help.Markdown,
+			Markers:            markers,
+			Cols:               [2]int{startCol, endCol},
+			Rows:               [2]int{startLine, endLine},
+			IsSecurityType:     isSecurityType,
+			IsAutofixable:      result.Properties.IsAutofixable,
+			PriorityScore:      result.Properties.PriorityScore,
+			DataFlow:           s.getCodeFlow(result, baseDir),
+		}
+
+		d := &snyk.Issue{
+			ID:                  result.RuleID,
+			Range:               myRange,
+			Severity:            issueSeverity(result.Level),
+			Message:             message,
+			FormattedMessage:    formattedMessage,
+			IssueType:           types.CodeSecurityVulnerability,
+			ContentRoot:         baseDir,
+			AffectedFilePath:    types.FilePath(absPath),
+			Product:             product.ProductCode,
+			IssueDescriptionURL: ruleLink,
+			References:          s.getReferences(testRule),
+			AdditionalData:      additionalData,
+			CWEs:                testRule.Properties.Cwe,
+			FindingId:           result.Fingerprints.SnykAssetFindingV1,
+		}
+		d.SetFingerPrint(result.Fingerprints.Num1)
+		d.SetGlobalIdentity(result.Fingerprints.Identity)
+		isIgnored, ignoreDetails := GetIgnoreDetailsFromSuppressions(result.Suppressions)
+		d.IsIgnored = isIgnored
+		d.IgnoreDetails = ignoreDetails
+		d.AdditionalData = additionalData
+
+		issues = append(issues, d)
+	}
+	return issues, errs
+}
+
+func (s *SarifConverter) toIssues(baseDir types.FilePath) ([]types.Issue, error) {
 	runs := s.sarif.Sarif.Runs
 	if len(runs) == 0 {
-		return issues, nil
+		return nil, nil
 	}
 	ruleLink := createRuleLink()
-
 	r := runs[0]
+	var issues []types.Issue
 	var errs error
 	for _, result := range r.Results {
-		for _, loc := range result.Locations {
-			// Response contains encoded relative paths that should be decoded and converted to absolute.
-			absPath, err := DecodePath(ToAbsolutePath(baseDir, types.FilePath(loc.PhysicalLocation.ArtifactLocation.URI)))
-			if err != nil {
-				s.logger.Error().
-					Err(err).
-					Msg("failed to convert URI to absolute path: base directory: " +
-						string(baseDir) +
-						", URI: " +
-						loc.PhysicalLocation.ArtifactLocation.URI)
-				errs = errors.Join(errs, err)
-				continue
-			}
-
-			position := loc.PhysicalLocation.Region
-			// NOTE: sarif uses 1-based location numbering, see
-			// https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Ref493492556
-			startLine := position.StartLine - 1
-			endLine := util.Max(position.EndLine-1, startLine)
-			startCol := position.StartColumn - 1
-			endCol := util.Max(position.EndColumn-1, 0)
-			myRange := types.Range{
-				Start: types.Position{
-					Line:      startLine,
-					Character: startCol,
-				},
-				End: types.Position{
-					Line:      endLine,
-					Character: endCol,
-				},
-			}
-
-			testRule := s.getRule(r, result.RuleID)
-
-			// only process security issues
-			isSecurityType := s.isSecurityIssue(testRule)
-			if !isSecurityType {
-				continue
-			}
-
-			message := s.getMessage(result, testRule)
-			formattedMessage := s.formattedMessageMarkdown(result, testRule, baseDir)
-
-			exampleCommits := s.getExampleCommits(testRule)
-			exampleFixes := make([]snyk.ExampleCommitFix, 0, len(exampleCommits))
-			for _, commit := range exampleCommits {
-				commitURL := commit.fix.CommitURL
-				commitFixLines := make([]snyk.CommitChangeLine, 0, len(commit.fix.Lines))
-				for _, line := range commit.fix.Lines {
-					commitFixLines = append(commitFixLines, snyk.CommitChangeLine{
-						Line:       line.Line,
-						LineNumber: line.LineNumber,
-						LineChange: line.LineChange})
-				}
-
-				exampleFixes = append(exampleFixes, snyk.ExampleCommitFix{
-					CommitURL: commitURL,
-					Lines:     commitFixLines,
-				})
-			}
-
-			markers, err := s.getMarkers(result, baseDir)
-			errs = errors.Join(errs, err)
-
-			key := util.GetIssueKey(result.RuleID, absPath, startLine, endLine, startCol, endCol)
-			title := testRule.ShortDescription.Text
-			if title == "" {
-				title = testRule.ID
-			}
-
-			additionalData := snyk.CodeIssueData{
-				Key:                key,
-				Title:              title,
-				Message:            result.Message.Text,
-				Rule:               testRule.Name,
-				RuleId:             testRule.ID,
-				RepoDatasetSize:    testRule.Properties.RepoDatasetSize,
-				ExampleCommitFixes: exampleFixes,
-				CWE:                testRule.Properties.Cwe,
-				Text:               testRule.Help.Markdown,
-				Markers:            markers,
-				Cols:               [2]int{startCol, endCol},
-				Rows:               [2]int{startLine, endLine},
-				IsSecurityType:     isSecurityType,
-				IsAutofixable:      result.Properties.IsAutofixable,
-				PriorityScore:      result.Properties.PriorityScore,
-				DataFlow:           s.getCodeFlow(result, baseDir),
-			}
-
-			d := &snyk.Issue{
-				ID:                  result.RuleID,
-				Range:               myRange,
-				Severity:            issueSeverity(result.Level),
-				Message:             message,
-				FormattedMessage:    formattedMessage,
-				IssueType:           types.CodeSecurityVulnerability,
-				ContentRoot:         baseDir,
-				AffectedFilePath:    types.FilePath(absPath),
-				Product:             product.ProductCode,
-				IssueDescriptionURL: ruleLink,
-				References:          s.getReferences(testRule),
-				AdditionalData:      additionalData,
-				CWEs:                testRule.Properties.Cwe,
-				FindingId:           result.Fingerprints.SnykAssetFindingV1,
-			}
-			d.SetFingerPrint(result.Fingerprints.Num1)
-			d.SetGlobalIdentity(result.Fingerprints.Identity)
-			isIgnored, ignoreDetails := GetIgnoreDetailsFromSuppressions(result.Suppressions)
-			d.IsIgnored = isIgnored
-			d.IgnoreDetails = ignoreDetails
-			d.AdditionalData = additionalData
-
-			issues = append(issues, d)
-		}
+		var appendErr error
+		issues, appendErr = s.appendIssuesForResult(r, result, baseDir, ruleLink, issues)
+		errs = errors.Join(errs, appendErr)
 	}
 	return issues, errs
 }

--- a/infrastructure/iac/iac.go
+++ b/infrastructure/iac/iac.go
@@ -121,9 +121,13 @@ func (iac *Scanner) Scan(ctx context.Context, pathToScan types.FilePath, workspa
 
 	logger.Debug().Msg("IAC scanner: starting scan")
 
+	if !iac.IsEnabledForFolder(workspaceFolderConfig) {
+		return nil, errors.New(utils.ErrSnykIacNotEnabledForFolder)
+	}
+
 	if !c.NonEmptyToken() {
-		logger.Info().Msg("not authenticated, not scanning")
-		return issues, err
+		logger.Info().Msg(utils.MsgNotAuthenticatedNoScan)
+		return nil, errors.New(utils.MsgNotAuthenticatedNoScan)
 	}
 
 	if ctx.Err() != nil {

--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/cli"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	ctx2 "github.com/snyk/snyk-ls/internal/context"
 	noti "github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
@@ -191,9 +192,12 @@ func (cliScanner *CLIScanner) Scan(ctx context.Context, pathToScan types.FilePat
 	deps[ctx2.DepFolderConfig] = workspaceFolderConfig
 	ctx = ctx2.NewContextWithDependencies(ctx, deps)
 
+	if !cliScanner.IsEnabledForFolder(workspaceFolderConfig) {
+		return nil, errors.New(utils.ErrSnykOssNotEnabledForFolder)
+	}
 	if !cliScanner.config.NonEmptyToken() {
-		logger.Info().Msg("not authenticated, not scanning")
-		return issues, err
+		logger.Info().Msg(utils.MsgNotAuthenticatedNoScan)
+		return nil, errors.New(utils.MsgNotAuthenticatedNoScan)
 	}
 	cliPathScan := cliScanner.isSupported(pathToScan)
 	if !cliPathScan {

--- a/infrastructure/oss/converter.go
+++ b/infrastructure/oss/converter.go
@@ -18,10 +18,12 @@
 package oss
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -77,19 +79,18 @@ func ProcessScanResults(ctx context.Context, scanOutput any, errorReporter error
 		return nil, nil
 	}
 
-	scanResults, err := UnmarshallOssJson(scanOutputBytes)
-	if err != nil {
-		errorReporter.CaptureErrorAndReportAsIssue(filePath, err)
-		return nil, nil
-	}
-
-	for _, scanResult := range scanResults {
-		targetFilePath := getAbsTargetFilePath(&logger, scanResult.Path, scanResult.DisplayTargetFile, workDir, filePath)
+	streamErr := StreamOssJson(bytes.NewReader(scanOutputBytes), func(sr *scanResult) error {
+		targetFilePath := getAbsTargetFilePath(&logger, sr.Path, sr.DisplayTargetFile, workDir, filePath)
 
 		fileContent := getFileContent(targetFilePath, readFiles, logger)
 
-		issues := convertScanResultToIssues(c, &scanResult, workDir, targetFilePath, fileContent, learnService, errorReporter, packageIssueCache, format)
+		issues := convertScanResultToIssues(c, sr, workDir, targetFilePath, fileContent, learnService, errorReporter, packageIssueCache, format)
 		allIssues = append(allIssues, issues...)
+		return nil
+	})
+	if streamErr != nil {
+		errorReporter.CaptureErrorAndReportAsIssue(filePath, streamErr)
+		return nil, nil
 	}
 
 	return allIssues, nil
@@ -104,6 +105,58 @@ func getFileContent(targetFilePath types.FilePath, readFiles bool, logger zerolo
 		return fc
 	}
 	return []byte{}
+}
+
+// StreamOssJson decodes the OSS CLI JSON from r, invoking yield once per scanResult.
+//
+// The array form ([{...}, {...}]) is consumed element-by-element via json.Decoder so
+// that only one *scanResult is resident at a time (IDE-1940). The single-object form
+// ({...}) is supported for parity with UnmarshallOssJson: yield is invoked once.
+//
+// Contract: yield MUST NOT retain *sr across calls. StreamOssJson may reuse the
+// underlying scanResult pointer between iterations; any fields the caller needs
+// after yield returns must be copied out by the caller.
+//
+// Returns the first error encountered (from r, from the decoder, or from yield).
+func StreamOssJson(r io.Reader, yield func(sr *scanResult) error) error {
+	dec := json.NewDecoder(r)
+	tok, err := dec.Token()
+	if err != nil {
+		return errors.Join(err, fmt.Errorf("couldn't read OSS CLI response opening token"))
+	}
+	delim, _ := tok.(json.Delim)
+	switch delim {
+	case '[':
+		for dec.More() {
+			sr := &scanResult{}
+			if decErr := dec.Decode(sr); decErr != nil {
+				return errors.Join(decErr, fmt.Errorf("couldn't decode OSS CLI scanResult element"))
+			}
+			if yieldErr := yield(sr); yieldErr != nil {
+				return yieldErr
+			}
+		}
+		// Consume closing ']' so the stream is fully drained; ignore error after the loop.
+		_, _ = dec.Token()
+		return nil
+	case '{':
+		// We've already consumed the opening '{'. Rebuild the full body by prepending
+		// it to dec.Buffered() (bytes read but not yet consumed) and any remaining
+		// bytes from r, then unmarshal as a single scanResult. Single-object mode is
+		// not the hot path, so correctness trumps streaming here.
+		var buf bytes.Buffer
+		buf.WriteByte('{')
+		if _, copyErr := io.Copy(&buf, io.MultiReader(dec.Buffered(), r)); copyErr != nil {
+			return errors.Join(copyErr, fmt.Errorf("couldn't read single-object OSS CLI response"))
+		}
+		sr := &scanResult{}
+		if unmErr := json.Unmarshal(buf.Bytes(), sr); unmErr != nil {
+			return errors.Join(unmErr, fmt.Errorf("couldn't unmarshal single-object OSS CLI response"))
+		}
+		return yield(sr)
+	default:
+		return fmt.Errorf("unexpected OSS CLI response opening token: %v", tok)
+	}
 }
 
 // UnmarshallOssJson is a standalone version of CLIScanner.unmarshallOssJson

--- a/infrastructure/oss/converter_test.go
+++ b/infrastructure/oss/converter_test.go
@@ -1,0 +1,168 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const threeElementArrayJSON = `[
+  {
+    "projectName": "proj-a",
+    "packageManager": "npm",
+    "path": "/tmp/a",
+    "displayTargetFile": "a/package.json",
+    "vulnerabilities": [
+      {"id": "SNYK-A-1", "name": "pkg-a", "title": "t-a", "severity": "high"}
+    ]
+  },
+  {
+    "projectName": "proj-b",
+    "packageManager": "maven",
+    "path": "/tmp/b",
+    "displayTargetFile": "b/pom.xml",
+    "vulnerabilities": [
+      {"id": "SNYK-B-1", "name": "pkg-b", "title": "t-b", "severity": "medium"},
+      {"id": "SNYK-B-2", "name": "pkg-b", "title": "t-b-2", "severity": "low"}
+    ]
+  },
+  {
+    "projectName": "proj-c",
+    "packageManager": "gomodules",
+    "path": "/tmp/c",
+    "displayTargetFile": "c/go.mod",
+    "vulnerabilities": []
+  }
+]`
+
+const singleObjectJSON = `{
+  "projectName": "solo",
+  "packageManager": "pip",
+  "path": "/tmp/solo",
+  "displayTargetFile": "solo/requirements.txt",
+  "vulnerabilities": [
+    {"id": "SNYK-SOLO-1", "name": "pkg-solo", "title": "t-solo", "severity": "critical"}
+  ]
+}`
+
+func TestStreamOssJson_ArrayForm_YieldsEachElement(t *testing.T) {
+	var got []scanResult
+	err := StreamOssJson(strings.NewReader(threeElementArrayJSON), func(sr *scanResult) error {
+		// copy out (the contract says yield must not retain *sr across calls)
+		got = append(got, *sr)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	assert.Equal(t, "proj-a", got[0].ProjectName)
+	assert.Equal(t, "npm", got[0].PackageManager)
+	assert.Equal(t, "a/package.json", got[0].DisplayTargetFile)
+	require.Len(t, got[0].Vulnerabilities, 1)
+	assert.Equal(t, "SNYK-A-1", got[0].Vulnerabilities[0].Id)
+
+	assert.Equal(t, "proj-b", got[1].ProjectName)
+	assert.Equal(t, "maven", got[1].PackageManager)
+	require.Len(t, got[1].Vulnerabilities, 2)
+	assert.Equal(t, "SNYK-B-1", got[1].Vulnerabilities[0].Id)
+	assert.Equal(t, "SNYK-B-2", got[1].Vulnerabilities[1].Id)
+
+	assert.Equal(t, "proj-c", got[2].ProjectName)
+	assert.Equal(t, "gomodules", got[2].PackageManager)
+	assert.Empty(t, got[2].Vulnerabilities)
+}
+
+func TestStreamOssJson_SingleObjectForm_YieldsOnce(t *testing.T) {
+	calls := 0
+	var got scanResult
+	err := StreamOssJson(strings.NewReader(singleObjectJSON), func(sr *scanResult) error {
+		calls++
+		got = *sr
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "solo", got.ProjectName)
+	assert.Equal(t, "pip", got.PackageManager)
+	assert.Equal(t, "solo/requirements.txt", got.DisplayTargetFile)
+	require.Len(t, got.Vulnerabilities, 1)
+	assert.Equal(t, "SNYK-SOLO-1", got.Vulnerabilities[0].Id)
+}
+
+func TestStreamOssJson_YieldErrorShortCircuits(t *testing.T) {
+	yieldErr := errors.New("stop here")
+	calls := 0
+	err := StreamOssJson(strings.NewReader(threeElementArrayJSON), func(sr *scanResult) error {
+		calls++
+		if calls == 2 {
+			return yieldErr
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, yieldErr)
+	assert.Equal(t, 2, calls, "yield must not be invoked after returning an error")
+}
+
+func TestStreamOssJson_MalformedJSON_ReturnsError(t *testing.T) {
+	truncated := `[{"projectName":"a"},`
+	calls := 0
+	err := StreamOssJson(strings.NewReader(truncated), func(sr *scanResult) error {
+		calls++
+		return nil
+	})
+	require.Error(t, err)
+}
+
+func TestStreamOssJson_EmptyArray_YieldsZeroTimes(t *testing.T) {
+	calls := 0
+	err := StreamOssJson(strings.NewReader(`[]`), func(sr *scanResult) error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, calls)
+}
+
+func TestStreamOssJson_ParityWithUnmarshallOssJson(t *testing.T) {
+	expected, err := UnmarshallOssJson([]byte(threeElementArrayJSON))
+	require.NoError(t, err)
+	require.Len(t, expected, 3)
+
+	var streamed []scanResult
+	err = StreamOssJson(strings.NewReader(threeElementArrayJSON), func(sr *scanResult) error {
+		streamed = append(streamed, *sr)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, streamed, len(expected))
+
+	for i := range expected {
+		assert.Equal(t, expected[i].ProjectName, streamed[i].ProjectName, "index %d", i)
+		assert.Equal(t, expected[i].PackageManager, streamed[i].PackageManager, "index %d", i)
+		assert.Equal(t, expected[i].Path, streamed[i].Path, "index %d", i)
+		assert.Equal(t, expected[i].DisplayTargetFile, streamed[i].DisplayTargetFile, "index %d", i)
+		require.Equal(t, len(expected[i].Vulnerabilities), len(streamed[i].Vulnerabilities), "index %d", i)
+		if len(expected[i].Vulnerabilities) > 0 {
+			assert.Equal(t, expected[i].Vulnerabilities[0].Id, streamed[i].Vulnerabilities[0].Id, "index %d", i)
+		}
+	}
+}

--- a/infrastructure/oss/inline_value.go
+++ b/infrastructure/oss/inline_value.go
@@ -17,14 +17,27 @@
 package oss
 
 import (
+	"path/filepath"
+
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
 type inlineValueMap map[types.FilePath][]snyk.InlineValue
 
+// inlineValuesPathKey normalizes paths used as inline-value cache keys so URI-derived
+// paths (textDocument/inlineValue) and OSS issue paths agree on Windows (slash style, cleaning).
+func inlineValuesPathKey(p types.FilePath) types.FilePath {
+	if p == "" {
+		return p
+	}
+	// ToSlash aligns Windows paths from URIs vs CLI; no-op on Unix-style paths.
+	return types.FilePath(filepath.ToSlash(filepath.Clean(string(p))))
+}
+
 func (cliScanner *CLIScanner) GetInlineValues(path types.FilePath, myRange types.Range) (result []snyk.InlineValue, err error) {
 	logger := cliScanner.config.Logger().With().Str("method", "CLIScanner.GetInlineValues").Logger()
+	path = inlineValuesPathKey(path)
 	cliScanner.inlineValueMutex.RLock()
 	inlineValues := cliScanner.inlineValues[path]
 	cliScanner.inlineValueMutex.RUnlock()
@@ -35,7 +48,7 @@ func (cliScanner *CLIScanner) GetInlineValues(path types.FilePath, myRange types
 
 func (cliScanner *CLIScanner) ClearInlineValues(path types.FilePath) {
 	cliScanner.inlineValueMutex.Lock()
-	cliScanner.inlineValues[path] = nil
+	cliScanner.inlineValues[inlineValuesPathKey(path)] = nil
 	cliScanner.inlineValueMutex.Unlock()
 }
 
@@ -54,6 +67,7 @@ func filterInlineValuesForRange(inlineValues []snyk.InlineValue, myRange types.R
 
 func (cliScanner *CLIScanner) addToCache(iv snyk.InlineValue, cache inlineValueMap) {
 	cliScanner.inlineValueMutex.Lock()
-	cache[iv.Path()] = append(cache[iv.Path()], iv)
+	key := inlineValuesPathKey(iv.Path())
+	cache[key] = append(cache[key], iv)
 	cliScanner.inlineValueMutex.Unlock()
 }

--- a/infrastructure/oss/issue.go
+++ b/infrastructure/oss/issue.go
@@ -35,20 +35,31 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
-func toIssue(c *config.Config, workDir types.FilePath, affectedFilePath types.FilePath, issue ossIssue, scanResult *scanResult, issueDepNode *ast.Node, learnService learn.Service, ep error_reporting.ErrorReporter, format string) *snyk.Issue {
+// vulnIndicesByID maps each vulnerability id to indices into scanResult.Vulnerabilities (scan order).
+func vulnIndicesByID(res *scanResult) map[string][]int {
+	if res == nil || len(res.Vulnerabilities) == 0 {
+		return nil
+	}
+	out := make(map[string][]int)
+	for i := range res.Vulnerabilities {
+		id := res.Vulnerabilities[i].Id
+		out[id] = append(out[id], i)
+	}
+	return out
+}
+
+func toIssue(c *config.Config, workDir types.FilePath, affectedFilePath types.FilePath, issue ossIssue, scanResult *scanResult, sameIDIndices []int, issueDepNode *ast.Node, learnService learn.Service, ep error_reporting.ErrorReporter, format string) *snyk.Issue {
 	rangeFromNode := getRangeFromNode(issueDepNode)
 
-	// find all issues with the same id
-	matchingIssues := []snyk.OssIssueData{}
-	for _, otherIssue := range scanResult.Vulnerabilities {
-		if otherIssue.Id == issue.Id {
-			matchingIssues = append(matchingIssues, otherIssue.toAdditionalData(
-				scanResult,
-				[]snyk.OssIssueData{},
-				affectedFilePath,
-				rangeFromNode,
-			))
-		}
+	matchingIssues := make([]snyk.OssIssueData, 0, len(sameIDIndices))
+	for _, idx := range sameIDIndices {
+		otherIssue := &scanResult.Vulnerabilities[idx]
+		matchingIssues = append(matchingIssues, otherIssue.toAdditionalData(
+			scanResult,
+			[]snyk.OssIssueData{},
+			affectedFilePath,
+			rangeFromNode,
+		))
 	}
 
 	additionalData := issue.toAdditionalData(scanResult, matchingIssues, affectedFilePath, rangeFromNode)
@@ -168,6 +179,7 @@ func convertScanResultToIssues(c *config.Config, res *scanResult, workDir types.
 	var issues []types.Issue
 
 	duplicateCheckMap := map[string]bool{}
+	byID := vulnIndicesByID(res)
 
 	for _, ossLegacyIssue := range res.Vulnerabilities {
 		if ossLegacyIssue.IsIgnored {
@@ -180,7 +192,8 @@ func convertScanResultToIssues(c *config.Config, res *scanResult, workDir types.
 			continue
 		}
 		node := getDependencyNode(&logger, targetFilePath, ossLegacyIssue.PackageManager, ossLegacyIssue.From, fileContent)
-		snykIssue := toIssue(c, workDir, targetFilePath, ossLegacyIssue, res, node, learnService, ep, format)
+		sameID := byID[ossLegacyIssue.Id]
+		snykIssue := toIssue(c, workDir, targetFilePath, ossLegacyIssue, res, sameID, node, learnService, ep, format)
 		packageIssueCacheMutex.Lock()
 		packageIssueCache[packageKey] = append(packageIssueCache[packageKey], snykIssue)
 		packageIssueCacheMutex.Unlock()

--- a/infrastructure/oss/issue_test.go
+++ b/infrastructure/oss/issue_test.go
@@ -1,0 +1,117 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/learn"
+	"github.com/snyk/snyk-ls/infrastructure/learn/mock_learn"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+func TestVulnIndicesByID_GroupsIndicesInScanOrder(t *testing.T) {
+	res := &scanResult{
+		Vulnerabilities: []ossIssue{
+			{Id: "A", PackageName: "p1"},
+			{Id: "B", PackageName: "p2"},
+			{Id: "A", PackageName: "p3"},
+		},
+	}
+	got := vulnIndicesByID(res)
+	require.Len(t, got, 2)
+	assert.Equal(t, []int{0, 2}, got["A"])
+	assert.Equal(t, []int{1}, got["B"])
+}
+
+func TestVulnIndicesByID_NilOrEmpty(t *testing.T) {
+	assert.Nil(t, vulnIndicesByID(nil))
+	assert.Nil(t, vulnIndicesByID(&scanResult{}))
+}
+
+func TestConvertScanResultToIssues_SameIdMultiplePackages_MatchingIssuesIncludesAllSameId(t *testing.T) {
+	c := testutil.UnitTest(t)
+	issueID := "SNYK-DUP-1"
+	scanResult := &scanResult{
+		ProjectName: "test-project",
+		Vulnerabilities: []ossIssue{
+			{
+				Id:             issueID,
+				Name:           "n1",
+				Title:          "t1",
+				Severity:       "high",
+				PackageName:    "pkg-a",
+				Version:        "1.0.0",
+				PackageManager: "npm",
+				From:           []string{"lodash@4.17.4"},
+			},
+			{
+				Id:             issueID,
+				Name:           "n2",
+				Title:          "t2",
+				Severity:       "high",
+				PackageName:    "pkg-b",
+				Version:        "2.0.0",
+				PackageManager: "npm",
+				From:           []string{"lodash@4.17.4"},
+			},
+			{
+				Id:             issueID,
+				Name:           "n3",
+				Title:          "t3",
+				Severity:       "high",
+				PackageName:    "pkg-c",
+				Version:        "3.0.0",
+				PackageManager: "npm",
+				From:           []string{"lodash@4.17.4"},
+			},
+		},
+	}
+
+	workDir := types.FilePath("/test/workdir")
+	targetFilePath := types.FilePath("/test/workdir/package.json")
+	fileContent := []byte(`{"dependencies":{"lodash":"4.17.4"}}`)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	learnService := mock_learn.NewMockService(ctrl)
+	learnService.EXPECT().
+		GetLesson(gomock.Any(), issueID, gomock.Any(), gomock.Any(), types.DependencyVulnerability).
+		Return(&learn.Lesson{Url: "https://learn.snyk.io/lesson/test"}, nil).
+		AnyTimes()
+
+	errorReporter := error_reporting.NewTestErrorReporter()
+	packageIssueCache := make(map[string][]types.Issue)
+
+	issues := convertScanResultToIssues(c, scanResult, workDir, targetFilePath, fileContent, learnService, errorReporter, packageIssueCache, c.Format())
+
+	require.Len(t, issues, 3)
+	for _, i := range issues {
+		si, ok := i.(*snyk.Issue)
+		require.True(t, ok)
+		ad, ok := si.AdditionalData.(snyk.OssIssueData)
+		require.True(t, ok)
+		assert.Len(t, ad.MatchingIssues, 3, "each issue should list all three same-id vulns as matching")
+	}
+}

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -104,7 +104,7 @@ func Test_toIssue_LearnParameterConversion(t *testing.T) {
 		learnService: getLearnMock(t),
 	}
 	contentRoot := types.FilePath("/path/to/issue")
-	issue := toIssue(c, contentRoot, "testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, c.Format())
+	issue := toIssue(c, contentRoot, "testPath", sampleOssIssue, &scanResult{}, nil, nonEmptyNode(), scanner.learnService, scanner.errorReporter, c.Format())
 
 	assert.Equal(t, sampleOssIssue.Id, issue.ID)
 	assert.Equal(t, sampleOssIssue.Identifiers.CWE, issue.CWEs)
@@ -148,7 +148,7 @@ func Test_toIssue_CodeActions(t *testing.T) {
 			sampleOssIssue.UpgradePath = []any{"false", test.packageName}
 			contentRoot := types.FilePath("/path/to/issue")
 
-			issue := toIssue(c, contentRoot, "testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, c.Format())
+			issue := toIssue(c, contentRoot, "testPath", sampleOssIssue, &scanResult{}, nil, nonEmptyNode(), scanner.learnService, scanner.errorReporter, c.Format())
 
 			assert.Equal(t, sampleOssIssue.Id, issue.ID)
 			assert.Equal(t, flashy+test.expectedUpgrade, issue.CodeActions[0].GetTitle())
@@ -179,7 +179,7 @@ func Test_toIssue_CodeActions_WithoutFix(t *testing.T) {
 	sampleOssIssue.UpgradePath = []any{"*"}
 	contentRoot := types.FilePath("/path/to/issue")
 
-	issue := toIssue(c, contentRoot, "testPath", sampleOssIssue, &scanResult{}, nonEmptyNode(), scanner.learnService, scanner.errorReporter, c.Format())
+	issue := toIssue(c, contentRoot, "testPath", sampleOssIssue, &scanResult{}, nil, nonEmptyNode(), scanner.learnService, scanner.errorReporter, c.Format())
 
 	assert.Equal(t, sampleOssIssue.Id, issue.ID)
 	assert.Equal(t, 2, len(issue.CodeActions))

--- a/infrastructure/oss/types.go
+++ b/infrastructure/oss/types.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gomarkdown/markdown"
@@ -183,7 +184,10 @@ func (i *ossIssue) getLessonURL() string {
 }
 
 func (i *ossIssue) toReferences() []types.Reference {
-	var references []types.Reference
+	if len(i.References) == 0 {
+		return nil
+	}
+	references := make([]types.Reference, 0, len(i.References))
 	for _, ref := range i.References {
 		references = append(references, ref.toReference())
 	}
@@ -191,7 +195,7 @@ func (i *ossIssue) toReferences() []types.Reference {
 }
 
 func (r reference) toReference() types.Reference {
-	u, err := url.Parse(string(r.Url))
+	u, err := urlParseCachedCopy(string(r.Url))
 	if err != nil {
 		config.CurrentConfig().Logger().Err(err).Msg("Unable to parse reference url: " + string(r.Url))
 	}
@@ -239,7 +243,84 @@ func (i *ossIssue) GetRemediation() string {
 	return "No remediation advice available"
 }
 
-func GetExtendedMessage(id, title, description, severity, packageName string, cves, cwes, fixedIn []string) string {
+const maxExtendedMessageCacheEntries = 4096
+
+// extendedMessageCache memoizes GetExtendedMessage for identical vulnerability rows while keeping
+// a hard cap so long-lived language-server sessions do not retain scan-derived text indefinitely.
+var extendedMessageCache = newBoundedExtendedMessageCache(maxExtendedMessageCacheEntries)
+
+type boundedExtendedMessageCache struct {
+	mu     sync.RWMutex
+	max    int
+	values map[extendedMessageCacheKey]string
+}
+
+func newBoundedExtendedMessageCache(limit int) *boundedExtendedMessageCache {
+	return &boundedExtendedMessageCache{
+		max:    limit,
+		values: make(map[extendedMessageCacheKey]string),
+	}
+}
+
+func (c *boundedExtendedMessageCache) load(key extendedMessageCacheKey) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v, ok := c.values[key]
+	return v, ok
+}
+
+func (c *boundedExtendedMessageCache) loadOrStore(key extendedMessageCacheKey, value string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.values[key]; ok {
+		return existing
+	}
+	if len(c.values) >= c.max {
+		return value
+	}
+	c.values[key] = value
+	return value
+}
+
+func (c *boundedExtendedMessageCache) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.values)
+}
+
+func (c *boundedExtendedMessageCache) resetForTests() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values = make(map[extendedMessageCacheKey]string)
+}
+
+type extendedMessageCacheKey struct {
+	formatKey   string
+	id          string
+	title       string
+	description string
+	severity    string
+	packageName string
+	cves        string
+	cwes        string
+	fixedIn     string
+}
+
+func joinIdentifierParts(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func extendedMessageFormatKey() string {
+	if config.CurrentConfig().Format() == config.FormatHtml {
+		return "html"
+	}
+	return "md"
+}
+
+func buildExtendedMessage(id, title, description, severity, packageName string, cves, cwes, fixedIn []string) string {
 	if config.CurrentConfig().Format() == config.FormatHtml {
 		title = string(markdown.ToHTML([]byte(title), nil, nil))
 		description = string(markdown.ToHTML([]byte(description), nil, nil))
@@ -260,6 +341,25 @@ func GetExtendedMessage(id, title, description, severity, packageName string, cv
 		description)
 }
 
+func GetExtendedMessage(id, title, description, severity, packageName string, cves, cwes, fixedIn []string) string {
+	key := extendedMessageCacheKey{
+		formatKey:   extendedMessageFormatKey(),
+		id:          id,
+		title:       title,
+		description: description,
+		severity:    severity,
+		packageName: packageName,
+		cves:        joinIdentifierParts(cves),
+		cwes:        joinIdentifierParts(cwes),
+		fixedIn:     joinIdentifierParts(fixedIn),
+	}
+	if s, ok := extendedMessageCache.load(key); ok {
+		return s
+	}
+	msg := buildExtendedMessage(id, title, description, severity, packageName, cves, cwes, fixedIn)
+	return extendedMessageCache.loadOrStore(key, msg)
+}
+
 func createCveLink(cves []string) string {
 	var formattedCve string
 	for _, c := range cves {
@@ -273,7 +373,7 @@ func createIssueUrlMarkdown(vulnID string) string {
 }
 
 func CreateIssueURL(vulnID string) *url.URL {
-	parse, err := url.Parse("https://snyk.io/vuln/" + vulnID)
+	parse, err := urlParseCachedCopy("https://snyk.io/vuln/" + vulnID)
 	if err != nil {
 		config.CurrentConfig().Logger().Err(err).Msg("Unable to create issue link for issue:" + vulnID)
 	}

--- a/infrastructure/oss/types_extended_message_test.go
+++ b/infrastructure/oss/types_extended_message_test.go
@@ -1,0 +1,109 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/internal/testutil"
+)
+
+func TestGetExtendedMessage_memoizationMatchesDirectBuild(t *testing.T) {
+	extendedMessageCache.resetForTests()
+	c := testutil.UnitTest(t)
+	c.SetFormat(config.FormatMd)
+	issue := sampleIssue()
+	want := buildExtendedMessage(
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+	)
+	got := GetExtendedMessage(
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+	)
+	require.Equal(t, want, got)
+	gotAgain := GetExtendedMessage(
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+	)
+	assert.Equal(t, want, gotAgain)
+}
+
+func TestGetExtendedMessage_differentPackageNameNotDeduped(t *testing.T) {
+	extendedMessageCache.resetForTests()
+	c := testutil.UnitTest(t)
+	c.SetFormat(config.FormatMd)
+	issue := sampleIssue()
+	a := GetExtendedMessage(
+		issue.Id, issue.Title, issue.Description, issue.Severity, "pkg-a",
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+	)
+	b := GetExtendedMessage(
+		issue.Id, issue.Title, issue.Description, issue.Severity, "pkg-b",
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+	)
+	require.NotEqual(t, a, b)
+	assert.Contains(t, a, "pkg-a")
+	assert.Contains(t, b, "pkg-b")
+}
+
+func TestGetExtendedMessage_concurrentSameArgs(t *testing.T) {
+	extendedMessageCache.resetForTests()
+	c := testutil.UnitTest(t)
+	c.SetFormat(config.FormatMd)
+	issue := sampleIssue()
+	first := GetExtendedMessage(
+		issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+		issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+	)
+	const workers = 64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			g := GetExtendedMessage(
+				issue.Id, issue.Title, issue.Description, issue.Severity, issue.PackageName,
+				issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+			)
+			assert.Equal(t, first, g)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGetExtendedMessage_cacheIsBounded(t *testing.T) {
+	extendedMessageCache.resetForTests()
+	c := testutil.UnitTest(t)
+	c.SetFormat(config.FormatMd)
+	issue := sampleIssue()
+
+	for i := range maxExtendedMessageCacheEntries + 10 {
+		_ = GetExtendedMessage(
+			issue.Id+"-"+strconv.Itoa(i), issue.Title, issue.Description, issue.Severity, issue.PackageName,
+			issue.Identifiers.CVE, issue.Identifiers.CWE, issue.FixedIn,
+		)
+	}
+
+	assert.LessOrEqual(t, extendedMessageCache.len(), maxExtendedMessageCacheEntries)
+}

--- a/infrastructure/oss/unified_converter.go
+++ b/infrastructure/oss/unified_converter.go
@@ -503,23 +503,20 @@ func buildOssIssueData(
 
 // extractReferences extracts references from finding and vulnerability problem
 func extractReferences(problem *testapi.SnykVulnProblem) []types.Reference {
-	references := []types.Reference{} // Initialize as empty slice, not nil
-
-	// Extract references from vulnerability problem if available
-	if problem != nil && len(problem.References) > 0 {
-		for _, ref := range problem.References {
-			// Parse URL string to *url.URL
-			parsedURL, err := url.Parse(ref.Url)
-			if err != nil {
-				continue
-			}
-			references = append(references, types.Reference{
-				Title: ref.Title,
-				Url:   parsedURL,
-			})
-		}
+	if problem == nil || len(problem.References) == 0 {
+		return []types.Reference{}
 	}
-
+	references := make([]types.Reference, 0, len(problem.References))
+	for _, ref := range problem.References {
+		parsedURL, err := urlParseCachedCopy(ref.Url)
+		if err != nil {
+			continue
+		}
+		references = append(references, types.Reference{
+			Title: ref.Title,
+			Url:   parsedURL,
+		})
+	}
 	return references
 }
 
@@ -686,11 +683,10 @@ func extractLicense(finding *testapi.FindingData) string {
 
 // createIssueURL creates the Snyk issue description URL
 func createIssueURL(id string) *url.URL {
-	u, err := url.Parse(fmt.Sprintf("https://snyk.io/vuln/%s", id))
+	u, err := urlParseCachedCopy("https://snyk.io/vuln/" + id)
 	if err != nil {
 		return nil
 	}
-
 	return u
 }
 

--- a/infrastructure/oss/url_parse_cache.go
+++ b/infrastructure/oss/url_parse_cache.go
@@ -1,0 +1,91 @@
+/*
+ * © 2025-2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"net/url"
+	"sync"
+)
+
+const maxParsedURLStringCacheEntries = 4096
+
+// parsedURLStringCache stores one *url.URL per distinct raw URL string while keeping
+// a hard cap so long-lived language-server sessions do not retain every unique URL.
+var parsedURLStringCache = newBoundedURLParseCache(maxParsedURLStringCacheEntries)
+
+type boundedURLParseCache struct {
+	mu     sync.RWMutex
+	max    int
+	values map[string]*url.URL
+}
+
+func newBoundedURLParseCache(limit int) *boundedURLParseCache {
+	return &boundedURLParseCache{
+		max:    limit,
+		values: make(map[string]*url.URL),
+	}
+}
+
+func (c *boundedURLParseCache) loadCopy(raw string) (*url.URL, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	orig, ok := c.values[raw]
+	if !ok {
+		return nil, false
+	}
+	copied := *orig
+	return &copied, true
+}
+
+func (c *boundedURLParseCache) storeCopy(raw string, parsed *url.URL) *url.URL {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.values[raw]; ok {
+		copied := *existing
+		return &copied
+	}
+	if len(c.values) < c.max {
+		c.values[raw] = parsed
+	}
+	copied := *parsed
+	return &copied
+}
+
+func (c *boundedURLParseCache) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.values)
+}
+
+func (c *boundedURLParseCache) resetForTests() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values = make(map[string]*url.URL)
+}
+
+// urlParseCachedCopy parses raw once per distinct string and returns a shallow copy of *url.URL
+// so each consumer keeps an independent pointer (same semantics as calling url.Parse every time).
+func urlParseCachedCopy(raw string) (*url.URL, error) {
+	if cached, ok := parsedURLStringCache.loadCopy(raw); ok {
+		return cached, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	return parsedURLStringCache.storeCopy(raw, u), nil
+}

--- a/infrastructure/oss/url_parse_cache_test.go
+++ b/infrastructure/oss/url_parse_cache_test.go
@@ -1,0 +1,65 @@
+/*
+ * © 2025 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+)
+
+func TestURLParseCachedCopy_sameRaw_distinctPointers_equalValue(t *testing.T) {
+	parsedURLStringCache.resetForTests()
+	const raw = "https://example.com/path?q=1"
+	a, err := urlParseCachedCopy(raw)
+	require.NoError(t, err)
+	b, err := urlParseCachedCopy(raw)
+	require.NoError(t, err)
+	assert.Equal(t, a.String(), b.String())
+	assert.NotSame(t, a, b, "each call should return an independent pointer")
+}
+
+func TestURLParseCachedCopy_parseError(t *testing.T) {
+	_, err := urlParseCachedCopy("://invalid")
+	assert.Error(t, err)
+}
+
+func TestCreateIssueURL_usesCache_distinctPointers(t *testing.T) {
+	parsedURLStringCache.resetForTests()
+	testutil.UnitTest(t)
+	u1 := CreateIssueURL("SNYK-JS-TEST")
+	u2 := CreateIssueURL("SNYK-JS-TEST")
+	require.NotNil(t, u1)
+	require.NotNil(t, u2)
+	assert.Equal(t, u1.String(), u2.String())
+	assert.NotSame(t, u1, u2)
+}
+
+func TestURLParseCachedCopy_cacheIsBounded(t *testing.T) {
+	parsedURLStringCache.resetForTests()
+
+	for i := range maxParsedURLStringCacheEntries + 10 {
+		_, err := urlParseCachedCopy("https://example.com/path/" + strconv.Itoa(i))
+		require.NoError(t, err)
+	}
+
+	assert.LessOrEqual(t, parsedURLStringCache.len(), maxParsedURLStringCacheEntries)
+}

--- a/infrastructure/secrets/errors.go
+++ b/infrastructure/secrets/errors.go
@@ -1,0 +1,56 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secrets
+
+import (
+	stderrors "errors"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// ignorableSecretsErrorCodes lists snyk_errors.Error ErrorCode values that indicate
+// expected no-op conditions (e.g. the target file is excluded or unsupported).
+// Scans that hit these codes return early without touching the issue cache so that
+// previously discovered findings remain visible in the IDE.
+//
+// SNYK-CLI-0016 (FeatureNotEnabled) is intentionally excluded: it signals an
+// org-level state change and should surface as a real error rather than silently
+// clearing cached findings.
+var ignorableSecretsErrorCodes = map[string]bool{
+	"SNYK-CLI-0008": true, // NoSupportedFilesFound: file ignored or unsupported type
+}
+
+// isIgnorableError returns true when err is a snyk catalog error whose code is
+// known to be non-critical (e.g. no files to scan because the target is ignored).
+func isIgnorableError(err error) bool {
+	var snykErr snyk_errors.Error
+	return stderrors.As(err, &snykErr) && ignorableSecretsErrorCodes[snykErr.ErrorCode]
+}
+
+// handleSecretsInvokeError processes a non-nil error from engine.InvokeWithConfig.
+// It returns (empty, nil) for ignorable conditions and (nil, wrappedErr) otherwise.
+func handleSecretsInvokeError(err error, logger *zerolog.Logger) ([]types.Issue, error) {
+	if isIgnorableError(err) {
+		logger.Debug().Msg("Secrets scanner: file excluded or unsupported, returning no error")
+		return []types.Issue{}, nil
+	}
+	return nil, fmt.Errorf("failed secrets scan: %w", err)
+}

--- a/infrastructure/secrets/secrets.go
+++ b/infrastructure/secrets/secrets.go
@@ -19,7 +19,6 @@ package secrets
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -154,7 +153,7 @@ func (sc *Scanner) Scan(ctx context.Context, pathToScan types.FilePath, workspac
 	secretsConfig.Set(configuration.INPUT_DIRECTORY, string(scanPath))
 	result, err := sc.c.Engine().InvokeWithConfig(workflow.NewWorkflowIdentifier("secrets.test"), secretsConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed secrets scan: %w", err)
+		return handleSecretsInvokeError(err, &logger)
 	}
 	if len(result) == 1 && result[0].GetPayload() != nil {
 		testApiRes := ufm.GetTestResultsFromWorkflowData(result[0])

--- a/infrastructure/secrets/secrets.go
+++ b/infrastructure/secrets/secrets.go
@@ -19,6 +19,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -31,6 +32,7 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	"github.com/snyk/snyk-ls/infrastructure/issuecache"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	ctx2 "github.com/snyk/snyk-ls/internal/context"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
@@ -116,15 +118,19 @@ func (sc *Scanner) Scan(ctx context.Context, pathToScan types.FilePath, workspac
 
 	logger.Info().Msg("Secrets scanner: starting scan")
 
+	if !sc.IsEnabledForFolder(workspaceFolderConfig) {
+		return nil, errors.New(utils.ErrSnykSecretsNotEnabledForFolder)
+	}
+
 	if !sc.c.NonEmptyToken() {
-		logger.Info().Msg("not authenticated, not scanning")
-		return issues, err
+		logger.Info().Msg(utils.MsgNotAuthenticatedNoScan)
+		return nil, errors.New(utils.MsgNotAuthenticatedNoScan)
 	}
 
 	isSecretsScannerEnabled := workspaceFolderConfig.FeatureFlags[featureflag.SnykSecretsEnabled]
 	if !isSecretsScannerEnabled {
-		logger.Error().Str("folderPath", string(workspaceFolder)).Msgf("feature flag %s not enabled", featureflag.SnykSecretsEnabled)
-		return issues, nil
+		logger.Debug().Str("folderPath", string(workspaceFolder)).Msgf("feature flag %s not enabled", featureflag.SnykSecretsEnabled)
+		return nil, errors.New(utils.ErrSnykSecretsNotEnabled)
 	}
 
 	scanStatus := NewScanStatus()

--- a/infrastructure/secrets/secrets_test.go
+++ b/infrastructure/secrets/secrets_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cli_errors "github.com/snyk/error-catalog-golang-public/cli"
+	"github.com/snyk/go-application-framework/pkg/mocks"
+
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
 	"github.com/snyk/snyk-ls/internal/notification"
@@ -261,5 +264,162 @@ func TestScanner_Scan(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, issues, 1)
 		assert.Equal(t, types.FilePath(filepath.Join(string(workspaceFolder), "config.yml")), issues[0].GetAffectedFilePath())
+	})
+
+	t.Run("returns empty without error when engine returns NoSupportedFilesFoundError", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+		mockEngine, _ := testutil.SetUpEngineMock(t, c)
+
+		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+			Return(nil, cli_errors.NewNoSupportedFilesFoundError("No supported files found."))
+
+		workspaceFolder := types.FilePath(t.TempDir())
+		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+
+		assert.NoError(t, err)
+		assert.Empty(t, issues)
+	})
+
+	t.Run("returns error when engine returns FeatureNotEnabledError", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+		mockEngine, _ := testutil.SetUpEngineMock(t, c)
+
+		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+			Return(nil, cli_errors.NewFeatureNotEnabledError("secrets not enabled for org."))
+
+		workspaceFolder := types.FilePath(t.TempDir())
+		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+
+		assert.Error(t, err)
+		assert.Nil(t, issues)
+	})
+
+	t.Run("returns error when engine returns non-ignorable snyk error", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+		mockEngine, _ := testutil.SetUpEngineMock(t, c)
+
+		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+			Return(nil, cli_errors.NewGeneralSecretsFailureError("something went wrong."))
+
+		workspaceFolder := types.FilePath(t.TempDir())
+		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+
+		assert.Error(t, err)
+		assert.Nil(t, issues)
+	})
+
+	t.Run("returns error when engine returns generic non-snyk error", func(t *testing.T) {
+		c := testutil.UnitTest(t)
+		mockEngine, _ := testutil.SetUpEngineMock(t, c)
+
+		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+			Return(nil, errors.New("network failure"))
+
+		workspaceFolder := types.FilePath(t.TempDir())
+		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+
+		assert.Error(t, err)
+		assert.Nil(t, issues)
+	})
+
+	t.Run("preserves cached issues when engine returns NoSupportedFilesFoundError", func(t *testing.T) {
+		scanner, mockEngine, workspaceFolder := seedScannerCache(t)
+
+		// Second scan: file is now excluded — SNYK-CLI-0008 must NOT wipe previous findings.
+		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+			Return(nil, cli_errors.NewNoSupportedFilesFoundError("No supported files found."))
+		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, totalCachedIssues(scanner), "previously discovered findings must survive an excluded-file scan")
+	})
+
+	t.Run("preserves cached issues and returns error when engine returns FeatureNotEnabledError", func(t *testing.T) {
+		scanner, mockEngine, workspaceFolder := seedScannerCache(t)
+
+		// Second scan: org-level feature disabled — SNYK-CLI-0016 is a real error and
+		// must not silently wipe cached findings.
+		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+			Return(nil, cli_errors.NewFeatureNotEnabledError("secrets not enabled for org."))
+		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+
+		assert.Error(t, err)
+		assert.NotEmpty(t, totalCachedIssues(scanner), "previously discovered findings must be preserved when feature is disabled")
+	})
+
+	t.Run("preserves cached issues when engine returns a real (non-ignorable) error", func(t *testing.T) {
+		scanner, mockEngine, workspaceFolder := seedScannerCache(t)
+
+		// Second scan: transient failure — cache must be preserved.
+		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+			Return(nil, errors.New("network failure"))
+		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+
+		assert.Error(t, err)
+		assert.NotEmpty(t, totalCachedIssues(scanner), "previously discovered findings must be preserved on transient error")
+	})
+}
+
+// seedScannerCache builds a Scanner, runs one successful scan that produces a single
+// finding, asserts the cache is populated, and returns the scanner/mockEngine/folder for
+// a follow-up scan to exercise cache-preservation behavior on errors.
+func seedScannerCache(t *testing.T) (*Scanner, *mocks.MockEngine, types.FilePath) {
+	t.Helper()
+	c := testutil.UnitTest(t)
+	mockEngine, _ := testutil.SetUpEngineMock(t, c)
+
+	loc := newSourceLocation("secret.yml", 1, intPtr(0), intPtr(0), intPtr(10))
+	finding := newFinding("stale-key", "Stale Secret", "A secret was found",
+		testapi.SeverityHigh, []testapi.FindingLocation{loc},
+		[]testapi.Problem{newSecretsRuleProblem("rule-id", "Rule", []string{"Security"})}, nil)
+	firstScanData := createUFMWorkflowData(t, []testapi.FindingData{finding})
+	workflowID := workflow.NewWorkflowIdentifier("secrets.test")
+	mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
+		Return([]workflow.Data{firstScanData}, nil)
+
+	workspaceFolder := types.FilePath(t.TempDir())
+	scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
+
+	_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+	require.NoError(t, err)
+	require.NotZero(t, totalCachedIssues(scanner), "seed scan must populate the cache")
+
+	return scanner, mockEngine, workspaceFolder
+}
+
+func totalCachedIssues(scanner *Scanner) int {
+	total := 0
+	for _, fileIssues := range scanner.Issues() {
+		total += len(fileIssues)
+	}
+	return total
+}
+
+func TestIsIgnorableError(t *testing.T) {
+	t.Run("SNYK-CLI-0008 NoSupportedFilesFound -> true", func(t *testing.T) {
+		assert.True(t, isIgnorableError(cli_errors.NewNoSupportedFilesFoundError("ignored")))
+	})
+
+	t.Run("SNYK-CLI-0016 FeatureNotEnabled -> false (org-level state)", func(t *testing.T) {
+		assert.False(t, isIgnorableError(cli_errors.NewFeatureNotEnabledError("not ignorable")))
+	})
+
+	t.Run("generic non-snyk error -> false", func(t *testing.T) {
+		assert.False(t, isIgnorableError(errors.New("network failure")))
+	})
+
+	t.Run("nil -> false", func(t *testing.T) {
+		assert.False(t, isIgnorableError(nil))
 	})
 }

--- a/infrastructure/secrets/secrets_test.go
+++ b/infrastructure/secrets/secrets_test.go
@@ -31,8 +31,10 @@ import (
 	cli_errors "github.com/snyk/error-catalog-golang-public/cli"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 
+	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
 	"github.com/snyk/snyk-ls/internal/testutil"
@@ -66,7 +68,12 @@ func createUFMWorkflowData(t *testing.T, findings []testapi.FindingData) workflo
 	)
 }
 
-func secretsEnabledFolderConfig(folderPath types.FilePath) *types.FolderConfig {
+// secretsEnabledFolderConfig sets up both the global Secrets enablement and the
+// per-folder SnykSecretsEnabled feature flag. Tests that construct the scanner
+// with a nil ConfigResolver need the global enablement so the Scanner's
+// IsEnabledForFolder guard (added in IDE-2002) does not short-circuit Scan.
+func secretsEnabledFolderConfig(c *config.Config, folderPath types.FilePath) *types.FolderConfig {
+	c.SetSnykSecretsEnabled(true)
 	return &types.FolderConfig{
 		FolderPath:   folderPath,
 		FeatureFlags: map[string]bool{featureflag.SnykSecretsEnabled: true},
@@ -94,7 +101,7 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		require.NoError(t, err)
 		require.Len(t, issues, 1)
@@ -120,7 +127,7 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		require.NoError(t, err)
 		require.Len(t, issues, 2)
@@ -143,7 +150,7 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		require.NoError(t, err)
 		require.Len(t, issues, 1)
@@ -156,7 +163,7 @@ func TestScanner_Scan(t *testing.T) {
 		assert.Equal(t, 1, totalCached)
 	})
 
-	t.Run("returns empty when no token", func(t *testing.T) {
+	t.Run("returns MsgNotAuthenticatedNoScan error when no token", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 		testutil.SetUpEngineMock(t, c)
 		c.SetToken("")
@@ -164,15 +171,20 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
-		assert.NoError(t, err)
-		assert.Empty(t, issues)
+		require.Error(t, err)
+		assert.Equal(t, utils.MsgNotAuthenticatedNoScan, err.Error())
+		assert.Nil(t, issues)
+		assert.True(t, utils.IsNonFailingScanError(err.Error()), "no-token error must classify as non-failing")
 	})
 
-	t.Run("returns empty without error when feature flag disabled", func(t *testing.T) {
+	t.Run("returns ErrSnykSecretsNotEnabled when feature flag disabled", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 		testutil.SetUpEngineMock(t, c)
+		// Enable Secrets on the config so the IsEnabledForFolder guard passes
+		// and we exercise the downstream per-folder FF check.
+		c.SetSnykSecretsEnabled(true)
 
 		workspaceFolder := types.FilePath(t.TempDir())
 		folderConfig := &types.FolderConfig{
@@ -183,8 +195,10 @@ func TestScanner_Scan(t *testing.T) {
 
 		issues, err := scanner.Scan(t.Context(), workspaceFolder, folderConfig)
 
-		assert.NoError(t, err)
-		assert.Empty(t, issues)
+		require.Error(t, err)
+		assert.Equal(t, utils.ErrSnykSecretsNotEnabled, err.Error())
+		assert.Nil(t, issues)
+		assert.True(t, utils.IsNonFailingScanError(err.Error()), "FF-disabled error must classify as non-failing")
 	})
 
 	t.Run("returns error when InvokeWithConfig fails", func(t *testing.T) {
@@ -198,7 +212,7 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "engine invocation failed")
@@ -216,7 +230,7 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.NoError(t, err)
 		assert.Empty(t, issues)
@@ -238,7 +252,7 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.NoError(t, err)
 		assert.Empty(t, issues)
@@ -259,7 +273,7 @@ func TestScanner_Scan(t *testing.T) {
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-		issues, err := scanner.Scan(t.Context(), "", secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), "", secretsEnabledFolderConfig(c, workspaceFolder))
 
 		require.NoError(t, err)
 		require.Len(t, issues, 1)
@@ -276,7 +290,7 @@ func TestScanner_Scan(t *testing.T) {
 
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.NoError(t, err)
 		assert.Empty(t, issues)
@@ -292,7 +306,7 @@ func TestScanner_Scan(t *testing.T) {
 
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.Error(t, err)
 		assert.Nil(t, issues)
@@ -308,7 +322,7 @@ func TestScanner_Scan(t *testing.T) {
 
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.Error(t, err)
 		assert.Nil(t, issues)
@@ -324,47 +338,47 @@ func TestScanner_Scan(t *testing.T) {
 
 		workspaceFolder := types.FilePath(t.TempDir())
 		scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
-		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.Error(t, err)
 		assert.Nil(t, issues)
 	})
 
 	t.Run("preserves cached issues when engine returns NoSupportedFilesFoundError", func(t *testing.T) {
-		scanner, mockEngine, workspaceFolder := seedScannerCache(t)
+		c, scanner, mockEngine, workspaceFolder := seedScannerCache(t)
 
 		// Second scan: file is now excluded — SNYK-CLI-0008 must NOT wipe previous findings.
 		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
 		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
 			Return(nil, cli_errors.NewNoSupportedFilesFoundError("No supported files found."))
-		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, totalCachedIssues(scanner), "previously discovered findings must survive an excluded-file scan")
 	})
 
 	t.Run("preserves cached issues and returns error when engine returns FeatureNotEnabledError", func(t *testing.T) {
-		scanner, mockEngine, workspaceFolder := seedScannerCache(t)
+		c, scanner, mockEngine, workspaceFolder := seedScannerCache(t)
 
 		// Second scan: org-level feature disabled — SNYK-CLI-0016 is a real error and
 		// must not silently wipe cached findings.
 		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
 		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
 			Return(nil, cli_errors.NewFeatureNotEnabledError("secrets not enabled for org."))
-		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.Error(t, err)
 		assert.NotEmpty(t, totalCachedIssues(scanner), "previously discovered findings must be preserved when feature is disabled")
 	})
 
 	t.Run("preserves cached issues when engine returns a real (non-ignorable) error", func(t *testing.T) {
-		scanner, mockEngine, workspaceFolder := seedScannerCache(t)
+		c, scanner, mockEngine, workspaceFolder := seedScannerCache(t)
 
 		// Second scan: transient failure — cache must be preserved.
 		workflowID := workflow.NewWorkflowIdentifier("secrets.test")
 		mockEngine.EXPECT().InvokeWithConfig(workflowID, gomock.Any()).
 			Return(nil, errors.New("network failure"))
-		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+		_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 
 		assert.Error(t, err)
 		assert.NotEmpty(t, totalCachedIssues(scanner), "previously discovered findings must be preserved on transient error")
@@ -372,9 +386,9 @@ func TestScanner_Scan(t *testing.T) {
 }
 
 // seedScannerCache builds a Scanner, runs one successful scan that produces a single
-// finding, asserts the cache is populated, and returns the scanner/mockEngine/folder for
-// a follow-up scan to exercise cache-preservation behavior on errors.
-func seedScannerCache(t *testing.T) (*Scanner, *mocks.MockEngine, types.FilePath) {
+// finding, asserts the cache is populated, and returns the config/scanner/mockEngine/folder
+// for a follow-up scan to exercise cache-preservation behavior on errors.
+func seedScannerCache(t *testing.T) (*config.Config, *Scanner, *mocks.MockEngine, types.FilePath) {
 	t.Helper()
 	c := testutil.UnitTest(t)
 	mockEngine, _ := testutil.SetUpEngineMock(t, c)
@@ -391,11 +405,11 @@ func seedScannerCache(t *testing.T) (*Scanner, *mocks.MockEngine, types.FilePath
 	workspaceFolder := types.FilePath(t.TempDir())
 	scanner := New(c, performance.NewInstrumentor(), &snyk_api.FakeApiClient{}, featureflag.NewFakeService(), notification.NewMockNotifier(), nil)
 
-	_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
+	_, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(c, workspaceFolder))
 	require.NoError(t, err)
 	require.NotZero(t, totalCachedIssues(scanner), "seed scan must populate the cache")
 
-	return scanner, mockEngine, workspaceFolder
+	return c, scanner, mockEngine, workspaceFolder
 }
 
 func totalCachedIssues(scanner *Scanner) int {

--- a/infrastructure/utils/error_messages.go
+++ b/infrastructure/utils/error_messages.go
@@ -18,8 +18,24 @@ package utils
 
 const (
 	ErrSnykCodeNotEnabled = "Snyk Code is not enabled for this organization"
-	ErrNoReferenceBranch  = "must specify reference for delta scans"
-	ErrNoRepo             = "repository does not exist"
+	// ErrSnykCodeNotEnabledForFolder is when Code is turned off for this workspace folder in the IDE / config (not org SAST).
+	ErrSnykCodeNotEnabledForFolder = "Snyk Code is not enabled for this workspace folder"
+	// ErrSnykSecretsNotEnabled is when Secrets is not available for the organization (e.g. feature flag).
+	ErrSnykSecretsNotEnabled = "Snyk Secrets is not enabled for this organization"
+	// ErrSnykSecretsNotEnabledForFolder is when Secrets is turned off for this workspace folder in the IDE / config.
+	ErrSnykSecretsNotEnabledForFolder = "Snyk Secrets is not enabled for this workspace folder"
+	// ErrSnykIacNotEnabledForFolder is when IaC is turned off for this workspace folder in the IDE / config.
+	ErrSnykIacNotEnabledForFolder = "Snyk IaC is not enabled for this workspace folder"
+	// ErrSnykOssNotEnabledForFolder is when Open Source is turned off for this workspace folder in the IDE / config.
+	ErrSnykOssNotEnabledForFolder = "Snyk Open Source is not enabled for this workspace folder"
+	ErrSastSettingsNotAvailable   = "SAST settings not available"
+	ErrNoReferenceBranch          = "must specify reference for delta scans"
+	ErrNoRepo                     = "repository does not exist"
+	// ErrFolderConfigNotInContext is returned when FolderConfig is missing from the scan context (configuration bug).
+	ErrFolderConfigNotInContext = "FolderConfig not found in context"
+
+	// MsgNotAuthenticatedNoScan is the standard log line when a scanner skips work because there is no auth token.
+	MsgNotAuthenticatedNoScan = "not authenticated, not scanning"
 )
 
 // ErrorMetadata contains metadata about how to handle specific errors
@@ -34,6 +50,30 @@ var ErrorConfig = map[string]ErrorMetadata{
 		ShowNotification: false,
 		TreeRootSuffix:   "(disabled at Snyk)",
 	},
+	ErrSnykCodeNotEnabledForFolder: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(disabled in workspace)",
+	},
+	ErrSnykSecretsNotEnabled: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(disabled at Snyk)",
+	},
+	ErrSnykSecretsNotEnabledForFolder: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(disabled in workspace)",
+	},
+	ErrSnykIacNotEnabledForFolder: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(disabled in workspace)",
+	},
+	ErrSnykOssNotEnabledForFolder: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(disabled in workspace)",
+	},
+	ErrSastSettingsNotAvailable: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(Code settings unavailable)",
+	},
 	ErrNoReferenceBranch: {
 		ShowNotification: false,
 		TreeRootSuffix:   "(no reference branch)",
@@ -42,4 +82,24 @@ var ErrorConfig = map[string]ErrorMetadata{
 		ShowNotification: false,
 		TreeRootSuffix:   "(repository not found)",
 	},
+	MsgNotAuthenticatedNoScan: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(not authenticated)",
+	},
+}
+
+// nonFailingScanErrors lists scanner-returned error strings that should not be logged as failures
+// or shown as error diagnostics. Do not add log-only strings here (scanners must return these as err).
+var nonFailingScanErrors = map[string]bool{
+	MsgNotAuthenticatedNoScan:         true,
+	ErrSnykCodeNotEnabledForFolder:    true,
+	ErrSnykIacNotEnabledForFolder:     true,
+	ErrSnykOssNotEnabledForFolder:     true,
+	ErrSnykSecretsNotEnabledForFolder: true,
+	ErrSnykCodeNotEnabled:             true,
+	ErrSnykSecretsNotEnabled:          true,
+}
+
+func IsNonFailingScanError(errorMessage string) bool {
+	return nonFailingScanErrors[errorMessage]
 }


### PR DESCRIPTION
### Description

Backporting fixes for the rc.

### Checklist

- [ ] Tests added and all succeed
 - N/A
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
