### PR TITLE
test: add TDD contract tests for context-based DI injection [IDE-1898]

### DIFF
--- a/application/server/di_context_injection_test.go
+++ b/application/server/di_context_injection_test.go
@@ -1,0 +1,141 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/handler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/application/di"
+	"github.com/snyk/snyk-ls/domain/ide/hover"
+	"github.com/snyk/snyk-ls/domain/snyk/persistence"
+	ctx2 "github.com/snyk/snyk-ls/internal/context"
+	er "github.com/snyk/snyk-ls/internal/observability/error_reporting"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// sentinelHoverService is a minimal hover.Service stub used to verify that
+// withContext injects the deps-provided service, not the di package global.
+type sentinelHoverService struct {
+	hover.Service
+}
+
+func (s *sentinelHoverService) GetHover(_ types.FilePath, _ types.Position) hover.Result {
+	return hover.Result{}
+}
+
+func (s *sentinelHoverService) ClearAllHovers() {}
+
+func (s *sentinelHoverService) Channel() chan hover.DocumentHovers {
+	return make(chan hover.DocumentHovers, 1)
+}
+
+// Test_withContext_injectsHoverService_isolatedFromGlobal proves that
+// withContext injects the HoverService from the deps struct into the handler
+// context, and that the injected value is the deps-provided instance — NOT
+// the di.HoverService() package global.
+//
+// This is the key regression guard for IDE-1898: if withContext stops injecting
+// HoverService, or a handler reverts to calling di.HoverService() directly,
+// the two sentinels will differ and the assertions will fail.
+func Test_withContext_injectsHoverService_isolatedFromGlobal(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	logger := engine.GetLogger()
+
+	globalSentinel := &sentinelHoverService{}
+	contextSentinel := &sentinelHoverService{}
+
+	// Set the di package-level global to globalSentinel.
+	di.TestInit(t, engine, tokenService, &di.Dependencies{
+		HoverService: globalSentinel,
+	})
+
+	// Pass a different instance in deps — withContext must inject this one.
+	deps := di.Dependencies{
+		HoverService: contextSentinel,
+	}
+
+	var gotService hover.Service
+	wrapped := withContext(handler.New(func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+		gotService, _ = hoverServiceFromContext(ctx)
+		return nil, nil
+	}), logger, conf, engine, deps)
+
+	_, err := wrapped(t.Context(), nil)
+	require.NoError(t, err)
+
+	gotSentinel, ok := gotService.(*sentinelHoverService)
+	require.True(t, ok, "expected *sentinelHoverService from context")
+	assert.True(t, gotSentinel == contextSentinel,
+		"withContext must inject the deps.HoverService into context, not read di.HoverService() global")
+	assert.True(t, gotSentinel != globalSentinel,
+		"handler must not use the di.HoverService() global")
+}
+
+// Test_withContext_injectsNewHandlerDependencies verifies that withContext
+// injects the following di.Dependencies fields into the handler context:
+// HoverService, ScanPersister, ErrorReporter.
+//
+// These are fields added in IDE-1898. AuthenticationService injection is
+// already covered by TestWithContext_InjectsAuthenticationService in server_test.go.
+func Test_withContext_injectsNewHandlerDependencies(t *testing.T) {
+	engine, _ := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	logger := engine.GetLogger()
+
+	scanPersister := persistence.NopScanPersister{}
+	sentinel := &sentinelHoverService{}
+	errReporter := er.NewTestErrorReporter(engine)
+
+	deps := di.Dependencies{
+		HoverService:  sentinel,
+		ScanPersister: scanPersister,
+		ErrorReporter: errReporter,
+	}
+
+	var (
+		gotHoverService  hover.Service
+		gotScanPersister persistence.ScanSnapshotPersister
+		gotErrorReporter er.ErrorReporter
+	)
+
+	wrapped := withContext(handler.New(func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+		ctxDeps, ok := ctx2.DependenciesFromContext(ctx)
+		require.True(t, ok, "expected deps map in context")
+		gotHoverService, _ = ctxDeps[ctx2.DepHoverService].(hover.Service)
+		gotScanPersister, _ = ctxDeps[ctx2.DepScanPersister].(persistence.ScanSnapshotPersister)
+		gotErrorReporter, _ = ctxDeps[ctx2.DepErrorReporter].(er.ErrorReporter)
+		return nil, nil
+	}), logger, conf, engine, deps)
+
+	_, err := wrapped(t.Context(), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, sentinel, gotHoverService,
+		"HoverService must be the exact instance injected into context")
+	assert.Equal(t, scanPersister, gotScanPersister,
+		"ScanPersister must be the exact instance injected into context")
+	assert.Equal(t, errReporter, gotErrorReporter,
+		"ErrorReporter must be the exact instance injected into context")
+}

