### PR TITLE
refactor: migrate LSP handler deps from di.*() globals to context injection [IDE-1898]

### DIFF
--- a/application/di/init.go
+++ b/application/di/init.go
@@ -102,18 +102,18 @@ type Dependencies struct {
 	ScanStateAggregator   scanstates.Aggregator
 	InlineValueProvider   snyk.InlineValueProvider
 	TreeEmitter           command.TreeEmitter
-	// Added fields — all handler-accessed singletons now live here so that
-	// withContext can inject them into the request context rather than handlers
-	// reaching for the package-level globals via di.*() accessor functions.
+	// Handler-accessed dependencies (previously read via di.*() globals).
+	// Note: Installer and Initializer are intentionally absent — they are
+	// process-lifecycle dependencies used during startup, not per-request.
+	// Access them via di.Installer() / di.Initializer() until those global
+	// accessors are retired.
+	Scanner           scanner2.Scanner
+	HoverService      hover.Service
+	ScanNotifier      scanner2.ScanNotifier
+	ScanPersister     persistence.ScanSnapshotPersister
 	FileWatcher       *watcher.FileWatcher
 	ErrorReporter     er.ErrorReporter
-	HoverService      hover.Service
-	Scanner           scanner2.Scanner
-	ScanPersister     persistence.ScanSnapshotPersister
-	ScanNotifier      scanner2.ScanNotifier
-	Installer         install.Installer
 	CodeActionService *codeaction.CodeActionsService
-	Initializer       initialize.Initializer
 }
 
 func currentDependencies() Dependencies {
@@ -131,15 +131,14 @@ func currentDependencies() Dependencies {
 		ScanStateAggregator:   scanStateAggregator,
 		InlineValueProvider:   inlineValueProvider,
 		TreeEmitter:           treeEmitterInstance,
-		FileWatcher:           fileWatcher,
-		ErrorReporter:         errorReporter,
-		HoverService:          hoverService,
-		Scanner:               scanner,
-		ScanPersister:         scanPersister,
-		ScanNotifier:          scanNotifier,
-		Installer:             installer,
-		CodeActionService:     codeActionService,
-		Initializer:           scanInitializer,
+		// Handler-accessed dependencies:
+		Scanner:           scanner,
+		HoverService:      hoverService,
+		ScanNotifier:      scanNotifier,
+		ScanPersister:     scanPersister,
+		FileWatcher:       fileWatcher,
+		ErrorReporter:     errorReporter,
+		CodeActionService: codeActionService,
 	}
 }
 

--- a/application/di/init_test.go
+++ b/application/di/init_test.go
@@ -47,9 +47,11 @@ func TestDependencies_AllFieldsPopulated(t *testing.T) {
 	assert.NotNil(t, deps.Scanner, "Scanner must be set")
 	assert.NotNil(t, deps.ScanPersister, "ScanPersister must be set")
 	assert.NotNil(t, deps.ScanNotifier, "ScanNotifier must be set")
-	assert.NotNil(t, deps.Installer, "Installer must be set")
 	assert.NotNil(t, deps.CodeActionService, "CodeActionService must be set")
-	assert.NotNil(t, deps.Initializer, "Initializer must be set")
+	// Installer and Initializer are process-lifecycle deps not in di.Dependencies;
+	// verify their global accessors are still populated after Init.
+	assert.NotNil(t, di.Installer(), "di.Installer() must be non-nil after Init")
+	assert.NotNil(t, di.Initializer(), "di.Initializer() must be non-nil after Init")
 }
 
 // TestTestInit_ReturnedDepsAreIndependent verifies that two consecutive TestInit

--- a/application/di/test_init.go
+++ b/application/di/test_init.go
@@ -137,7 +137,11 @@ func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenServ
 	openSourceScanner = oss.NewCLIScanner(engine, instrumentor, errorReporter, snykCli, learnService, notifier, configResolver)
 	infrastructureAsCodeScanner = iac.New(gafConfiguration, logger, instrumentor, errorReporter, snykCli, configResolver)
 	scanner = scanner2.NewDelegatingScanner(engine, tokenService, scanInitializer, instrumentor, scanNotifier, snykApiClient, authenticationService, notifier, scanPersister, scanStateAggregator, configResolver, snykCodeScanner, infrastructureAsCodeScanner, openSourceScanner)
