### PR TITLE
feat(folder): emit failure analytics for failed scans [IDE-1668]

### DIFF
--- a/domain/ide/workspace/analytics_errors.go
+++ b/domain/ide/workspace/analytics_errors.go
@@ -23,44 +23,28 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 )
 
-// categorizeError returns a low-cardinality product prefix derived from the
-// Snyk error catalog code on err (e.g. "SNYK-CLI", "SNYK-OS"). For errors that
-// do not carry a catalog entry it returns "unknown". For a nil error it
-// returns the empty string.
+// classifyError returns the analytics (category, code) pair for err, unwrapping
+// the Snyk error catalog entry exactly once so the two values cannot drift.
 //
-// Why a prefix and not the full ErrorCode: ErrorCodes are ~hundreds across the
-// catalog and would inflate analytics cardinality without adding signal to the
-// default "Is Snyk OK?" dashboard rollup. The full code is emitted alongside
-// via errorCode() for drill-downs.
-func categorizeError(err error) string {
+// category is a low-cardinality product prefix (e.g. "SNYK-CLI") suitable for
+// the default "Is Snyk OK?" dashboard rollup. code is the full catalog code
+// (e.g. "SNYK-CLI-0008") for drill-down.
+//
+// For a nil error: ("", ""). For errors without a catalog entry:
+// ("unknown", ""). Raw error.Error() text is never returned — only stable
+// catalog identifiers — to keep analytics free of PII.
+func classifyError(err error) (category, code string) {
 	if err == nil {
-		return ""
+		return "", ""
 	}
 	var snykErr snyk_errors.Error
-	if stderrors.As(err, &snykErr) && snykErr.ErrorCode != "" {
-		parts := strings.SplitN(snykErr.ErrorCode, "-", 3)
-		if len(parts) >= 2 {
-			return parts[0] + "-" + parts[1]
-		}
-		return snykErr.ErrorCode
+	if !stderrors.As(err, &snykErr) || snykErr.ErrorCode == "" {
+		return "unknown", ""
 	}
-	return "unknown"
-}
-
-// errorCode returns the full Snyk catalog ErrorCode (e.g. "SNYK-CLI-0008") for
-// errors that wrap a catalog entry, or the empty string otherwise. It is
-// emitted alongside categorizeError so dashboards can drill from prefix bucket
-// (e.g. "SNYK-CLI") into the specific code.
-//
-// Raw error.Error() text is never returned — only stable catalog identifiers —
-// to keep analytics free of file paths, repo URLs, and other PII.
-func errorCode(err error) string {
-	if err == nil {
-		return ""
+	code = snykErr.ErrorCode
+	parts := strings.SplitN(code, "-", 3)
+	if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0] + "-" + parts[1], code
 	}
-	var snykErr snyk_errors.Error
-	if stderrors.As(err, &snykErr) {
-		return snykErr.ErrorCode
-	}
-	return ""
+	return code, code
 }

--- a/domain/ide/workspace/analytics_errors.go
+++ b/domain/ide/workspace/analytics_errors.go
@@ -1,0 +1,66 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workspace
+
+import (
+	stderrors "errors"
+	"strings"
+
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+)
+
+// categorizeError returns a low-cardinality product prefix derived from the
+// Snyk error catalog code on err (e.g. "SNYK-CLI", "SNYK-OS"). For errors that
+// do not carry a catalog entry it returns "unknown". For a nil error it
+// returns the empty string.
+//
+// Why a prefix and not the full ErrorCode: ErrorCodes are ~hundreds across the
+// catalog and would inflate analytics cardinality without adding signal to the
+// default "Is Snyk OK?" dashboard rollup. The full code is emitted alongside
+// via errorCode() for drill-downs.
+func categorizeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var snykErr snyk_errors.Error
+	if stderrors.As(err, &snykErr) && snykErr.ErrorCode != "" {
+		parts := strings.SplitN(snykErr.ErrorCode, "-", 3)
+		if len(parts) >= 2 {
+			return parts[0] + "-" + parts[1]
+		}
+		return snykErr.ErrorCode
+	}
+	return "unknown"
+}
+
+// errorCode returns the full Snyk catalog ErrorCode (e.g. "SNYK-CLI-0008") for
+// errors that wrap a catalog entry, or the empty string otherwise. It is
+// emitted alongside categorizeError so dashboards can drill from prefix bucket
+// (e.g. "SNYK-CLI") into the specific code.
+//
+// Raw error.Error() text is never returned — only stable catalog identifiers —
+// to keep analytics free of file paths, repo URLs, and other PII.
+func errorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	var snykErr snyk_errors.Error
+	if stderrors.As(err, &snykErr) {
+		return snykErr.ErrorCode
+	}
+	return ""
+}

--- a/domain/ide/workspace/analytics_errors.go
+++ b/domain/ide/workspace/analytics_errors.go
@@ -22,11 +22,33 @@ import (
 	"strings"
 
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+
+	"github.com/snyk/snyk-ls/infrastructure/utils"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
+// shouldEmitAnalytics centralizes the "do we record this scan on the
+// 'Is Snyk OK?' dashboard?" policy. Checked at the call site so cancelled and
+// non-failing scans skip the goroutine entirely instead of spawning one that
+// bails after categorization work.
+func shouldEmitAnalytics(data *types.ScanData) bool {
+	if data == nil || !data.SendAnalytics || data.Product == "" {
+		return false
+	}
+	if data.Err != nil {
+		if utils.IsNonFailingScanError(data.Err.Error()) {
+			return false
+		}
+		if isCancellationError(data.Err) {
+			return false
+		}
+	}
+	return true
+}
+
 // isCancellationError reports whether err represents a routine cancellation
-// (user abort, credential rotation, timeout). Analytics callers skip emission
-// for these so cancellations don't count on the "Is Snyk OK?" rollup.
+// (user abort, credential rotation, timeout). Routine cancellations are not
+// scan failures and must not count on the "Is Snyk OK?" rollup.
 func isCancellationError(err error) bool {
 	return err != nil && (stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded))
 }

--- a/domain/ide/workspace/analytics_errors.go
+++ b/domain/ide/workspace/analytics_errors.go
@@ -17,11 +17,19 @@
 package workspace
 
 import (
+	"context"
 	stderrors "errors"
 	"strings"
 
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 )
+
+// isCancellationError reports whether err represents a routine cancellation
+// (user abort, credential rotation, timeout). Analytics callers skip emission
+// for these so cancellations don't count on the "Is Snyk OK?" rollup.
+func isCancellationError(err error) bool {
+	return err != nil && (stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded))
+}
 
 // classifyError returns the analytics (category, code) pair for err, unwrapping
 // the Snyk error catalog entry exactly once so the two values cannot drift.

--- a/domain/ide/workspace/analytics_errors.go
+++ b/domain/ide/workspace/analytics_errors.go
@@ -28,7 +28,7 @@ import (
 )
 
 // shouldEmitAnalytics centralizes the "do we record this scan on the
-// 'Is Snyk OK?' dashboard?" policy. Checked at the call site so cancelled and
+// 'Is Snyk OK?' dashboard?" policy. Checked at the call site so canceled and
 // non-failing scans skip the goroutine entirely instead of spawning one that
 // bails after categorization work.
 func shouldEmitAnalytics(data *types.ScanData) bool {

--- a/domain/ide/workspace/analytics_errors_test.go
+++ b/domain/ide/workspace/analytics_errors_test.go
@@ -26,53 +26,60 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 )
 
