### PR TITLE
feat(html-settings): add Eclipse-only Path field in config dialog [IDE-2037]

### DIFF
--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -307,6 +307,7 @@ func processConfigSettings(conf configuration.Configuration, engine workflow.Eng
 	applyAutoScan(conf, settings)
 	globalOrgChanged := applyOrganization(conf, engine, logger, settings, triggerSource, configResolver)
 	applyCliConfig(conf, settings)
+	applyUserSettingsPath(conf, settings)
 	applyEnvironment(conf, logger, settings)
 	applyCliBaseDownloadURL(conf, engine, logger, settings, triggerSource, configResolver)
 	applyErrorReporting(conf, engine, logger, settings, triggerSource, configResolver)
@@ -889,6 +890,14 @@ func applyPathToEnv(conf configuration.Configuration, logger *zerolog.Logger, pa
 		subLogger.Err(err).Msgf("couldn't add path %s", path)
 	}
 	subLogger.Debug().Msgf("new PATH is '%s'", os.Getenv("PATH"))
+}
+
+func applyUserSettingsPath(conf configuration.Configuration, settings map[string]*types.ConfigSetting) {
+	v, ok := settingStr(settings, types.SettingUserSettingsPath)
+	if !ok {
+		return
+	}
+	types.SetGlobalUser(conf, types.SettingUserSettingsPath, v)
 }
 
 func applySnykLearnCodeActions(conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, settings map[string]*types.ConfigSetting, triggerSource analytics.TriggerSource, configResolver types.ConfigResolverInterface) {

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -2262,12 +2262,14 @@ func TestApplyUserSettingsPath_PersistsValue(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
+	originalPath := os.Getenv("PATH")
 	settings := map[string]*types.ConfigSetting{
 		types.SettingUserSettingsPath: {Value: "/foo/bar", Changed: true},
 	}
 	applyUserSettingsPath(conf, settings)
 
 	assert.Equal(t, "/foo/bar", types.GetGlobalString(conf, types.SettingUserSettingsPath))
+	assert.Equal(t, originalPath, os.Getenv("PATH"), "didChangeConfiguration must not mutate os PATH — restart required")
 }
 
 func TestApplyUserSettingsPath_IgnoresUnchanged(t *testing.T) {

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -2257,3 +2257,28 @@ func TestResetSummaryPanelForOrgChange_EmptyFolderPaths_DoesNotCallInit(t *testi
 	})
 	assert.Empty(t, agg.initCalls, "Init must not be called when folderPaths is empty")
 }
+
+func TestApplyUserSettingsPath_PersistsValue(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	settings := map[string]*types.ConfigSetting{
+		types.SettingUserSettingsPath: {Value: "/foo/bar", Changed: true},
+	}
+	applyUserSettingsPath(conf, settings)
+
+	assert.Equal(t, "/foo/bar", types.GetGlobalString(conf, types.SettingUserSettingsPath))
+}
+
+func TestApplyUserSettingsPath_IgnoresUnchanged(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	types.SetGlobalUser(conf, types.SettingUserSettingsPath, "/original")
+
+	settings := map[string]*types.ConfigSetting{
+		types.SettingUserSettingsPath: {Value: "/new", Changed: false},
+	}
+	applyUserSettingsPath(conf, settings)
+
+	assert.Equal(t, "/original", types.GetGlobalString(conf, types.SettingUserSettingsPath))
+}

--- a/domain/ide/command/configuration_command.go
+++ b/domain/ide/command/configuration_command.go
@@ -99,6 +99,7 @@ func ConstructSettingsFromConfig(engine workflow.Engine, r types.ConfigResolverI
 		types.SettingAutomaticDownload:      r.GetBool(types.SettingAutomaticDownload, nil),
 		types.SettingBinaryBaseUrl:          r.GetString(types.SettingBinaryBaseUrl, nil),
 		types.SettingTrustedFolders:         trustedFoldersAsStrings(r),
+		types.SettingUserSettingsPath:       r.GetString(types.SettingUserSettingsPath, nil),
 	}
 
 	folderConfigs := collectFolderConfigs(conf, logger, engine, r)

