### PR TITLE
fix(secrets): return errors on skip so scan analytics are not sent [IDE-2041]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/getsentry/sentry-go v0.31.1
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/golang/mock v1.6.0
-	github.com/gomarkdown/markdown v0.0.0-20250207164621-7a1f277a159e
+	github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/hashdir v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/gomarkdown/markdown v0.0.0-20250207164621-7a1f277a159e h1:ESHlT0RVZphh4JGBz49I5R6nTdC8Qyc08vU25GQHzzQ=
-github.com/gomarkdown/markdown v0.0.0-20250207164621-7a1f277a159e/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df h1:Mwihr/o+v4L5h56rwHLOE20+hh7Okhwno5BHz3zDuao=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/infrastructure/code/autofix.go
+++ b/infrastructure/code/autofix.go
@@ -69,8 +69,8 @@ func (sc *Scanner) GetAutofixDiffs(ctx context.Context, baseDir types.FilePath, 
 	// ticker sends a trigger every second to its channel
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	// timeoutTimer sends a trigger after 2 minutes to its channel
-	timeoutTimer := time.NewTimer(2 * time.Minute)
+	// timeoutTimer sends a trigger after 4 minutes to its channel
+	timeoutTimer := time.NewTimer(4 * time.Minute)
 	defer timeoutTimer.Stop()
 	for {
 		select {

--- a/infrastructure/secrets/secrets.go
+++ b/infrastructure/secrets/secrets.go
@@ -19,6 +19,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	"github.com/snyk/snyk-ls/infrastructure/issuecache"
 	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	ctx2 "github.com/snyk/snyk-ls/internal/context"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
@@ -118,14 +120,14 @@ func (sc *Scanner) Scan(ctx context.Context, pathToScan types.FilePath, workspac
 	logger.Info().Msg("Secrets scanner: starting scan")
 
 	if !sc.c.NonEmptyToken() {
-		logger.Info().Msg("not authenticated, not scanning")
-		return issues, err
+		logger.Info().Msg(utils.MsgNotAuthenticatedNoScan)
+		return nil, errors.New(utils.MsgNotAuthenticatedNoScan)
 	}
 
 	isSecretsScannerEnabled := workspaceFolderConfig.FeatureFlags[featureflag.SnykSecretsEnabled]
 	if !isSecretsScannerEnabled {
-		logger.Error().Str("folderPath", string(workspaceFolder)).Msgf("feature flag %s not enabled", featureflag.SnykSecretsEnabled)
-		return issues, nil
+		logger.Debug().Str("folderPath", string(workspaceFolder)).Msgf("feature flag %s not enabled, skipping scan", featureflag.SnykSecretsEnabled)
+		return nil, errors.New(utils.ErrSnykSecretsNotEnabled)
 	}
 
 	scanStatus := NewScanStatus()

--- a/infrastructure/secrets/secrets_test.go
+++ b/infrastructure/secrets/secrets_test.go
@@ -153,7 +153,7 @@ func TestScanner_Scan(t *testing.T) {
 		assert.Equal(t, 1, totalCached)
 	})
 
-	t.Run("returns empty when no token", func(t *testing.T) {
+	t.Run("returns error when no token", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 		testutil.SetUpEngineMock(t, c)
 		c.SetToken("")
@@ -163,11 +163,11 @@ func TestScanner_Scan(t *testing.T) {
 
 		issues, err := scanner.Scan(t.Context(), workspaceFolder, secretsEnabledFolderConfig(workspaceFolder))
 
-		assert.NoError(t, err)
+		assert.EqualError(t, err, "not authenticated, not scanning")
 		assert.Empty(t, issues)
 	})
 
-	t.Run("returns empty without error when feature flag disabled", func(t *testing.T) {
+	t.Run("returns error when feature flag disabled", func(t *testing.T) {
 		c := testutil.UnitTest(t)
 		testutil.SetUpEngineMock(t, c)
 
@@ -180,7 +180,7 @@ func TestScanner_Scan(t *testing.T) {
 
 		issues, err := scanner.Scan(t.Context(), workspaceFolder, folderConfig)
 
-		assert.NoError(t, err)
+		assert.EqualError(t, err, "Snyk Secrets is not enabled for this organization")
 		assert.Empty(t, issues)
 	})
 

--- a/infrastructure/utils/error_messages.go
+++ b/infrastructure/utils/error_messages.go
@@ -18,8 +18,13 @@ package utils
 
 const (
 	ErrSnykCodeNotEnabled = "Snyk Code is not enabled for this organization"
-	ErrNoReferenceBranch  = "must specify reference for delta scans"
-	ErrNoRepo             = "repository does not exist"
+	// ErrSnykSecretsNotEnabled is when Secrets is not available for the organization (e.g. feature flag).
+	ErrSnykSecretsNotEnabled = "Snyk Secrets is not enabled for this organization"
+	ErrNoReferenceBranch     = "must specify reference for delta scans"
+	ErrNoRepo                = "repository does not exist"
+
+	// MsgNotAuthenticatedNoScan is the standard log line when a scanner skips work because there is no auth token.
+	MsgNotAuthenticatedNoScan = "not authenticated, not scanning"
 )
 
 // ErrorMetadata contains metadata about how to handle specific errors
@@ -33,6 +38,14 @@ var ErrorConfig = map[string]ErrorMetadata{
 	ErrSnykCodeNotEnabled: {
 		ShowNotification: false,
 		TreeRootSuffix:   "(disabled at Snyk)",
+	},
+	ErrSnykSecretsNotEnabled: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(disabled at Snyk)",
+	},
+	MsgNotAuthenticatedNoScan: {
+		ShowNotification: false,
+		TreeRootSuffix:   "(not authenticated)",
 	},
 	ErrNoReferenceBranch: {
 		ShowNotification: false,


### PR DESCRIPTION
### Description

**Jira:** [IDE-2041](https://snyksec.atlassian.net/browse/IDE-2041)

When the secrets scanner skipped work (no auth token or org `isSecretsEnabled` feature flag off), it returned `(nil, nil)`. `Folder.ProcessResults` treated that as a successful scan and emitted a **"Scan done"** analytics event even though no secrets scan had run.

This PR returns explicit skip errors from `secrets.Scanner.Scan` so analytics are not sent:

| Skip reason | Before | After |
|-------------|--------|-------|
| No token | `return issues, err` with `err == nil` | `errors.New(utils.MsgNotAuthenticatedNoScan)` |
| Org secrets FF off | `return issues, nil` | `errors.New(utils.ErrSnykSecretsNotEnabled)` |

`ProcessResults` already skips `sendAnalytics` when `scanData.Err != nil`.

Also adds `ErrSnykSecretsNotEnabled`, `MsgNotAuthenticatedNoScan`, and matching `ErrorConfig` entries for tree-view suffixes.

**Included via merge of `release/1.1305` (already on release branch as [#1288](https://github.com/snyk/snyk-ls/pull/1288)):**

- Autofix: increase `GetAutofixDiffs` polling timeout from 2 to 4 minutes ([#1277](https://github.com/snyk/snyk-ls/pull/1277))
- Upgrade `gomarkdown/markdown` ([#1287](https://github.com/snyk/snyk-ls/pull/1287))

Related release backport: [#1289](https://github.com/snyk/snyk-ls/pull/1289) (same secrets fix, target `release/1.1305`).

### Checklist

- [x] Tests added and all succeed
- [x] Regenerated mocks, etc. (`make generate`) — not required
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Test plan

- [x] `go test ./infrastructure/secrets/... -run 'TestScanner_Scan/returns_error_when_no_token|TestScanner_Scan/returns_error_when_feature_flag_disabled'`
- [ ] Verify no secrets "Scan done" analytics when logged out or org secrets disabled

[IDE-2041]: https://snyksec.atlassian.net/browse/IDE-2041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