### PR TITLE
fix(secrets): return errors on skip so scan analytics are not sent [I…

### DIFF
--- a/infrastructure/secrets/secrets.go
+++ b/infrastructure/secrets/secrets.go
@@ -19,6 +19,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	"github.com/snyk/snyk-ls/infrastructure/issuecache"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	ctx2 "github.com/snyk/snyk-ls/internal/context"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
@@ -118,14 +120,14 @@ func (sc *Scanner) Scan(ctx context.Context, pathToScan types.FilePath, workspac
 	logger.Info().Msg("Secrets scanner: starting scan")
 
 	if !sc.c.NonEmptyToken() {
-		logger.Info().Msg("not authenticated, not scanning")
-		return issues, err
+		logger.Info().Msg(utils.MsgNotAuthenticatedNoScan)
+		return nil, errors.New(utils.MsgNotAuthenticatedNoScan)
 	}
 
 	isSecretsScannerEnabled := workspaceFolderConfig.FeatureFlags[featureflag.SnykSecretsEnabled]
 	if !isSecretsScannerEnabled {
-		logger.Error().Str("folderPath", string(workspaceFolder)).Msgf("feature flag %s not enabled", featureflag.SnykSecretsEnabled)
-		return issues, nil
+		logger.Debug().Str("folderPath", string(workspaceFolder)).Msgf("feature flag %s not enabled, skipping scan", featureflag.SnykSecretsEnabled)
+		return nil, errors.New(utils.ErrSnykSecretsNotEnabled)
 	}
 
 	scanStatus := NewScanStatus()

--- a/infrastructure/secrets/secrets_test.go
+++ b/infrastructure/secrets/secrets_test.go
@@ -153,7 +153,7 @@ func TestScanner_Scan(t *testing.T) {
 		assert.Equal(t, 1, totalCached)
 	})
 
-	t.Run("returns empty when no token", func(t *testing.T) {
+	t.Run("returns error when no token", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 		testutil.SetUpEngineMock(t, c)
 		c.SetToken("")
@@ -163,11 +163,11 @@ func TestScanner_Scan(t *testing.T) {
 
 		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
 
-		assert.NoError(t, err)
+		assert.EqualError(t, err, "not authenticated, not scanning")
 		assert.Empty(t, issues)
 	})
 
-	t.Run("returns empty without error when feature flag disabled", func(t *testing.T) {
+	t.Run("returns error when feature flag disabled", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 		testutil.SetUpEngineMock(t, c)
 
@@ -180,7 +180,7 @@ func TestScanner_Scan(t *testing.T) {
 
 		issues, err := scanner.Scan(t.Context(), workspaceFolder, folderConfig)
 
-		assert.NoError(t, err)
+		assert.EqualError(t, err, "Snyk Secrets is not enabled for this organization")
 		assert.Empty(t, issues)
 	})
 

--- a/infrastructure/utils/error_messages.go
+++ b/infrastructure/utils/error_messages.go
@@ -18,8 +18,13 @@ package utils
 
 const (
 	ErrSnykCodeNotEnabled = "Snyk Code is not enabled for this organization"
-	ErrNoReferenceBranch  = "must specify reference for delta scans"
-	ErrNoRepo             = "repository does not exist"
+	// ErrSnykSecretsNotEnabled is when Secrets is not available for the organization (e.g. feature flag).
+	ErrSnykSecretsNotEnabled = "Snyk Secrets is not enabled for this organization"
+	ErrNoReferenceBranch     = "must specify reference for delta scans"
+	ErrNoRepo                = "repository does not exist"
+
+	// MsgNotAuthenticatedNoScan is the standard log line when a scanner skips work because there is no auth token.
+	MsgNotAuthenticatedNoScan = "not authenticated, not scanning"
 )
 
 // ErrorMetadata contains metadata about how to handle specific errors
@@ -33,6 +38,14 @@ var ErrorConfig = map[string]ErrorMetadata{
 	ErrSnykCodeNotEnabled: {
 		ShowNotification: false,
 		TreeRootSuffix:   "(disabled at Snyk)",
+	},
+	ErrSnykSecretsNotEnabled: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(disabled at Snyk)",
+	},
+	MsgNotAuthenticatedNoScan: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(not authenticated)",
 	},
 	ErrNoReferenceBranch: {
 		ShowNotification: false,


### PR DESCRIPTION
When secrets scanning is skipped (no token or org feature flag off), return an error instead of nil so ProcessResults does not emit a successful "Scan done" analytics event for a scan that never ran.

### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