-	hoverService = hover.NewDefaultService(logger)
+	if overrideDeps != nil && overrideDeps.HoverService != nil {
+		hoverService = overrideDeps.HoverService
+	} else {
+		hoverService = hover.NewDefaultService(logger)
+	}
 
 	if overrideDeps != nil && overrideDeps.LdxSyncService != nil {
 		ldxSyncService = overrideDeps.LdxSyncService

--- a/application/di/test_init.go
+++ b/application/di/test_init.go
@@ -52,6 +52,7 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
+//nolint:gocyclo // high branching is inherent: one nil-check per overrideable dependency
 func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenService, overrideDeps *Dependencies) Dependencies {
 	t.Helper()
 	initMutex.Lock()

--- a/application/server/codeaction_handlers.go
+++ b/application/server/codeaction_handlers.go
@@ -60,11 +60,6 @@ func GetCodeActionHandler(logger *zerolog.Logger, svc *codeaction.CodeActionsSer
 	l := logger.With().Str("method", "CodeActionHandler").Logger()
 
 	return func(paramCtx context.Context, params types.CodeActionParams) ([]types.LSPCodeAction, error) {
-		if svc == nil {
-			l.Warn().Msg("CodeActionsService is nil; code actions are unavailable — check server startup wiring")
-			return nil, nil
-		}
-
 		var ctx context.Context
 		mu.Lock()
 		cancel()

--- a/application/server/codeaction_handlers.go
+++ b/application/server/codeaction_handlers.go
@@ -60,6 +60,11 @@ func GetCodeActionHandler(logger *zerolog.Logger, svc *codeaction.CodeActionsSer
 	l := logger.With().Str("method", "CodeActionHandler").Logger()
 
 	return func(paramCtx context.Context, params types.CodeActionParams) ([]types.LSPCodeAction, error) {
+		if svc == nil {
+			l.Warn().Msg("CodeActionsService is nil; code actions are unavailable — check server startup wiring")
+			return nil, nil
+		}
+
 		var ctx context.Context
 		mu.Lock()
 		cancel()

--- a/application/server/codeaction_handlers_test.go
+++ b/application/server/codeaction_handlers_test.go
@@ -1,0 +1,40 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+func TestGetCodeActionHandler_NilService_ReturnsNilAndNoError(t *testing.T) {
+	// When svc is nil (programming error — service not wired at startup), the handler
+	// must log a warning and return nil, nil rather than panicking.
+	engine := testutil.UnitTest(t)
+	logger := engine.GetLogger()
+	handler := GetCodeActionHandler(logger, nil)
+	require.NotNil(t, handler, "handler closure must always be returned even for nil svc")
+
+	actions, err := handler(t.Context(), types.CodeActionParams{})
+	assert.Nil(t, actions)
+	assert.NoError(t, err)
+}

--- a/application/server/codeaction_handlers_test.go
+++ b/application/server/codeaction_handlers_test.go
@@ -16,25 +16,6 @@
 
 package server
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/snyk/snyk-ls/internal/testutil"
-	"github.com/snyk/snyk-ls/internal/types"
-)
-
-func TestGetCodeActionHandler_NilService_ReturnsNilAndNoError(t *testing.T) {
-	// When svc is nil (programming error — service not wired at startup), the handler
-	// must log a warning and return nil, nil rather than panicking.
-	engine := testutil.UnitTest(t)
-	logger := engine.GetLogger()
-	handler := GetCodeActionHandler(logger, nil)
-	require.NotNil(t, handler, "handler closure must always be returned even for nil svc")
-
-	actions, err := handler(t.Context(), types.CodeActionParams{})
-	assert.Nil(t, actions)
-	assert.NoError(t, err)
-}
+// TestGetCodeActionHandler_NilService is removed: CodeActionsService is now a
+// mandatory DI dep validated by withContext.validateMandatoryDeps before any
+// handler runs, so the nil case is unreachable in production.

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -39,10 +39,10 @@ import (
 	mcpWorkflow "github.com/snyk/snyk-ls/internal/mcp"
 
 	"github.com/snyk/snyk-ls/application/config"
-	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/scanstates"
 	"github.com/snyk/snyk-ls/infrastructure/analytics"
+	"github.com/snyk/snyk-ls/infrastructure/authentication"
 	ctx2 "github.com/snyk/snyk-ls/internal/context"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/product"
@@ -98,7 +98,8 @@ func handlePushModel(ctx context.Context, conf configuration.Configuration, engi
 	if !conf.GetBool(types.SettingIsLspInitialized) {
 		triggerSource = analytics.TriggerSourceInitialize
 	}
-	UpdateSettings(ctx, conf, engine, logger, params.Settings, params.FolderConfigs, triggerSource, di.ConfigResolver())
+	configResolver, _ := ctx2.ConfigResolverFromContext(ctx)
+	UpdateSettings(ctx, conf, engine, logger, params.Settings, params.FolderConfigs, triggerSource, configResolver)
 	return true, nil
 }
 
@@ -142,7 +143,8 @@ func handlePullModel(ctx context.Context, conf configuration.Configuration, engi
 	if !conf.GetBool(types.SettingIsLspInitialized) {
 		triggerSource = analytics.TriggerSourceInitialize
 	}
-	UpdateSettings(ctx, conf, engine, logger, fetched.Settings.Settings, fetched.Settings.FolderConfigs, triggerSource, di.ConfigResolver())
+	configResolver, _ := ctx2.ConfigResolverFromContext(ctx)
+	UpdateSettings(ctx, conf, engine, logger, fetched.Settings.Settings, fetched.Settings.FolderConfigs, triggerSource, configResolver)
 	return true, nil
 }
 
@@ -188,7 +190,7 @@ func processInitMetadata(conf configuration.Configuration, engine workflow.Engin
 // Only settings explicitly marked Changed by the IDE are applied; IDE defaults
 // (Changed=false) are left alone so they don't override ldx-sync or GAF defaults.
 func InitializeSettings(ctx context.Context, conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, opts types.InitializationOptions) {
-	resolver := di.ConfigResolver()
+	resolver, _ := ctx2.ConfigResolverFromContext(ctx)
 
 	processInitMetadata(conf, engine, logger, opts)
 	// global
@@ -200,7 +202,8 @@ func InitializeSettings(ctx context.Context, conf configuration.Configuration, e
 	if resolver != nil {
 		fm = resolver.ConfigurationOptionsMetaData()
 	}
-	notifyLockedFieldsRejected(di.Notifier(), fm, lockedMachineFields, lockedFolderFields)
+	n, _ := notifierFromContext(ctx)
+	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
 }
 
 // UpdateSettings processes settings from workspace/didChangeConfiguration.
@@ -232,7 +235,8 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 	if configResolver != nil {
 		fm = configResolver.ConfigurationOptionsMetaData()
 	}
-	notifyLockedFieldsRejected(di.Notifier(), fm, lockedMachineFields, lockedFolderFields)
+	n, _ := notifierFromContext(ctx)
+	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
 
 	if ws != nil {
 		for _, folder := range ws.Folders() {
@@ -261,8 +265,12 @@ func refreshLdxSyncOnTokenChange(ctx context.Context, conf configuration.Configu
 		return
 	}
 	logger.Info().Msg("token changed via settings, refreshing LDX-Sync configuration")
-	ldxSyncService := mustLdxSyncServiceFromContext(ctx)
-	notifier := mustNotifierFromContext(ctx)
+	ldxSyncService, ok := ldxSyncServiceFromContext(ctx)
+	if !ok {
+		logger.Warn().Msg("ldxSyncService not in context; skipping LDX-Sync refresh on token change")
+		return
+	}
+	notifier, _ := notifierFromContext(ctx)
 	ldxSyncService.RefreshConfigFromLdxSync(context.Background(), conf, engine, logger, folders, notifier)
 }
 
@@ -311,6 +319,9 @@ func validateLockedMachineFields(settings map[string]*types.ConfigSetting, confi
 // (e.g. "Snyk Code Enabled") rather than the internal snake_case identifier.
 // See [IDE-1970].
 func notifyLockedFieldsRejected(notifier notification.Notifier, fm workflow.ConfigurationOptionsMetaData, lockedFieldGroups ...[]string) {
+	if notifier == nil {
+		return
+	}
 	// Dedup on the resolved display name rather than the raw identifier so two
 	// distinct raw keys that resolve to the same display name (e.g. legacy and
 	// canonical identifiers for the same setting) collapse to a single entry
@@ -378,9 +389,10 @@ func processConfigSettings(ctx context.Context, conf configuration.Configuration
 	}
 	lockedMachineFields := validateLockedMachineFields(settings, configResolver, fm, &subLogger)
 
-	applyApiEndpoints(conf, engine, logger, settings, triggerSource, configResolver)
-	applyAuthenticationMethod(conf, engine, logger, settings, triggerSource, configResolver)
-	applyToken(settings)
+	authService, _ := authenticationServiceFromContext(ctx)
+	applyApiEndpoints(conf, engine, logger, settings, triggerSource, configResolver, authService)
+	applyAuthenticationMethod(conf, engine, logger, settings, triggerSource, configResolver, authService)
+	applyToken(settings, authService)
 	applyAutomaticAuthentication(conf, settings)
 	applyProductEnablement(conf, engine, logger, settings, triggerSource, configResolver)
 	applySeverityFilter(conf, engine, logger, settings, triggerSource, configResolver)
@@ -516,7 +528,9 @@ func processFolderConfigs(ctx context.Context, conf configuration.Configuration,
 		for p := range orgChangedFolderPaths {
 			paths = append(paths, p)
 		}
-		resetSummaryPanelForOrgChange(di.ScanStateAggregator(), paths)
+		if sa, ok := scanStateAggregatorFromContext(ctx); ok {
+			resetSummaryPanelForOrgChange(sa, paths)
+		}
 	}
 
 	sendFolderConfigUpdateIfNeeded(conf, engine, logger, notifier, processedConfigs, len(changedConfigs) > 0, triggerSource, configResolver)
@@ -599,36 +613,36 @@ func settingPresent(settings map[string]*types.ConfigSetting, name string) bool 
 
 // --- Side-effect handlers ---
 
-func applyApiEndpoints(conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, settings map[string]*types.ConfigSetting, triggerSource analytics.TriggerSource, configResolver types.ConfigResolverInterface) {
+func applyApiEndpoints(conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, settings map[string]*types.ConfigSetting, triggerSource analytics.TriggerSource, configResolver types.ConfigResolverInterface, authService authentication.AuthenticationService) {
 	v, ok := settingStr(settings, types.SettingApiEndpoint)
 	if !ok {
 		return
 	}
 	snykApiUrl := strings.TrimSpace(v)
 	oldEndpoint := types.GetGlobalString(conf, types.SettingApiEndpoint)
-	endpointsUpdated := command.ApplyEndpointChange(context.Background(), conf, di.AuthenticationService(), logger, snykApiUrl)
+	endpointsUpdated := command.ApplyEndpointChange(context.Background(), conf, authService, logger, snykApiUrl)
 	if endpointsUpdated && conf.GetBool(types.SettingIsLspInitialized) {
 		analytics.SendConfigChangedAnalytics(conf, engine, logger, configEndpoint, oldEndpoint, snykApiUrl, triggerSource, configResolver)
 	}
 }
 
-func applyToken(settings map[string]*types.ConfigSetting) {
+func applyToken(settings map[string]*types.ConfigSetting, authService authentication.AuthenticationService) {
 	tokenFromIde, tokenExistsInMap := settings[types.SettingToken]
 	if tokenExistsInMap {
 		tokenAsString, parsable := tokenFromIde.Value.(string)
-		if parsable {
-			di.AuthenticationService().UpdateCredentials(tokenAsString, false, false)
+		if parsable && authService != nil {
+			authService.UpdateCredentials(tokenAsString, false, false)
 		}
 	}
 }
 
-func applyAuthenticationMethod(conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, settings map[string]*types.ConfigSetting, triggerSource analytics.TriggerSource, configResolver types.ConfigResolverInterface) {
+func applyAuthenticationMethod(conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, settings map[string]*types.ConfigSetting, triggerSource analytics.TriggerSource, configResolver types.ConfigResolverInterface, authService authentication.AuthenticationService) {
 	v, ok := settingStr(settings, types.SettingAuthenticationMethod)
 	if !ok || types.AuthenticationMethod(v) == types.EmptyAuthenticationMethod {
 		return
 	}
 	oldValue := config.GetAuthenticationMethodFromConfig(conf)
-	command.ApplyAuthMethodChange(conf, di.AuthenticationService(), logger, types.AuthenticationMethod(v))
+	command.ApplyAuthMethodChange(conf, authService, logger, types.AuthenticationMethod(v))
 	if oldValue != types.AuthenticationMethod(v) && conf.GetBool(types.SettingIsLspInitialized) {
 		analytics.SendConfigChangedAnalytics(conf, engine, logger, configAuthenticationMethod, oldValue, types.AuthenticationMethod(v), triggerSource, configResolver)
 	}
@@ -1152,12 +1166,14 @@ func processSingleLspFolderConfig(ctx context.Context, conf configuration.Config
 	applyChanged := false
 	var lockedFields []string
 	if incoming, hasIncoming := incomingMap[normalizedPath]; hasIncoming {
-		lockedFields = validateLockedFields(conf, fc, &incoming, &subLogger, configResolver)
+		lockedFields = validateLockedFields(configResolver, conf, fc, &incoming, &subLogger)
 		applyChanged = fc.ApplyLspUpdate(&incoming)
 	}
 
 	orgSettingsChanged := updateFolderOrgIfNeeded(ctx, conf, engine, logger, fc, fc, oldSnapshot, notifier)
-	di.FeatureFlagService().PopulateFolderConfig(fc)
+	if ffs, ok := featureFlagServiceFromContext(ctx); ok {
+		ffs.PopulateFolderConfig(fc)
+	}
 
 	newSnapshot := types.ReadFolderConfigSnapshot(conf, normalizedPath)
 
@@ -1182,7 +1198,7 @@ func processSingleLspFolderConfig(ctx context.Context, conf configuration.Config
 //
 // If the incoming update changes PreferredOrg, locks are evaluated against the NEW org's policies
 // to prevent bypassing stricter locks during an org switch.
-func validateLockedFields(conf configuration.Configuration, folderConfig *types.FolderConfig, incoming *types.LspFolderConfig, subLogger *zerolog.Logger, resolver types.ConfigResolverInterface) []string {
+func validateLockedFields(resolver types.ConfigResolverInterface, conf configuration.Configuration, folderConfig *types.FolderConfig, incoming *types.LspFolderConfig, subLogger *zerolog.Logger) []string {
 	if resolver == nil || incoming.Settings == nil {
 		return nil
 	}
@@ -1295,7 +1311,7 @@ func handleFolderCacheClearing(conf configuration.Configuration, engine workflow
 func sendFolderConfigUpdateIfNeeded(conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, notifier notification.Notifier, folderConfigs []types.FolderConfig, needsToSendUpdate bool, triggerSource analytics.TriggerSource, configResolver types.ConfigResolverInterface) {
 	// Don't send folder configs on initialize, since initialized will always send them.
 	if needsToSendUpdate && triggerSource != analytics.TriggerSourceInitialize {
-		lspConfig := command.BuildLspConfiguration(conf, engine, logger, nil, di.ConfigResolver())
+		lspConfig := command.BuildLspConfiguration(conf, engine, logger, nil, configResolver)
 		notifier.Send(lspConfig)
 	}
 }

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -393,7 +393,7 @@ func processConfigSettings(ctx context.Context, conf configuration.Configuration
 	}
 	lockedMachineFields := validateLockedMachineFields(settings, configResolver, fm, &subLogger)
 
-	authService, _ := authenticationServiceFromContext(ctx)
+	authService := mustAuthenticationServiceFromContext(ctx)
 	applyApiEndpoints(conf, engine, logger, settings, triggerSource, configResolver, authService)
 	applyAuthenticationMethod(conf, engine, logger, settings, triggerSource, configResolver, authService)
 	applyToken(settings, authService)
@@ -531,9 +531,7 @@ func processFolderConfigs(ctx context.Context, conf configuration.Configuration,
 		for p := range orgChangedFolderPaths {
 			paths = append(paths, p)
 		}
-		if sa, ok := scanStateAggregatorFromContext(ctx); ok {
-			resetSummaryPanelForOrgChange(sa, paths)
-		}
+		resetSummaryPanelForOrgChange(mustScanStateAggregatorFromContext(ctx), paths)
 	}
 
 	sendFolderConfigUpdateIfNeeded(conf, engine, logger, notifier, processedConfigs, len(changedConfigs) > 0, triggerSource, configResolver)
@@ -1174,9 +1172,7 @@ func processSingleLspFolderConfig(ctx context.Context, conf configuration.Config
 	}
 
 	orgSettingsChanged := updateFolderOrgIfNeeded(ctx, conf, engine, logger, fc, fc, oldSnapshot, notifier)
-	if ffs, ok := featureFlagServiceFromContext(ctx); ok {
-		ffs.PopulateFolderConfig(fc)
-	}
+	mustFeatureFlagServiceFromContext(ctx).PopulateFolderConfig(fc)
 
 	newSnapshot := types.ReadFolderConfigSnapshot(conf, normalizedPath)
 

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -323,9 +323,6 @@ func validateLockedMachineFields(settings map[string]*types.ConfigSetting, confi
 // (e.g. "Snyk Code Enabled") rather than the internal snake_case identifier.
 // See [IDE-1970].
 func notifyLockedFieldsRejected(notifier notification.Notifier, fm workflow.ConfigurationOptionsMetaData, lockedFieldGroups ...[]string) {
-	if notifier == nil {
-		return
-	}
 	// Dedup on the resolved display name rather than the raw identifier so two
 	// distinct raw keys that resolve to the same display name (e.g. legacy and
 	// canonical identifiers for the same setting) collapse to a single entry

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -20,6 +20,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -98,7 +99,10 @@ func handlePushModel(ctx context.Context, conf configuration.Configuration, engi
 	if !conf.GetBool(types.SettingIsLspInitialized) {
 		triggerSource = analytics.TriggerSourceInitialize
 	}
-	configResolver, _ := ctx2.ConfigResolverFromContext(ctx)
+	configResolver, ok := ctx2.ConfigResolverFromContext(ctx)
+	if !ok {
+		return false, errors.New("config resolver missing from context")
+	}
 	UpdateSettings(ctx, conf, engine, logger, params.Settings, params.FolderConfigs, triggerSource, configResolver)
 	return true, nil
 }
@@ -143,7 +147,10 @@ func handlePullModel(ctx context.Context, conf configuration.Configuration, engi
 	if !conf.GetBool(types.SettingIsLspInitialized) {
 		triggerSource = analytics.TriggerSourceInitialize
 	}
-	configResolver, _ := ctx2.ConfigResolverFromContext(ctx)
+	configResolver, ok := ctx2.ConfigResolverFromContext(ctx)
+	if !ok {
+		return false, errors.New("config resolver missing from context")
+	}
 	UpdateSettings(ctx, conf, engine, logger, fetched.Settings.Settings, fetched.Settings.FolderConfigs, triggerSource, configResolver)
 	return true, nil
 }
@@ -189,8 +196,11 @@ func processInitMetadata(conf configuration.Configuration, engine workflow.Engin
 // InitializeSettings processes settings from the LSP initialize request.
 // Only settings explicitly marked Changed by the IDE are applied; IDE defaults
 // (Changed=false) are left alone so they don't override ldx-sync or GAF defaults.
-func InitializeSettings(ctx context.Context, conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, opts types.InitializationOptions) {
-	resolver, _ := ctx2.ConfigResolverFromContext(ctx)
+func InitializeSettings(ctx context.Context, conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, opts types.InitializationOptions) error {
+	resolver, ok := ctx2.ConfigResolverFromContext(ctx)
+	if !ok {
+		return errors.New("config resolver missing from context")
+	}
 
 	processInitMetadata(conf, engine, logger, opts)
 	// global
@@ -202,11 +212,12 @@ func InitializeSettings(ctx context.Context, conf configuration.Configuration, e
 	if resolver != nil {
 		fm = resolver.ConfigurationOptionsMetaData()
 	}
-	n, ok := notifierFromContext(ctx)
-	if !ok {
+	n, nOk := notifierFromContext(ctx)
+	if !nOk {
 		logger.Warn().Str("method", "InitializeSettings").Msg("notifier not in context; locked-field notifications will not be sent")
 	}
 	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
+	return nil
 }
 
 // UpdateSettings processes settings from workspace/didChangeConfiguration.

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -230,7 +230,7 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 		if ffs, ok := featureFlagServiceFromContext(ctx); ok {
 			ffs.FlushCache()
 		} else {
-			logger.Debug().Str("method", "UpdateSettings").Msg("feature flag service not in context; skipping cache flush on token change")
+			logger.Error().Str("method", "UpdateSettings").Msg("feature flag service not in context; stale feature flag state may persist for new token")
 		}
 	}
 

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -202,7 +202,10 @@ func InitializeSettings(ctx context.Context, conf configuration.Configuration, e
 	if resolver != nil {
 		fm = resolver.ConfigurationOptionsMetaData()
 	}
-	n, _ := notifierFromContext(ctx)
+	n, ok := notifierFromContext(ctx)
+	if !ok {
+		logger.Warn().Str("method", "InitializeSettings").Msg("notifier not in context; locked-field notifications will not be sent")
+	}
 	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
 }
 
@@ -237,7 +240,10 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 	if configResolver != nil {
 		fm = configResolver.ConfigurationOptionsMetaData()
 	}
-	n, _ := notifierFromContext(ctx)
+	n, ok := notifierFromContext(ctx)
+	if !ok {
+		logger.Warn().Str("method", "UpdateSettings").Msg("notifier not in context; locked-field notifications will not be sent")
+	}
 	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
 
 	if ws != nil {
@@ -272,7 +278,10 @@ func refreshLdxSyncOnTokenChange(ctx context.Context, conf configuration.Configu
 		logger.Warn().Msg("ldxSyncService not in context; skipping LDX-Sync refresh on token change")
 		return
 	}
-	notifier, _ := notifierFromContext(ctx)
+	notifier, ok := notifierFromContext(ctx)
+	if !ok {
+		logger.Warn().Msg("notifier not in context; LDX-Sync refresh will proceed without locked-field notifications")
+	}
 	ldxSyncService.RefreshConfigFromLdxSync(context.Background(), conf, engine, logger, folders, notifier)
 }
 
@@ -414,7 +423,10 @@ func processConfigSettings(ctx context.Context, conf configuration.Configuration
 	applySnykLearnCodeActions(conf, engine, logger, settings, triggerSource, configResolver)
 	applySnykOssQuickFixCodeActions(conf, engine, logger, settings, triggerSource, configResolver)
 	applySnykOpenBrowserActions(conf, settings)
-	n, _ := notifierFromContext(ctx)
+	n, ok := notifierFromContext(ctx)
+	if !ok {
+		subLogger.Warn().Msg("notifier not in context; MCP configuration notifications will not be sent")
+	}
 	applyMcpConfiguration(n, conf, engine, logger, settings, triggerSource, configResolver)
 	applyPublishSecurityAtInceptionRules(conf, settings)
 	// this is without function right now, we do not use/distribute proxy settings from/to IDEs

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -234,11 +234,7 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 	// PopulateFolderConfig runs inside processFolderConfigs. Flushing here
 	// ensures every folder sees fresh results with the new token.
 	if newToken := config.GetToken(conf); newToken != "" && newToken != oldToken {
-		if ffs, ok := featureFlagServiceFromContext(ctx); ok {
-			ffs.FlushCache()
-		} else {
-			logger.Error().Str("method", "UpdateSettings").Msg("feature flag service not in context; stale feature flag state may persist for new token")
-		}
+		mustFeatureFlagServiceFromContext(ctx).FlushCache()
 	}
 
 	lockedFolderFields := processFolderConfigs(ctx, conf, engine, logger, folderConfigs, triggerSource, configResolver, globalOrgChanged)
@@ -247,7 +243,8 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 	if configResolver != nil {
 		fm = configResolver.ConfigurationOptionsMetaData()
 	}
-	notifyLockedFieldsRejected(mustNotifierFromContext(ctx), fm, lockedMachineFields, lockedFolderFields)
+	n := mustNotifierFromContext(ctx)
+	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
 
 	if ws != nil {
 		for _, folder := range ws.Folders() {
@@ -260,10 +257,12 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 		}
 	}
 
-	refreshLdxSyncOnTokenChange(ctx, conf, engine, logger, ws, oldToken)
+	refreshLdxSyncOnTokenChange(ctx, conf, engine, logger, ws, oldToken, n)
 }
 
-func refreshLdxSyncOnTokenChange(ctx context.Context, conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, ws types.Workspace, oldToken string) {
+// refreshLdxSyncOnTokenChange triggers an LDX-Sync refresh when the token changes.
+// ldxSyncService is read from ctx via mustLdxSyncServiceFromContext; notifier is passed by the caller.
+func refreshLdxSyncOnTokenChange(ctx context.Context, conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, ws types.Workspace, oldToken string, notifier notification.Notifier) {
 	newToken := config.GetToken(conf)
 	if newToken == oldToken || newToken == "" {
 		return
@@ -276,16 +275,7 @@ func refreshLdxSyncOnTokenChange(ctx context.Context, conf configuration.Configu
 		return
 	}
 	logger.Info().Msg("token changed via settings, refreshing LDX-Sync configuration")
-	ldxSyncService, ok := ldxSyncServiceFromContext(ctx)
-	if !ok {
-		logger.Warn().Msg("ldxSyncService not in context; skipping LDX-Sync refresh on token change")
-		return
-	}
-	n, ok := notifierFromContext(ctx)
-	if !ok {
-		logger.Warn().Msg("notifier not in context; LDX-Sync refresh will proceed without locked-field notifications")
-	}
-	ldxSyncService.RefreshConfigFromLdxSync(context.Background(), conf, engine, logger, folders, n)
+	mustLdxSyncServiceFromContext(ctx).RefreshConfigFromLdxSync(context.Background(), conf, engine, logger, folders, notifier)
 }
 
 // validateLockedMachineFields rejects user PATCH attempts for machine-scope settings

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -212,11 +212,7 @@ func InitializeSettings(ctx context.Context, conf configuration.Configuration, e
 	if resolver != nil {
 		fm = resolver.ConfigurationOptionsMetaData()
 	}
-	n, nOk := notifierFromContext(ctx)
-	if !nOk {
-		logger.Warn().Str("method", "InitializeSettings").Msg("notifier not in context; locked-field notifications will not be sent")
-	}
-	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
+	notifyLockedFieldsRejected(mustNotifierFromContext(ctx), fm, lockedMachineFields, lockedFolderFields)
 	return nil
 }
 
@@ -251,11 +247,7 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 	if configResolver != nil {
 		fm = configResolver.ConfigurationOptionsMetaData()
 	}
-	n, ok := notifierFromContext(ctx)
-	if !ok {
-		logger.Warn().Str("method", "UpdateSettings").Msg("notifier not in context; locked-field notifications will not be sent")
-	}
-	notifyLockedFieldsRejected(n, fm, lockedMachineFields, lockedFolderFields)
+	notifyLockedFieldsRejected(mustNotifierFromContext(ctx), fm, lockedMachineFields, lockedFolderFields)
 
 	if ws != nil {
 		for _, folder := range ws.Folders() {
@@ -289,11 +281,11 @@ func refreshLdxSyncOnTokenChange(ctx context.Context, conf configuration.Configu
 		logger.Warn().Msg("ldxSyncService not in context; skipping LDX-Sync refresh on token change")
 		return
 	}
-	notifier, ok := notifierFromContext(ctx)
+	n, ok := notifierFromContext(ctx)
 	if !ok {
 		logger.Warn().Msg("notifier not in context; LDX-Sync refresh will proceed without locked-field notifications")
 	}
-	ldxSyncService.RefreshConfigFromLdxSync(context.Background(), conf, engine, logger, folders, notifier)
+	ldxSyncService.RefreshConfigFromLdxSync(context.Background(), conf, engine, logger, folders, n)
 }
 
 // validateLockedMachineFields rejects user PATCH attempts for machine-scope settings
@@ -434,11 +426,7 @@ func processConfigSettings(ctx context.Context, conf configuration.Configuration
 	applySnykLearnCodeActions(conf, engine, logger, settings, triggerSource, configResolver)
 	applySnykOssQuickFixCodeActions(conf, engine, logger, settings, triggerSource, configResolver)
 	applySnykOpenBrowserActions(conf, settings)
-	n, ok := notifierFromContext(ctx)
-	if !ok {
-		subLogger.Warn().Msg("notifier not in context; MCP configuration notifications will not be sent")
-	}
-	applyMcpConfiguration(n, conf, engine, logger, settings, triggerSource, configResolver)
+	applyMcpConfiguration(mustNotifierFromContext(ctx), conf, engine, logger, settings, triggerSource, configResolver)
 	applyPublishSecurityAtInceptionRules(conf, settings)
 	// this is without function right now, we do not use/distribute proxy settings from/to IDEs
 	applyProxyConfig(conf, settings)

--- a/application/server/configuration.go
+++ b/application/server/configuration.go
@@ -224,8 +224,10 @@ func UpdateSettings(ctx context.Context, conf configuration.Configuration, engin
 	// PopulateFolderConfig runs inside processFolderConfigs. Flushing here
 	// ensures every folder sees fresh results with the new token.
 	if newToken := config.GetToken(conf); newToken != "" && newToken != oldToken {
-		if svc := di.FeatureFlagService(); svc != nil {
-			svc.FlushCache()
+		if ffs, ok := featureFlagServiceFromContext(ctx); ok {
+			ffs.FlushCache()
+		} else {
+			logger.Debug().Str("method", "UpdateSettings").Msg("feature flag service not in context; skipping cache flush on token change")
 		}
 	}
 

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -89,22 +89,6 @@ func keyFoundInEnv(key string) bool {
 	return found
 }
 
-func contextWithNotifier(ctx context.Context) context.Context {
-	return ctx2.NewContextWithDependencies(ctx, map[string]any{
-		ctx2.DepNotifier: notification.NewMockNotifier(),
-	})
-}
-
-func contextWithResolver(ctx context.Context, engine workflow.Engine) context.Context {
-	existing, _ := ctx2.DependenciesFromContext(ctx)
-	merged := make(map[string]any, len(existing)+1)
-	for k, v := range existing {
-		merged[k] = v
-	}
-	merged[ctx2.DepConfigResolver] = testutil.DefaultConfigResolver(engine)
-	return ctx2.NewContextWithDependencies(ctx, merged)
-}
-
 // testCtx builds a test context with all mandatory DI deps that UpdateSettings /
 // InitializeSettings requires (Notifier, ConfigResolver, AuthService,
 // FeatureFlagService, LdxSyncService, ScanStateAggregator). Engine must be the
@@ -881,51 +865,34 @@ func Test_refreshLdxSyncOnTokenChange_NilNotifier_StillCallsRefresh(t *testing.T
 	refreshLdxSyncOnTokenChange(ctx, conf, engine, engine.GetLogger(), config.GetWorkspace(conf), "old-token", nil)
 }
 
-func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing.T) {
-	engine, tokenService := testutil.IntegTestWithEngine(t)
-	conf := engine.GetConfiguration()
-	if config.GetToken(conf) == "" {
-		t.Skip("SNYK_TOKEN is required to resolve the user's preferred default org via /rest/self")
+func Test_UpdateSettings_BlankOrWhitespaceOrganizationResetsToDefault_Integration(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"blank", ""},
+		{"whitespace", " "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, tokenService := testutil.IntegTestWithEngine(t)
+			conf := engine.GetConfiguration()
+			if config.GetToken(conf) == "" {
+				t.Skip("SNYK_TOKEN is required to resolve the user's preferred default org via /rest/self")
+			}
+			initialOrgId := "00000000-0000-0000-0000-000000000001"
+			config.SetOrganization(conf, initialOrgId)
+			require.Equal(t, initialOrgId, conf.GetString(configuration.ORGANIZATION))
+
+			UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingOrganization: {Value: tc.value, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+
+			// GAF's DefaultValueFunction for ORGANIZATION is synchronous.
+			actualOrg := conf.GetString(configuration.ORGANIZATION)
+			assert.NotEqual(t, initialOrgId, actualOrg)
+			assert.NotEmpty(t, actualOrg)
+			_, err := uuid.Parse(actualOrg)
+			assert.NoError(t, err, "resolved org should be a valid UUID")
+		})
 	}
-
-	// Set to a specific org first
-	initialOrgId := "00000000-0000-0000-0000-000000000001"
-	config.SetOrganization(conf, initialOrgId)
-	require.Equal(t, initialOrgId, conf.GetString(configuration.ORGANIZATION), "org should be set to the value we just set it to")
-
-	// Set to empty string to reset to the user's preferred default org they defined in the web UI.
-	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingOrganization: {Value: "", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
-
-	// GAF's DefaultValueFunction for ORGANIZATION is synchronous: GetString blocks until the API call completes.
-	actualOrg := conf.GetString(configuration.ORGANIZATION)
-	assert.NotEqual(t, initialOrgId, actualOrg, "org should have changed from initial value")
-	assert.NotEmpty(t, actualOrg, "org should have resolved to the user's preferred default org they defined in the web UI")
-	_, err := uuid.Parse(actualOrg)
-	assert.NoError(t, err, "resolved org should be a valid UUID")
-}
-
-func Test_UpdateSettings_WhitespaceOrganizationResetsToDefault_Integration(t *testing.T) {
-	engine, tokenService := testutil.IntegTestWithEngine(t)
-	conf := engine.GetConfiguration()
-	if config.GetToken(conf) == "" {
-		t.Skip("SNYK_TOKEN is required to resolve the user's preferred default org via /rest/self")
-	}
-
-	// Set to a specific org first
-	initialOrgId := "00000000-0000-0000-0000-000000000001"
-	config.SetOrganization(conf, initialOrgId)
-	require.Equal(t, initialOrgId, conf.GetString(configuration.ORGANIZATION), "org should be set to the value we just set it to")
-
-	// Set to whitespace to reset to the user's preferred default org they defined in the web UI.
-	// Whitespace should be trimmed to empty string.
-	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingOrganization: {Value: " ", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
-
-	// GAF's DefaultValueFunction for ORGANIZATION is synchronous: GetString blocks until the API call completes.
-	actualOrg := conf.GetString(configuration.ORGANIZATION)
-	assert.NotEqual(t, initialOrgId, actualOrg, "org should have changed from initial value")
-	assert.NotEmpty(t, actualOrg, "org should have resolved to the user's preferred default org they defined in the web UI")
-	_, err := uuid.Parse(actualOrg)
-	assert.NoError(t, err, "resolved org should be a valid UUID")
 }
 
 // Common test setup for updateFolderConfig tests

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -92,6 +92,16 @@ func contextWithNotifier(ctx context.Context) context.Context {
 	})
 }
 
+func contextWithResolver(ctx context.Context, engine workflow.Engine) context.Context {
+	existing, _ := ctx2.DependenciesFromContext(ctx)
+	merged := make(map[string]any, len(existing)+1)
+	for k, v := range existing {
+		merged[k] = v
+	}
+	merged[ctx2.DepConfigResolver] = testutil.DefaultConfigResolver(engine)
+	return ctx2.NewContextWithDependencies(ctx, merged)
+}
+
 func Test_WorkspaceDidChangeConfiguration_Push(t *testing.T) {
 	engine, tokenService := testutil.UnitTestWithEngine(t)
 	loc, _, _ := setupServer(t, engine, tokenService)
@@ -202,12 +212,12 @@ func Test_InitializeSettings_PreservesRefreshedOAuthTokenWhenInitializeSendsStal
 
 	di.AuthenticationService().UpdateCredentials(refreshedToken, true, false)
 
-	InitializeSettings(contextWithNotifier(t.Context()), conf, engine, logger, types.InitializationOptions{
+	require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), conf, engine, logger, types.InitializationOptions{
 		Settings: map[string]*types.ConfigSetting{
 			types.SettingToken:                {Value: staleToken, Changed: true},
 			types.SettingAuthenticationMethod: {Value: string(types.OAuthAuthentication), Changed: true},
 		},
-	})
+	}))
 
 	assert.Equal(t, refreshedToken, config.GetToken(conf))
 	require.Eventually(t, func() bool {
@@ -364,14 +374,12 @@ func Test_UpdateSettings(t *testing.T) {
 		// Path is init-only; apply via InitializeSettings first.
 		// TrustedFolders now goes through the settings map.
 		settingsMap[types.SettingTrustedFolders] = &types.ConfigSetting{Value: []interface{}{"trustedPath1", "trustedPath2"}, Changed: true}
-		// Build the context from the deps returned by di.TestInit rather than manually
-		// instantiating services, so the context always uses the same instances that
-		// di.TestInit wired together.
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepNotifier:    deps.Notifier,
-			ctx2.DepAuthService: deps.AuthenticationService,
+			ctx2.DepNotifier:       deps.Notifier,
+			ctx2.DepAuthService:    deps.AuthenticationService,
+			ctx2.DepConfigResolver: deps.ConfigResolver,
 		})
-		InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
+		require.NoError(t, InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Path:           "addPath",
 			OsPlatform:     "windows",
 			OsArch:         "amd64",
@@ -379,7 +387,7 @@ func Test_UpdateSettings(t *testing.T) {
 			RuntimeVersion: "1.8.0_275",
 			HoverVerbosity: &hoverVerbosity,
 			OutputFormat:   &outputFormat,
-		})
+		}))
 		UpdateSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), settingsMap, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.Equal(t, false, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)))
@@ -474,11 +482,11 @@ func Test_UpdateSettings(t *testing.T) {
 
 			path1 := filepath.Join("a", "b")
 			path2 := filepath.Join("b", "c")
-			InitializeSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
+			require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 				Settings: map[string]*types.ConfigSetting{
 					types.SettingTrustedFolders: {Value: []interface{}{path1, path2}, Changed: true},
 				},
-			})
+			}))
 
 			tf := types.GetGlobalSliceFilePath(engine.GetConfiguration(), types.SettingTrustedFolders)
 			assert.Contains(t, tf, types.FilePath(path1))
@@ -497,7 +505,7 @@ func Test_UpdateSettings(t *testing.T) {
 					types.SettingTrustedFolders: {Value: []interface{}{path1, path2}, Changed: true},
 				},
 			}
-			_, err := handlePushModel(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), params)
+			_, err := handlePushModel(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), params)
 			assert.NoError(t, err)
 
 			tf := types.GetGlobalSliceFilePath(engine.GetConfiguration(), types.SettingTrustedFolders)
@@ -1114,7 +1122,7 @@ func Test_InitializeSettings(t *testing.T) {
 		engine, _ := testutil.UnitTestWithEngine(t)
 		deviceId := "test-device-id"
 
-		InitializeSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{DeviceId: deviceId})
+		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{DeviceId: deviceId}))
 
 		assert.Equal(t, deviceId, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingDeviceId)))
 	})
@@ -1123,7 +1131,7 @@ func Test_InitializeSettings(t *testing.T) {
 		engine, _ := testutil.UnitTestWithEngine(t)
 		deviceId := engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingDeviceId))
 
-		InitializeSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{})
+		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{}))
 
 		assert.Equal(t, deviceId, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingDeviceId)))
 	})
@@ -1131,16 +1139,16 @@ func Test_InitializeSettings(t *testing.T) {
 	t.Run("activateSnykCodeSecurity enables SnykCode via OR on init", func(t *testing.T) {
 		engine, _ := testutil.UnitTestWithEngine(t)
 
-		InitializeSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
+		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Settings: map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}},
-		})
+		}))
 
 		assert.True(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)), "snyk_code_enabled should enable Snyk Code on init")
 	})
 	t.Run("activateSnykCodeSecurity not passed does not enable SnykCode on init", func(t *testing.T) {
 		engine, _ := testutil.UnitTestWithEngine(t)
 
-		InitializeSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{})
+		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{}))
 
 		assert.False(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)))
 	})
