### PR TITLE
fix: When creating git tags, don't fail if the tag exists and points to the same commit.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,9 +86,19 @@ jobs:
         uses: fregante/setup-git-user@v2
 
       - name: Create Release Tag
+        # Check if the tag already exists, and create it if not.
+        # If the tag does exist, only continue if it points to the same commit (this allows re-runs of the workflow).
         run: |
-          VERSION=$(git show -s --format=%cd --date=format:%Y%m%d.%H%M%S)
-          git tag "v$VERSION"
+          TAG="v$(git show -s --format=%cd --date=format:%Y%m%d.%H%M%S)"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            if [ "$(git rev-list -n1 "$TAG")" = "$(git rev-parse HEAD)" ]; then
+              echo "Tag $TAG already on HEAD — skipping"
+            else
+              echo "Tag $TAG exists but points elsewhere"; exit 1
+            fi
+          else
+            git tag "$TAG"
+          fi
           git push --tags
 
       - name: Create License Report

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,8 +98,8 @@ jobs:
             fi
           else
             git tag "$TAG"
+            git push --tags
           fi
-          git push --tags
 
       - name: Create License Report
         id: create_license_report


### PR DESCRIPTION
If the goreleaser job fails, we currently have to manually delete the tag, or start a new run from main (leaving a stale tag).

This change updates the goreleaser job to skip tag creation if the tag already exists AND the tag is pointing at the correct commit. This will allow failed jobs to be rerun directly from the Actions page on GitHub.

If the tag exists but points to a different commit, we error out as before.

If the tag does not exist (which will be the case on first run), we create it as before.

### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