-func Test_categorizeError_NilError(t *testing.T) {
-	assert.Equal(t, "", categorizeError(nil))
+func Test_classifyError_NilError(t *testing.T) {
+	cat, code := classifyError(nil)
+	assert.Equal(t, "", cat)
+	assert.Equal(t, "", code)
 }
 
-func Test_categorizeError_NonCatalogError(t *testing.T) {
-	assert.Equal(t, "unknown", categorizeError(stderrors.New("boom")))
+func Test_classifyError_NonCatalogError(t *testing.T) {
+	cat, code := classifyError(stderrors.New("boom"))
+	assert.Equal(t, "unknown", cat)
+	assert.Equal(t, "", code)
 }
 
-func Test_categorizeError_CatalogError_SnykCliPrefix(t *testing.T) {
-	err := snyk_errors.Error{ErrorCode: "SNYK-CLI-0008", Title: "NoSupportedFilesFound"}
-	assert.Equal(t, "SNYK-CLI", categorizeError(err))
+func Test_classifyError_CatalogError_SnykCliPrefix(t *testing.T) {
+	cat, code := classifyError(snyk_errors.Error{ErrorCode: "SNYK-CLI-0008", Title: "NoSupportedFilesFound"})
+	assert.Equal(t, "SNYK-CLI", cat)
+	assert.Equal(t, "SNYK-CLI-0008", code)
 }
 
-func Test_categorizeError_CatalogError_SnykOsPrefix(t *testing.T) {
-	err := snyk_errors.Error{ErrorCode: "SNYK-OS-7001", Title: "Request timeout"}
-	assert.Equal(t, "SNYK-OS", categorizeError(err))
+func Test_classifyError_CatalogError_SnykOsPrefix(t *testing.T) {
+	cat, code := classifyError(snyk_errors.Error{ErrorCode: "SNYK-OS-7001", Title: "Request timeout"})
+	assert.Equal(t, "SNYK-OS", cat)
+	assert.Equal(t, "SNYK-OS-7001", code)
 }
 
-func Test_categorizeError_CatalogError_MalformedCode(t *testing.T) {
-	// Codes without a "-" separator fall back to the full code string so
-	// the dashboard still gets a usable bucket name.
-	err := snyk_errors.Error{ErrorCode: "SHORT", Title: "Malformed"}
-	assert.Equal(t, "SHORT", categorizeError(err))
+func Test_classifyError_CatalogError_MalformedNoSeparator(t *testing.T) {
+	// Codes without a "-" separator fall back to the full code string so the
+	// dashboard still gets a usable bucket name and the drill-down code matches.
+	cat, code := classifyError(snyk_errors.Error{ErrorCode: "SHORT", Title: "Malformed"})
+	assert.Equal(t, "SHORT", cat)
+	assert.Equal(t, "SHORT", code)
 }
 
-func Test_categorizeError_WrappedCatalogError(t *testing.T) {
+func Test_classifyError_CatalogError_TrailingDashIsHardened(t *testing.T) {
+	// "SNYK-" used to produce category "SNYK-" because SplitN admits an empty
+	// second part. Fall back to the full code so analytics bucket names never
+	// end with a dangling separator.
+	cat, code := classifyError(snyk_errors.Error{ErrorCode: "SNYK-", Title: "Malformed"})
+	assert.Equal(t, "SNYK-", cat, "category falls back to the full code when split parts are empty")
+	assert.Equal(t, "SNYK-", code)
+}
+
+func Test_classifyError_WrappedCatalogError(t *testing.T) {
 	// errors.As must unwrap to find the catalog error.
 	inner := snyk_errors.Error{ErrorCode: "SNYK-CLI-0008"}
 	wrapped := fmt.Errorf("scan failed: %w", inner)
-	assert.Equal(t, "SNYK-CLI", categorizeError(wrapped))
+	cat, code := classifyError(wrapped)
+	assert.Equal(t, "SNYK-CLI", cat)
+	assert.Equal(t, "SNYK-CLI-0008", code)
 }
 
-func Test_errorCode_NilError(t *testing.T) {
-	assert.Equal(t, "", errorCode(nil))
-}
-
-func Test_errorCode_NonCatalogError(t *testing.T) {
-	assert.Equal(t, "", errorCode(stderrors.New("boom")))
-}
-
-func Test_errorCode_CatalogError(t *testing.T) {
-	err := snyk_errors.Error{ErrorCode: "SNYK-CLI-0008", Title: "NoSupportedFilesFound"}
-	assert.Equal(t, "SNYK-CLI-0008", errorCode(err))
-}
-
-func Test_errorCode_WrappedCatalogError(t *testing.T) {
-	inner := snyk_errors.Error{ErrorCode: "SNYK-OS-7001"}
-	wrapped := fmt.Errorf("upstream failure: %w", inner)
-	assert.Equal(t, "SNYK-OS-7001", errorCode(wrapped))
+func Test_classifyError_CatalogError_EmptyErrorCode(t *testing.T) {
+	// snyk_errors.Error wrapper with no ErrorCode should still classify as
+	// "unknown" rather than emitting an empty category.
+	cat, code := classifyError(snyk_errors.Error{Title: "no code"})
+	assert.Equal(t, "unknown", cat)
+	assert.Equal(t, "", code)
 }

--- a/domain/ide/workspace/analytics_errors_test.go
+++ b/domain/ide/workspace/analytics_errors_test.go
@@ -1,0 +1,78 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workspace
+
+import (
+	stderrors "errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+)
+
+func Test_categorizeError_NilError(t *testing.T) {
+	assert.Equal(t, "", categorizeError(nil))
+}
+
+func Test_categorizeError_NonCatalogError(t *testing.T) {
+	assert.Equal(t, "unknown", categorizeError(stderrors.New("boom")))
+}
+
+func Test_categorizeError_CatalogError_SnykCliPrefix(t *testing.T) {
+	err := snyk_errors.Error{ErrorCode: "SNYK-CLI-0008", Title: "NoSupportedFilesFound"}
+	assert.Equal(t, "SNYK-CLI", categorizeError(err))
+}
+
+func Test_categorizeError_CatalogError_SnykOsPrefix(t *testing.T) {
+	err := snyk_errors.Error{ErrorCode: "SNYK-OS-7001", Title: "Request timeout"}
+	assert.Equal(t, "SNYK-OS", categorizeError(err))
+}
+
+func Test_categorizeError_CatalogError_MalformedCode(t *testing.T) {
+	// Codes without a "-" separator fall back to the full code string so
+	// the dashboard still gets a usable bucket name.
+	err := snyk_errors.Error{ErrorCode: "SHORT", Title: "Malformed"}
+	assert.Equal(t, "SHORT", categorizeError(err))
+}
+
+func Test_categorizeError_WrappedCatalogError(t *testing.T) {
+	// errors.As must unwrap to find the catalog error.
+	inner := snyk_errors.Error{ErrorCode: "SNYK-CLI-0008"}
+	wrapped := fmt.Errorf("scan failed: %w", inner)
+	assert.Equal(t, "SNYK-CLI", categorizeError(wrapped))
+}
+
+func Test_errorCode_NilError(t *testing.T) {
+	assert.Equal(t, "", errorCode(nil))
+}
+
+func Test_errorCode_NonCatalogError(t *testing.T) {
+	assert.Equal(t, "", errorCode(stderrors.New("boom")))
+}
+
+func Test_errorCode_CatalogError(t *testing.T) {
+	err := snyk_errors.Error{ErrorCode: "SNYK-CLI-0008", Title: "NoSupportedFilesFound"}
+	assert.Equal(t, "SNYK-CLI-0008", errorCode(err))
+}
+
+func Test_errorCode_WrappedCatalogError(t *testing.T) {
+	inner := snyk_errors.Error{ErrorCode: "SNYK-OS-7001"}
+	wrapped := fmt.Errorf("upstream failure: %w", inner)
+	assert.Equal(t, "SNYK-OS-7001", errorCode(wrapped))
+}

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -493,8 +493,8 @@ func sendAnalytics(ctx context.Context, engine workflow.Engine, configResolver t
 	// scanner.cancelFunc) surface as context.Canceled / DeadlineExceeded. These
 	// are not scan failures — skip emission entirely so they don't show up as
 	// either status on the "Is Snyk OK?" rollup.
-	if data.Err != nil && (errors.Is(data.Err, context.Canceled) || errors.Is(data.Err, context.DeadlineExceeded)) {
-		log.Debug().Err(data.Err).Msg("skipping analytics emission for cancelled scan")
+	if isCancellationError(data.Err) {
+		log.Debug().Err(data.Err).Msg("skipping analytics emission for canceled scan")
 		return
 	}
 

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -358,6 +358,13 @@ func (f *Folder) scan(ctx context.Context, path types.FilePath) {
 func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 	if scanData.Err != nil {
 		f.sendScanError(scanData.Product, scanData.Err)
+		// IDE-1668: emit failure analytics so the "Is Snyk OK?" dashboard's
+		// IDE panel reflects scan errors. Skip for reference baselines, matching
+		// the success path's IsReferenceScan guard (baseline scans aren't a
+		// user-meaningful "scan done" interaction).
+		if !scanData.IsReferenceScan || f.configResolver.GetBool(types.SettingScanNetNew, f.FolderConfigReadOnly()) {
+			go sendAnalytics(ctx, f.engine, f.configResolver, f.logger, &scanData)
+		}
 		return
 	}
 
@@ -459,11 +466,6 @@ func sendAnalytics(ctx context.Context, engine workflow.Engine, configResolver t
 		return
 	}
 
-	if data.Err != nil {
-		log.Debug().Err(data.Err).Msg("Skipping analytics for error")
-		return
-	}
-
 	// this information is not filled automatically, so we need to collect it
 	folderConfig := config.GetFolderConfigFromEngine(engine, configResolver, data.Path, logger)
 	categories := setupCategories(data, configResolver, engine, folderConfig)
@@ -485,10 +487,23 @@ func sendAnalytics(ctx context.Context, engine workflow.Engine, configResolver t
 		extension["scan_type"] = deltaScanType.String()
 	}
 
+	// IDE-1668: emit failure analytics events alongside success ones so the
+	// "Is Snyk OK?" dashboard's IDE panel reflects scan errors. categorizeError
+	// returns a low-cardinality catalog prefix (e.g. "SNYK-CLI") for rollups;
+	// errorCode adds the full code (e.g. "SNYK-CLI-0008") for drill-downs.
+	status := gafanalytics.Success
+	if data.Err != nil {
+		status = gafanalytics.Failure
+		extension["error_category"] = categorizeError(data.Err)
+		if code := errorCode(data.Err); code != "" {
+			extension["error_code"] = code
+		}
+	}
+
 	param := types.AnalyticsEventParam{
 		InteractionType: "Scan done",
 		Category:        categories,
-		Status:          string(gafanalytics.Success),
+		Status:          string(status),
 		TargetId:        targetId,
 		TimestampMs:     data.TimestampFinished.UnixMilli(),
 		DurationMs:      int64(data.Duration),

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -359,11 +359,10 @@ func (f *Folder) scan(ctx context.Context, path types.FilePath) {
 func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 	if scanData.Err != nil {
 		f.sendScanError(scanData.Product, scanData.Err)
-		// IDE-1668: emit failure analytics so the "Is Snyk OK?" dashboard's
-		// IDE panel reflects scan errors. Mirror sendScanError's filter — auth-not-set
-		// and "product disabled" outcomes are user state, not failures, and would
-		// inflate the failure rate one event per enabled product per scan.
-		// Reference scans short-circuit inside sendAnalytics via SendAnalytics:false.
+		// Mirror sendScanError's filter — auth-not-set and "product disabled" outcomes
+		// are user state, not failures, and would inflate the dashboard failure rate one
+		// event per enabled product per scan. Reference scans short-circuit inside
+		// sendAnalytics via SendAnalytics:false.
 		if !utils.IsNonFailingScanError(scanData.Err.Error()) {
 			go sendAnalytics(ctx, f.engine, f.configResolver, f.logger, &scanData)
 		}

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/samber/lo"
@@ -359,10 +360,11 @@ func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 	if scanData.Err != nil {
 		f.sendScanError(scanData.Product, scanData.Err)
 		// IDE-1668: emit failure analytics so the "Is Snyk OK?" dashboard's
-		// IDE panel reflects scan errors. Skip for reference baselines, matching
-		// the success path's IsReferenceScan guard (baseline scans aren't a
-		// user-meaningful "scan done" interaction).
-		if !scanData.IsReferenceScan || f.configResolver.GetBool(types.SettingScanNetNew, f.FolderConfigReadOnly()) {
+		// IDE panel reflects scan errors. Mirror sendScanError's filter — auth-not-set
+		// and "product disabled" outcomes are user state, not failures, and would
+		// inflate the failure rate one event per enabled product per scan.
+		// Reference scans short-circuit inside sendAnalytics via SendAnalytics:false.
+		if !utils.IsNonFailingScanError(scanData.Err.Error()) {
 			go sendAnalytics(ctx, f.engine, f.configResolver, f.logger, &scanData)
 		}
 		return
@@ -487,17 +489,35 @@ func sendAnalytics(ctx context.Context, engine workflow.Engine, configResolver t
 		extension["scan_type"] = deltaScanType.String()
 	}
 
+	// IDE-1668: routine cancellations (credential rotation, user abort via
+	// scanner.cancelFunc) surface as context.Canceled / DeadlineExceeded. These
+	// are not scan failures — skip emission entirely so they don't show up as
+	// either status on the "Is Snyk OK?" rollup.
+	if data.Err != nil && (errors.Is(data.Err, context.Canceled) || errors.Is(data.Err, context.DeadlineExceeded)) {
+		log.Debug().Err(data.Err).Msg("skipping analytics emission for cancelled scan")
+		return
+	}
+
 	// IDE-1668: emit failure analytics events alongside success ones so the
-	// "Is Snyk OK?" dashboard's IDE panel reflects scan errors. categorizeError
-	// returns a low-cardinality catalog prefix (e.g. "SNYK-CLI") for rollups;
-	// errorCode adds the full code (e.g. "SNYK-CLI-0008") for drill-downs.
+	// "Is Snyk OK?" dashboard's IDE panel reflects scan errors. classifyError
+	// returns (category, code): the category is a low-cardinality catalog
+	// prefix (e.g. "SNYK-CLI") for rollups, the code is the full catalog code
+	// (e.g. "SNYK-CLI-0008") for drill-down.
 	status := gafanalytics.Success
 	if data.Err != nil {
 		status = gafanalytics.Failure
-		extension["error_category"] = categorizeError(data.Err)
-		if code := errorCode(data.Err); code != "" {
+		category, code := classifyError(data.Err)
+		extension["error_category"] = category
+		if code != "" {
 			extension["error_code"] = code
 		}
+	}
+
+	// Failure paths may build ScanData without TimestampFinished; the zero
+	// time.Time produces a negative epoch via UnixMilli(). Default to now.
+	timestampFinished := data.TimestampFinished
+	if timestampFinished.IsZero() {
+		timestampFinished = time.Now().UTC()
 	}
 
 	param := types.AnalyticsEventParam{
@@ -505,7 +525,7 @@ func sendAnalytics(ctx context.Context, engine workflow.Engine, configResolver t
 		Category:        categories,
 		Status:          string(status),
 		TargetId:        targetId,
-		TimestampMs:     data.TimestampFinished.UnixMilli(),
+		TimestampMs:     timestampFinished.UnixMilli(),
 		DurationMs:      int64(data.Duration),
 		Extension:       extension,
 	}

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -358,7 +358,13 @@ func (f *Folder) scan(ctx context.Context, path types.FilePath) {
 
 func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 	if scanData.Err != nil {
-		f.sendScanError(scanData.Product, scanData.Err, scanData.UserNotified)
+		// UserNotified means the caller has already surfaced the error (toast +
+		// any diagnostic) and only routed through here for analytics emission.
+		// Skip sendScanError entirely so we don't fire a duplicate SendError or
+		// an unwanted SendErrorDiagnostic.
+		if !scanData.UserNotified {
+			f.sendScanError(scanData.Product, scanData.Err)
+		}
 		if shouldEmitAnalytics(&scanData) {
 			go sendAnalytics(ctx, f.engine, f.configResolver, f.logger, &scanData)
 		}
@@ -387,10 +393,8 @@ func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 	f.FilterAndPublishDiagnostics(scanData.Product)
 }
 
-func (f *Folder) sendScanError(product product.Product, err error, userAlreadyNotified bool) {
-	if !userAlreadyNotified {
-		f.scanNotifier.SendError(product, f.path, err.Error())
-	}
+func (f *Folder) sendScanError(product product.Product, err error) {
+	f.scanNotifier.SendError(product, f.path, err.Error())
 
 	if utils.IsNonFailingScanError(err.Error()) {
 		f.logger.Debug().
@@ -847,7 +851,7 @@ func (f *Folder) publishDiagnostics(p product.Product, issuesToSendByProduct sny
 	f.sendDiagnostics(issuesToSendByProduct.AggregateFromAllProducts(p))
 	scanErr := f.scanStateAggregator.GetScanErr(f.path, p, f.IsDeltaFindingsEnabled())
 	if scanErr != nil {
-		f.sendScanError(p, scanErr, false)
+		f.sendScanError(p, scanErr)
 	} else {
 		f.sendSuccess(p)
 	}

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -358,12 +358,8 @@ func (f *Folder) scan(ctx context.Context, path types.FilePath) {
 
 func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 	if scanData.Err != nil {
-		f.sendScanError(scanData.Product, scanData.Err)
-		// Mirror sendScanError's filter — auth-not-set and "product disabled" outcomes
-		// are user state, not failures, and would inflate the dashboard failure rate one
-		// event per enabled product per scan. Reference scans short-circuit inside
-		// sendAnalytics via SendAnalytics:false.
-		if !utils.IsNonFailingScanError(scanData.Err.Error()) {
+		f.sendScanError(scanData.Product, scanData.Err, scanData.UserNotified)
+		if shouldEmitAnalytics(&scanData) {
 			go sendAnalytics(ctx, f.engine, f.configResolver, f.logger, &scanData)
 		}
 		return
@@ -383,14 +379,18 @@ func (f *Folder) ProcessResults(ctx context.Context, scanData types.ScanData) {
 		return
 	}
 
-	go sendAnalytics(ctx, f.engine, f.configResolver, f.logger, &scanData)
+	if shouldEmitAnalytics(&scanData) {
+		go sendAnalytics(ctx, f.engine, f.configResolver, f.logger, &scanData)
+	}
 
 	// Filter and publish cached diagnostics
 	f.FilterAndPublishDiagnostics(scanData.Product)
 }
 
-func (f *Folder) sendScanError(product product.Product, err error) {
-	f.scanNotifier.SendError(product, f.path, err.Error())
+func (f *Folder) sendScanError(product product.Product, err error, userAlreadyNotified bool) {
+	if !userAlreadyNotified {
+		f.scanNotifier.SendError(product, f.path, err.Error())
+	}
 
 	if utils.IsNonFailingScanError(err.Error()) {
 		f.logger.Debug().
@@ -457,15 +457,11 @@ func (f *Folder) updateGlobalCacheAndSeverityCounts(scanData *types.ScanData) {
 	}
 }
 
+// sendAnalytics emits a "Scan done" analytics event for data. Callers MUST gate
+// the call with shouldEmitAnalytics — this function does not re-check the
+// SendAnalytics / Product / cancellation / non-failing-error policy.
 func sendAnalytics(ctx context.Context, engine workflow.Engine, configResolver types.ConfigResolverInterface, logger *zerolog.Logger, data *types.ScanData) {
 	log := logger.With().Str("method", "folder.sendAnalytics").Logger()
-	if !data.SendAnalytics {
-		return
-	}
-	if data.Product == "" {
-		log.Debug().Any("data", data).Msg("Skipping analytics for empty product")
-		return
-	}
 
 	// this information is not filled automatically, so we need to collect it
 	folderConfig := config.GetFolderConfigFromEngine(engine, configResolver, data.Path, logger)
@@ -488,16 +484,7 @@ func sendAnalytics(ctx context.Context, engine workflow.Engine, configResolver t
 		extension["scan_type"] = deltaScanType.String()
 	}
 
-	// IDE-1668: routine cancellations (credential rotation, user abort via
-	// scanner.cancelFunc) surface as context.Canceled / DeadlineExceeded. These
-	// are not scan failures — skip emission entirely so they don't show up as
-	// either status on the "Is Snyk OK?" rollup.
-	if isCancellationError(data.Err) {
-		log.Debug().Err(data.Err).Msg("skipping analytics emission for canceled scan")
-		return
-	}
-
-	// IDE-1668: emit failure analytics events alongside success ones so the
+	// Emit failure analytics events alongside success ones so the
 	// "Is Snyk OK?" dashboard's IDE panel reflects scan errors. classifyError
 	// returns (category, code): the category is a low-cardinality catalog
 	// prefix (e.g. "SNYK-CLI") for rollups, the code is the full catalog code
@@ -860,7 +847,7 @@ func (f *Folder) publishDiagnostics(p product.Product, issuesToSendByProduct sny
 	f.sendDiagnostics(issuesToSendByProduct.AggregateFromAllProducts(p))
 	scanErr := f.scanStateAggregator.GetScanErr(f.path, p, f.IsDeltaFindingsEnabled())
 	if scanErr != nil {
-		f.sendScanError(p, scanErr)
+		f.sendScanError(p, scanErr, false)
 	} else {
 		f.sendSuccess(p)
 	}

--- a/domain/ide/workspace/folder_failure_analytics_test.go
+++ b/domain/ide/workspace/folder_failure_analytics_test.go
@@ -17,6 +17,7 @@
 package workspace
 
 import (
+	"context"
 	stderrors "errors"
 	"testing"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 
+	"github.com/snyk/snyk-ls/infrastructure/utils"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testsupport"
@@ -40,8 +42,17 @@ import (
 // These tests cover the contract: sendAnalytics() must produce a
 // `interaction.status:"Failure"` event with `error_category` (catalog prefix,
 // e.g. "SNYK-CLI") and, when available, `error_code` (full catalog code).
-// The empty-product and SendAnalytics=false guards must continue to suppress
-// emission even on the failure path.
+// The empty-product, SendAnalytics=false, non-failing-error and
+// context-cancellation guards must continue to suppress emission even on the
+// failure path.
+
+// negativeAssertionWindow is how long negative tests wait while polling the
+// captured workflow channel before declaring "no emission". With gomock
+// Times(0), any incorrect emission fails the test the moment it occurs, so
+// this window only needs to cover the analytics goroutine's typical startup
+// time. 200ms is comfortably above realistic goroutine scheduling latency on
+// slow CI boxes.
+const negativeAssertionWindow = 200 * time.Millisecond
 
 // T1 — failed scan whose error wraps a snyk catalog entry produces a Failure
 // analytics event with the full error code and its product prefix.
@@ -172,13 +183,12 @@ func Test_processResults_FailedScan_EmptyProduct_NoEmission(t *testing.T) {
 		Err:               stderrors.New("boom"),
 	}
 
-	// Times(0) — gomock will fail the test if the analytics workflow gets invoked.
-	_ = testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
+	// Times(0) — gomock fails the test immediately if the analytics workflow gets invoked.
+	capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
 
 	f.ProcessResults(t.Context(), data)
 
-	// Small settle window so any (incorrect) async emission would have time to land.
-	time.Sleep(50 * time.Millisecond)
+	testsupport.RequireNeverReceive(t, capturedCh, negativeAssertionWindow, 10*time.Millisecond, "empty-product guard must suppress emission")
 }
 
 // T5 — when SendAnalytics is false, the caller opt-out must continue to
@@ -203,17 +213,18 @@ func Test_processResults_FailedScan_SendAnalyticsFalse_NoEmission(t *testing.T) 
 		Err:               stderrors.New("boom"),
 	}
 
-	_ = testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
+	capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
 
 	f.ProcessResults(t.Context(), data)
 
-	time.Sleep(50 * time.Millisecond)
+	testsupport.RequireNeverReceive(t, capturedCh, negativeAssertionWindow, 10*time.Millisecond, "SendAnalytics:false must suppress emission")
 }
 
 // T6 — sendAnalytics must tolerate partial ScanData on the failure path
-// (no Issues, no severity counts). It must emit a Failure event without
-// panicking and the test summary should at least contain the product type.
-func Test_processResults_FailedScan_PartialScanData_DoesNotPanic(t *testing.T) {
+// (no Issues, no severity counts, zero TimestampFinished). It must emit a
+// Failure event without panicking, and the zero TimestampFinished must be
+// replaced with "now" so the event doesn't carry a negative epoch.
+func Test_processResults_FailedScan_PartialScanData_DoesNotPanicAndDefaultsTimestamp(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
 	engineMock.EXPECT().GetWorkflows().AnyTimes()
@@ -225,7 +236,7 @@ func Test_processResults_FailedScan_PartialScanData_DoesNotPanic(t *testing.T) {
 	const testFolderOrg = "test-org"
 	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, testFolderOrg, true)
 
-	// Deliberately minimal ScanData: nil Issues, zero Duration, etc.
+	// Deliberately minimal ScanData: nil Issues, zero Duration, zero TimestampFinished.
 	data := types.ScanData{
 		Product:       product.ProductOpenSource,
 		Path:          f.path,
@@ -247,4 +258,97 @@ func Test_processResults_FailedScan_PartialScanData_DoesNotPanic(t *testing.T) {
 	assert.Contains(t, payload, `"status":"failure"`)
 	assert.Contains(t, payload, `"error_category":"SNYK-OS"`)
 	assert.Contains(t, payload, `"error_code":"SNYK-OS-7001"`)
+	// Zero TimestampFinished must be defaulted to "now" — never emitted as the
+	// negative-epoch UnixMilli of time.Time{}.
+	assert.NotContains(t, payload, `"timestampMs":-`, "zero TimestampFinished must be defaulted, not emitted as a negative epoch")
+}
+
+// T7 — non-failing scan errors (auth not set, product disabled for folder/org)
+// must NOT produce a failure analytics event. These are user state, not
+// failures, and the "Is Snyk OK?" dashboard's failure rate is meant to track
+// real scan errors only.
+func Test_processResults_FailedScan_NonFailingError_NoEmission(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"not authenticated", stderrors.New(utils.MsgNotAuthenticatedNoScan)},
+		{"oss not enabled for folder", stderrors.New(utils.ErrSnykOssNotEnabledForFolder)},
+		{"code not enabled for folder", stderrors.New(utils.ErrSnykCodeNotEnabledForFolder)},
+		{"iac not enabled for folder", stderrors.New(utils.ErrSnykIacNotEnabledForFolder)},
+		{"secrets not enabled for folder", stderrors.New(utils.ErrSnykSecretsNotEnabledForFolder)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := testutil.UnitTest(t)
+			engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+			engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+			notifier := notification.NewNotifier()
+			f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+			setupWorkspaceWithFolder(engineMock, f, notifier)
+
+			types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, "test-org", true)
+
+			data := types.ScanData{
+				Product:           product.ProductOpenSource,
+				Path:              f.path,
+				UpdateGlobalCache: true,
+				SendAnalytics:     true,
+				Err:               tc.err,
+			}
+
+			capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
+
+			f.ProcessResults(t.Context(), data)
+
+			testsupport.RequireNeverReceive(t, capturedCh, negativeAssertionWindow, 10*time.Millisecond,
+				"non-failing scan error %q must not emit failure analytics", tc.err)
+		})
+	}
+}
+
+// T8 — routine cancellations (credential rotation, user abort) surface as
+// context.Canceled or context.DeadlineExceeded. These are not scan failures
+// and must not be counted on the failure rate. sendAnalytics must skip
+// emission entirely (neither failure nor success) for these errors.
+func Test_processResults_FailedScan_Cancellation_NoEmission(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"context.Canceled", context.Canceled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded},
+		{"wrapped context.Canceled", stderrors.Join(stderrors.New("upstream"), context.Canceled)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := testutil.UnitTest(t)
+			engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+			engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+			notifier := notification.NewNotifier()
+			f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+			setupWorkspaceWithFolder(engineMock, f, notifier)
+
+			types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, "test-org", true)
+
+			data := types.ScanData{
+				Product:           product.ProductOpenSource,
+				Path:              f.path,
+				UpdateGlobalCache: true,
+				SendAnalytics:     true,
+				Err:               tc.err,
+			}
+
+			capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
+
+			f.ProcessResults(t.Context(), data)
+
+			testsupport.RequireNeverReceive(t, capturedCh, negativeAssertionWindow, 10*time.Millisecond,
+				"cancellation %q must not emit analytics", tc.err)
+		})
+	}
 }

--- a/domain/ide/workspace/folder_failure_analytics_test.go
+++ b/domain/ide/workspace/folder_failure_analytics_test.go
@@ -18,6 +18,7 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"testing"
 	"time"
@@ -257,8 +258,21 @@ func Test_processResults_FailedScan_PartialScanData_DoesNotPanicAndDefaultsTimes
 	assert.Contains(t, payload, `"error_category":"SNYK-OS"`)
 	assert.Contains(t, payload, `"error_code":"SNYK-OS-7001"`)
 	// Zero TimestampFinished must be defaulted to "now" — never emitted as the
-	// negative-epoch UnixMilli of time.Time{}.
-	assert.NotContains(t, payload, `"timestampMs":-`, "zero TimestampFinished must be defaulted, not emitted as a negative epoch")
+	// negative-epoch UnixMilli of time.Time{}. Assert on the actual emitted
+	// value, not on string presence (the GAF schema serialises the key as
+	// `timestamp_ms`, so a substring check for `timestampMs` is vacuous).
+	var envelope struct {
+		Data struct {
+			Attributes struct {
+				Interaction struct {
+					TimestampMs int64 `json:"timestamp_ms"`
+				} `json:"interaction"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(payload), &envelope))
+	assert.Positive(t, envelope.Data.Attributes.Interaction.TimestampMs,
+		"zero TimestampFinished must be defaulted to a positive epoch, not emitted as a negative or zero value")
 }
 
 // T7 — non-failing scan errors (auth not set, product disabled for folder/org)
@@ -305,6 +319,40 @@ func Test_processResults_FailedScan_NonFailingError_NoEmission(t *testing.T) {
 				"non-failing scan error %q must not emit failure analytics", tc.err)
 		})
 	}
+}
+
+// T7b — when UserNotified is true the caller has already surfaced the error
+// (toast notification and any diagnostic). ProcessResults must skip
+// sendScanError entirely so no duplicate SendError and no unexpected
+// SendErrorDiagnostic fire, while still emitting failure analytics.
+func Test_processResults_FailedScan_UserNotified_SkipsSendScanError(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+	engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+	notifier := notification.NewMockNotifier()
+	f, scanNotifier := NewMockFolderWithScanNotifier(engineMock, notifier)
+	setupWorkspaceWithFolder(engineMock, f, notifier)
+
+	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, "test-org", true)
+
+	data := types.ScanData{
+		Product:       product.ProductOpenSource,
+		Path:          f.path,
+		SendAnalytics: true,
+		Err:           stderrors.New("pre-scan command boom"),
+		UserNotified:  true,
+	}
+
+	capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 1)
+
+	f.ProcessResults(t.Context(), data)
+
+	assert.Empty(t, scanNotifier.ErrorCalls(),
+		"UserNotified=true must skip SendError — caller already notified the user")
+	assert.Equal(t, 0, notifier.SendErrorDiagnosticCount(),
+		"UserNotified=true must skip SendErrorDiagnostic — no unexpected publishDiagnostics for caller-handled errors")
+	testsupport.RequireEventuallyReceive(t, capturedCh, time.Second, 10*time.Millisecond, "analytics emission should still happen")
 }
 
 // T8 — routine cancellations (credential rotation, user abort) surface as

--- a/domain/ide/workspace/folder_failure_analytics_test.go
+++ b/domain/ide/workspace/folder_failure_analytics_test.go
@@ -37,10 +37,8 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
-// IDE-1668: emit failure analytics when a scan returns an error.
-//
-// These tests cover the contract: sendAnalytics() must produce a
-// `interaction.status:"Failure"` event with `error_category` (catalog prefix,
+// These tests cover the failure-analytics contract: sendAnalytics() must produce
+// an `interaction.status:"Failure"` event with `error_category` (catalog prefix,
 // e.g. "SNYK-CLI") and, when available, `error_code` (full catalog code).
 // The empty-product, SendAnalytics=false, non-failing-error and
 // context-cancellation guards must continue to suppress emission even on the

--- a/domain/ide/workspace/folder_failure_analytics_test.go
+++ b/domain/ide/workspace/folder_failure_analytics_test.go
@@ -259,7 +259,7 @@ func Test_processResults_FailedScan_PartialScanData_DoesNotPanicAndDefaultsTimes
 	assert.Contains(t, payload, `"error_code":"SNYK-OS-7001"`)
 	// Zero TimestampFinished must be defaulted to "now" — never emitted as the
 	// negative-epoch UnixMilli of time.Time{}. Assert on the actual emitted
-	// value, not on string presence (the GAF schema serialises the key as
+	// value, not on string presence (the GAF schema serializes the key as
 	// `timestamp_ms`, so a substring check for `timestampMs` is vacuous).
 	var envelope struct {
 		Data struct {

--- a/domain/ide/workspace/folder_failure_analytics_test.go
+++ b/domain/ide/workspace/folder_failure_analytics_test.go
@@ -1,0 +1,250 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workspace
+
+import (
+	stderrors "errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cli_errors "github.com/snyk/error-catalog-golang-public/cli"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+
+	"github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/testsupport"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// IDE-1668: emit failure analytics when a scan returns an error.
+//
+// These tests cover the contract: sendAnalytics() must produce a
+// `interaction.status:"Failure"` event with `error_category` (catalog prefix,
+// e.g. "SNYK-CLI") and, when available, `error_code` (full catalog code).
+// The empty-product and SendAnalytics=false guards must continue to suppress
+// emission even on the failure path.
+
+// T1 — failed scan whose error wraps a snyk catalog entry produces a Failure
+// analytics event with the full error code and its product prefix.
+func Test_processResults_FailedScan_EmitsFailureAnalytics_WithCatalogError(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+	engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+	notifier := notification.NewNotifier()
+	f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+	setupWorkspaceWithFolder(engineMock, f, notifier)
+
+	const testFolderOrg = "test-org"
+	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, testFolderOrg, true)
+
+	catalogErr := cli_errors.NewNoSupportedFilesFoundError("nothing to scan")
+
+	data := types.ScanData{
+		Product:           product.ProductOpenSource,
+		Path:              f.path,
+		UpdateGlobalCache: true,
+		SendAnalytics:     true,
+		Err:               catalogErr,
+	}
+
+	capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 1)
+
+	f.ProcessResults(t.Context(), data)
+
+	captured := testsupport.RequireEventuallyReceive(t, capturedCh, time.Second, 10*time.Millisecond, "failure analytics should have been sent")
+	require.Len(t, captured.Input, 1)
+	payload := string(captured.Input[0].GetPayload().([]byte))
+
+	assert.Contains(t, payload, `"status":"failure"`, "interaction.status should be failure on errored scan")
+	assert.Contains(t, payload, `"error_category":"SNYK-CLI"`, "error_category should be the catalog prefix")
+	// NewNoSupportedFilesFoundError maps to SNYK-CLI-0008 (see infrastructure/secrets/errors.go).
+	assert.Contains(t, payload, `"error_code":"SNYK-CLI-0008"`, "error_code should be the full catalog code")
+}
+
+// T2 — failed scan whose error is NOT a catalog entry produces a Failure event
+// with error_category:"unknown" and no error_code field.
+func Test_processResults_FailedScan_EmitsFailureAnalytics_WithNonCatalogError(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+	engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+	notifier := notification.NewNotifier()
+	f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+	setupWorkspaceWithFolder(engineMock, f, notifier)
+
+	const testFolderOrg = "test-org"
+	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, testFolderOrg, true)
+
+	data := types.ScanData{
+		Product:           product.ProductOpenSource,
+		Path:              f.path,
+		UpdateGlobalCache: true,
+		SendAnalytics:     true,
+		Err:               stderrors.New("boom"),
+	}
+
+	capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 1)
+
+	f.ProcessResults(t.Context(), data)
+
+	captured := testsupport.RequireEventuallyReceive(t, capturedCh, time.Second, 10*time.Millisecond, "failure analytics should have been sent")
+	require.Len(t, captured.Input, 1)
+	payload := string(captured.Input[0].GetPayload().([]byte))
+
+	assert.Contains(t, payload, `"status":"failure"`)
+	assert.Contains(t, payload, `"error_category":"unknown"`)
+	assert.NotContains(t, payload, `"error_code"`, "non-catalog errors must not produce an error_code field")
+}
+
+// T3 — successful scan continues to emit Success and must not pick up
+// error_category / error_code in the extension. Regression guard.
+func Test_processResults_SuccessfulScan_StillEmitsSuccessAnalytics(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+	engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+	notifier := notification.NewNotifier()
+	f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+	setupWorkspaceWithFolder(engineMock, f, notifier)
+
+	const testFolderOrg = "test-org"
+	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, testFolderOrg, true)
+
+	data := types.ScanData{
+		Product:           product.ProductOpenSource,
+		Path:              f.path,
+		UpdateGlobalCache: true,
+		SendAnalytics:     true,
+	}
+
+	capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 1)
+
+	f.ProcessResults(t.Context(), data)
+
+	captured := testsupport.RequireEventuallyReceive(t, capturedCh, time.Second, 10*time.Millisecond, "success analytics should have been sent")
+	require.Len(t, captured.Input, 1)
+	payload := string(captured.Input[0].GetPayload().([]byte))
+
+	assert.Contains(t, payload, `"status":"success"`)
+	assert.NotContains(t, payload, `"error_category"`, "success events must not carry error_category")
+	assert.NotContains(t, payload, `"error_code"`, "success events must not carry error_code")
+}
+
+// T4 — when Product is empty, the empty-product guard suppresses emission
+// even though data.Err is set. Suppressing this branch keeps existing behavior.
+func Test_processResults_FailedScan_EmptyProduct_NoEmission(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+	engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+	notifier := notification.NewNotifier()
+	f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+	setupWorkspaceWithFolder(engineMock, f, notifier)
+
+	const testFolderOrg = "test-org"
+	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, testFolderOrg, true)
+
+	data := types.ScanData{
+		Product:           "",
+		Path:              f.path,
+		UpdateGlobalCache: true,
+		SendAnalytics:     true,
+		Err:               stderrors.New("boom"),
+	}
+
+	// Times(0) — gomock will fail the test if the analytics workflow gets invoked.
+	_ = testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
+
+	f.ProcessResults(t.Context(), data)
+
+	// Small settle window so any (incorrect) async emission would have time to land.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// T5 — when SendAnalytics is false, the caller opt-out must continue to
+// suppress emission even with an error present.
+func Test_processResults_FailedScan_SendAnalyticsFalse_NoEmission(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+	engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+	notifier := notification.NewNotifier()
+	f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+	setupWorkspaceWithFolder(engineMock, f, notifier)
+
+	const testFolderOrg = "test-org"
+	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, testFolderOrg, true)
+
+	data := types.ScanData{
+		Product:           product.ProductOpenSource,
+		Path:              f.path,
+		UpdateGlobalCache: true,
+		SendAnalytics:     false,
+		Err:               stderrors.New("boom"),
+	}
+
+	_ = testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 0)
+
+	f.ProcessResults(t.Context(), data)
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+// T6 — sendAnalytics must tolerate partial ScanData on the failure path
+// (no Issues, no severity counts). It must emit a Failure event without
+// panicking and the test summary should at least contain the product type.
+func Test_processResults_FailedScan_PartialScanData_DoesNotPanic(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineMock, engineConfig := testutil.SetUpEngineMock(t, engine)
+	engineMock.EXPECT().GetWorkflows().AnyTimes()
+
+	notifier := notification.NewNotifier()
+	f, _ := NewMockFolderWithScanNotifier(engineMock, notifier)
+	setupWorkspaceWithFolder(engineMock, f, notifier)
+
+	const testFolderOrg = "test-org"
+	types.SetPreferredOrgAndOrgSetByUser(engineConfig, f.path, testFolderOrg, true)
+
+	// Deliberately minimal ScanData: nil Issues, zero Duration, etc.
+	data := types.ScanData{
+		Product:       product.ProductOpenSource,
+		Path:          f.path,
+		SendAnalytics: true,
+		Err:           snyk_errors.Error{ErrorCode: "SNYK-OS-7001", Title: "Request timeout"},
+	}
+
+	capturedCh := testutil.MockAndCaptureWorkflowInvocation(t, engineMock, localworkflows.WORKFLOWID_REPORT_ANALYTICS, 1)
+
+	// Must not panic.
+	require.NotPanics(t, func() {
+		f.ProcessResults(t.Context(), data)
+	})
+
+	captured := testsupport.RequireEventuallyReceive(t, capturedCh, time.Second, 10*time.Millisecond, "failure analytics should still be emitted on partial scan data")
+	require.Len(t, captured.Input, 1)
+	payload := string(captured.Input[0].GetPayload().([]byte))
+
+	assert.Contains(t, payload, `"status":"failure"`)
+	assert.Contains(t, payload, `"error_category":"SNYK-OS"`)
+	assert.Contains(t, payload, `"error_code":"SNYK-OS-7001"`)
+}

--- a/domain/snyk/scanner/scanner.go
+++ b/domain/snyk/scanner/scanner.go
@@ -282,16 +282,17 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 			err := sc.executePreScanCommand(span.Context(), sc.engine, s.Product(), workspaceFolderConfig, folderPath, true)
 			if err != nil {
 				scanLogger.Err(err).Send()
+				sc.scanNotifier.SendError(scanner.Product(), folderPath, err.Error())
 				sc.scanStateAggregator.SetScanDone(folderPath, scanner.Product(), false, err)
-				// Route the pre-scan-command failure through processResults so it surfaces
-				// on the "Is Snyk OK?" dashboard alongside other scan failures.
-				// processResults handles the scanNotifier.SendError side-effect via sendScanError.
+				// Route through processResults purely for failure analytics; UserNotified
+				// suppresses the duplicate SendError that sendScanError would otherwise emit.
 				processResults(span.Context(), types.ScanData{
 					Product:           s.Product(),
 					Err:               err,
 					TimestampFinished: time.Now().UTC(),
 					Path:              folderPath,
 					SendAnalytics:     true,
+					UserNotified:      true,
 				})
 				return
 			}

--- a/domain/snyk/scanner/scanner.go
+++ b/domain/snyk/scanner/scanner.go
@@ -279,6 +279,7 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 
 			scanSpan := sc.instrumentor.StartSpan(span.Context(), "scan")
 
+			preScanStart := time.Now()
 			err := sc.executePreScanCommand(span.Context(), sc.engine, s.Product(), workspaceFolderConfig, folderPath, true)
 			if err != nil {
 				scanLogger.Err(err).Send()
@@ -289,6 +290,7 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 				processResults(span.Context(), types.ScanData{
 					Product:           s.Product(),
 					Err:               err,
+					Duration:          time.Since(preScanStart),
 					TimestampFinished: time.Now().UTC(),
 					Path:              folderPath,
 					SendAnalytics:     true,

--- a/domain/snyk/scanner/scanner.go
+++ b/domain/snyk/scanner/scanner.go
@@ -282,8 +282,17 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 			err := sc.executePreScanCommand(span.Context(), sc.engine, s.Product(), workspaceFolderConfig, folderPath, true)
 			if err != nil {
 				scanLogger.Err(err).Send()
-				sc.scanNotifier.SendError(scanner.Product(), folderPath, err.Error())
 				sc.scanStateAggregator.SetScanDone(folderPath, scanner.Product(), false, err)
+				// IDE-1668: route the pre-scan-command failure through processResults so
+				// it surfaces on the "Is Snyk OK?" dashboard alongside other scan failures.
+				// processResults handles the scanNotifier.SendError side-effect via sendScanError.
+				processResults(span.Context(), types.ScanData{
+					Product:           s.Product(),
+					Err:               err,
+					TimestampFinished: time.Now().UTC(),
+					Path:              folderPath,
+					SendAnalytics:     true,
+				})
 				return
 			}
 

--- a/domain/snyk/scanner/scanner.go
+++ b/domain/snyk/scanner/scanner.go
@@ -283,8 +283,8 @@ func (sc *DelegatingConcurrentScanner) Scan(ctx context.Context, pathToScan type
 			if err != nil {
 				scanLogger.Err(err).Send()
 				sc.scanStateAggregator.SetScanDone(folderPath, scanner.Product(), false, err)
-				// IDE-1668: route the pre-scan-command failure through processResults so
-				// it surfaces on the "Is Snyk OK?" dashboard alongside other scan failures.
+				// Route the pre-scan-command failure through processResults so it surfaces
+				// on the "Is Snyk OK?" dashboard alongside other scan failures.
 				// processResults handles the scanNotifier.SendError side-effect via sendScanError.
 				processResults(span.Context(), types.ScanData{
 					Product:           s.Product(),

--- a/internal/testsupport/channels.go
+++ b/internal/testsupport/channels.go
@@ -64,3 +64,19 @@ func RequireEventuallyClosed[T any](t *testing.T, ch <-chan T, waitFor, tick tim
 		}
 	}, waitFor, tick, msgAndArgs...)
 }
+
+// RequireNeverReceive asserts that ch does not receive a value within waitFor,
+// polling every tick. Negative analog of RequireEventuallyReceive. Use for
+// negative async assertions where a fixed time.Sleep would either flake on slow
+// CI or accept incorrect emissions that arrive after the sleep window.
+func RequireNeverReceive[T any](t *testing.T, ch <-chan T, waitFor, tick time.Duration, msgAndArgs ...any) {
+	t.Helper()
+	require.Never(t, func() bool {
+		select {
+		case _, ok := <-ch:
+			return ok
+		default:
+			return false
+		}
+	}, waitFor, tick, msgAndArgs...)
+}

--- a/internal/types/scan.go
+++ b/internal/types/scan.go
@@ -42,6 +42,11 @@ type ScanData struct {
 	IsReferenceScan   bool
 	SendAnalytics     bool
 	UpdateGlobalCache bool
+	// UserNotified signals that the caller already invoked scanNotifier.SendError
+	// for this scan; downstream processors must not send a duplicate user-facing
+	// notification. Set by callers that emit the error themselves and then route
+	// the ScanData through a processor purely for analytics/state updates.
+	UserNotified bool
 }
 
 type Scanner interface {

--- a/internal/types/scan.go
+++ b/internal/types/scan.go
@@ -42,10 +42,11 @@ type ScanData struct {
 	IsReferenceScan   bool
 	SendAnalytics     bool
 	UpdateGlobalCache bool
-	// UserNotified signals that the caller already invoked scanNotifier.SendError
-	// for this scan; downstream processors must not send a duplicate user-facing
-	// notification. Set by callers that emit the error themselves and then route
-	// the ScanData through a processor purely for analytics/state updates.
+	// UserNotified signals that the caller has already surfaced this scan error
+	// to the user (toast notification and any error diagnostic). Downstream
+	// processors must skip all user-facing error surfacing for this ScanData so
+	// it can be routed through purely for analytics/state updates without
+	// firing a duplicate notification or an unexpected publishDiagnostics.
 	UserNotified bool
 }
 


### PR DESCRIPTION
### **User description**
## Summary

- snyk-ls now emits an analytics interaction with `status:failure` when a scan errors, so the [Is Snyk OK?](https://app.datadoghq.com/dashboard/f56-fxs-zmp) dashboard's IDE panel starts populating.
- New helpers `categorizeError` and `errorCode` derive a low-cardinality category (e.g. `SNYK-CLI`) and the full catalog code (e.g. `SNYK-CLI-0008`) from `github.com/snyk/error-catalog-golang-public/snyk_errors`, already imported in three other snyk-ls call sites.
- `ProcessResults` now calls `sendAnalytics` on the error branch (with the same reference-baseline guard the success path uses) and `sendAnalytics` no longer short-circuits on `data.Err`.

## Why

The dashboard query

```
@service:analytics-service message:"analytics payload"
@analytics-service.interaction.status:failure
@analytics-service.runtime.application.name:snyk-ls
```

returned zero results in production despite real IDE scan failures. Two specific spots dropped the emission: `ProcessResults` short-circuited on `scanData.Err != nil`, and `sendAnalytics` had its own early-return guard and a hardcoded `Status: gafanalytics.Success`. This PR fixes both.

The CLI side already does the equivalent in `cliv2/cmd/cliv2/instrumentation.go:77-80` (`if exitCode == 2 { SetStatus(analytics.Failure) }`), which is why the CLI panel works today.

## What's in the payload now

| Field | Success | Failure (catalog error) | Failure (non-catalog error) |
|---|---|---|---|
| `interaction.status` | `success` | `failure` | `failure` |
| `extension.error_category` | (absent) | catalog prefix, e.g. `SNYK-CLI` | `unknown` |
| `extension.error_code` | (absent) | full code, e.g. `SNYK-CLI-0008` | (absent) |

Raw `err.Error()` strings are never passed to analytics fields — only stable catalog identifiers — to keep events free of file paths, repo URLs, and other PII.

## PR stack

```mermaid
flowchart LR
  main --> pr["#CURRENT: emit failure analytics ← you are here"]
```

Single PR, no stacking needed (~415 lines changed, under the 700-line limit).

## Test plan

- [x] `make test` (full suite) — green
- [x] `make format` — 0 issues
- [x] New tests for the helpers cover: nil, non-catalog, catalog `SNYK-CLI-*`, catalog `SNYK-OS-*`, malformed code, wrapped catalog errors.
- [x] New integration-level tests in `folder_failure_analytics_test.go` cover:
  - failed scan with catalog error → `status:failure` + correct prefix + full code
  - failed scan with non-catalog error → `status:failure` + `error_category:"unknown"`, no `error_code`
  - successful scan still emits `status:success` (regression guard, no error fields)
  - failed scan with empty `Product` → no emission
  - failed scan with `SendAnalytics:false` → no emission
  - failed scan with partial `ScanData` → no panic, still emits Failure
- [x] Existing `Test_processResults_ShouldSendAnalyticsToAPI` still passes (regression guard).
- [ ] Post-deploy: confirm the IDE panel on dashboard `f56-fxs-zmp` starts showing non-zero failure counts within one scan cycle.

## Acceptance criteria (from RFC)

- [x] Early-return on `data.Err != nil` in `sendAnalytics` removed.
- [x] `Status` derived from `data.Err` rather than hardcoded to `Success`.
- [x] `extension["error_category"]` set on failure via catalog prefix, `unknown` fallback for non-catalog errors.
- [x] `extension["error_code"]` set when a full catalog `ErrorCode` is available.
- [x] Unit tests cover success, catalog error, non-catalog error, empty product, `SendAnalytics:false`, partial `ScanData`.
- [x] `createTestSummary` handles partial `ScanData` without panicking (existing early-return on empty severity counts already handles this; T6 confirms).
- [x] No raw `err.Error()` strings appear in any analytics field.
- [ ] Post-deploy verification on the dashboard.

## References

- **RFC v7**: https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4827676673/RFC+Emit+Errors+from+Snyk+Language+Server
- **Jira**: [IDE-1668](https://snyksec.atlassian.net/browse/IDE-1668)
- **Dashboard**: https://app.datadoghq.com/dashboard/f56-fxs-zmp
- **Error catalog**: https://github.com/snyk/error-catalog-golang-public

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-1668]: https://snyksec.atlassian.net/browse/IDE-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Emit analytics events for failed scans to populate the "Is Snyk OK?" dashboard.

- Categorize errors into low-cardinality prefixes and full codes for improved reporting.

- Ensure existing analytics guards for cancellation and opt-outs remain effective.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>analytics_errors.go</strong><dd><code>Add functions to classify and control scan analytics emission</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1308/changes#diff-2bfec5ce7cec0d627af7bd9198e6e442623e5931ae0ec088321189b08dc5b5da">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>folder.go</strong><dd><code>Update scan processing and analytics for error reporting</code>&nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1308/changes#diff-92ee5447150d64c4b9a6c8c8e8834577ada9e739d1a0a2842ef5bc79fd014f26">+40/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>scanner.go</strong><dd><code>Route pre-scan errors for analytics and avoid duplicate notifications</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1308/changes#diff-ca9273debc8b1b659b1a630df729fe1be56f139b823c0b6d4d5a296d55ba47cb">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scan.go</strong><dd><code>Add UserNotified flag to ScanData</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1308/changes#diff-f0637e314c04ee2a64ce1284958e7e4b782719a4d225264a67d302eb8225aaa0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>analytics_errors_test.go</strong><dd><code>Unit tests for error classification and analytics emission logic</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1308/changes#diff-7f31fcb38d6acfc25d8eb5d3b017f79a26d13b77a822b1ad48965c3316a12fa3">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>folder_failure_analytics_test.go</strong><dd><code>Comprehensive tests for failure analytics reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1308/changes#diff-cfb8d9ba9012fbbf2707589fac82884563ddadd847e5ab19cc1296d3b914a579">+352/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>channels.go</strong><dd><code>Add utility to assert channel never receives data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1308/changes#diff-46d04268ab60ff7ca13961938b8b33cd6efac87179b0d1ae1da2ffe7312f6c40">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