@@ -1155,20 +1163,18 @@ func Test_InitializeSettings(t *testing.T) {
 		caseSensitivePathKey := "Path"
 		t.Setenv(caseSensitivePathKey, "something_meaningful")
 
-		// Path is init-only; use InitializeSettings
-		ctx := contextWithNotifier(t.Context())
-		InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{Path: first})
+		ctx := contextWithResolver(contextWithNotifier(t.Context()), engine)
+		require.NoError(t, InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{Path: first}))
 		assert.True(t, strings.HasPrefix(os.Getenv(upperCasePathKey), first+string(os.PathListSeparator)))
 
-		InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{Path: second})
+		require.NoError(t, InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{Path: second}))
 		assert.True(t, strings.HasPrefix(os.Getenv(upperCasePathKey), second+string(os.PathListSeparator)))
 		assert.False(t, strings.Contains(os.Getenv(upperCasePathKey), first))
 
-		// reset path and set auth method
-		InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
+		require.NoError(t, InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Path:     "",
 			Settings: map[string]*types.ConfigSetting{types.SettingAuthenticationMethod: {Value: "token", Changed: true}},
-		})
+		}))
 		assert.False(t, strings.Contains(os.Getenv(upperCasePathKey), second))
 
 		assert.True(t, keyFoundInEnv(upperCasePathKey))

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -375,11 +375,11 @@ func Test_UpdateSettings(t *testing.T) {
 		// TrustedFolders now goes through the settings map.
 		settingsMap[types.SettingTrustedFolders] = &types.ConfigSetting{Value: []interface{}{"trustedPath1", "trustedPath2"}, Changed: true}
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepNotifier:          deps.Notifier,
-			ctx2.DepAuthService:       deps.AuthenticationService,
-			ctx2.DepConfigResolver:    deps.ConfigResolver,
+			ctx2.DepNotifier:           deps.Notifier,
+			ctx2.DepAuthService:        deps.AuthenticationService,
+			ctx2.DepConfigResolver:     deps.ConfigResolver,
 			ctx2.DepFeatureFlagService: deps.FeatureFlagService,
-			ctx2.DepLdxSyncService:    deps.LdxSyncService,
+			ctx2.DepLdxSyncService:     deps.LdxSyncService,
 		})
 		require.NoError(t, InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Path:           "addPath",

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -710,16 +710,17 @@ func initTestRepo(t *testing.T, tempDir string) error {
 func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 	t.Run("new token triggers refresh", func(t *testing.T) {
 		engine, tokenService := testutil.UnitTestWithEngine(t)
-		di.TestInit(t, engine, tokenService, nil)
+		deps := di.TestInit(t, engine, tokenService, nil)
 
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
 
 		mockLdx := mock_command.NewMockLdxSyncService(ctrl)
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepLdxSyncService: mockLdx,
-			ctx2.DepNotifier:       notification.NewMockNotifier(),
-			ctx2.DepAuthService:    di.AuthenticationService(),
+			ctx2.DepLdxSyncService:     mockLdx,
+			ctx2.DepNotifier:           notification.NewMockNotifier(),
+			ctx2.DepAuthService:        deps.AuthenticationService,
+			ctx2.DepFeatureFlagService: deps.FeatureFlagService,
 		})
 
 		folderPath := types.FilePath(t.TempDir())
@@ -747,15 +748,16 @@ func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			engine, tokenService := testutil.UnitTestWithEngine(t)
-			di.TestInit(t, engine, tokenService, nil)
+			deps := di.TestInit(t, engine, tokenService, nil)
 
 			ctrl := gomock.NewController(t)
 			t.Cleanup(ctrl.Finish)
 
 			mockLdx := mock_command.NewMockLdxSyncService(ctrl)
 			ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-				ctx2.DepLdxSyncService: mockLdx,
-				ctx2.DepNotifier:       notification.NewMockNotifier(),
+				ctx2.DepLdxSyncService:     mockLdx,
+				ctx2.DepNotifier:           notification.NewMockNotifier(),
+				ctx2.DepFeatureFlagService: deps.FeatureFlagService,
 			})
 
 			folderPath := types.FilePath(t.TempDir())
@@ -775,15 +777,16 @@ func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 
 	t.Run("no workspace folders skips refresh", func(t *testing.T) {
 		engine, tokenService := testutil.UnitTestWithEngine(t)
-		di.TestInit(t, engine, tokenService, nil)
+		deps := di.TestInit(t, engine, tokenService, nil)
 
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
 
 		mockLdx := mock_command.NewMockLdxSyncService(ctrl)
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepLdxSyncService: mockLdx,
-			ctx2.DepNotifier:       notification.NewMockNotifier(),
+			ctx2.DepLdxSyncService:     mockLdx,
+			ctx2.DepNotifier:           notification.NewMockNotifier(),
+			ctx2.DepFeatureFlagService: deps.FeatureFlagService,
 		})
 
 		tokenService.SetToken(engine.GetConfiguration(), "old-token")
@@ -798,9 +801,8 @@ func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 	})
 }
 
-func Test_refreshLdxSyncOnTokenChange_NotifierAbsentFromContext_StillCallsRefresh(t *testing.T) {
-	// When the notifier is not in context, refreshLdxSyncOnTokenChange must log a warning
-	// but must still call RefreshConfigFromLdxSync (nil notifier is tolerated by that function).
+func Test_refreshLdxSyncOnTokenChange_NilNotifier_StillCallsRefresh(t *testing.T) {
+	// Passing nil for the notifier must still call RefreshConfigFromLdxSync — it tolerates nil.
 	engine, tokenService := testutil.UnitTestWithEngine(t)
 	di.TestInit(t, engine, tokenService, nil)
 
@@ -830,7 +832,8 @@ func Test_refreshLdxSyncOnTokenChange_NotifierAbsentFromContext_StillCallsRefres
 	// (We bypass UpdateSettings to avoid the processFolderConfigs → mustNotifierFromContext path.)
 	tokenService.SetToken(conf, "new-token")
 	// Explicitly call the function under test.
-	refreshLdxSyncOnTokenChange(ctx, conf, engine, engine.GetLogger(), config.GetWorkspace(conf), "old-token")
+	// nil notifier: verifies that RefreshConfigFromLdxSync is still called even without one.
+	refreshLdxSyncOnTokenChange(ctx, conf, engine, engine.GetLogger(), config.GetWorkspace(conf), "old-token", nil)
 }
 
 func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing.T) {
@@ -887,12 +890,13 @@ type folderConfigTestSetup struct {
 	engineConfig configuration.Configuration
 	logger       *zerolog.Logger
 	folderPath   types.FilePath
+	deps         di.Dependencies
 }
 
 func setupFolderConfigTest(t *testing.T) *folderConfigTestSetup {
 	t.Helper()
 	engine, tokenService := testutil.UnitTestWithEngine(t)
-	di.TestInit(t, engine, tokenService, nil)
+	deps := di.TestInit(t, engine, tokenService, nil)
 
 	engineConfig := engine.GetConfiguration()
 
@@ -914,6 +918,7 @@ func setupFolderConfigTest(t *testing.T) *folderConfigTestSetup {
 		engineConfig: engineConfig,
 		logger:       logger,
 		folderPath:   folderPath,
+		deps:         deps,
 	}
 }
 
@@ -1199,9 +1204,10 @@ func Test_processFolderConfigs_AutoMode_DoesNotLeakGlobalOrgToLdxSync(t *testing
 	mockApiClient := mock_command.NewMockLdxSyncApiClient(ctrl)
 	realService := command.NewLdxSyncServiceWithApiClient(mockApiClient, testutil.DefaultConfigResolver(setup.engine))
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: realService,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
-		ctx2.DepAuthService:    di.AuthenticationService(),
+		ctx2.DepLdxSyncService:     realService,
+		ctx2.DepNotifier:           notification.NewMockNotifier(),
+		ctx2.DepAuthService:        setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService: setup.deps.FeatureFlagService,
 	})
 
 	folders := config.GetWorkspace(setup.engine.GetConfiguration()).Folders()

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -50,9 +50,12 @@ import (
 	mock_command "github.com/snyk/snyk-ls/domain/ide/command/mock"
 	"github.com/snyk/snyk-ls/domain/scanstates"
 	"github.com/snyk/snyk-ls/infrastructure/analytics"
+	"github.com/snyk/snyk-ls/infrastructure/authentication"
+	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	ctx2 "github.com/snyk/snyk-ls/internal/context"
 	"github.com/snyk/snyk-ls/internal/folderconfig"
 	"github.com/snyk/snyk-ls/internal/notification"
+	er "github.com/snyk/snyk-ls/internal/observability/error_reporting"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/testutil/workspaceutil"
@@ -100,6 +103,43 @@ func contextWithResolver(ctx context.Context, engine workflow.Engine) context.Co
 	}
 	merged[ctx2.DepConfigResolver] = testutil.DefaultConfigResolver(engine)
 	return ctx2.NewContextWithDependencies(ctx, merged)
+}
+
+// testCtx builds a test context with all mandatory DI deps that UpdateSettings /
+// InitializeSettings requires (Notifier, ConfigResolver, AuthService,
+// FeatureFlagService, LdxSyncService, ScanStateAggregator). Engine must be the
+// same instance passed to UpdateSettings / InitializeSettings so configuration
+// reads are consistent.
+func testCtx(t *testing.T, ctx context.Context, engine workflow.Engine, tokenService types.TokenService) context.Context {
+	t.Helper()
+	cr := testutil.DefaultConfigResolver(engine)
+	notifier := notification.NewMockNotifier()
+	authSvc := authentication.NewAuthenticationService(
+		engine,
+		tokenService,
+		authentication.NewFakeCliAuthenticationProvider(engine),
+		er.NewTestErrorReporter(engine),
+		notifier,
+		cr,
+	)
+	t.Cleanup(authSvc.Shutdown)
+	ffSvc := featureflag.New(engine.GetConfiguration(), engine.GetLogger(), engine, cr)
+	ldxSvc := command.NewLdxSyncService(cr)
+	deps := map[string]any{
+		ctx2.DepNotifier:            notifier,
+		ctx2.DepConfigResolver:      cr,
+		ctx2.DepAuthService:         authSvc,
+		ctx2.DepFeatureFlagService:  ffSvc,
+		ctx2.DepLdxSyncService:      ldxSvc,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+	}
+	existing, _ := ctx2.DependenciesFromContext(ctx)
+	for k, v := range existing {
+		if _, already := deps[k]; !already {
+			deps[k] = v
+		}
+	}
+	return ctx2.NewContextWithDependencies(ctx, deps)
 }
 
 func Test_WorkspaceDidChangeConfiguration_Push(t *testing.T) {
@@ -210,9 +250,12 @@ func Test_InitializeSettings_PreservesRefreshedOAuthTokenWhenInitializeSendsStal
 	})
 	t.Cleanup(func() { di.Notifier().DisposeListener() })
 
+	// UpdateCredentials on the global singleton: both the global service and testCtx's
+	// service write through to the shared engine configuration, so the refreshed token
+	// is visible to whichever service instance ends up in the context.
 	di.AuthenticationService().UpdateCredentials(refreshedToken, true, false)
 
-	require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), conf, engine, logger, types.InitializationOptions{
+	require.NoError(t, InitializeSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, logger, types.InitializationOptions{
 		Settings: map[string]*types.ConfigSetting{
 			types.SettingToken:                {Value: staleToken, Changed: true},
 			types.SettingAuthenticationMethod: {Value: string(types.OAuthAuthentication), Changed: true},
@@ -444,34 +487,34 @@ func Test_UpdateSettings(t *testing.T) {
 	})
 
 	t.Run("hover defaults are set", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		engine, tokenService := testutil.UnitTestWithEngine(t)
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.Equal(t, 3, types.GetGlobalInt(engine.GetConfiguration(), types.SettingHoverVerbosity))
 		assert.Equal(t, config.FormatMd, types.GetGlobalString(engine.GetConfiguration(), types.SettingFormat))
 	})
 
 	t.Run("incomplete env vars", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAdditionalEnvironment: {Value: "a=", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAdditionalEnvironment: {Value: "a=", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.Empty(t, os.Getenv("a"))
 	})
 
 	t.Run("empty env vars", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 		varCount := len(os.Environ())
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAdditionalEnvironment: {Value: " ", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAdditionalEnvironment: {Value: " ", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.Equal(t, varCount, len(os.Environ()))
 	})
 
 	t.Run("broken env variables", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAdditionalEnvironment: {Value: "a=; b", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAdditionalEnvironment: {Value: "a=; b", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.Empty(t, os.Getenv("a"))
 		assert.Empty(t, os.Getenv("b"))
@@ -484,7 +527,7 @@ func Test_UpdateSettings(t *testing.T) {
 
 			path1 := filepath.Join("a", "b")
 			path2 := filepath.Join("b", "c")
-			require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
+			require.NoError(t, InitializeSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 				Settings: map[string]*types.ConfigSetting{
 					types.SettingTrustedFolders: {Value: []interface{}{path1, path2}, Changed: true},
 				},
@@ -507,7 +550,7 @@ func Test_UpdateSettings(t *testing.T) {
 					types.SettingTrustedFolders: {Value: []interface{}{path1, path2}, Changed: true},
 				},
 			}
-			_, err := handlePushModel(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), params)
+			_, err := handlePushModel(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), params)
 			assert.NoError(t, err)
 
 			tf := types.GetGlobalSliceFilePath(engine.GetConfiguration(), types.SettingTrustedFolders)
@@ -517,20 +560,20 @@ func Test_UpdateSettings(t *testing.T) {
 	})
 
 	t.Run("manage binaries automatically", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 		t.Run("true", func(t *testing.T) {
-			UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAutomaticDownload: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+			UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAutomaticDownload: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 			assert.True(t, types.GetGlobalBool(engine.GetConfiguration(), types.SettingAutomaticDownload))
 		})
 		t.Run("false", func(t *testing.T) {
-			UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAutomaticDownload: {Value: false, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+			UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAutomaticDownload: {Value: false, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 			assert.False(t, types.GetGlobalBool(engine.GetConfiguration(), types.SettingAutomaticDownload))
 		})
 
 		t.Run("invalid value does not update", func(t *testing.T) {
-			ctx := contextWithNotifier(t.Context())
+			ctx := testCtx(t, t.Context(), engine, tokenService)
 			UpdateSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAutomaticDownload: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 			UpdateSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingAutomaticDownload: {Value: "dog", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -540,30 +583,30 @@ func Test_UpdateSettings(t *testing.T) {
 	})
 
 	t.Run("activateSnykCodeSecurity enables SnykCode via OR", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.True(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)), "snyk_code_enabled should enable Snyk Code")
 	})
 	t.Run("activateSnykCode and activateSnykCodeSecurity are ORed", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.True(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)), "Should be enabled when snyk_code_enabled is true")
 	})
 	t.Run("activateSnykCode alone enables SnykCode", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.True(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)))
 	})
 	t.Run("neither activateSnykCode nor activateSnykCodeSecurity disables SnykCode", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: false, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: false, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.False(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)))
 	})
@@ -572,7 +615,7 @@ func Test_UpdateSettings(t *testing.T) {
 		engine, tokenService := testutil.UnitTestWithEngine(t)
 		di.TestInit(t, engine, tokenService, nil)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykSecretsEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykSecretsEnabled: {Value: true, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.True(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled)))
 	})
@@ -580,7 +623,7 @@ func Test_UpdateSettings(t *testing.T) {
 		engine, tokenService := testutil.UnitTestWithEngine(t)
 		di.TestInit(t, engine, tokenService, nil)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykSecretsEnabled: {Value: false, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingSnykSecretsEnabled: {Value: false, Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.False(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled)))
 	})
@@ -590,16 +633,16 @@ func Test_UpdateSettings(t *testing.T) {
 
 		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled), true)
 