--- a/domain/ide/command/configuration_command_settings_test.go
+++ b/domain/ide/command/configuration_command_settings_test.go
@@ -69,6 +69,8 @@ func TestConstructSettingsFromConfig_AllFieldsPopulated(t *testing.T) {
 		assert.NotNil(t, settings[types.SettingCliPath])
 		assert.Equal(t, true, settings[types.SettingAutomaticDownload])
 		assert.NotNil(t, settings[types.SettingBinaryBaseUrl])
+		_, ok := settings[types.SettingUserSettingsPath]
+		assert.True(t, ok, "user_settings_path key must be present in settings map")
 	})
 
 	t.Run("Trusted Folders", func(t *testing.T) {

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -372,7 +372,8 @@ func isVisualStudio(integrationName string) bool {
 }
 
 func isEclipse(integrationName string) bool {
-	return strings.EqualFold(integrationName, "ECLIPSE")
+	upper := strings.ToUpper(integrationName)
+	return upper == "ECLIPSE" || upper == "ECLIPSE IDE"
 }
 
 // getCliReleaseChannel derives the CLI release channel from the runtime version

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -282,7 +282,6 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 	// as it's more user-friendly. Other than Visual Studio, which we will respect.
 	folderLabel := "Project"
 	integrationEnv := conf.GetString(configuration.INTEGRATION_ENVIRONMENT)
-	integrationName := conf.GetString(configuration.INTEGRATION_NAME)
 	if isVisualStudio(integrationEnv) {
 		folderLabel = "Solution"
 	}
@@ -345,7 +344,7 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 		"FolderNames":             folderNames,
 		"CliReleaseChannel":       cliReleaseChannel,
 		"IsSecretsFeatureEnabled": isAnyFolderSecretsEnabled(folderConfigs),
-		"IsEclipse":               isEclipse(integrationName),
+		"IsEclipse":               isEclipse(integrationEnv),
 	}
 
 	var buffer bytes.Buffer
@@ -373,7 +372,8 @@ func isVisualStudio(integrationName string) bool {
 }
 
 func isEclipse(integrationName string) bool {
-	return strings.EqualFold(integrationName, "ECLIPSE")
+	upper := strings.ToUpper(integrationName)
+	return upper == "ECLIPSE" || upper == "ECLIPSE IDE" || upper == "ECLIPSE PLATFORM"
 }
 
 // getCliReleaseChannel derives the CLI release channel from the runtime version

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -281,8 +281,8 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 	// For every IDE we'll call them "Projects" even if not technically correct,
 	// as it's more user-friendly. Other than Visual Studio, which we will respect.
 	folderLabel := "Project"
-	integrationEnv := conf.GetString(configuration.INTEGRATION_ENVIRONMENT)
-	if isVisualStudio(integrationEnv) {
+	integrationName := conf.GetString(configuration.INTEGRATION_NAME)
+	if isVisualStudio(integrationName) {
 		folderLabel = "Solution"
 	}
 
@@ -344,7 +344,7 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 		"FolderNames":             folderNames,
 		"CliReleaseChannel":       cliReleaseChannel,
 		"IsSecretsFeatureEnabled": isAnyFolderSecretsEnabled(folderConfigs),
-		"IsEclipse":               isEclipse(integrationEnv),
+		"IsEclipse":               isEclipse(integrationName),
 	}
 
 	var buffer bytes.Buffer
@@ -366,14 +366,12 @@ func isAnyFolderSecretsEnabled(folderConfigs []types.FolderConfig) bool {
 	return false
 }
 
-// isVisualStudio checks if the integration name indicates Visual Studio
 func isVisualStudio(integrationName string) bool {
-	return integrationName == "VISUAL_STUDIO" || integrationName == "Visual Studio"
+	return integrationName == "VISUAL_STUDIO"
 }
 
 func isEclipse(integrationName string) bool {
-	upper := strings.ToUpper(integrationName)
-	return upper == "ECLIPSE" || upper == "ECLIPSE IDE" || upper == "ECLIPSE PLATFORM"
+	return integrationName == "ECLIPSE"
 }
 
 // getCliReleaseChannel derives the CLI release channel from the runtime version

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -282,6 +282,7 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 	// as it's more user-friendly. Other than Visual Studio, which we will respect.
 	folderLabel := "Project"
 	integrationEnv := conf.GetString(configuration.INTEGRATION_ENVIRONMENT)
+	integrationName := conf.GetString(configuration.INTEGRATION_NAME)
 	if isVisualStudio(integrationEnv) {
 		folderLabel = "Solution"
 	}
@@ -344,7 +345,7 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 		"FolderNames":             folderNames,
 		"CliReleaseChannel":       cliReleaseChannel,
 		"IsSecretsFeatureEnabled": isAnyFolderSecretsEnabled(folderConfigs),
-		"IsEclipse":               isEclipse(integrationEnv),
+		"IsEclipse":               isEclipse(integrationName),
 	}
 
 	var buffer bytes.Buffer
