### PR TITLE
fix(treeview): position scan-error overlay using measured height [IDE-1808]

### DIFF
--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -77,7 +77,6 @@
   var activeErrorOutsideClick = null;
   var activeErrorResize = null;
   var activeErrorRow = null;
-  var ERROR_OVERLAY_GAP = 4;
 
   function dismissErrorOverlay() {
     if (activeErrorOverlay && activeErrorOverlay.parentNode) {
@@ -110,19 +109,27 @@
   function positionErrorOverlay(overlay, row) {
     if (!overlay || !row) return;
     var rect = row.getBoundingClientRect();
+    // 600 = sensible fallback viewport width when neither window.innerWidth
+    // nor documentElement.clientWidth is reported (very old WebViews / tests).
     var vw = window.innerWidth || document.documentElement.clientWidth || 600;
-    var vh = window.innerHeight || document.documentElement.clientHeight || 400;
     var overlayH = overlay.getBoundingClientRect().height;
     if (overlayH <= 0) return;
 
-    var gap = ERROR_OVERLAY_GAP;
+    // 4 = gap in px between the row and the overlay (and a minimum margin
+    // from the viewport edge).
+    var gap = 4;
     var topPos = rect.bottom + gap;
     if (rect.top - overlayH - gap >= gap) {
       topPos = rect.top - overlayH - gap;
     }
     topPos = Math.max(gap, topPos);
 
+    // 520 = preferred max overlay width (keeps error text at a comfortable
+    // reading width); 16 = total horizontal viewport padding (8px each side)
+    // so a narrow viewport still leaves a small margin.
     var overlayW = Math.min(520, vw - 16);
+    // 8 = right-edge margin: when the row is far right, pin the overlay so
+    // there is still ~8px between its right edge and the viewport.
     var leftPos = Math.max(gap, Math.min(rect.left, vw - overlayW - 8));
 
     overlay.style.position = 'fixed';

--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -101,9 +101,10 @@
 
   // Computes and applies the final overlay position using its measured height,
   // so a tall overlay against a row at the bottom of the viewport flips above
-  // the row instead of being clipped (IDE-1808). Defaults to below; flips above
-  // only when there isn't room below AND there is room above — otherwise the
-  // overlay stays below (clipped is preferable to overlapping the row).
+  // the row instead of being clipped (IDE-1808). Prefers above whenever there
+  // is room above: tree views in IDEs typically have more chrome below them
+  // (status bars, help panels) than above, so above is the safer default and
+  // matches the behavior of the previous VS Code-side shim.
   // Clears `bottom` and `transform` defensively so future style sources can't
   // stretch the overlay between opposing anchors.
   function positionErrorOverlay(overlay, row) {
@@ -116,9 +117,7 @@
 
     var gap = ERROR_OVERLAY_GAP;
     var topPos = rect.bottom + gap;
-    var fitsBelow = topPos + overlayH + gap <= vh;
-    var fitsAbove = rect.top - overlayH - gap >= gap;
-    if (!fitsBelow && fitsAbove) {
+    if (rect.top - overlayH - gap >= gap) {
       topPos = rect.top - overlayH - gap;
     }
     topPos = Math.max(gap, topPos);

--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -76,6 +76,7 @@
   var activeErrorKeyDown = null;
   var activeErrorOutsideClick = null;
   var activeErrorResize = null;
+  var activeErrorScroll = null;
   var activeErrorRow = null;
 
   function dismissErrorOverlay() {
@@ -93,6 +94,11 @@
     if (activeErrorResize) {
       window.removeEventListener('resize', activeErrorResize);
       activeErrorResize = null;
+    }
+    if (activeErrorScroll) {
+      // Match the `capture: true` used when adding the listener.
+      document.removeEventListener('scroll', activeErrorScroll, true);
+      activeErrorScroll = null;
     }
     activeErrorOverlay = null;
     activeErrorRow = null;
@@ -112,6 +118,21 @@
     // 600 = sensible fallback viewport width when neither window.innerWidth
     // nor documentElement.clientWidth is reported (very old WebViews / tests).
     var vw = window.innerWidth || document.documentElement.clientWidth || 600;
+
+    // 520 = preferred max overlay width (keeps error text at a comfortable
+    // reading width); 16 = total horizontal viewport padding (8px each side)
+    // so a narrow viewport still leaves a small margin.
+    var overlayW = Math.min(520, vw - 16);
+
+    // Apply width and clear stale top/bottom before measuring height: the
+    // <pre> message wraps, so width determines height. Measuring height first
+    // would use the pre-wrap layout and place the overlay incorrectly once
+    // the width is applied.
+    overlay.style.position = 'fixed';
+    overlay.style.bottom = '';
+    overlay.style.transform = '';
+    overlay.style.width = overlayW + 'px';
+
     var overlayH = overlay.getBoundingClientRect().height;
     if (overlayH <= 0) return;
 
@@ -124,20 +145,12 @@
     }
     topPos = Math.max(gap, topPos);
 
-    // 520 = preferred max overlay width (keeps error text at a comfortable
-    // reading width); 16 = total horizontal viewport padding (8px each side)
-    // so a narrow viewport still leaves a small margin.
-    var overlayW = Math.min(520, vw - 16);
     // 8 = right-edge margin: when the row is far right, pin the overlay so
     // there is still ~8px between its right edge and the viewport.
     var leftPos = Math.max(gap, Math.min(rect.left, vw - overlayW - 8));
 
-    overlay.style.position = 'fixed';
     overlay.style.top = topPos + 'px';
-    overlay.style.bottom = '';
-    overlay.style.transform = '';
     overlay.style.left = leftPos + 'px';
-    overlay.style.width = overlayW + 'px';
   }
 
   function showErrorOverlay(row, productLabel, errorMessage) {
@@ -193,6 +206,17 @@
       }
     };
     window.addEventListener('resize', activeErrorResize);
+
+    // Reposition on scroll so the overlay tracks its row when any scrollable
+    // ancestor (e.g. the tree container) scrolls. `capture: true` is required
+    // because scroll events do not bubble; capturing on the document catches
+    // them from any element.
+    activeErrorScroll = function() {
+      if (activeErrorOverlay && activeErrorRow) {
+        positionErrorOverlay(activeErrorOverlay, activeErrorRow);
+      }
+    };
+    document.addEventListener('scroll', activeErrorScroll, true);
 
     setTimeout(function() {
       if (!activeErrorOverlay) return;

--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -75,6 +75,9 @@
   var activeErrorOverlay = null;
   var activeErrorKeyDown = null;
   var activeErrorOutsideClick = null;
+  var activeErrorResize = null;
+  var activeErrorRow = null;
+  var ERROR_OVERLAY_GAP = 4;
 
   function dismissErrorOverlay() {
     if (activeErrorOverlay && activeErrorOverlay.parentNode) {
@@ -88,7 +91,47 @@
       document.removeEventListener('click', activeErrorOutsideClick);
       activeErrorOutsideClick = null;
     }
+    if (activeErrorResize) {
+      window.removeEventListener('resize', activeErrorResize);
+      activeErrorResize = null;
+    }
     activeErrorOverlay = null;
+    activeErrorRow = null;
+  }
+
+  // Computes and applies the final overlay position using its measured height,
+  // so a tall overlay against a row at the bottom of the viewport flips above
+  // the row instead of being clipped (IDE-1808). Defaults to below; flips above
+  // only when there isn't room below AND there is room above — otherwise the
+  // overlay stays below (clipped is preferable to overlapping the row).
+  // Clears `bottom` and `transform` defensively so future style sources can't
+  // stretch the overlay between opposing anchors.
+  function positionErrorOverlay(overlay, row) {
+    if (!overlay || !row) return;
+    var rect = row.getBoundingClientRect();
+    var vw = window.innerWidth || document.documentElement.clientWidth || 600;
+    var vh = window.innerHeight || document.documentElement.clientHeight || 400;
+    var overlayH = overlay.getBoundingClientRect().height;
+    if (overlayH <= 0) return;
+
+    var gap = ERROR_OVERLAY_GAP;
+    var topPos = rect.bottom + gap;
+    var fitsBelow = topPos + overlayH + gap <= vh;
+    var fitsAbove = rect.top - overlayH - gap >= gap;
+    if (!fitsBelow && fitsAbove) {
+      topPos = rect.top - overlayH - gap;
+    }
+    topPos = Math.max(gap, topPos);
+
+    var overlayW = Math.min(520, vw - 16);
+    var leftPos = Math.max(gap, Math.min(rect.left, vw - overlayW - 8));
+
+    overlay.style.position = 'fixed';
+    overlay.style.top = topPos + 'px';
+    overlay.style.bottom = '';
+    overlay.style.transform = '';
+    overlay.style.left = leftPos + 'px';
+    overlay.style.width = overlayW + 'px';
   }
 
   function showErrorOverlay(row, productLabel, errorMessage) {
@@ -118,23 +161,18 @@
     });
     overlay.appendChild(closeBtn);
 
-    // Position below the clicked row using fixed positioning so the overlay is
-    // viewport-relative and not clipped by the scrollable tree container.
-    var rect = row.getBoundingClientRect();
-    var vw = window.innerWidth || document.documentElement.clientWidth || 600;
-    var vh = window.innerHeight || document.documentElement.clientHeight || 400;
-    var overlayW = Math.min(520, vw - 16);
-    var topPos = rect.bottom + 4;
-    // Flip above the row if not enough space below
-    if (topPos + 200 > vh) { topPos = Math.max(4, rect.top - 4); }
-    var leftPos = Math.max(4, Math.min(rect.left, vw - overlayW - 8));
+    // Insert offscreen so we can measure the real height without a visible
+    // flash, then reposition correctly using `positionErrorOverlay`.
     overlay.style.position = 'fixed';
-    overlay.style.top = topPos + 'px';
-    overlay.style.left = leftPos + 'px';
-    overlay.style.width = overlayW + 'px';
-
+    overlay.style.top = '0px';
+    overlay.style.left = '0px';
+    overlay.style.visibility = 'hidden';
     document.body.appendChild(overlay);
+    positionErrorOverlay(overlay, row);
+    overlay.style.visibility = '';
+
     activeErrorOverlay = overlay;
+    activeErrorRow = row;
 
     activeErrorKeyDown = function(ev) {
       if (ev.key === 'Escape' || ev.key === 'Esc' || ev.keyCode === 27) {
@@ -142,6 +180,13 @@
       }
     };
     document.addEventListener('keydown', activeErrorKeyDown);
+
+    activeErrorResize = function() {
+      if (activeErrorOverlay && activeErrorRow) {
+        positionErrorOverlay(activeErrorOverlay, activeErrorRow);
+      }
+    };
+    window.addEventListener('resize', activeErrorResize);
 
     setTimeout(function() {
       if (!activeErrorOverlay) return;


### PR DESCRIPTION
## Summary

The scan-error overlay (shown when clicking a `.tree-node-error` row in the LS-generated tree webview) was clipped at the bottom of the panel for product-error rows near the bottom of the sidebar. All four IDE clients (VS Code, IntelliJ, Eclipse, Visual Studio) inherit this webview, so the bug was IDE-agnostic.

Three issues in the previous positioning code:
1. **Hardcoded `200`** as the overlay height estimate — real overlays with non-trivial error messages exceed 300px, so the flip-above branch was effectively dead.
2. **Wrong flip-above math** (`top = rect.top - 4`) — placed the overlay's *top* 4px above the row's top, leaving the body overlapping the row downward instead of sitting above it.
3. **Position computed before the overlay was in the DOM**, so the real rendered height could never be measured.

## What changed

- Append the overlay with `visibility: hidden` first, then measure its real height via `getBoundingClientRect()`, then position it.
- New `positionErrorOverlay(overlay, row)` helper. Policy: **prefer above whenever there's room above**; fall back to below otherwise. Tree views in IDEs usually have more chrome below them (status bars, help panels) than above, so above is the safer default. Matches the policy the VS Code extension used to apply as a client-side shim, which can now be removed.
- When flipping above, use `rect.top - overlayH - gap` so the overlay's bottom sits a gap above the row's top.
- Clear `bottom` and `transform` defensively when writing `top`.
- Add a `window.resize` listener that re-runs the positioning, with matching teardown in `dismissErrorOverlay`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./domain/ide/treeview/...` passes
- [x] Manually verified in IntelliJ IDEA 2025.3 by clicking a Secrets product-error row at the bottom of the sidebar: overlay now flips above instead of being clipped
- [ ] Smoke-check on remaining IDE plugins (VS Code, Eclipse, Visual Studio) — happy path, no regression for rows that have room below

## Follow-up

Once this ships in a snyk-ls release and IDEs pin to that LS protocol version, the VS Code-side `treeViewOverlayPositioner` shim and its tests can be removed (tracked separately under IDE-1808 cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)