-		UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+		UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 		assert.True(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykSecretsEnabled)))
 	})
 
 	t.Run("severity filter", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 		t.Run("filtering gets passed", func(t *testing.T) {
 			mixedSeverityFilter := types.NewSeverityFilter(true, false, true, false)
-			UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+			UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 				types.SettingSeverityFilterCritical: {Value: true, Changed: true},
 				types.SettingSeverityFilterHigh:     {Value: false, Changed: true},
 				types.SettingSeverityFilterMedium:   {Value: true, Changed: true},
@@ -610,7 +653,7 @@ func Test_UpdateSettings(t *testing.T) {
 		})
 		t.Run("equivalent of the \"empty\" struct as a filter gets passed", func(t *testing.T) {
 			emptyLikeSeverityFilter := types.NewSeverityFilter(false, false, false, false)
-			UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+			UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 				types.SettingSeverityFilterCritical: {Value: false, Changed: true},
 				types.SettingSeverityFilterHigh:     {Value: false, Changed: true},
 				types.SettingSeverityFilterMedium:   {Value: false, Changed: true},
@@ -621,7 +664,7 @@ func Test_UpdateSettings(t *testing.T) {
 		})
 		t.Run("omitting filter does not cause an update", func(t *testing.T) {
 			mixedSeverityFilter := types.NewSeverityFilter(false, false, true, false)
-			ctx := contextWithNotifier(t.Context())
+			ctx := testCtx(t, t.Context(), engine, tokenService)
 			UpdateSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 				types.SettingSeverityFilterCritical: {Value: false, Changed: true},
 				types.SettingSeverityFilterHigh:     {Value: false, Changed: true},
@@ -635,7 +678,7 @@ func Test_UpdateSettings(t *testing.T) {
 		})
 		t.Run("partial update preserves unchanged severities", func(t *testing.T) {
 			// Set initial state: Critical=false, High=false, Medium=true, Low=false
-			ctx := contextWithNotifier(t.Context())
+			ctx := testCtx(t, t.Context(), engine, tokenService)
 			UpdateSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 				types.SettingSeverityFilterCritical: {Value: false, Changed: true},
 				types.SettingSeverityFilterHigh:     {Value: false, Changed: true},
@@ -655,10 +698,10 @@ func Test_UpdateSettings(t *testing.T) {
 	})
 
 	t.Run("issue view options", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 		t.Run("filtering gets passed", func(t *testing.T) {
 			mixedIssueViewOptions := types.NewIssueViewOptions(false, true)
-			UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+			UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 				types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
 				types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
 			}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -667,7 +710,7 @@ func Test_UpdateSettings(t *testing.T) {
 		})
 		t.Run("equivalent of the \"empty\" struct as a filter gets passed", func(t *testing.T) {
 			emptyLikeIssueViewOptions := types.NewIssueViewOptions(false, false)
-			UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+			UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 				types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
 				types.SettingIssueViewIgnoredIssues: {Value: false, Changed: true},
 			}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -676,7 +719,7 @@ func Test_UpdateSettings(t *testing.T) {
 		})
 		t.Run("omitting filter does not cause an update", func(t *testing.T) {
 			mixedIssueViewOptions := types.NewIssueViewOptions(false, true)
-			ctx := contextWithNotifier(t.Context())
+			ctx := testCtx(t, t.Context(), engine, tokenService)
 			UpdateSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 				types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
 				types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
@@ -757,6 +800,7 @@ func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 			ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
 				ctx2.DepLdxSyncService:     mockLdx,
 				ctx2.DepNotifier:           notification.NewMockNotifier(),
+				ctx2.DepAuthService:        deps.AuthenticationService,
 				ctx2.DepFeatureFlagService: deps.FeatureFlagService,
 			})
 
@@ -786,6 +830,7 @@ func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
 			ctx2.DepLdxSyncService:     mockLdx,
 			ctx2.DepNotifier:           notification.NewMockNotifier(),
+			ctx2.DepAuthService:        deps.AuthenticationService,
 			ctx2.DepFeatureFlagService: deps.FeatureFlagService,
 		})
 
@@ -837,7 +882,7 @@ func Test_refreshLdxSyncOnTokenChange_NilNotifier_StillCallsRefresh(t *testing.T
 }
 
 func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing.T) {
-	engine := testutil.IntegTest(t)
+	engine, tokenService := testutil.IntegTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	if config.GetToken(conf) == "" {
 		t.Skip("SNYK_TOKEN is required to resolve the user's preferred default org via /rest/self")
@@ -849,7 +894,7 @@ func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing
 	require.Equal(t, initialOrgId, conf.GetString(configuration.ORGANIZATION), "org should be set to the value we just set it to")
 
 	// Set to empty string to reset to the user's preferred default org they defined in the web UI.
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingOrganization: {Value: "", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingOrganization: {Value: "", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 	// GAF's DefaultValueFunction for ORGANIZATION is synchronous: GetString blocks until the API call completes.
 	actualOrg := conf.GetString(configuration.ORGANIZATION)
@@ -860,7 +905,7 @@ func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing
 }
 
 func Test_UpdateSettings_WhitespaceOrganizationResetsToDefault_Integration(t *testing.T) {
-	engine := testutil.IntegTest(t)
+	engine, tokenService := testutil.IntegTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	if config.GetToken(conf) == "" {
 		t.Skip("SNYK_TOKEN is required to resolve the user's preferred default org via /rest/self")
@@ -873,7 +918,7 @@ func Test_UpdateSettings_WhitespaceOrganizationResetsToDefault_Integration(t *te
 
 	// Set to whitespace to reset to the user's preferred default org they defined in the web UI.
 	// Whitespace should be trimmed to empty string.
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingOrganization: {Value: " ", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{types.SettingOrganization: {Value: " ", Changed: true}}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 	// GAF's DefaultValueFunction for ORGANIZATION is synchronous: GetString blocks until the API call completes.
 	actualOrg := conf.GetString(configuration.ORGANIZATION)
@@ -891,6 +936,7 @@ type folderConfigTestSetup struct {
 	logger       *zerolog.Logger
 	folderPath   types.FilePath
 	deps         di.Dependencies
+	tokenService types.TokenService
 }
 
 func setupFolderConfigTest(t *testing.T) *folderConfigTestSetup {
@@ -919,6 +965,7 @@ func setupFolderConfigTest(t *testing.T) *folderConfigTestSetup {
 		logger:       logger,
 		folderPath:   folderPath,
 		deps:         deps,
+		tokenService: tokenService,
 	}
 }
 
@@ -972,7 +1019,7 @@ func Test_updateFolderConfig_UserSetOrg_PreservedOnUpdate(t *testing.T) {
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), settingsMap, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), settingsMap, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 	// Verify the org was kept by reading directly from configuration
 	snap := types.ReadFolderConfigSnapshot(engineConfig, folderPath)
@@ -990,7 +1037,7 @@ func Test_updateFolderConfig_EmptyOrgSent_LeavesPreferredOrgEmpty(t *testing.T) 
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	updatedConfig := setup.getUpdatedConfig()
 	assert.False(t, updatedConfig.OrgSetByUser(), "OrgSetByUser should be false in auto mode")
@@ -1009,7 +1056,7 @@ func Test_updateFolderConfig_EmptyStoredOrg_LeavesPreferredOrgEmpty(t *testing.T
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	updatedConfig := setup.getUpdatedConfig()
 	assert.False(t, updatedConfig.OrgSetByUser(), "OrgSetByUser should be false in auto mode")
@@ -1029,7 +1076,7 @@ func Test_updateFolderConfig_LdxSyncReturnsDifferentOrg(t *testing.T) {
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	updatedConfig := setup.getUpdatedConfig()
 	assert.False(t, updatedConfig.OrgSetByUser(), "OrgSetByUser should be false when inheriting from LDX-Sync")
@@ -1051,7 +1098,7 @@ func Test_updateFolderConfig_UserSetButInheritingFromBlankGlobal(t *testing.T) {
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	// Verify: should attempt to resolve from LDX-Sync because inheriting from blank global
 	// This test specifically checks the case where both folder and global orgs are empty
@@ -1087,7 +1134,7 @@ func Test_updateFolderConfig_SkipsUpdateWhenConfigUnchanged(t *testing.T) {
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), settingsMap, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), settingsMap, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 	// Verify config remains unchanged by reading directly from configuration
 	snap := types.ReadFolderConfigSnapshot(engineConfig, folderPath)
@@ -1117,7 +1164,7 @@ func Test_updateFolderConfig_HandlesNilStoredConfig(t *testing.T) {
 	}
 
 	// Should not panic and should handle nil gracefully
-	UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), settingsMap, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), settingsMap, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 	// If we get here without panic, the nil check worked
 }
 
@@ -1126,42 +1173,42 @@ func Test_InitializeSettings(t *testing.T) {
 	di.TestInit(t, engine, tokenService, nil)
 
 	t.Run("device ID is passed", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 		deviceId := "test-device-id"
 
-		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{DeviceId: deviceId}))
+		require.NoError(t, InitializeSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{DeviceId: deviceId}))
 
 		assert.Equal(t, deviceId, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingDeviceId)))
 	})
 
 	t.Run("device ID is not passed", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 		deviceId := engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingDeviceId))
 
-		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{}))
+		require.NoError(t, InitializeSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{}))
 
 		assert.Equal(t, deviceId, engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingDeviceId)))
 	})
 
 	t.Run("activateSnykCodeSecurity enables SnykCode via OR on init", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
+		require.NoError(t, InitializeSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Settings: map[string]*types.ConfigSetting{types.SettingSnykCodeEnabled: {Value: true, Changed: true}},
 		}))
 
 		assert.True(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)), "snyk_code_enabled should enable Snyk Code on init")
 	})
 	t.Run("activateSnykCodeSecurity not passed does not enable SnykCode on init", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
-		require.NoError(t, InitializeSettings(contextWithResolver(contextWithNotifier(t.Context()), engine), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{}))
+		require.NoError(t, InitializeSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{}))
 
 		assert.False(t, engine.GetConfiguration().GetBool(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled)))
 	})
 
 	t.Run("custom path configuration", func(t *testing.T) {
-		engine, _ := testutil.UnitTestWithEngine(t)
+		engine, tokenService := testutil.UnitTestWithEngine(t)
 
 		first := "first"
 		second := "second"
@@ -1170,7 +1217,7 @@ func Test_InitializeSettings(t *testing.T) {
 		caseSensitivePathKey := "Path"
 		t.Setenv(caseSensitivePathKey, "something_meaningful")
 
-		ctx := contextWithResolver(contextWithNotifier(t.Context()), engine)
+		ctx := testCtx(t, t.Context(), engine, tokenService)
 		require.NoError(t, InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{Path: first}))
 		assert.True(t, strings.HasPrefix(os.Getenv(upperCasePathKey), first+string(os.PathListSeparator)))
 
@@ -1204,10 +1251,12 @@ func Test_processFolderConfigs_AutoMode_DoesNotLeakGlobalOrgToLdxSync(t *testing
 	mockApiClient := mock_command.NewMockLdxSyncApiClient(ctrl)
 	realService := command.NewLdxSyncServiceWithApiClient(mockApiClient, testutil.DefaultConfigResolver(setup.engine))
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService:     realService,
-		ctx2.DepNotifier:           notification.NewMockNotifier(),
-		ctx2.DepAuthService:        setup.deps.AuthenticationService,
-		ctx2.DepFeatureFlagService: setup.deps.FeatureFlagService,
+		ctx2.DepLdxSyncService:      realService,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  setup.deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(setup.engine),
 	})
 
 	folders := config.GetWorkspace(setup.engine.GetConfiguration()).Folders()
@@ -1248,7 +1297,7 @@ func Test_updateFolderConfig_AutoMode_EmptyOrg_LeavesPreferredOrgEmpty(t *testin
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	updatedConfig := setup.getUpdatedConfig()
 	assert.False(t, updatedConfig.OrgSetByUser(), "OrgSetByUser should be false in auto mode")
@@ -1263,8 +1312,12 @@ func Test_updateFolderConfig_OrgChange_TriggersLdxSyncRefresh(t *testing.T) {
 
 	mockLdxSyncService := mock_command.NewMockLdxSyncService(ctrl)
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: mockLdxSyncService,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
+		ctx2.DepLdxSyncService:      mockLdxSyncService,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  setup.deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(setup.engine),
 	})
 
 	setup.createStoredConfig("initial-org", true)
@@ -1307,7 +1360,7 @@ func Test_updateFolderConfig_StoredUserOrg_PreservedOnUpdate(t *testing.T) {
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	updatedConfig := setup.getUpdatedConfig()
 	assert.Equal(t, "user-chosen-org", updatedConfig.PreferredOrg(), "User-set org should be preserved")
@@ -1327,8 +1380,12 @@ func Test_updateFolderConfig_MissingAutoDeterminedOrg(t *testing.T) {
 		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1)
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: mockLdx,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
+		ctx2.DepLdxSyncService:      mockLdx,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  setup.deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(setup.engine),
 	})
 
 	// Setup folderConfig WITHOUT AutoDeterminedOrg (simulating old config)
@@ -1367,8 +1424,12 @@ func Test_updateFolderConfig_SwitchFromAutoToManualOrg(t *testing.T) {
 		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1)
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: mockLdx,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
+		ctx2.DepLdxSyncService:      mockLdx,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  setup.deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(setup.engine),
 	})
 
 	userManualOrg := "user-manual-org"
@@ -1405,7 +1466,7 @@ func Test_updateFolderConfig_Unauthenticated_UserSetsPreferredOrg(t *testing.T) 
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 	updatedConfig, err := folderconfig.GetOrCreateFolderConfig(engineConfig, folderPath, engine.GetLogger())
 	require.NoError(t, err)
@@ -1431,7 +1492,7 @@ func Test_updateFolderConfig_ProcessesLspFolderConfigUpdates(t *testing.T) {
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	// Verify: UserOverrides should be set in folderConfig
 	updatedConfig := setup.getUpdatedConfig()
@@ -1449,13 +1510,16 @@ func Test_FC105_WriteSettings_OldFormat_ProcessesSettingsStruct(t *testing.T) {
 	mockLdx.EXPECT().
 		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1)
-	di.TestInit(t, engine, tokenService, &di.Dependencies{
+	deps := di.TestInit(t, engine, tokenService, &di.Dependencies{
 		LdxSyncService: mockLdx,
 	})
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: mockLdx,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
-		ctx2.DepAuthService:    di.AuthenticationService(),
+		ctx2.DepLdxSyncService:      mockLdx,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(engine),
 	})
 
 	folderPath := types.FilePath(t.TempDir())
@@ -1497,7 +1561,7 @@ func Test_FC106_WriteSettings_NewFormat_ProcessesFolderConfigSettingsMap(t *test
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	updatedConfig := setup.getUpdatedConfig()
 	assert.True(t, types.HasUserOverride(updatedConfig.Conf(), updatedConfig.FolderPath, types.SettingScanAutomatic))
@@ -1525,7 +1589,7 @@ func Test_updateFolderConfig_DualWritesUserOverride(t *testing.T) {
 			},
 		},
 	}
-	UpdateSettings(contextWithNotifier(t.Context()), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
+	UpdateSettings(testCtx(t, t.Context(), setup.engine, setup.tokenService), setup.engine.GetConfiguration(), setup.engine, setup.engine.GetLogger(), nil, folderConfigs, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(setup.engine))
 
 	// Verify: UserFolderKey prefix key must be written (dual-write from SetUserOverride)
 	// processSingleLspFolderConfig must set ConfigResolver before ApplyLspUpdate
@@ -1620,8 +1684,12 @@ func Test_updateFolderConfig_SwitchFromManualToAutoOrg_BlanksPreferredOrg(t *tes
 		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1)
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: mockLdx,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
+		ctx2.DepLdxSyncService:      mockLdx,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  setup.deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(setup.engine),
 	})
 
 	// Folder has a user-set org
@@ -1654,8 +1722,12 @@ func Test_updateFolderConfig_UserSetOrg_BlankedPreferredOrg_GlobalAlsoBlank_Reve
 		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1)
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: mockLdx,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
+		ctx2.DepLdxSyncService:      mockLdx,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  setup.deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(setup.engine),
 	})
 
 	// User had a specific org set; global org is blank (e.g. not configured).
@@ -1693,8 +1765,12 @@ func Test_updateFolderConfig_UserSetOrg_BlankedPreferredOrg_UsesGlobalOrg(t *tes
 		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1)
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepLdxSyncService: mockLdx,
-		ctx2.DepNotifier:       notification.NewMockNotifier(),
+		ctx2.DepLdxSyncService:      mockLdx,
+		ctx2.DepNotifier:            notification.NewMockNotifier(),
+		ctx2.DepAuthService:         setup.deps.AuthenticationService,
+		ctx2.DepFeatureFlagService:  setup.deps.FeatureFlagService,
+		ctx2.DepScanStateAggregator: scanstates.NewNoopStateAggregator(),
+		ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(setup.engine),
 	})
 
 	// User previously set a specific org
@@ -1759,9 +1835,9 @@ func Test_validateLockedFields_RestoresConfigAfterValidation(t *testing.T) {
 }
 
 func Test_applySeverityFilter_AcceptsSeverityFilterStruct(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 
-	UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingSeverityFilterCritical: {Value: true, Changed: true},
 		types.SettingSeverityFilterHigh:     {Value: false, Changed: true},
 		types.SettingSeverityFilterMedium:   {Value: true, Changed: true},
@@ -1790,9 +1866,9 @@ func Test_SettingIsLspInitialized_UseBareKey(t *testing.T) {
 }
 
 func Test_applySeverityFilter_AcceptsSeverityFilterValueStruct(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 
-	UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingSeverityFilterCritical: {Value: false, Changed: true},
 		types.SettingSeverityFilterHigh:     {Value: true, Changed: true},
 		types.SettingSeverityFilterMedium:   {Value: false, Changed: true},
@@ -1807,9 +1883,9 @@ func Test_applySeverityFilter_AcceptsSeverityFilterValueStruct(t *testing.T) {
 }
 
 func Test_applySeverityFilter_AcceptsIndividualBooleans(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 
-	UpdateSettings(contextWithNotifier(t.Context()), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), engine.GetConfiguration(), engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingSeverityFilterCritical: {Value: true, Changed: true},
 		types.SettingSeverityFilterHigh:     {Value: false, Changed: true},
 		types.SettingSeverityFilterMedium:   {Value: true, Changed: true},
@@ -1824,7 +1900,7 @@ func Test_applySeverityFilter_AcceptsIndividualBooleans(t *testing.T) {
 }
 
 func Test_applySeverityFilter_IndividualBooleansPartialUpdate(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	// Set initial state: all enabled
@@ -1833,7 +1909,7 @@ func Test_applySeverityFilter_IndividualBooleansPartialUpdate(t *testing.T) {
 	}, engine.GetLogger())
 
 	// Only change critical and low, leave high and medium unchanged
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingSeverityFilterCritical: {Value: false, Changed: true},
 		types.SettingSeverityFilterLow:      {Value: false, Changed: true},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -1846,7 +1922,7 @@ func Test_applySeverityFilter_IndividualBooleansPartialUpdate(t *testing.T) {
 }
 
 func Test_applySeverityFilter_IndividualBooleansIgnoreUnchanged(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	// Set initial state: all disabled
@@ -1855,7 +1931,7 @@ func Test_applySeverityFilter_IndividualBooleansIgnoreUnchanged(t *testing.T) {
 	}, engine.GetLogger())
 
 	// Send all keys but only mark high as Changed
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingSeverityFilterCritical: {Value: true, Changed: false},
 		types.SettingSeverityFilterHigh:     {Value: true, Changed: true},
 		types.SettingSeverityFilterMedium:   {Value: true, Changed: false},
@@ -1978,7 +2054,7 @@ func seedIssueViewOptions(t *testing.T, conf configuration.Configuration, opts t
 }
 
 func TestApplyIssueViewOptions_PreservesOpenWhenOnlyIgnoredChanged(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})
@@ -1986,7 +2062,7 @@ func TestApplyIssueViewOptions_PreservesOpenWhenOnlyIgnoredChanged(t *testing.T)
 	// Open's Value (false) intentionally contradicts its seeded value (true)
 	// while Changed=false. If Changed were ignored, OpenIssues would flip to
 	// false and the assertion below would fail.
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingIssueViewOpenIssues:    {Value: false, Changed: false},
 		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -1997,7 +2073,7 @@ func TestApplyIssueViewOptions_PreservesOpenWhenOnlyIgnoredChanged(t *testing.T)
 }
 
 func TestApplyIssueViewOptions_PreservesIgnoredWhenOnlyOpenChanged(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: true})