@@ -372,8 +373,7 @@ func isVisualStudio(integrationName string) bool {
 }
 
 func isEclipse(integrationName string) bool {
-	upper := strings.ToUpper(integrationName)
-	return upper == "ECLIPSE" || upper == "ECLIPSE IDE"
+	return strings.EqualFold(integrationName, "ECLIPSE")
 }
 
 // getCliReleaseChannel derives the CLI release channel from the runtime version

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -281,7 +281,8 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 	// For every IDE we'll call them "Projects" even if not technically correct,
 	// as it's more user-friendly. Other than Visual Studio, which we will respect.
 	folderLabel := "Project"
-	if isVisualStudio(conf.GetString(configuration.INTEGRATION_ENVIRONMENT)) {
+	integrationEnv := conf.GetString(configuration.INTEGRATION_ENVIRONMENT)
+	if isVisualStudio(integrationEnv) {
 		folderLabel = "Solution"
 	}
 
@@ -343,6 +344,7 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 		"FolderNames":             folderNames,
 		"CliReleaseChannel":       cliReleaseChannel,
 		"IsSecretsFeatureEnabled": isAnyFolderSecretsEnabled(folderConfigs),
+		"IsEclipse":               isEclipse(integrationEnv),
 	}
 
 	var buffer bytes.Buffer
@@ -367,6 +369,10 @@ func isAnyFolderSecretsEnabled(folderConfigs []types.FolderConfig) bool {
 // isVisualStudio checks if the integration name indicates Visual Studio
 func isVisualStudio(integrationName string) bool {
 	return integrationName == "VISUAL_STUDIO" || integrationName == "Visual Studio"
+}
+
+func isEclipse(integrationName string) bool {
+	return integrationName == "ECLIPSE"
 }
 
 // getCliReleaseChannel derives the CLI release channel from the runtime version

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -372,7 +372,7 @@ func isVisualStudio(integrationName string) bool {
 }
 
 func isEclipse(integrationName string) bool {
-	return integrationName == "ECLIPSE"
+	return strings.EqualFold(integrationName, "ECLIPSE")
 }
 
 // getCliReleaseChannel derives the CLI release channel from the runtime version

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -532,7 +532,7 @@ func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
 		return renderer.GetConfigHtml(settings, nil)
 	}
 