--- a/application/server/di_context_injection_test.go
+++ b/application/server/di_context_injection_test.go
@@ -34,19 +34,25 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
-// sentinelHoverService is a minimal hover.Service stub used to verify that
+// diTestScanPersister is a pointer-type stub so pointer-identity assertions
+// (assert.Same) can distinguish the injected instance from any other NopScanPersister.
+type diTestScanPersister struct {
+	persistence.NopScanPersister
+}
+
+// diTestHoverService is a minimal hover.Service stub used to verify that
 // withContext injects the deps-provided service, not the di package global.
-type sentinelHoverService struct {
+type diTestHoverService struct {
 	hover.Service
 }
 
-func (s *sentinelHoverService) GetHover(_ types.FilePath, _ types.Position) hover.Result {
+func (s *diTestHoverService) GetHover(_ types.FilePath, _ types.Position) hover.Result {
 	return hover.Result{}
 }
 
-func (s *sentinelHoverService) ClearAllHovers() {}
+func (s *diTestHoverService) ClearAllHovers() {}
 
-func (s *sentinelHoverService) Channel() chan hover.DocumentHovers {
+func (s *diTestHoverService) Channel() chan hover.DocumentHovers {
 	return make(chan hover.DocumentHovers, 1)
 }
 
@@ -63,30 +69,31 @@ func Test_withContext_injectsHoverService_isolatedFromGlobal(t *testing.T) {
 	conf := engine.GetConfiguration()
 	logger := engine.GetLogger()
 
-	globalSentinel := &sentinelHoverService{}
-	contextSentinel := &sentinelHoverService{}
+	globalSentinel := &diTestHoverService{}
+	contextSentinel := &diTestHoverService{}
 
-	// Set the di package-level global to globalSentinel.
-	di.TestInit(t, engine, tokenService, &di.Dependencies{
+	// Set the di package-level global to globalSentinel. Use the returned deps
+	// as a base so all mandatory fields (e.g. ConfigResolver) are populated.
+	baseDeps := di.TestInit(t, engine, tokenService, &di.Dependencies{
 		HoverService: globalSentinel,
 	})
 
-	// Pass a different instance in deps — withContext must inject this one.
-	deps := di.Dependencies{
-		HoverService: contextSentinel,
-	}
+	// Override only HoverService — withContext must inject contextSentinel, not
+	// the globalSentinel that was passed to TestInit above.
+	deps := baseDeps
+	deps.HoverService = contextSentinel
 
 	var gotService hover.Service
 	wrapped := withContext(handler.New(func(ctx context.Context, _ *jrpc2.Request) (any, error) {
 		gotService, _ = hoverServiceFromContext(ctx)
 		return nil, nil
-	}), logger, conf, engine, deps)
+	}), logger, conf, engine, deps, nil)
 
 	_, err := wrapped(t.Context(), nil)
 	require.NoError(t, err)
 
-	gotSentinel, ok := gotService.(*sentinelHoverService)
-	require.True(t, ok, "expected *sentinelHoverService from context")
+	gotSentinel, ok := gotService.(*diTestHoverService)
+	require.True(t, ok, "expected *diTestHoverService from context")
 	assert.True(t, gotSentinel == contextSentinel,
 		"withContext must inject the deps.HoverService into context, not read di.HoverService() global")
 	assert.True(t, gotSentinel != globalSentinel,
@@ -100,19 +107,21 @@ func Test_withContext_injectsHoverService_isolatedFromGlobal(t *testing.T) {
 // These are fields added in IDE-1898. AuthenticationService injection is
 // already covered by TestWithContext_InjectsAuthenticationService in server_test.go.
 func Test_withContext_injectsNewHandlerDependencies(t *testing.T) {
-	engine, _ := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	logger := engine.GetLogger()
 
-	scanPersister := persistence.NopScanPersister{}
-	sentinel := &sentinelHoverService{}
+	scanPersister := &diTestScanPersister{}
+	sentinel := &diTestHoverService{}
 	errReporter := er.NewTestErrorReporter(engine)
 
-	deps := di.Dependencies{
-		HoverService:  sentinel,
-		ScanPersister: scanPersister,
-		ErrorReporter: errReporter,
-	}
+	// Prime global DI state (satisfies validateMandatoryDeps inside withContext),
+	// then override the three fields under test on the returned struct copy so the
+	// test proves context injection uses the deps struct, not the di package globals.
+	deps := di.TestInit(t, engine, tokenService, nil)
+	deps.HoverService = sentinel
+	deps.ScanPersister = scanPersister
+	deps.ErrorReporter = errReporter
 
 	var (
 		gotHoverService  hover.Service
@@ -127,15 +136,15 @@ func Test_withContext_injectsNewHandlerDependencies(t *testing.T) {
 		gotScanPersister, _ = ctxDeps[ctx2.DepScanPersister].(persistence.ScanSnapshotPersister)
 		gotErrorReporter, _ = ctxDeps[ctx2.DepErrorReporter].(er.ErrorReporter)
 		return nil, nil
-	}), logger, conf, engine, deps)
+	}), logger, conf, engine, deps, nil)
 
 	_, err := wrapped(t.Context(), nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, sentinel, gotHoverService,
+	assert.Same(t, sentinel, gotHoverService,
 		"HoverService must be the exact instance injected into context")
-	assert.Equal(t, scanPersister, gotScanPersister,
+	assert.Same(t, scanPersister, gotScanPersister,
 		"ScanPersister must be the exact instance injected into context")
-	assert.Equal(t, errReporter, gotErrorReporter,
+	assert.Same(t, errReporter, gotErrorReporter,
 		"ErrorReporter must be the exact instance injected into context")
 }


### PR DESCRIPTION
### **User description**
## Summary
- Add `di_context_injection_test.go` with two white-box contract tests proving handlers read dependencies from context (not from `di.*()` globals)
- `Test_withContext_injectsHoverService_isolatedFromGlobal`: uses two distinct sentinel instances — one in the `di` package global, one in `deps` — to prove `withContext` injects the deps-provided value and handlers do not fall back to the global
- `Test_withContext_injectsNewHandlerDependencies`: verifies `HoverService`, `ScanPersister`, and `ErrorReporter` are injected with `assert.Equal` identity checks (not just `NotNil`)

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#1302 PR-1\nDI context injection\n(production code)"]
    PR2["#1303 PR-2 ← YOU ARE HERE\nTDD contract tests"]
    main --> PR1 --> PR2
    style PR2 fill:#ffd700,color:#000
```

**Depends on:** #1302

## Deferred to later PRs
- Full parallel test execution (`t.Parallel()`) — requires the write-path in `di.TestInit` to also be fixed (currently still mutates package-level globals)

## Test plan
- [x] `Test_withContext_injectsHoverService_isolatedFromGlobal` — passes with `-race`
- [x] `Test_withContext_injectsNewHandlerDependencies` — passes with `-race`
- [x] `go build ./...` clean
- [x] `go vet ./...` clean


___

### **PR Type**
Tests


___

### **Description**
- Add contract tests for DI context injection.

- Test `HoverService` context isolation.

- Verify `ScanPersister`/`ErrorReporter` injection.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>di_context_injection_test.go</strong><dd><code>TDD contract tests for DI context injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/di_context_injection_test.go

<ul><li>Introduces <code>di_context_injection_test.go</code> with contract tests for <br>dependency injection.<br> <li> Tests verify <code>HoverService</code> is injected via context, not global <br>accessors.<br> <li> Verifies <code>ScanPersister</code> and <code>ErrorReporter</code> are correctly injected into <br>the context.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1303/changes#diff-292bc3a0ab1933038d1f9b033e0acdfb355320806d372670ed603d583500236f">+150/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