@@ -2005,7 +2081,7 @@ func TestApplyIssueViewOptions_PreservesIgnoredWhenOnlyOpenChanged(t *testing.T)
 	// Ignored's Value (false) intentionally contradicts its seeded value (true)
 	// while Changed=false. If Changed were ignored, IgnoredIssues would flip to
 	// false and the assertion below would fail.
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
 		types.SettingIssueViewIgnoredIssues: {Value: false, Changed: false},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -2016,12 +2092,12 @@ func TestApplyIssueViewOptions_PreservesIgnoredWhenOnlyOpenChanged(t *testing.T)
 }
 
 func TestApplyIssueViewOptions_BothChangedWritesBoth(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	seedIssueViewOptions(t, conf, types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false})
 
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingIssueViewOpenIssues:    {Value: false, Changed: true},
 		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: true},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -2037,25 +2113,25 @@ func TestApplyIssueViewOptions_BothChangedWritesBoth(t *testing.T) {
 // `!openPresent && !ignoredPresent` guard is covered by
 // TestApplyIssueViewOptions_NeitherChangedIsNoOp below.
 func TestApplyIssueViewOptions_EmptySettingsMapIsNoOp(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	seed := types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false}
 	seedIssueViewOptions(t, conf, seed)
 
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 
 	assert.Equal(t, seed, config.GetIssueViewOptions(conf))
 }
 
 func TestApplyIssueViewOptions_NeitherChangedIsNoOp(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	seed := types.IssueViewOptions{OpenIssues: true, IgnoredIssues: false}
 	seedIssueViewOptions(t, conf, seed)
 
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingIssueViewOpenIssues:    {Value: false, Changed: false},
 		types.SettingIssueViewIgnoredIssues: {Value: true, Changed: false},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -2082,7 +2158,7 @@ func Test_UpdateSettings_LockedMachineField_RejectsPATCH(t *testing.T) {
 		Origin:   "ldx-sync-test",
 	})
 
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingPublishSecurityAtInceptionRules: {Value: false, Changed: true},
 		types.SettingCodeEndpoint:                    {Value: "https://user-attempted.snyk.io", Changed: true},
 	}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
@@ -2108,7 +2184,7 @@ func Test_UpdateSettings_MachineFields_PATCHWrapsAsLocalConfigField(t *testing.T
 	di.TestInit(t, engine, tokenService, nil)
 	conf := engine.GetConfiguration()
 
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
+	UpdateSettings(testCtx(t, t.Context(), engine, tokenService), conf, engine, engine.GetLogger(), map[string]*types.ConfigSetting{
 		types.SettingAutomaticDownload: {Value: false, Changed: true},
 		types.SettingSendErrorReports:  {Value: false, Changed: true},
 		types.SettingTrustEnabled:      {Value: false, Changed: true},
@@ -2187,6 +2263,9 @@ func Test_applyOrganization_ResetsSummaryPanelOnOrgChange(t *testing.T) {
 			ctx2.DepNotifier:            mockNotifier,
 			ctx2.DepLdxSyncService:      mockLdxSync,
 			ctx2.DepScanStateAggregator: realAgg,
+			ctx2.DepAuthService:         di.AuthenticationService(),
+			ctx2.DepFeatureFlagService:  di.FeatureFlagService(),
+			ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(engine),
 		})
 		return engine, folderPath, realAgg, ctx
 	}
@@ -2250,11 +2329,14 @@ func Test_updateFolderConfig_PreferredOrgChange_ResetsSummaryPanelOnOrgChange(t 
 		mockNotifier := notification.NewMockNotifier()
 		mockLdxSync := mock_command.NewMockLdxSyncService(ctrl)
 		mockLdxSync.EXPECT().RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-		di.TestInit(t, engine, tokenService, &di.Dependencies{ScanStateAggregator: realAgg, Notifier: mockNotifier, LdxSyncService: mockLdxSync})
+		deps := di.TestInit(t, engine, tokenService, &di.Dependencies{ScanStateAggregator: realAgg, Notifier: mockNotifier, LdxSyncService: mockLdxSync})
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
 			ctx2.DepNotifier:            mockNotifier,
 			ctx2.DepLdxSyncService:      mockLdxSync,
 			ctx2.DepScanStateAggregator: realAgg,
+			ctx2.DepAuthService:         deps.AuthenticationService,
+			ctx2.DepFeatureFlagService:  deps.FeatureFlagService,
+			ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(engine),
 		})
 
 		engineConfig := engine.GetConfiguration()
@@ -2344,11 +2426,14 @@ func Test_updateFolderConfig_PreferredOrgChange_ResetsSummaryPanelOnOrgChange(t 
 		mockNotifier := notification.NewMockNotifier()
 		mockLdxSync := mock_command.NewMockLdxSyncService(ctrl)
 		mockLdxSync.EXPECT().RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-		di.TestInit(t, engine, tokenService, &di.Dependencies{ScanStateAggregator: realAgg, Notifier: mockNotifier, LdxSyncService: mockLdxSync})
+		deps := di.TestInit(t, engine, tokenService, &di.Dependencies{ScanStateAggregator: realAgg, Notifier: mockNotifier, LdxSyncService: mockLdxSync})
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
 			ctx2.DepNotifier:            mockNotifier,
 			ctx2.DepLdxSyncService:      mockLdxSync,
 			ctx2.DepScanStateAggregator: realAgg,
+			ctx2.DepAuthService:         deps.AuthenticationService,
+			ctx2.DepFeatureFlagService:  deps.FeatureFlagService,
+			ctx2.DepConfigResolver:      testutil.DefaultConfigResolver(engine),
 		})
 
 		conf := engine.GetConfiguration()
@@ -2688,7 +2773,10 @@ func Test_UpdateSettings_LockedFields_EmitsExactlyOneNotification(t *testing.T) 
 	}
 
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-		ctx2.DepNotifier: localNotifier,
+		ctx2.DepNotifier:           localNotifier,
+		ctx2.DepAuthService:        di.AuthenticationService(),
+		ctx2.DepConfigResolver:     resolver,
+		ctx2.DepFeatureFlagService: di.FeatureFlagService(),
 	})
 	UpdateSettings(ctx, conf, engine, logger, machineSettings, folderConfigs, analytics.TriggerSourceTest, resolver)
 

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -364,7 +364,10 @@ func Test_UpdateSettings(t *testing.T) {
 		// Path is init-only; apply via InitializeSettings first.
 		// TrustedFolders now goes through the settings map.
 		settingsMap[types.SettingTrustedFolders] = &types.ConfigSetting{Value: []interface{}{"trustedPath1", "trustedPath2"}, Changed: true}
-		ctx := contextWithNotifier(t.Context())
+		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
+			ctx2.DepNotifier:    notification.NewMockNotifier(),
+			ctx2.DepAuthService: di.AuthenticationService(),
+		})
 		InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Path:           "addPath",
 			OsPlatform:     "windows",
@@ -703,6 +706,7 @@ func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
 			ctx2.DepLdxSyncService: mockLdx,
 			ctx2.DepNotifier:       notification.NewMockNotifier(),
+			ctx2.DepAuthService:    di.AuthenticationService(),
 		})
 
 		folderPath := types.FilePath(t.TempDir())
@@ -1151,6 +1155,7 @@ func Test_processFolderConfigs_AutoMode_DoesNotLeakGlobalOrgToLdxSync(t *testing
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
 		ctx2.DepLdxSyncService: realService,
 		ctx2.DepNotifier:       notification.NewMockNotifier(),
+		ctx2.DepAuthService:    di.AuthenticationService(),
 	})
 
 	folders := config.GetWorkspace(setup.engine.GetConfiguration()).Folders()
@@ -1392,12 +1397,13 @@ func Test_FC105_WriteSettings_OldFormat_ProcessesSettingsStruct(t *testing.T) {
 	mockLdx.EXPECT().
 		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1)
+	di.TestInit(t, engine, tokenService, &di.Dependencies{
+		LdxSyncService: mockLdx,
+	})
 	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
 		ctx2.DepLdxSyncService: mockLdx,
 		ctx2.DepNotifier:       notification.NewMockNotifier(),
-	})
-	di.TestInit(t, engine, tokenService, &di.Dependencies{
-		LdxSyncService: mockLdx,
+		ctx2.DepAuthService:    di.AuthenticationService(),
 	})
 
 	folderPath := types.FilePath(t.TempDir())
@@ -1507,7 +1513,7 @@ func Test_validateLockedFields_UsesNewOrgPolicyOnOrgSwitch(t *testing.T) {
 
 		folderConfig := setup.getUpdatedConfig()
 
-		rejected := validateLockedFields(setup.engine.GetConfiguration(), folderConfig, &incoming, setup.logger, resolver)
+		rejected := validateLockedFields(resolver, setup.engine.GetConfiguration(), folderConfig, &incoming, setup.logger)
 
 		assert.ElementsMatch(t, []string{types.SettingSnykCodeEnabled}, rejected,
 			"should report the locked setting name so the caller can dedupe into one notification")
@@ -1544,7 +1550,7 @@ func Test_validateLockedFields_UsesNewOrgPolicyOnOrgSwitch(t *testing.T) {
 
 		folderConfig := setup.getUpdatedConfig()
 
-		rejected := validateLockedFields(setup.engine.GetConfiguration(), folderConfig, &incoming, setup.logger, resolver)
+		rejected := validateLockedFields(resolver, setup.engine.GetConfiguration(), folderConfig, &incoming, setup.logger)
 
 		assert.Empty(t, rejected, "should allow changes when new org has no locks")
 		assert.NotNil(t, incoming.Settings[types.SettingSnykCodeEnabled], "setting should remain since new org doesn't lock it")
@@ -1693,7 +1699,7 @@ func Test_validateLockedFields_RestoresConfigAfterValidation(t *testing.T) {
 	}
 
 	folderConfig := setup.getUpdatedConfig()
-	validateLockedFields(prefixKeyConf, folderConfig, &incoming, setup.logger, resolver)
+	validateLockedFields(resolver, prefixKeyConf, folderConfig, &incoming, setup.logger)
 
 	// Config should be restored to original state after validation
 	assert.Equal(t, origOrgVal, prefixKeyConf.Get(orgKey), "OrgSetByUser config key should be restored after validation")
@@ -2126,8 +2132,9 @@ func Test_applyOrganization_ResetsSummaryPanelOnOrgChange(t *testing.T) {
 
 		config.SetOrganization(engine.GetConfiguration(), oldOrg)
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepNotifier:       mockNotifier,
-			ctx2.DepLdxSyncService: mockLdxSync,
+			ctx2.DepNotifier:            mockNotifier,
+			ctx2.DepLdxSyncService:      mockLdxSync,
+			ctx2.DepScanStateAggregator: realAgg,
 		})
 		return engine, folderPath, realAgg, ctx
 	}
@@ -2193,8 +2200,9 @@ func Test_updateFolderConfig_PreferredOrgChange_ResetsSummaryPanelOnOrgChange(t 
 		mockLdxSync.EXPECT().RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		di.TestInit(t, engine, tokenService, &di.Dependencies{ScanStateAggregator: realAgg, Notifier: mockNotifier, LdxSyncService: mockLdxSync})
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepNotifier:       mockNotifier,
-			ctx2.DepLdxSyncService: mockLdxSync,
+			ctx2.DepNotifier:            mockNotifier,
+			ctx2.DepLdxSyncService:      mockLdxSync,
+			ctx2.DepScanStateAggregator: realAgg,
 		})
 
 		engineConfig := engine.GetConfiguration()
@@ -2286,8 +2294,9 @@ func Test_updateFolderConfig_PreferredOrgChange_ResetsSummaryPanelOnOrgChange(t 
 		mockLdxSync.EXPECT().RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		di.TestInit(t, engine, tokenService, &di.Dependencies{ScanStateAggregator: realAgg, Notifier: mockNotifier, LdxSyncService: mockLdxSync})
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepNotifier:       mockNotifier,
-			ctx2.DepLdxSyncService: mockLdxSync,
+			ctx2.DepNotifier:            mockNotifier,
+			ctx2.DepLdxSyncService:      mockLdxSync,
+			ctx2.DepScanStateAggregator: realAgg,
 		})
 
 		conf := engine.GetConfiguration()