-	for _, env := range []string{"ECLIPSE", "Eclipse", "eclipse"} {
+	for _, env := range []string{"ECLIPSE", "Eclipse", "eclipse", "Eclipse IDE", "eclipse ide", "ECLIPSE IDE"} {
 		t.Run(env+" shows path field", func(t *testing.T) {
 			html := renderForIDE(t, env)
 			assert.Contains(t, html, `id="user_settings_path"`)

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -520,10 +520,10 @@ func TestConfigHtmlRenderer_EclipseShowsProjectSettings(t *testing.T) {
 }
 
 func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
-	renderForIntegration := func(t *testing.T, integrationName string) string {
+	renderForIDE := func(t *testing.T, ideEnv string) string {
 		t.Helper()
 		engine := testutil.UnitTest(t)
-		engine.GetConfiguration().Set(gafconfiguration.INTEGRATION_NAME, integrationName)
+		engine.GetConfiguration().Set(gafconfiguration.INTEGRATION_ENVIRONMENT, ideEnv)
 		renderer, err := NewConfigHtmlRenderer(engine)
 		require.NoError(t, err)
 		settings := map[string]any{
@@ -532,18 +532,17 @@ func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
 		return renderer.GetConfigHtml(settings, nil)
 	}
 
-	// INTEGRATION_NAME is set explicitly by Eclipse plugin as "ECLIPSE" (server.go uppercases it)
-	for _, name := range []string{"ECLIPSE", "Eclipse", "eclipse"} {
-		t.Run(name+" shows path field", func(t *testing.T) {
-			html := renderForIntegration(t, name)
+	for _, env := range []string{"ECLIPSE", "Eclipse", "eclipse", "Eclipse IDE", "eclipse ide", "Eclipse Platform", "ECLIPSE PLATFORM"} {
+		t.Run(env+" shows path field", func(t *testing.T) {
+			html := renderForIDE(t, env)
 			assert.Contains(t, html, `id="user_settings_path"`)
 			assert.Contains(t, html, `/usr/local/bin`)
 		})
 	}
 
-	for _, name := range []string{"VSCODE", "VISUAL_STUDIO", "INTELLIJ"} {
-		t.Run(name+" hides path field", func(t *testing.T) {
-			html := renderForIntegration(t, name)
+	for _, ide := range []string{"VSCODE", "VISUAL_STUDIO", "INTELLIJ"} {
+		t.Run(ide+" hides path field", func(t *testing.T) {
+			html := renderForIDE(t, ide)
 			assert.NotContains(t, html, `id="user_settings_path"`)
 		})
 	}

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -532,11 +532,13 @@ func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
 		return renderer.GetConfigHtml(settings, nil)
 	}
 
-	t.Run("Eclipse shows path field", func(t *testing.T) {
-		html := renderForIDE(t, "ECLIPSE")
-		assert.Contains(t, html, `id="user_settings_path"`)
-		assert.Contains(t, html, `/usr/local/bin`)
-	})
+	for _, env := range []string{"ECLIPSE", "Eclipse", "eclipse"} {
+		t.Run(env+" shows path field", func(t *testing.T) {
+			html := renderForIDE(t, env)
+			assert.Contains(t, html, `id="user_settings_path"`)
+			assert.Contains(t, html, `/usr/local/bin`)
+		})
+	}
 
 	for _, ide := range []string{"VSCODE", "VISUAL_STUDIO", "INTELLIJ"} {
 		t.Run(ide+" hides path field", func(t *testing.T) {

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -520,10 +520,10 @@ func TestConfigHtmlRenderer_EclipseShowsProjectSettings(t *testing.T) {
 }
 
 func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
-	renderForIDE := func(t *testing.T, ideEnv string) string {
+	renderForIntegration := func(t *testing.T, integrationName string) string {
 		t.Helper()
 		engine := testutil.UnitTest(t)
-		engine.GetConfiguration().Set(gafconfiguration.INTEGRATION_ENVIRONMENT, ideEnv)
+		engine.GetConfiguration().Set(gafconfiguration.INTEGRATION_NAME, integrationName)
 		renderer, err := NewConfigHtmlRenderer(engine)
 		require.NoError(t, err)
 		settings := map[string]any{
@@ -532,17 +532,18 @@ func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
 		return renderer.GetConfigHtml(settings, nil)
 	}
 
-	for _, env := range []string{"ECLIPSE", "Eclipse", "eclipse", "Eclipse IDE", "eclipse ide", "ECLIPSE IDE"} {
-		t.Run(env+" shows path field", func(t *testing.T) {
-			html := renderForIDE(t, env)
+	// INTEGRATION_NAME is set explicitly by Eclipse plugin as "ECLIPSE" (server.go uppercases it)
+	for _, name := range []string{"ECLIPSE", "Eclipse", "eclipse"} {
+		t.Run(name+" shows path field", func(t *testing.T) {
+			html := renderForIntegration(t, name)
 			assert.Contains(t, html, `id="user_settings_path"`)
 			assert.Contains(t, html, `/usr/local/bin`)
 		})
 	}
 
-	for _, ide := range []string{"VSCODE", "VISUAL_STUDIO", "INTELLIJ"} {
-		t.Run(ide+" hides path field", func(t *testing.T) {
-			html := renderForIDE(t, ide)
+	for _, name := range []string{"VSCODE", "VISUAL_STUDIO", "INTELLIJ"} {
+		t.Run(name+" hides path field", func(t *testing.T) {
+			html := renderForIntegration(t, name)
 			assert.NotContains(t, html, `id="user_settings_path"`)
 		})
 	}

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -519,6 +519,33 @@ func TestConfigHtmlRenderer_EclipseShowsProjectSettings(t *testing.T) {
 	assert.Contains(t, html, "- Project")
 }
 
+func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
+	renderForIDE := func(t *testing.T, ideEnv string) string {
+		t.Helper()
+		engine := testutil.UnitTest(t)
+		engine.GetConfiguration().Set(gafconfiguration.INTEGRATION_ENVIRONMENT, ideEnv)
+		renderer, err := NewConfigHtmlRenderer(engine)
+		require.NoError(t, err)
+		settings := map[string]any{
+			types.SettingUserSettingsPath: "/usr/local/bin",
+		}
+		return renderer.GetConfigHtml(settings, nil)
+	}
+
+	t.Run("Eclipse shows path field", func(t *testing.T) {
+		html := renderForIDE(t, "ECLIPSE")
+		assert.Contains(t, html, `id="user_settings_path"`)
+		assert.Contains(t, html, `/usr/local/bin`)
+	})
+
+	for _, ide := range []string{"VSCODE", "VISUAL_STUDIO", "INTELLIJ"} {
+		t.Run(ide+" hides path field", func(t *testing.T) {
+			html := renderForIDE(t, ide)
+			assert.NotContains(t, html, `id="user_settings_path"`)
+		})
+	}
+}
+
 func TestTmplSourceIndicator(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -520,10 +520,10 @@ func TestConfigHtmlRenderer_EclipseShowsProjectSettings(t *testing.T) {
 }
 
 func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
-	renderForIDE := func(t *testing.T, ideEnv string) string {
+	renderForIntegration := func(t *testing.T, integrationName string) string {
 		t.Helper()
 		engine := testutil.UnitTest(t)
-		engine.GetConfiguration().Set(gafconfiguration.INTEGRATION_ENVIRONMENT, ideEnv)
+		engine.GetConfiguration().Set(gafconfiguration.INTEGRATION_NAME, integrationName)
 		renderer, err := NewConfigHtmlRenderer(engine)
 		require.NoError(t, err)
 		settings := map[string]any{
@@ -532,17 +532,15 @@ func TestConfigHtmlRenderer_EclipsePathField(t *testing.T) {
 		return renderer.GetConfigHtml(settings, nil)
 	}
 
-	for _, env := range []string{"ECLIPSE", "Eclipse", "eclipse", "Eclipse IDE", "eclipse ide", "Eclipse Platform", "ECLIPSE PLATFORM"} {
-		t.Run(env+" shows path field", func(t *testing.T) {
-			html := renderForIDE(t, env)
-			assert.Contains(t, html, `id="user_settings_path"`)
-			assert.Contains(t, html, `/usr/local/bin`)
-		})
-	}
+	t.Run("ECLIPSE shows path field", func(t *testing.T) {
+		html := renderForIntegration(t, "ECLIPSE")
+		assert.Contains(t, html, `id="user_settings_path"`)
+		assert.Contains(t, html, `/usr/local/bin`)
+	})
 
-	for _, ide := range []string{"VSCODE", "VISUAL_STUDIO", "INTELLIJ"} {
-		t.Run(ide+" hides path field", func(t *testing.T) {
-			html := renderForIDE(t, ide)
+	for _, name := range []string{"VS_CODE", "VISUAL_STUDIO", "JETBRAINS_IDE"} {
+		t.Run(name+" hides path field", func(t *testing.T) {
+			html := renderForIntegration(t, name)
 			assert.NotContains(t, html, `id="user_settings_path"`)
 		})
 	}

--- a/infrastructure/configuration/template/config.html
+++ b/infrastructure/configuration/template/config.html
@@ -121,6 +121,16 @@
                                 <input type="text" id="cli_path" name="cli_path" value="{{index .Settings "cli_path"}}" placeholder="/path/to/snyk-cli">
                             </div>
 
+                            {{if .IsEclipse}}
+                            <div class="form-group">
+                                <label for="user_settings_path">
+                                    <span data-toggle="tooltip" title="Additional directories prepended to PATH before launching CLI subprocesses. Restart required for changes to take effect.">Path</span>
+                                    <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="user_settings_path"></span>
+                                </label>
+                                <input type="text" id="user_settings_path" name="user_settings_path" value="{{index .Settings "user_settings_path"}}" placeholder="/usr/local/bin:/opt/snyk/bin">
+                            </div>
+                            {{end}}
+
                             <div class="form-group">
                                 <label class="checkbox-label">
                                     <input type="checkbox" name="automatic_download" {{if index .Settings "automatic_download"}}checked{{end}}>

--- a/scripts/config-dialog/config_output_multi_project.html
+++ b/scripts/config-dialog/config_output_multi_project.html
@@ -968,6 +968,16 @@ button.secondary[disabled] {
                                 <input type="text" id="cli_path" name="cli_path" value="" placeholder="/path/to/snyk-cli">
                             </div>
 
+                            
+                            <div class="form-group">
+                                <label for="user_settings_path">
+                                    <span data-toggle="tooltip" title="Additional directories prepended to PATH before launching CLI subprocesses. Restart required for changes to take effect.">Path</span>
+                                    <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="user_settings_path"></span>
+                                </label>
+                                <input type="text" id="user_settings_path" name="user_settings_path" value="" placeholder="/usr/local/bin:/opt/snyk/bin">
+                            </div>
+                            
+
                             <div class="form-group">
                                 <label class="checkbox-label">
                                     <input type="checkbox" name="automatic_download" >

--- a/scripts/config-dialog/config_output_no_projects.html
+++ b/scripts/config-dialog/config_output_no_projects.html
@@ -942,6 +942,8 @@ button.secondary[disabled] {
                                 <input type="text" id="cli_path" name="cli_path" value="" placeholder="/path/to/snyk-cli">
                             </div>
 
+                            
+
                             <div class="form-group">
                                 <label class="checkbox-label">
                                     <input type="checkbox" name="automatic_download" >

--- a/scripts/config-dialog/config_output_single_solution.html
+++ b/scripts/config-dialog/config_output_single_solution.html
@@ -949,6 +949,8 @@ button.secondary[disabled] {
                                 <input type="text" id="cli_path" name="cli_path" value="" placeholder="/path/to/snyk-cli">
                             </div>
 
+                            
+
                             <div class="form-group">
                                 <label class="checkbox-label">
                                     <input type="checkbox" name="automatic_download" >


### PR DESCRIPTION
## Summary

- Adds a **Path** input to the HTML settings dialog, visible only when `INTEGRATION_ENVIRONMENT=ECLIPSE`
- Maps to the existing `user_settings_path` / `SettingUserSettingsPath` setting (already `machineScope`, already excluded from LDX sync)
- Directories entered are prepended to `PATH` before CLI subprocesses start; value is persisted via `applyUserSettingsPath` on `didChangeConfiguration` (conf-write only — no mid-session `os.Setenv` mutation, restart required)
- Non-Eclipse IDEs (VS Code, IntelliJ, Visual Studio) are unaffected: `{{if .IsEclipse}}` guard hides the field entirely

## Changes

| File | Change |
|------|--------|
| `infrastructure/configuration/config_html.go` | `isEclipse()` helper + `"IsEclipse"` data key in `GetConfigHtml` |
| `infrastructure/configuration/template/config.html` | conditional `user_settings_path` form-group in CLI section |
| `domain/ide/command/configuration_command.go` | expose `user_settings_path` in `ConstructSettingsFromConfig` |
| `application/server/configuration.go` | `applyUserSettingsPath()` + wired into `processConfigSettings` |
| Test files (×3) | rendering show/hide, settings-map key, apply round-trip |

## Test plan

- [ ] `go test ./infrastructure/configuration/... ./domain/ide/command/... ./application/server/...` passes
- [ ] `make lint-fix` → 0 issues
- [ ] Manual: build LS, start Eclipse against it → Settings → CLI section shows **Path** input
- [ ] Manual: VS Code / IntelliJ / Visual Studio → Path input must **not** appear
- [ ] Enter `/tmp/fake-bin`, save, restart → LS log shows `applyPathToEnv` prepending the value

## Related

Jira: [IDE-2037](https://snyksec.atlassian.net/browse/IDE-2037)
Eclipse plugin wiring (EC1-EC5) is a separate plugin-side change; this PR covers the snyk-ls side only.

[IDE-2037]: https://snyksec.atlassian.net/browse/IDE-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