@@ -2520,12 +2529,11 @@ func Test_notifyLockedFieldsRejected_DeduplicatesAcrossGroupsAndEmitsOnce(t *tes
 // Test_UpdateSettings_LockedFields_EmitsExactlyOneNotification is the
 // end-to-end regression test for IDE-1970. It drives `UpdateSettings` through
 // the full pipeline (machine-scope validation + multi-folder accumulator +
-// notification emission) and asserts that the real `di.Notifier()` channel
-// receives exactly one ShowMessageParams covering every locked field across
-// every folder. If a future refactor re-introduces an inline `SendShowMessage`
-// call in `processConfigSettings` or `processSingleLspFolderConfig` (the bug
-// IDE-1970 fixed), this test fails — the helper-level unit tests above would
-// not.
+// notification emission) and asserts that exactly one ShowMessageParams is
+// emitted covering every locked field across every folder. If a future refactor
+// re-introduces an inline `SendShowMessage` call in `processConfigSettings` or
+// `processSingleLspFolderConfig` (the bug IDE-1970 fixed), this test fails —
+// the helper-level unit tests above would not.
 // Test_validateLockedMachineFields_EarlyReturns pins the two early-return
 // paths that the integration suite exercises only indirectly. Catching a
 // regression on either path here is much faster than running the full
@@ -2588,20 +2596,21 @@ func Test_UpdateSettings_LockedFields_EmitsExactlyOneNotification(t *testing.T) 
 	resolver := testutil.DefaultConfigResolver(engine)
 	di.SetConfigResolver(resolver)
 
-	// Subscribe to the real notifier before driving the change so we don't miss
-	// any messages produced on the request goroutine.
+	// Use a local notifier so this test is fully isolated from the global DI
+	// singleton and can run in parallel without cross-test interference.
+	localNotifier := notification.NewNotifier()
 	var (
 		mu           sync.Mutex
 		showMessages []sglsp.ShowMessageParams
 	)
-	di.Notifier().CreateListener(func(params any) {
+	localNotifier.CreateListener(func(params any) {
 		if sm, ok := params.(sglsp.ShowMessageParams); ok {
 			mu.Lock()
 			defer mu.Unlock()
 			showMessages = append(showMessages, sm)
 		}
 	})
-	t.Cleanup(func() { di.Notifier().DisposeListener() })
+	t.Cleanup(func() { localNotifier.DisposeListener() })
 
 	// One triggering event that tries to PATCH every locked setting across
 	// machine scope and both folders. folderB also tries to change
@@ -2626,7 +2635,10 @@ func Test_UpdateSettings_LockedFields_EmitsExactlyOneNotification(t *testing.T) 
 		},
 	}
 
-	UpdateSettings(contextWithNotifier(t.Context()), conf, engine, logger, machineSettings, folderConfigs, analytics.TriggerSourceTest, resolver)
+	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
+		ctx2.DepNotifier: localNotifier,
+	})
+	UpdateSettings(ctx, conf, engine, logger, machineSettings, folderConfigs, analytics.TriggerSourceTest, resolver)
 
 	// Wait for the listener goroutine to drain at least one ShowMessage.
 	require.Eventually(t, func() bool {

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -306,7 +306,7 @@ func Test_UpdateSettings(t *testing.T) {
 
 	t.Run("All settings are updated", func(t *testing.T) {
 		engine, tokenService := testutil.UnitTestWithEngine(t)
-		di.TestInit(t, engine, tokenService, nil)
+		deps := di.TestInit(t, engine, tokenService, nil)
 
 		tempDir1 := filepath.Join(t.TempDir(), "tempDir1")
 		tempDir2 := filepath.Join(t.TempDir(), "tempDir2")
@@ -364,9 +364,12 @@ func Test_UpdateSettings(t *testing.T) {
 		// Path is init-only; apply via InitializeSettings first.
 		// TrustedFolders now goes through the settings map.
 		settingsMap[types.SettingTrustedFolders] = &types.ConfigSetting{Value: []interface{}{"trustedPath1", "trustedPath2"}, Changed: true}
+		// Build the context from the deps returned by di.TestInit rather than manually
+		// instantiating services, so the context always uses the same instances that
+		// di.TestInit wired together.
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepNotifier:    notification.NewMockNotifier(),
-			ctx2.DepAuthService: di.AuthenticationService(),
+			ctx2.DepNotifier:    deps.Notifier,
+			ctx2.DepAuthService: deps.AuthenticationService,
 		})
 		InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Path:           "addPath",
@@ -783,6 +786,41 @@ func Test_UpdateSettings_TokenChange_TriggersLdxSyncRefresh(t *testing.T) {
 			types.SettingToken: {Value: "new-token", Changed: true},
 		}, nil, analytics.TriggerSourceTest, testutil.DefaultConfigResolver(engine))
 	})
+}
+
+func Test_refreshLdxSyncOnTokenChange_NotifierAbsentFromContext_StillCallsRefresh(t *testing.T) {
+	// When the notifier is not in context, refreshLdxSyncOnTokenChange must log a warning
+	// but must still call RefreshConfigFromLdxSync (nil notifier is tolerated by that function).
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	di.TestInit(t, engine, tokenService, nil)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockLdx := mock_command.NewMockLdxSyncService(ctrl)
+	// Notifier is intentionally absent from the context.
+	ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
+		ctx2.DepLdxSyncService: mockLdx,
+	})
+
+	folderPath := types.FilePath(t.TempDir())
+	workspaceutil.SetupWorkspace(t, engine, folderPath)
+
+	conf := engine.GetConfiguration()
+	tokenService.SetToken(conf, "old-token")
+	conf.Set(types.SettingIsLspInitialized, false) // ws check passes if folders exist
+
+	folders := config.GetWorkspace(conf).Folders()
+	// RefreshConfigFromLdxSync must still be called even though notifier is absent (nil is OK).
+	mockLdx.EXPECT().
+		RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(folders), gomock.Nil()).
+		Times(1)
+
+	// Set a new token directly into conf to simulate a token change.
+	// (We bypass UpdateSettings to avoid the processFolderConfigs → mustNotifierFromContext path.)
+	tokenService.SetToken(conf, "new-token")
+	// Explicitly call the function under test.
+	refreshLdxSyncOnTokenChange(ctx, conf, engine, engine.GetLogger(), config.GetWorkspace(conf), "old-token")
 }
 
 func Test_UpdateSettings_BlankOrganizationResetsToDefault_Integration(t *testing.T) {

--- a/application/server/configuration_test.go
+++ b/application/server/configuration_test.go
@@ -375,9 +375,11 @@ func Test_UpdateSettings(t *testing.T) {
 		// TrustedFolders now goes through the settings map.
 		settingsMap[types.SettingTrustedFolders] = &types.ConfigSetting{Value: []interface{}{"trustedPath1", "trustedPath2"}, Changed: true}
 		ctx := ctx2.NewContextWithDependencies(t.Context(), map[string]any{
-			ctx2.DepNotifier:       deps.Notifier,
-			ctx2.DepAuthService:    deps.AuthenticationService,
-			ctx2.DepConfigResolver: deps.ConfigResolver,
+			ctx2.DepNotifier:          deps.Notifier,
+			ctx2.DepAuthService:       deps.AuthenticationService,
+			ctx2.DepConfigResolver:    deps.ConfigResolver,
+			ctx2.DepFeatureFlagService: deps.FeatureFlagService,
+			ctx2.DepLdxSyncService:    deps.LdxSyncService,
 		})
 		require.NoError(t, InitializeSettings(ctx, engine.GetConfiguration(), engine, engine.GetLogger(), types.InitializationOptions{
 			Path:           "addPath",

--- a/application/server/execute_command.go
+++ b/application/server/execute_command.go
@@ -39,8 +39,7 @@ func executeCommandHandler(srv *jrpc2.Server) jrpc2.Handler {
 		commandData := types.CommandData{CommandId: params.Command, Arguments: params.Arguments, Title: params.Command}
 
 		result, err := command.Service().ExecuteCommandData(ctx, commandData, srv)
-		reporter, _ := errorReporterFromContext(ctx)
-		logError(logger, reporter, err, fmt.Sprintf("Error executing command %v", commandData))
+		logError(logger, mustErrorReporterFromContext(ctx), err, fmt.Sprintf("Error executing command %v", commandData))
 		return result, err
 	})
 }

--- a/application/server/notification.go
+++ b/application/server/notification.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snyk/snyk-ls/internal/uri"
 )
 
-func notifier(logger *zerolog.Logger, srv types.Server, method string, params any) {
+func notifyClient(logger *zerolog.Logger, srv types.Server, method string, params any) {
 	err := srv.Notify(context.Background(), method, params)
 	logError(logger, nil, err, "notifier")
 }
@@ -96,24 +96,24 @@ func registerNotifier(conf configuration.Configuration, logger *zerolog.Logger, 
 		case types.GetSdk:
 			handleGetSdks(params, l, srv)
 		case types.LspConfigurationParam:
-			notifier(logger, srv, "$/snyk.configuration", params)
+			notifyClient(logger, srv, "$/snyk.configuration", params)
 			l.Debug().Int("folderConfigs", len(params.FolderConfigs)).Msg("sending configuration to client")
 		case types.AuthenticationParams:
-			notifier(logger, srv, "$/snyk.hasAuthenticated", params)
+			notifyClient(logger, srv, "$/snyk.hasAuthenticated", params)
 			l.Debug().Msg("sending token")
 		case types.SnykIsAvailableCli:
-			notifier(logger, srv, "$/snyk.isAvailableCli", params)
+			notifyClient(logger, srv, "$/snyk.isAvailableCli", params)
 			l.Debug().Msg("sending cli path")
 		case sglsp.ShowMessageParams:
-			notifier(logger, srv, "window/showMessage", params)
+			notifyClient(logger, srv, "window/showMessage", params)
 			l.Debug().Interface("message", params.Message).Msg("showing message")
 		case types.SnykTrustedFoldersParams:
-			notifier(logger, srv, "$/snyk.addTrustedFolders", params)
+			notifyClient(logger, srv, "$/snyk.addTrustedFolders", params)
 			l.Info().
 				Interface("trustedPaths", params.TrustedFolders).
 				Msg("sending trusted Folders to client")
 		case types.SnykScanParams:
-			notifier(logger, srv, "$/snyk.scan", params)
+			notifyClient(logger, srv, "$/snyk.scan", params)
 			l.Info().
 				Interface("product", params.Product).
 				Interface("status", params.Status).
@@ -122,8 +122,8 @@ func registerNotifier(conf configuration.Configuration, logger *zerolog.Logger, 
 			go handleShowMessageRequest(srv, params, &l)
 			l.Debug().Msg("sending show message request to client")
 		case types.PublishDiagnosticsParams:
-			notifier(logger, srv, "textDocument/publishDiagnostics", params)
-			notifier(logger, srv, "$/snyk.publishDiagnostics316", params)
+			notifyClient(logger, srv, "textDocument/publishDiagnostics", params)
+			notifyClient(logger, srv, "$/snyk.publishDiagnostics316", params)
 			source := "LSP"
 			if len(params.Diagnostics) > 0 {
 				source = params.Diagnostics[0].Source
@@ -134,10 +134,10 @@ func registerNotifier(conf configuration.Configuration, logger *zerolog.Logger, 
 				Interface("diagnosticCount", len(params.Diagnostics)).
 				Msg("publishing diagnostics")
 		case types.ScanSummary:
-			notifier(logger, srv, "$/snyk.scanSummary", params)
+			notifyClient(logger, srv, "$/snyk.scanSummary", params)
 			l.Debug().Msg("sending scan summary to client")
 		case types.TreeView:
-			notifier(logger, srv, "$/snyk.treeView", params)
+			notifyClient(logger, srv, "$/snyk.treeView", params)
 			l.Debug().Msg("sending tree view to client")
 		case types.ApplyWorkspaceEditParams:
 			handleApplyWorkspaceEdit(conf, srv, params, &l)
@@ -152,7 +152,7 @@ func registerNotifier(conf configuration.Configuration, logger *zerolog.Logger, 
 			l.Debug().
 				Msg("sending inline value refresh request to client")
 		case types.SnykRegisterMcpParams:
-			notifier(logger, srv, "$/snyk.registerMcp", params)
+			notifyClient(logger, srv, "$/snyk.registerMcp", params)
 			l.Debug().Interface("mcpConfig", params).Msg("sending MCP config to client")
 		default:
 			l.Warn().

--- a/application/server/notification.go
+++ b/application/server/notification.go
@@ -84,6 +84,9 @@ func disposeProgressListener() {
 
 //nolint:gocyclo // this is ok, as it's so high because of forwarding the calls
 func registerNotifier(conf configuration.Configuration, logger *zerolog.Logger, srv types.Server, n noti.Notifier) {
+	if n == nil {
+		panic("registerNotifier: Notifier must not be nil — check server startup wiring")
+	}
 	l := logger.With().Str("method", "registerNotifier").Logger()
 	callbackFunction := func(params any) {
 		if !conf.GetBool(types.SettingIsLspInitialized) {

--- a/application/server/notification_test.go
+++ b/application/server/notification_test.go
@@ -39,7 +39,7 @@ import (
 
 func TestRegisterNotifier_NilNotifier_Panics(t *testing.T) {
 	// registerNotifier has "notifier" in its name; a nil notifier is a programming error
-	// that must be caught at initialization time — not silently produce no-op behaviour.
+	// that must be caught at initialization time — not silently produce no-op behavior.
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	logger := engine.GetLogger()

--- a/application/server/notification_test.go
+++ b/application/server/notification_test.go
@@ -37,6 +37,21 @@ import (
 	"github.com/snyk/snyk-ls/internal/types/mock_types"
 )
 
+func TestRegisterNotifier_NilNotifier_Panics(t *testing.T) {
+	// registerNotifier has "notifier" in its name; a nil notifier is a programming error
+	// that must be caught at initialization time — not silently produce no-op behaviour.
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	logger := engine.GetLogger()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	srv := mock_types.NewMockServer(ctrl)
+
+	assert.Panics(t, func() {
+		registerNotifier(conf, logger, srv, nil)
+	}, "registerNotifier must panic when notifier is nil")
+}
+
 func TestCreateProgressListener(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	ctrl := gomock.NewController(t)

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/creachadair/jrpc2"
@@ -149,14 +150,22 @@ func withContext(
 	deps di.Dependencies,
 	srv *jrpc2.Server,
 ) jrpc2.Handler {
+	var stopOnce sync.Once
 	return func(ctx context.Context, req *jrpc2.Request) (any, error) {
 		if err := validateMandatoryDeps(deps); err != nil {
 			logger.Error().Err(err).Msg("stopping server: mandatory DI dependency missing")
 			if srv != nil {
-				go func() {
-					time.Sleep(100 * time.Millisecond)
-					srv.Stop()
-				}()
+				// stopOnce ensures only one Stop() goroutine per handler registration
+				// regardless of concurrent requests hitting the same missing-dep error.
+				// The 100ms delay gives jrpc2 time to transmit the error response before
+				// the channel closes; this is a best-effort guarantee on a fast local
+				// transport — inherently racy on slow pipes.
+				stopOnce.Do(func() {
+					go func() {
+						time.Sleep(100 * time.Millisecond)
+						srv.Stop()
+					}()
+				})
 			}
 			return nil, err
 		}

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -348,8 +348,8 @@ func mustScanPersisterFromContext(ctx context.Context) persistence.ScanSnapshotP
 	return sp
 }
 
-// scanNotifierFromContext uses the (ok) pattern rather than a must* variant because
-// addWorkspaceFolders does graceful error-log-and-return on missing deps.
+// scanNotifierFromContext uses the (ok) pattern; addWorkspaceFolders returns an
+// error to initializeHandler when the dep is absent.
 func scanNotifierFromContext(ctx context.Context) (scanner2.ScanNotifier, bool) {
 	deps, ok := ctx2.DependenciesFromContext(ctx)
 	if !ok {
@@ -563,7 +563,9 @@ func initializeHandler(conf configuration.Configuration, engine workflow.Engine,
 		}
 		authentication.RegisterOAuthStorageBridge(storage, authenticationService)
 
-		addWorkspaceFolders(ctx, conf, &logger, engine, params)
+		if err := addWorkspaceFolders(ctx, conf, &logger, engine, params); err != nil {
+			return nil, err
+		}
 		// Prime ORGANIZATION for hot-path GlobalOrg(); see GetGlobalOrganization.
 		// Must run before RefreshConfigFromLdxSync and HandleFolders, which rely
 		// on the resolver's global-org fallback for folders without a preferred org.
@@ -887,7 +889,7 @@ func periodicallyCheckForExpiredCache(ctx context.Context, conf configuration.Co
 	}
 }
 
-func addWorkspaceFolders(ctx context.Context, conf configuration.Configuration, logger *zerolog.Logger, engine workflow.Engine, params types.InitializeParams) {
+func addWorkspaceFolders(ctx context.Context, conf configuration.Configuration, logger *zerolog.Logger, engine workflow.Engine, params types.InitializeParams) error {
 	const method = "addWorkspaceFolders"
 	w := config.GetWorkspace(conf)
 
@@ -909,8 +911,8 @@ func addWorkspaceFolders(ctx context.Context, conf configuration.Configuration, 
 			Bool("scanStateAggregator", ssaOk).
 			Bool("featureFlagService", ffOk).
 			Bool("configResolver", crOk).
-			Msg("missing mandatory dependency in context; aborting workspace folder creation")
-		return
+			Msg("missing mandatory dependency in context; LSP initialize will fail")
+		return errors.New("snyk-ls: missing mandatory DI dependency at initialize")
 	}
 
 	newFolder := func(path types.FilePath, name string) *workspace.Folder {
@@ -929,6 +931,7 @@ func addWorkspaceFolders(ctx context.Context, conf configuration.Configuration, 
 			w.AddFolder(newFolder(types.FilePath(params.RootPath), params.ClientInfo.Name))
 		}
 	}
+	return nil
 }
 
 // setClientInformation sets the integration name and version from the client information.

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -120,6 +120,15 @@ func withContext(
 		ctxDeps, found := ctx2.DependenciesFromContext(ctx)
 		if !found {
 			ctxDeps = map[string]any{}
+		} else {
+			// Clone defensively: the map was created by NewContextWithConfigResolver moments
+			// earlier in this closure, but a future jrpc2 NewContext option could pass a
+			// shared parent context carrying a deps map — cloning prevents cross-request mutation.
+			cloned := make(map[string]any, len(ctxDeps))
+			for k, v := range ctxDeps {
+				cloned[k] = v
+			}
+			ctxDeps = cloned
 		}
 		injectCoreServicesIntoMap(ctxDeps, deps)
 		injectScanServicesIntoMap(ctxDeps, deps)
@@ -148,14 +157,8 @@ func injectCoreServicesIntoMap(m map[string]any, deps di.Dependencies) {
 	if deps.ErrorReporter != nil {
 		m[ctx2.DepErrorReporter] = deps.ErrorReporter
 	}
-	if deps.Installer != nil {
-		m[ctx2.DepInstaller] = deps.Installer
-	}
 	if deps.CodeActionService != nil {
 		m[ctx2.DepCodeActionService] = deps.CodeActionService
-	}
-	if deps.Initializer != nil {
-		m[ctx2.DepInitializer] = deps.Initializer
 	}
 	if deps.FeatureFlagService != nil {
 		m[ctx2.DepFeatureFlagService] = deps.FeatureFlagService
@@ -513,21 +516,23 @@ func workspaceDidChangeWorkspaceFoldersHandler(conf configuration.Configuration,
 		defer logger.Info().Msg("SENDING")
 		changedFolders := config.GetWorkspace(conf).ChangeWorkspaceFolders(params)
 
-		authSvc, _ := authenticationServiceFromContext(ctx)
-		if authSvc != nil && authSvc.IsAuthenticated() {
-			ldxSvc, _ := ldxSyncServiceFromContext(ctx)
-			notifier, _ := notifierFromContext(ctx)
-			if ldxSvc != nil {
-				ldxSvc.RefreshConfigFromLdxSync(bgCtx, conf, engine, &logger, changedFolders, notifier)
-			}
-		}
-
-		notifier, _ := notifierFromContext(ctx)
+		// Deps below are injected by withContext if non-nil in DI wiring; each is checked
+		// before use below. HandleFolders guards nil featureFlagService internally, and a
+		// missing dep here surfaces as a no-op in HandleFolders — acceptable because
+		// workspace-folder changes are non-destructive and the handler can be retried.
+		authService, _ := authenticationServiceFromContext(ctx)
+		notifier := mustNotifierFromContext(ctx)
+		ldxSyncSvc, _ := ldxSyncServiceFromContext(ctx)
 		scanPersister, _ := scanPersisterFromContext(ctx)
 		scanStateAgg, _ := scanStateAggregatorFromContext(ctx)
-		ffService, _ := featureFlagServiceFromContext(ctx)
-		configRes, _ := configResolverFromContext(ctx)
-		command.HandleFolders(conf, engine, &logger, bgCtx, srv, notifier, scanPersister, scanStateAgg, ffService, configRes)
+		featureFlags, _ := featureFlagServiceFromContext(ctx)
+		configResolver, _ := ctx2.ConfigResolverFromContext(ctx)
+
+		if authService != nil && authService.IsAuthenticated() && ldxSyncSvc != nil {
+			ldxSyncSvc.RefreshConfigFromLdxSync(bgCtx, conf, engine, &logger, changedFolders, notifier)
+		}
+
+		command.HandleFolders(conf, engine, &logger, bgCtx, srv, notifier, scanPersister, scanStateAgg, featureFlags, configResolver)
 		for _, f := range changedFolders {
 			if f.IsAutoScanEnabled() {
 				go f.ScanFolder(bgCtx)
@@ -904,17 +909,30 @@ func addWorkspaceFolders(ctx context.Context, conf configuration.Configuration, 
 	const method = "addWorkspaceFolders"
 	w := config.GetWorkspace(conf)
 
-	sc := mustScannerFromContext(ctx)
-	hoverSvc := mustHoverServiceFromContext(ctx)
-	scanNotifier := mustScanNotifierFromContext(ctx)
-	notifier := mustNotifierFromContext(ctx)
-	scanPersister := mustScanPersisterFromContext(ctx)
-	scanStateAgg := mustScanStateAggregatorFromContext(ctx)
-	ffService := mustFeatureFlagServiceFromContext(ctx)
-	configRes := mustConfigResolverFromContext(ctx)
+	scn, scnOk := scannerFromContext(ctx)
+	hs, hsOk := hoverServiceFromContext(ctx)
+	scanNotifier, snOk := scanNotifierFromContext(ctx)
+	notifier, nOk := notifierFromContext(ctx)
+	scanPersister, spOk := scanPersisterFromContext(ctx)
+	scanStateAgg, ssaOk := scanStateAggregatorFromContext(ctx)
+	featureFlags, ffOk := featureFlagServiceFromContext(ctx)
+	configResolver, crOk := ctx2.ConfigResolverFromContext(ctx)
+	if !scnOk || !hsOk || !snOk || !nOk || !spOk || !ssaOk || !ffOk || !crOk {
+		logger.Error().Str("method", method).
+			Bool("scanner", scnOk).
+			Bool("hoverService", hsOk).
+			Bool("scanNotifier", snOk).
+			Bool("notifier", nOk).
+			Bool("scanPersister", spOk).
+			Bool("scanStateAggregator", ssaOk).
+			Bool("featureFlagService", ffOk).
+			Bool("configResolver", crOk).
+			Msg("missing mandatory dependency in context; aborting workspace folder creation")
+		return
+	}
 
 	newFolder := func(path types.FilePath, name string) *workspace.Folder {
-		return workspace.NewFolder(conf, logger, path, name, sc, hoverSvc, scanNotifier, notifier, scanPersister, scanStateAgg, ffService, configRes, engine)
+		return workspace.NewFolder(conf, logger, path, name, scn, hs, scanNotifier, notifier, scanPersister, scanStateAgg, featureFlags, configResolver, engine)
 	}
 
 	if len(params.WorkspaceFolders) > 0 {

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -360,6 +360,8 @@ func mustScanPersisterFromContext(ctx context.Context) persistence.ScanSnapshotP
 	return sp
 }
 
+// scanNotifierFromContext uses the (ok) pattern rather than a must* variant because
+// addWorkspaceFolders does graceful error-log-and-return on missing deps.
 func scanNotifierFromContext(ctx context.Context) (scanner2.ScanNotifier, bool) {
 	deps, ok := ctx2.DependenciesFromContext(ctx)
 	if !ok {
@@ -367,14 +369,6 @@ func scanNotifierFromContext(ctx context.Context) (scanner2.ScanNotifier, bool) 
 	}
 	sn, ok := deps[ctx2.DepScanNotifier].(scanner2.ScanNotifier)
 	return sn, ok
-}
-
-func mustScanNotifierFromContext(ctx context.Context) scanner2.ScanNotifier {
-	sn, ok := scanNotifierFromContext(ctx)
-	if !ok {
-		panic("ScanNotifier missing from context")
-	}
-	return sn
 }
 
 func featureFlagServiceFromContext(ctx context.Context) (featureflag.Service, bool) {

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -100,17 +100,66 @@ func Start(engine workflow.Engine, tokenService *config.TokenServiceImpl) {
 	}
 }
 
+// validateMandatoryDeps returns an error if any mandatory DI dependency is nil.
+// All deps in this list are always created by di.Init and di.TestInit; a nil value
+// means the server was started with broken wiring and cannot function correctly.
+func validateMandatoryDeps(deps di.Dependencies) error {
+	switch {
+	case deps.ConfigResolver == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: ConfigResolver")
+	case deps.AuthenticationService == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: AuthenticationService")
+	case deps.LdxSyncService == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: LdxSyncService")
+	case deps.Notifier == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: Notifier")
+	case deps.FeatureFlagService == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: FeatureFlagService")
+	case deps.ErrorReporter == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: ErrorReporter")
+	case deps.LearnService == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: LearnService")
+	case deps.Scanner == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: Scanner")
+	case deps.HoverService == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: HoverService")
+	case deps.ScanNotifier == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: ScanNotifier")
+	case deps.ScanPersister == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: ScanPersister")
+	case deps.ScanStateAggregator == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: ScanStateAggregator")
+	case deps.FileWatcher == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: FileWatcher")
+	default:
+		return nil
+	}
+}
+
 // withContext wraps a jrpc2.Handler to inject logger, configuration, engine,
 // and all handler dependencies into the context so that handlers can read them
 // from ctx rather than reaching for package-level di.* globals.
+// If any mandatory dependency is nil, it returns a jrpc2 error to the client
+// and stops the server — a server with broken DI wiring cannot function correctly.
 func withContext(
 	h jrpc2.Handler,
 	logger *zerolog.Logger,
 	conf configuration.Configuration,
 	engine workflow.Engine,
 	deps di.Dependencies,
+	srv *jrpc2.Server,
 ) jrpc2.Handler {
 	return func(ctx context.Context, req *jrpc2.Request) (any, error) {
+		if err := validateMandatoryDeps(deps); err != nil {
+			logger.Error().Err(err).Msg("stopping server: mandatory DI dependency missing")
+			if srv != nil {
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					srv.Stop()
+				}()
+			}
+			return nil, err
+		}
 		ctx = ctx2.NewContextWithLogger(ctx, logger)
 		ctxDeps := make(map[string]any)
 		ctxDeps[ctx2.DepConfiguration] = conf
@@ -186,7 +235,7 @@ const textDocumentDidSaveOperation = "textDocument/didSave"
 
 func initHandlers(srv *jrpc2.Server, handlers handler.Map, conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger, deps di.Dependencies) {
 	enrich := func(h jrpc2.Handler) jrpc2.Handler {
-		return withContext(h, logger, conf, engine, deps)
+		return withContext(h, logger, conf, engine, deps, srv)
 	}
 	handlers["initialize"] = enrich(initializeHandler(conf, engine, srv))
 	handlers["initialized"] = enrich(initializedHandler(conf, engine, srv))
@@ -218,6 +267,14 @@ func authenticationServiceFromContext(ctx context.Context) (authentication.Authe
 	}
 	authService, ok := deps[ctx2.DepAuthService].(authentication.AuthenticationService)
 	return authService, ok
+}
+
+func mustAuthenticationServiceFromContext(ctx context.Context) authentication.AuthenticationService {
+	svc, ok := authenticationServiceFromContext(ctx)
+	if !ok {
+		panic("AuthenticationService missing from context")
+	}
+	return svc
 }
 
 func ldxSyncServiceFromContext(ctx context.Context) (command.LdxSyncService, bool) {
@@ -557,11 +614,8 @@ func initializeHandler(conf configuration.Configuration, engine workflow.Engine,
 		// Register the OAuth storage bridge before any pre-initialization API
 		// call so a rotated refresh token is reliably propagated to the IDE
 		// (queued until SettingIsLspInitialized turns true).
-		authenticationService, ok := authenticationServiceFromContext(ctx)
-		if !ok {
-			return nil, errors.New("authentication service missing from request context")
-		}
-		authentication.RegisterOAuthStorageBridge(storage, authenticationService)
+		// withContext guarantees AuthenticationService is non-nil before any handler runs.
+		authentication.RegisterOAuthStorageBridge(storage, mustAuthenticationServiceFromContext(ctx))
 
 		if err := addWorkspaceFolders(ctx, conf, &logger, engine, params); err != nil {
 			return nil, err
@@ -570,11 +624,8 @@ func initializeHandler(conf configuration.Configuration, engine workflow.Engine,
 		// Must run before RefreshConfigFromLdxSync and HandleFolders, which rely
 		// on the resolver's global-org fallback for folders without a preferred org.
 		_ = types.GetGlobalOrganization(conf)
-		ldxSyncService, ok := ldxSyncServiceFromContext(ctx)
-		if !ok {
-			return nil, errors.New("LDX Sync service missing from request context")
-		}
-		ldxSyncService.RefreshConfigFromLdxSync(ctx, conf, engine, &logger, config.GetWorkspace(conf).Folders(), nil)
+		// withContext guarantees LdxSyncService is non-nil before any handler runs.
+		mustLdxSyncServiceFromContext(ctx).RefreshConfigFromLdxSync(ctx, conf, engine, &logger, config.GetWorkspace(conf).Folders(), nil)
 		if err := InitializeSettings(ctx, conf, engine, &logger, params.InitializationOptions); err != nil {
 			return nil, err
 		}

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -112,24 +112,9 @@ func withContext(
 ) jrpc2.Handler {
 	return func(ctx context.Context, req *jrpc2.Request) (any, error) {
 		ctx = ctx2.NewContextWithLogger(ctx, logger)
-		ctx = ctx2.NewContextWithConfiguration(ctx, conf)
-		ctx = ctx2.NewContextWithEngine(ctx, engine)
-		if deps.ConfigResolver != nil {
-			ctx = ctx2.NewContextWithConfigResolver(ctx, deps.ConfigResolver)
-		}
-		ctxDeps, found := ctx2.DependenciesFromContext(ctx)
-		if !found {
-			ctxDeps = map[string]any{}
-		} else {
-			// Clone defensively: the map was created by NewContextWithConfigResolver moments
-			// earlier in this closure, but a future jrpc2 NewContext option could pass a
-			// shared parent context carrying a deps map — cloning prevents cross-request mutation.
-			cloned := make(map[string]any, len(ctxDeps))
-			for k, v := range ctxDeps {
-				cloned[k] = v
-			}
-			ctxDeps = cloned
-		}
+		ctxDeps := make(map[string]any)
+		ctxDeps[ctx2.DepConfiguration] = conf
+		ctxDeps[ctx2.DepEngine] = engine
 		injectCoreServicesIntoMap(ctxDeps, deps)
 		injectScanServicesIntoMap(ctxDeps, deps)
 		ctx = ctx2.NewContextWithDependencies(ctx, ctxDeps)
@@ -142,6 +127,9 @@ func withContext(
 // each function's cyclomatic complexity below the gocyclo limit (15); it does
 // not reflect a semantic boundary between the services.
 func injectCoreServicesIntoMap(m map[string]any, deps di.Dependencies) {
+	if deps.ConfigResolver != nil {
+		m[ctx2.DepConfigResolver] = deps.ConfigResolver
+	}
 	if deps.AuthenticationService != nil {
 		m[ctx2.DepAuthService] = deps.AuthenticationService
 	}

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -429,8 +429,6 @@ func mustScanPersisterFromContext(ctx context.Context) persistence.ScanSnapshotP
 	return sp
 }
 
-// scanNotifierFromContext uses the (ok) pattern; addWorkspaceFolders returns an
-// error to initializeHandler when the dep is absent.
 func scanNotifierFromContext(ctx context.Context) (scanner2.ScanNotifier, bool) {
 	deps, ok := ctx2.DependenciesFromContext(ctx)
 	if !ok {

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -151,22 +152,35 @@ func withContext(
 	srv *jrpc2.Server,
 ) jrpc2.Handler {
 	var stopOnce sync.Once
-	return func(ctx context.Context, req *jrpc2.Request) (any, error) {
-		if err := validateMandatoryDeps(deps); err != nil {
-			logger.Error().Err(err).Msg("stopping server: mandatory DI dependency missing")
-			if srv != nil {
-				// stopOnce ensures only one Stop() goroutine per handler registration
-				// regardless of concurrent requests hitting the same missing-dep error.
-				// The 100ms delay gives jrpc2 time to transmit the error response before
-				// the channel closes; this is a best-effort guarantee on a fast local
-				// transport — inherently racy on slow pipes.
-				stopOnce.Do(func() {
-					go func() {
-						time.Sleep(100 * time.Millisecond)
-						srv.Stop()
-					}()
-				})
+	// stop closes over logger, stopOnce, and srv — no parameters needed.
+	stop := func(reason string) {
+		logger.Error().Str("reason", reason).Msg("stopping server")
+		if srv != nil {
+			// stopOnce ensures only one Stop() goroutine per handler registration.
+			// The 100ms delay gives jrpc2 time to transmit the error response before
+			// the channel closes; best-effort on a fast local transport.
+			stopOnce.Do(func() {
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					srv.Stop()
+				}()
+			})
+		}
+	}
+	return func(ctx context.Context, req *jrpc2.Request) (res any, rerr error) {
+		// Single enforcement point for all failure modes: both explicit dep
+		// validation and synchronous panics in h's call stack are caught here,
+		// converted to a jrpc2 error (returned to the LSP client) and trigger
+		// server stop. Panics in goroutines launched by h are not covered.
+		defer func() {
+			if r := recover(); r != nil {
+				rerr = fmt.Errorf("snyk-ls: internal server error: %v", r)
+				logger.Error().Str("stack", string(debug.Stack())).Msg(rerr.Error())
+				stop(rerr.Error())
 			}
+		}()
+		if err := validateMandatoryDeps(deps); err != nil {
+			stop(err.Error())
 			return nil, err
 		}
 		ctx = ctx2.NewContextWithLogger(ctx, logger)
@@ -176,7 +190,8 @@ func withContext(
 		injectCoreServicesIntoMap(ctxDeps, deps)
 		injectScanServicesIntoMap(ctxDeps, deps)
 		ctx = ctx2.NewContextWithDependencies(ctx, ctxDeps)
-		return h(ctx, req)
+		res, rerr = h(ctx, req)
+		return
 	}
 }
 

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -575,7 +575,9 @@ func initializeHandler(conf configuration.Configuration, engine workflow.Engine,
 			return nil, errors.New("LDX Sync service missing from request context")
 		}
 		ldxSyncService.RefreshConfigFromLdxSync(ctx, conf, engine, &logger, config.GetWorkspace(conf).Folders(), nil)
-		InitializeSettings(ctx, conf, engine, &logger, params.InitializationOptions)
+		if err := InitializeSettings(ctx, conf, engine, &logger, params.InitializationOptions); err != nil {
+			return nil, err
+		}
 
 		startClientMonitor(params, logger)
 

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -133,6 +133,8 @@ func validateMandatoryDeps(deps di.Dependencies) error {
 		return errors.New("snyk-ls: mandatory DI dependency missing: ScanStateAggregator")
 	case deps.FileWatcher == nil:
 		return errors.New("snyk-ls: mandatory DI dependency missing: FileWatcher")
+	case deps.CodeActionService == nil:
+		return errors.New("snyk-ls: mandatory DI dependency missing: CodeActionService")
 	default:
 		return nil
 	}
@@ -218,9 +220,7 @@ func injectCoreServicesIntoMap(m map[string]any, deps di.Dependencies) {
 	if deps.ErrorReporter != nil {
 		m[ctx2.DepErrorReporter] = deps.ErrorReporter
 	}
-	if deps.CodeActionService != nil {
-		m[ctx2.DepCodeActionService] = deps.CodeActionService
-	}
+	m[ctx2.DepCodeActionService] = deps.CodeActionService
 	if deps.FeatureFlagService != nil {
 		m[ctx2.DepFeatureFlagService] = deps.FeatureFlagService
 	}
@@ -579,19 +579,15 @@ func workspaceDidChangeWorkspaceFoldersHandler(conf configuration.Configuration,
 		defer logger.Info().Msg("SENDING")
 		changedFolders := config.GetWorkspace(conf).ChangeWorkspaceFolders(params)
 
-		// Deps below are injected by withContext if non-nil in DI wiring; each is checked
-		// before use below. HandleFolders guards nil featureFlagService internally, and a
-		// missing dep here surfaces as a no-op in HandleFolders — acceptable because
-		// workspace-folder changes are non-destructive and the handler can be retried.
-		authService, _ := authenticationServiceFromContext(ctx)
+		authService := mustAuthenticationServiceFromContext(ctx)
 		notifier := mustNotifierFromContext(ctx)
-		ldxSyncSvc, _ := ldxSyncServiceFromContext(ctx)
-		scanPersister, _ := scanPersisterFromContext(ctx)
-		scanStateAgg, _ := scanStateAggregatorFromContext(ctx)
-		featureFlags, _ := featureFlagServiceFromContext(ctx)
-		configResolver, _ := ctx2.ConfigResolverFromContext(ctx)
+		ldxSyncSvc := mustLdxSyncServiceFromContext(ctx)
+		scanPersister := mustScanPersisterFromContext(ctx)
+		scanStateAgg := mustScanStateAggregatorFromContext(ctx)
+		featureFlags := mustFeatureFlagServiceFromContext(ctx)
+		configResolver := mustConfigResolverFromContext(ctx)
 
-		if authService != nil && authService.IsAuthenticated() && ldxSyncSvc != nil {
+		if authService.IsAuthenticated() {
 			ldxSyncSvc.RefreshConfigFromLdxSync(bgCtx, conf, engine, &logger, changedFolders, notifier)
 		}
 

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -1633,3 +1633,15 @@ func Test_shouldHandleFilesOutsideWorkspace(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestAddWorkspaceFolders_MissingDeps_ReturnsError(t *testing.T) {
+	// Empty context — no deps injected — so all ok-checks return false.
+	engine := testutil.UnitTest(t)
+	conf := engine.GetConfiguration()
+	logger := engine.GetLogger()
+
+	err := addWorkspaceFolders(t.Context(), conf, logger, engine, types.InitializeParams{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing mandatory DI dependency")
+}

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -267,6 +267,25 @@ func TestWithContext_InjectsAuthenticationService(t *testing.T) {
 	assert.Equal(t, authService, gotAuthService)
 }
 
+// TestWithContext_HandlerPanic_ReturnsJRPC2Error verifies that a synchronous panic
+// inside a handler is caught by withContext's defer/recover, returned as a jrpc2
+// error to the LSP client, and does not crash the process.
+func TestWithContext_HandlerPanic_ReturnsJRPC2Error(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	logger := zerolog.Nop()
+	deps := di.TestInit(t, engine, tokenService, nil)
+
+	panicking := withContext(func(_ context.Context, _ *jrpc2.Request) (any, error) {
+		panic("test panic from handler")
+	}, &logger, engine.GetConfiguration(), engine, deps, nil)
+
+	_, err := panicking(t.Context(), nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "internal server error")
+	assert.Contains(t, err.Error(), "test panic from handler")
+}
+
 type onCallbackFn = func(ctx context.Context, request *jrpc2.Request) (any, error)
 
 func startServer(engine workflow.Engine, tokenService *config.TokenServiceImpl, callBackFn onCallbackFn, jsonRPCRecorder *testsupport.JsonRPCRecorder, deps di.Dependencies) server.Local {

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -1645,3 +1645,52 @@ func TestAddWorkspaceFolders_MissingDeps_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing mandatory DI dependency")
 }
+
+// TestInitializeHandler_MissingDep_PropagatesLSPError verifies that when a required
+// dependency is absent from the DI wiring, the initializeHandler returns an error that
+// propagates through the jrpc2 layer back to the LSP client as a protocol-level error
+// response — not a silent no-op or a server crash.
+func TestInitializeHandler_MissingDep_PropagatesLSPError(t *testing.T) {
+	cases := []struct {
+		name        string
+		mutate      func(deps *di.Dependencies)
+		wantMessage string
+	}{
+		{
+			name:        "missing AuthenticationService",
+			mutate:      func(d *di.Dependencies) { d.AuthenticationService = nil },
+			wantMessage: "authentication service missing",
+		},
+		{
+			name:        "missing LdxSyncService",
+			mutate:      func(d *di.Dependencies) { d.LdxSyncService = nil },
+			wantMessage: "LDX Sync service missing",
+		},
+		{
+			name:        "missing ConfigResolver",
+			mutate:      func(d *di.Dependencies) { d.ConfigResolver = nil },
+			wantMessage: "missing mandatory DI dependency",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, tokenService := testutil.UnitTestWithEngine(t)
+			deps := di.TestInit(t, engine, tokenService, nil)
+
+			// Remove the dep under test so withContext does not inject it.
+			tc.mutate(&deps)
+
+			jsonRPCRecorder := &testsupport.JsonRPCRecorder{}
+			loc := startServer(engine, tokenService, nil, jsonRPCRecorder, deps)
+			t.Cleanup(func() { _ = loc.Close() })
+
+			_, err := loc.Client.Call(t.Context(), "initialize", nil)
+
+			require.Error(t, err)
+			var rpcErr *jrpc2.Error
+			require.ErrorAs(t, err, &rpcErr, "expected a jrpc2 protocol error, not a transport failure")
+			assert.Contains(t, rpcErr.Message, tc.wantMessage)
+		})
+	}
+}

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -213,17 +213,14 @@ func (s *sentinelHoverService) GetHover(_ types.FilePath, _ types.Position) hove
 // reads HoverService from the request context (injected via withContext) rather than
 // calling the di.HoverService() global.
 func TestTextDocumentHover_UsesHoverServiceFromContext(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	logger := zerolog.Nop()
 	conf := engine.GetConfiguration()
 
 	sentinel := &sentinelHoverService{}
+	deps := di.TestInit(t, engine, tokenService, &di.Dependencies{HoverService: sentinel})
 
-	deps := di.Dependencies{
-		HoverService: sentinel,
-	}
-
-	h := withContext(textDocumentHover(), &logger, conf, engine, deps)
+	h := withContext(textDocumentHover(), &logger, conf, engine, deps, nil)
 
 	hoverParams := hover.Params{
 		TextDocument: sglsp.TextDocumentIdentifier{URI: "file:///foo.go"},
@@ -239,6 +236,8 @@ func TestTextDocumentHover_UsesHoverServiceFromContext(t *testing.T) {
 func TestWithContext_InjectsAuthenticationService(t *testing.T) {
 	engine, tokenService := testutil.UnitTestWithEngine(t)
 	logger := zerolog.Nop()
+
+	// Build a concrete authService to assert identity after injection.
 	configResolver := testutil.DefaultConfigResolver(engine)
 	notifier := notification.NewNotifier()
 	authService := authentication.NewAuthenticationService(
@@ -249,12 +248,9 @@ func TestWithContext_InjectsAuthenticationService(t *testing.T) {
 		notifier,
 		configResolver,
 	)
-
-	deps := di.Dependencies{
-		ConfigResolver:        configResolver,
+	deps := di.TestInit(t, engine, tokenService, &di.Dependencies{
 		AuthenticationService: authService,
-		Notifier:              notifier,
-	}
+	})
 
 	var gotAuthService authentication.AuthenticationService
 	wrapped := withContext(func(ctx context.Context, _ *jrpc2.Request) (any, error) {
@@ -263,7 +259,7 @@ func TestWithContext_InjectsAuthenticationService(t *testing.T) {
 		gotAuthService, ok = ctxDeps[ctx2.DepAuthService].(authentication.AuthenticationService)
 		require.True(t, ok)
 		return nil, nil
-	}, &logger, engine.GetConfiguration(), engine, deps)
+	}, &logger, engine.GetConfiguration(), engine, deps, nil)
 
 	_, err := wrapped(t.Context(), nil)
 
@@ -1659,17 +1655,17 @@ func TestInitializeHandler_MissingDep_PropagatesLSPError(t *testing.T) {
 		{
 			name:        "missing AuthenticationService",
 			mutate:      func(d *di.Dependencies) { d.AuthenticationService = nil },
-			wantMessage: "authentication service missing",
+			wantMessage: "mandatory DI dependency missing: AuthenticationService",
 		},
 		{
 			name:        "missing LdxSyncService",
 			mutate:      func(d *di.Dependencies) { d.LdxSyncService = nil },
-			wantMessage: "LDX Sync service missing",
+			wantMessage: "mandatory DI dependency missing: LdxSyncService",
 		},
 		{
 			name:        "missing ConfigResolver",
 			mutate:      func(d *di.Dependencies) { d.ConfigResolver = nil },
-			wantMessage: "missing mandatory DI dependency",
+			wantMessage: "mandatory DI dependency missing: ConfigResolver",
 		},
 	}
 

--- a/domain/ide/command/apply_auth_config.go
+++ b/domain/ide/command/apply_auth_config.go
@@ -39,7 +39,7 @@ func ApplyEndpointChange(ctx context.Context, conf gafConfig.Configuration, auth
 				Str("old_endpoint", oldEndpoint).
 				Str("new_endpoint", endpoint).
 				Msg("authService is nil; skipping logout on endpoint change — credentials may persist against wrong endpoint")
-			return false
+			return changed
 		}
 		logger.Info().
 			Str("old_endpoint", oldEndpoint).

--- a/domain/ide/command/apply_auth_config.go
+++ b/domain/ide/command/apply_auth_config.go
@@ -33,7 +33,14 @@ import (
 func ApplyEndpointChange(ctx context.Context, conf gafConfig.Configuration, authService authentication.AuthenticationService, logger *zerolog.Logger, endpoint string) bool {
 	oldEndpoint := types.GetGlobalString(conf, types.SettingApiEndpoint)
 	changed := config.UpdateApiEndpointsOnConfig(conf, endpoint)
-	if changed && conf.GetBool(types.SettingIsLspInitialized) && authService != nil {
+	if changed && conf.GetBool(types.SettingIsLspInitialized) {
+		if authService == nil {
+			logger.Error().
+				Str("old_endpoint", oldEndpoint).
+				Str("new_endpoint", endpoint).
+				Msg("authService is nil; skipping logout on endpoint change — credentials may persist against wrong endpoint")
+			return changed
+		}
 		logger.Info().
 			Str("old_endpoint", oldEndpoint).
 			Str("new_endpoint", endpoint).

--- a/domain/ide/command/apply_auth_config.go
+++ b/domain/ide/command/apply_auth_config.go
@@ -77,12 +77,6 @@ func ApplyAuthMethodChange(conf gafConfig.Configuration, authService authenticat
 		Str("new_auth_method", string(authMethod)).
 		Msg("auth method change requested")
 	types.SetGlobalUser(conf, types.SettingAuthenticationMethod, string(authMethod))
-	if authService == nil {
-		logger.Warn().
-			Str("auth_method", string(authMethod)).
-			Msg("authService is nil; auth method persisted but ConfigureProviders skipped")
-		return authMethod != previousMethod
-	}
 	authService.ConfigureProviders(conf, logger)
 
 	return authMethod != previousMethod

--- a/domain/ide/command/apply_auth_config.go
+++ b/domain/ide/command/apply_auth_config.go
@@ -39,7 +39,7 @@ func ApplyEndpointChange(ctx context.Context, conf gafConfig.Configuration, auth
 				Str("old_endpoint", oldEndpoint).
 				Str("new_endpoint", endpoint).
 				Msg("authService is nil; skipping logout on endpoint change — credentials may persist against wrong endpoint")
-			return changed
+			return false
 		}
 		logger.Info().
 			Str("old_endpoint", oldEndpoint).
@@ -61,8 +61,10 @@ func ApplyInsecureSetting(conf gafConfig.Configuration, insecure bool) {
 
 // ApplyAuthMethodChange sets the auth method and calls ConfigureProviders.
 // Returns true if the method actually changed.
+// SetGlobalUser is called unconditionally so the new method persists across restarts even
+// when authService is nil. ConfigureProviders is skipped when authService is nil.
 func ApplyAuthMethodChange(conf gafConfig.Configuration, authService authentication.AuthenticationService, logger *zerolog.Logger, authMethod types.AuthenticationMethod) bool {
-	if authMethod == types.EmptyAuthenticationMethod || authService == nil {
+	if authMethod == types.EmptyAuthenticationMethod {
 		return false
 	}
 
@@ -72,6 +74,12 @@ func ApplyAuthMethodChange(conf gafConfig.Configuration, authService authenticat
 		Str("new_auth_method", string(authMethod)).
 		Msg("auth method change requested")
 	types.SetGlobalUser(conf, types.SettingAuthenticationMethod, string(authMethod))
+	if authService == nil {
+		logger.Warn().
+			Str("auth_method", string(authMethod)).
+			Msg("authService is nil; auth method persisted but ConfigureProviders skipped")
+		return false
+	}
 	authService.ConfigureProviders(conf, logger)
 
 	return authMethod != previousMethod

--- a/domain/ide/command/apply_auth_config.go
+++ b/domain/ide/command/apply_auth_config.go
@@ -32,15 +32,18 @@ import (
 // Logout internally calls configureProviders, so no explicit ConfigureProviders call is needed.
 func ApplyEndpointChange(ctx context.Context, conf gafConfig.Configuration, authService authentication.AuthenticationService, logger *zerolog.Logger, endpoint string) bool {
 	oldEndpoint := types.GetGlobalString(conf, types.SettingApiEndpoint)
+	// When LSP is initialized, an endpoint switch requires logout to clear credentials.
+	// Mutating config without logout would leave the system with new-endpoint config
+	// but old-environment credentials — a session leakage risk.
+	if conf.GetBool(types.SettingIsLspInitialized) && authService == nil {
+		logger.Error().
+			Str("old_endpoint", oldEndpoint).
+			Str("new_endpoint", endpoint).
+			Msg("authService is nil; skipping endpoint switch to prevent session leakage")
+		return false
+	}
 	changed := config.UpdateApiEndpointsOnConfig(conf, endpoint)
 	if changed && conf.GetBool(types.SettingIsLspInitialized) {
-		if authService == nil {
-			logger.Error().
-				Str("old_endpoint", oldEndpoint).
-				Str("new_endpoint", endpoint).
-				Msg("authService is nil; skipping logout on endpoint change — credentials may persist against wrong endpoint")
-			return changed
-		}
 		logger.Info().
 			Str("old_endpoint", oldEndpoint).
 			Str("new_endpoint", endpoint).
@@ -78,7 +81,7 @@ func ApplyAuthMethodChange(conf gafConfig.Configuration, authService authenticat
 		logger.Warn().
 			Str("auth_method", string(authMethod)).
 			Msg("authService is nil; auth method persisted but ConfigureProviders skipped")
-		return false
+		return authMethod != previousMethod
 	}
 	authService.ConfigureProviders(conf, logger)
 

--- a/domain/ide/command/apply_auth_config.go
+++ b/domain/ide/command/apply_auth_config.go
@@ -33,7 +33,7 @@ import (
 func ApplyEndpointChange(ctx context.Context, conf gafConfig.Configuration, authService authentication.AuthenticationService, logger *zerolog.Logger, endpoint string) bool {
 	oldEndpoint := types.GetGlobalString(conf, types.SettingApiEndpoint)
 	changed := config.UpdateApiEndpointsOnConfig(conf, endpoint)
-	if changed && conf.GetBool(types.SettingIsLspInitialized) {
+	if changed && conf.GetBool(types.SettingIsLspInitialized) && authService != nil {
 		logger.Info().
 			Str("old_endpoint", oldEndpoint).
 			Str("new_endpoint", endpoint).
@@ -55,7 +55,7 @@ func ApplyInsecureSetting(conf gafConfig.Configuration, insecure bool) {
 // ApplyAuthMethodChange sets the auth method and calls ConfigureProviders.
 // Returns true if the method actually changed.
 func ApplyAuthMethodChange(conf gafConfig.Configuration, authService authentication.AuthenticationService, logger *zerolog.Logger, authMethod types.AuthenticationMethod) bool {
-	if authMethod == types.EmptyAuthenticationMethod {
+	if authMethod == types.EmptyAuthenticationMethod || authService == nil {
 		return false
 	}
 

--- a/domain/ide/command/apply_auth_config_test.go
+++ b/domain/ide/command/apply_auth_config_test.go
@@ -88,16 +88,28 @@ func TestApplyEndpointChange_EndpointSame_ReturnsFalse(t *testing.T) {
 	assert.Equal(t, "some-token", config.GetToken(conf), "token must be preserved when endpoint is unchanged")
 }
 
-func TestApplyEndpointChange_NilAuthService_LSPInitialized_ReturnsChangedAndSkipsLogout(t *testing.T) {
+func TestApplyEndpointChange_NilAuthService_LSPNotInitialized_MutationProceeds(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
-	conf.Set(types.SettingIsLspInitialized, true)
-
-	// When authService is nil we skip logout, but the config mutation already happened —
-	// returning changed (true) lets the caller report the endpoint update in telemetry.
+	// LSP not initialized — no logout needed, so nil authService must not block the change.
 	changed := ApplyEndpointChange(t.Context(), conf, nil, engine.GetLogger(), "https://api.custom.io")
 
 	assert.True(t, changed)
+	assert.Equal(t, "https://api.custom.io", types.GetGlobalString(conf, types.SettingApiEndpoint))
+}
+
+func TestApplyEndpointChange_NilAuthService_LSPInitialized_SkipsMutationAndReturnsFalse(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	conf.Set(types.SettingIsLspInitialized, true)
+	originalEndpoint := types.GetGlobalString(conf, types.SettingApiEndpoint)
+
+	// When authService is nil and LSP is initialized, the config must NOT be mutated —
+	// switching endpoints without logging out would leave credentials pointing at the wrong endpoint.
+	changed := ApplyEndpointChange(t.Context(), conf, nil, engine.GetLogger(), "https://api.custom.io")
+
+	assert.False(t, changed)
+	assert.Equal(t, originalEndpoint, types.GetGlobalString(conf, types.SettingApiEndpoint), "endpoint must not be mutated when logout cannot be performed")
 }
 
 func TestApplyInsecureSetting_SetsInsecureFlag(t *testing.T) {
@@ -151,15 +163,16 @@ func TestApplyAuthMethodChange_MethodSame_ReturnsFalse(t *testing.T) {
 	assert.Equal(t, "some-token", config.GetToken(conf), "token must be preserved when auth method is unchanged")
 }
 
-func TestApplyAuthMethodChange_NilAuthService_PersistsMethodButReturnsFalse(t *testing.T) {
+func TestApplyAuthMethodChange_NilAuthService_PersistsMethodAndReturnsChanged(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 
 	// Even when authService is nil (ConfigureProviders cannot run), SetGlobalUser must
-	// still be called so the auth method persists across restarts.
+	// still be called so the auth method persists across restarts. The return value must
+	// reflect whether the method actually changed — not suppress it due to the nil authService.
 	changed := ApplyAuthMethodChange(conf, nil, engine.GetLogger(), types.TokenAuthentication)
 
-	assert.False(t, changed, "must return false when authService is nil")
+	assert.True(t, changed, "must return true when method changed, even if authService is nil")
 	assert.Equal(t, types.TokenAuthentication, config.GetAuthenticationMethodFromConfig(conf),
 		"auth method must be persisted even when authService is nil")
 }

--- a/domain/ide/command/apply_auth_config_test.go
+++ b/domain/ide/command/apply_auth_config_test.go
@@ -88,6 +88,17 @@ func TestApplyEndpointChange_EndpointSame_ReturnsFalse(t *testing.T) {
 	assert.Equal(t, "some-token", config.GetToken(conf), "token must be preserved when endpoint is unchanged")
 }
 
+func TestApplyEndpointChange_NilAuthService_LSPInitialized_ReturnsChangedWithoutPanic(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	conf.Set(types.SettingIsLspInitialized, true)
+
+	// Must not panic and must still report changed=true so callers (e.g. analytics) observe the update.
+	changed := ApplyEndpointChange(t.Context(), conf, nil, engine.GetLogger(), "https://api.custom.io")
+
+	assert.True(t, changed)
+}
+
 func TestApplyInsecureSetting_SetsInsecureFlag(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	conf := engine.GetConfiguration()

--- a/domain/ide/command/apply_auth_config_test.go
+++ b/domain/ide/command/apply_auth_config_test.go
@@ -88,15 +88,17 @@ func TestApplyEndpointChange_EndpointSame_ReturnsFalse(t *testing.T) {
 	assert.Equal(t, "some-token", config.GetToken(conf), "token must be preserved when endpoint is unchanged")
 }
 
-func TestApplyEndpointChange_NilAuthService_LSPInitialized_ReturnsChangedWithoutPanic(t *testing.T) {
+func TestApplyEndpointChange_NilAuthService_LSPInitialized_ReturnsFalseAndNoLogout(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	conf.Set(types.SettingIsLspInitialized, true)
 
-	// Must not panic and must still report changed=true so callers (e.g. analytics) observe the update.
+	// When authService is nil we cannot perform logout, so we must not signal "changed"
+	// to the caller — returning true would cause downstream actions (e.g. analytics, workspace
+	// clear) to proceed as if the change succeeded, which is misleading.
 	changed := ApplyEndpointChange(t.Context(), conf, nil, engine.GetLogger(), "https://api.custom.io")
 
-	assert.True(t, changed)
+	assert.False(t, changed)
 }
 
 func TestApplyInsecureSetting_SetsInsecureFlag(t *testing.T) {
@@ -148,6 +150,19 @@ func TestApplyAuthMethodChange_MethodSame_ReturnsFalse(t *testing.T) {
 	assert.False(t, changed)
 	assert.Equal(t, types.FakeAuthentication, config.GetAuthenticationMethodFromConfig(conf))
 	assert.Equal(t, "some-token", config.GetToken(conf), "token must be preserved when auth method is unchanged")
+}
+
+func TestApplyAuthMethodChange_NilAuthService_PersistsMethodButReturnsFalse(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	// Even when authService is nil (ConfigureProviders cannot run), SetGlobalUser must
+	// still be called so the auth method persists across restarts.
+	changed := ApplyAuthMethodChange(conf, nil, engine.GetLogger(), types.TokenAuthentication)
+
+	assert.False(t, changed, "must return false when authService is nil")
+	assert.Equal(t, types.TokenAuthentication, config.GetAuthenticationMethodFromConfig(conf),
+		"auth method must be persisted even when authService is nil")
 }
 
 func TestApplyAuthMethodChange_EmptyMethod_NoEffect(t *testing.T) {

--- a/domain/ide/command/apply_auth_config_test.go
+++ b/domain/ide/command/apply_auth_config_test.go
@@ -163,19 +163,8 @@ func TestApplyAuthMethodChange_MethodSame_ReturnsFalse(t *testing.T) {
 	assert.Equal(t, "some-token", config.GetToken(conf), "token must be preserved when auth method is unchanged")
 }
 
-func TestApplyAuthMethodChange_NilAuthService_PersistsMethodAndReturnsChanged(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
-	conf := engine.GetConfiguration()
-
-	// Even when authService is nil (ConfigureProviders cannot run), SetGlobalUser must
-	// still be called so the auth method persists across restarts. The return value must
-	// reflect whether the method actually changed — not suppress it due to the nil authService.
-	changed := ApplyAuthMethodChange(conf, nil, engine.GetLogger(), types.TokenAuthentication)
-
-	assert.True(t, changed, "must return true when method changed, even if authService is nil")
-	assert.Equal(t, types.TokenAuthentication, config.GetAuthenticationMethodFromConfig(conf),
-		"auth method must be persisted even when authService is nil")
-}
+// TestApplyAuthMethodChange_NilAuthService removed: authService is now guaranteed
+// non-nil by withContext.validateMandatoryDeps before any handler runs.
 
 func TestApplyAuthMethodChange_EmptyMethod_NoEffect(t *testing.T) {
 	engine, ts := testutil.UnitTestWithEngine(t)

--- a/domain/ide/command/apply_auth_config_test.go
+++ b/domain/ide/command/apply_auth_config_test.go
@@ -88,17 +88,16 @@ func TestApplyEndpointChange_EndpointSame_ReturnsFalse(t *testing.T) {
 	assert.Equal(t, "some-token", config.GetToken(conf), "token must be preserved when endpoint is unchanged")
 }
 
-func TestApplyEndpointChange_NilAuthService_LSPInitialized_ReturnsFalseAndNoLogout(t *testing.T) {
+func TestApplyEndpointChange_NilAuthService_LSPInitialized_ReturnsChangedAndSkipsLogout(t *testing.T) {
 	engine, _ := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	conf.Set(types.SettingIsLspInitialized, true)
 
-	// When authService is nil we cannot perform logout, so we must not signal "changed"
-	// to the caller — returning true would cause downstream actions (e.g. analytics, workspace
-	// clear) to proceed as if the change succeeded, which is misleading.
+	// When authService is nil we skip logout, but the config mutation already happened —
+	// returning changed (true) lets the caller report the endpoint update in telemetry.
 	changed := ApplyEndpointChange(t.Context(), conf, nil, engine.GetLogger(), "https://api.custom.io")
 
-	assert.False(t, changed)
+	assert.True(t, changed)
 }
 
 func TestApplyInsecureSetting_SetsInsecureFlag(t *testing.T) {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -106,13 +106,11 @@ const DepEngine = "engine"
 const DepConfiguration = "configuration"
 const DepLdxSyncService = "ldxSyncService"
 const DepTreeEmitter = "treeEmitter"
-
-// New dep keys — added so that withContext can inject all handler deps into ctx.
 const DepHoverService = "hoverService"
-const DepInstaller = "installer"
+const DepFileWatcher = "fileWatcher"
 const DepCodeActionService = "codeActionService"
 const DepFeatureFlagService = "featureFlagService"
-const DepFileWatcher = "fileWatcher"
+const DepInstaller = "installer"
 
 // NewContextWithDependencies returns a new Context that carries dependencies.
 // This can be used to pass pointers to injected (service) dependencies, e.g. a pointer


### PR DESCRIPTION
### **User description**
## Summary
- Migrate all `di.*()` global accessor calls in LSP handler functions to context-based dependency injection
- Extend `di.Dependencies` struct with handler-accessed fields: `Scanner`, `HoverService`, `ScanNotifier`, `ScanPersister`, `FileWatcher`, `ErrorReporter`, `CodeActionService`, `FeatureFlagService`
- Add nil-guarded injections for all new fields in `withContext` middleware
- Add typed context extractors for each new field (`hoverServiceFromContext`, `scannerFromContext`, etc.)
- Remove dead `initializerFromContext` / `installerFromContext` helpers (Installer/Initializer are process-lifecycle deps, not per-request)
- Fix `logError` to call `di.ErrorReporter().CaptureError(err)` (regression restore)
- Add nil guard in `notifyLockedFieldsRejected`; soft-fail in `refreshLdxSyncOnTokenChange`

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#1302 PR-1 ← YOU ARE HERE\nDI context injection\n(production code)"]
    PR2["#1303 PR-2\nTDD contract tests"]
    main --> PR1 --> PR2
    style PR1 fill:#ffd700,color:#000
```

## Deferred to later PRs
- `di.TestInit` write-path still mutates package-level globals (PR2 notes this as a known gap; full parallel test safety requires fixing this too)
- Full `t.Parallel()` adoption once the write-path is fixed

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./application/server/...` passes with `-race`
- [x] `go test ./application/di/...` passes
- [x] PR size: 601 changed lines (under 700 limit)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Migrate LSP handler dependencies to context injection.

- Introduce `must*FromContext` helpers for mandatory dependencies.

- Enhance nil-safety and error handling in config updates.

- Update DI struct, tests, and server startup logic.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>init.go</strong><dd><code>Update DI Dependencies struct for context injection.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-3dfa2a6c1d0ed218f91d033ea2c5e5575f64d80c2575b71fe0605ec4fa41d4f6">+17/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.go</strong><dd><code>Refactor server handlers to use context DI.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-eb3fe6fd1956591838595b08979653ec23c0b0c16f5340e9e89a05c30e921607">+44/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>notification.go</strong><dd><code>Refactor client notification logic to use context.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-3ac97f07d29586cd80b9c63b5ac84fa3c0c029c0786ad485ae98d5d143cdaa53">+15/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Implement context injection wrapper and dependency validation.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-1b5a200b7dc3f37ed67632d0c2682eeb53762813f96edb15cb7660e076fa6031">+136/-62</a></td>

</tr>

<tr>
  <td><strong>context.go</strong><dd><code>Define new dependency keys for context injection.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-5ba4125877fb56856b4bb75f14ff968c77cdee83e09ea4cefd9d24fc2d453923">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>init_test.go</strong><dd><code>Update tests for DI context injection changes.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-fcd7ecadf7c2cc1571bea1e6d6238bb60ffce015cbe3f70cd9b3978a3facd621">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_init.go</strong><dd><code>Adjust test initialization for DI context.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-fc304a8ceac9f55997a1ed4f30020de933d3ada1a11eacd32c236acdce0cec81">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codeaction_handlers_test.go</strong><dd><code>Remove obsolete test for nil CodeActionsService.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-c7a7efea54d261bb20456900c55c74e98224241d0b1bacdcbfd43b28551cf453">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration_test.go</strong><dd><code>Enhance tests with new DI context helpers.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-e141faafb3f0507956b85e92ac3b584c7c706bd96e7f428c7ef95d0d8b2df564">+304/-185</a></td>

</tr>

<tr>
  <td><strong>notification_test.go</strong><dd><code>Add test for nil notifier panic in registerNotifier.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-09b80ca28f0c9f8db60c941c24e92dfc65ded48c06249e70e2004faec30b9891">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>apply_auth_config_test.go</strong><dd><code>Add tests for nil authService in endpoint change logic.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-1a300a09b5bd741eaaf57331b3a671e61e68bdd8f84a83b8d8333d497447e093">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>execute_command.go</strong><dd><code>Use must* helper for ErrorReporter in command handler.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-523ba95647cc7cf643285dc5a700fafb1c295bfbdc06065624232a888d1df3ef">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>apply_auth_config.go</strong><dd><code>Add nil checks for authService in config apply functions.</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-dcbb2ac73cd481e142a8a55439036be377feb70e23eb5bfd18f59909d7678074">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server_test.go</strong></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1302/changes#diff-165bad981a0cc202462a2fea7f236eab9ca3a72bd47fe8bae6b3adad801351fb">+88/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

