### PR TITLE
fix(tree-view): prevent tree jump on manual issue selection [IDE-2077]

### DIFF
--- a/docs/tree-view.md
+++ b/docs/tree-view.md
@@ -172,7 +172,7 @@ window.__selectTreeNode__(issueId)
 
 This finds the node by `data-issue-id`, expands any collapsed ancestors so the node is visible, applies the `.selected` class, and removes it from any previously selected node.
 
-**Scroll behavior on programmatic selection:** if the selected row is already fully visible vertically within `#treeContainer`, the scroll position is preserved unchanged. If the row is off-screen, the container scrolls vertically to center the row in the viewport. The horizontal scroll position (`scrollLeft`) is never changed.
+**Scroll behavior on programmatic selection:** the container scrolls the minimum amount needed to make the row visible (`block: 'nearest'`); if the row is already fully visible, no scroll occurs. The horizontal scroll position (`scrollLeft`) is never changed.
 
 ### Issue Badges
 

--- a/docs/tree-view.md
+++ b/docs/tree-view.md
@@ -172,7 +172,7 @@ window.__selectTreeNode__(issueId)
 
 This finds the node by `data-issue-id`, expands any collapsed ancestors so the node is visible, applies the `.selected` class, and removes it from any previously selected node.
 
-**Scroll behavior on programmatic selection:** if the selected row is already fully visible vertically within `#treeContainer`, the scroll position is preserved unchanged. If the row is off-screen, the container scrolls vertically to center the row. The horizontal scroll position (`scrollLeft`) is never changed.
+**Scroll behavior on programmatic selection:** if the selected row is already fully visible vertically within `#treeContainer`, the scroll position is preserved unchanged. If the row is off-screen, the container scrolls vertically to center the row in the viewport. The horizontal scroll position (`scrollLeft`) is never changed.
 
 ### Issue Badges
 
@@ -263,9 +263,9 @@ The `Makefile` includes dedicated targets:
 - **Auto-expand**: trees with <= 50 total issues auto-expand progressively
 - **State persistence**: expand/collapse state survives re-renders via `ExpandState` in the LS
 
-### IE11 Compatibility
+### Browser Compatibility
 
-All JS is ES5 (no arrow functions, no `const`/`let`, no template literals). CSS uses no variables, no grid, no `:focus-visible`. The `<meta http-equiv='X-UA-Compatible' content='IE=edge' />` tag is included. `scrollIntoView` uses the boolean argument form (`scrollIntoView(false)`) instead of the options object, since IE11 (used by Visual Studio's webview) does not support `ScrollIntoViewOptions`.
+All JS is ES5 (no arrow functions, no `const`/`let`, no template literals). CSS uses no variables, no grid, no `:focus-visible`. Visual Studio's webview has migrated to Chromium; IE11 is no longer a supported target. `scrollIntoView` uses the options-object form (`{ block: 'nearest', inline: 'nearest' }`).
 
 ### Test Scenarios
 

--- a/docs/tree-view.md
+++ b/docs/tree-view.md
@@ -162,15 +162,17 @@ Disabled products (not in `SupportedIssueTypes`) are rendered with `opacity: 0.5
 
 ### Node Selection
 
-Clicking an issue node highlights it with the `.selected` CSS class. Only one node can be selected at a time.
+Clicking an issue node highlights it with the `.selected` CSS class. Only one node can be selected at a time. Manual clicks (mouse) do not change the scroll position.
 
 The IDE can programmatically select a node by calling:
 
 ```javascript
-window.__selectTreeNode__(nodeId)
+window.__selectTreeNode__(issueId)
 ```
 
-This finds the node by `data-node-id`, applies the `.selected` class, and removes it from any previously selected node.
+This finds the node by `data-issue-id`, expands any collapsed ancestors so the node is visible, applies the `.selected` class, and removes it from any previously selected node.
+
+**Scroll behavior on programmatic selection:** if the selected row is already fully visible vertically within `#treeContainer`, the scroll position is preserved unchanged. If the row is off-screen, the container scrolls vertically to center the row. The horizontal scroll position (`scrollLeft`) is never changed.
 
 ### Issue Badges
 

--- a/docs/ui-rendering.md
+++ b/docs/ui-rendering.md
@@ -233,13 +233,13 @@ For example, clicking an issue calls `__ideExecuteCommand__('snyk.navigateToRang
 where `range` is `{ start: { line, character }, end: { line, character } }`. When `issueId` and `product` are provided,
 the command also opens the issue detail panel via a `snyk://` URI constructed from `uri.PathToUri`.
 
-### IE11 Compatibility (Visual Studio)
+### Browser Compatibility
+
+Visual Studio's webview has migrated to Chromium; IE11 is no longer a supported target.
 
 - ES5 JavaScript only (no `const`, `let`, arrow functions, template literals)
 - No `<details>`/`<summary>` — uses `div` + class toggling
-- `document.createEvent('Event')` fallback for event dispatching
-- CSS compatible with IE11 (no CSS variables, no grid)
-- `scrollIntoView(false)` instead of `scrollIntoView({ block: 'nearest' })` (options object not supported in IE11)
+- CSS compatible with Chromium-based webviews (no CSS variables, no grid)
 
 ### Filtering
 

--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -57,9 +57,10 @@
     // Preserve horizontal scroll — scrollIntoView may shift it even with inline:'nearest'
     // if the row is horizontally out of view. Capture and restore unconditionally.
     var savedScrollLeft = container.scrollLeft;
-    // block:'center' scrolls the row to the vertical centre of the viewport.
+    // block:'nearest' is a no-op when the row is already fully visible, so manual clicks
+    // that trigger a programmatic __selectTreeNode__ round-trip don't cause any scroll jump.
     // inline:'nearest' minimises horizontal movement, but we restore scrollLeft anyway.
-    row.scrollIntoView({ block: 'center', inline: 'nearest' });
+    row.scrollIntoView({ block: 'nearest', inline: 'nearest' });
     // scroll-behavior: smooth on #treeContainer would run after this line and overwrite
     // the restored value. tree.css must not set scroll-behavior: smooth on this element.
     container.scrollLeft = savedScrollLeft;

--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -52,14 +52,16 @@
   }
 
   function scrollRowIntoViewVerticalOnly(row) {
-    if (!row || !container) return;
+    if (!row) return;
     if (!row.scrollIntoView) return;
     // Preserve horizontal scroll — scrollIntoView may shift it even with inline:'nearest'
     // if the row is horizontally out of view. Capture and restore unconditionally.
     var savedScrollLeft = container.scrollLeft;
-    // block:'nearest' scrolls vertically only when the row is not already visible.
+    // block:'center' scrolls the row to the vertical centre of the viewport.
     // inline:'nearest' minimises horizontal movement, but we restore scrollLeft anyway.
-    row.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    row.scrollIntoView({ block: 'center', inline: 'nearest' });
+    // scroll-behavior: smooth on #treeContainer would run after this line and overwrite
+    // the restored value. tree.css must not set scroll-behavior: smooth on this element.
     container.scrollLeft = savedScrollLeft;
   }
 

--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -51,6 +51,18 @@
     }
   }
 
+  function scrollRowIntoViewVerticalOnly(row) {
+    if (!row || !container) return;
+    if (!row.scrollIntoView) return;
+    // Preserve horizontal scroll — scrollIntoView may shift it even with inline:'nearest'
+    // if the row is horizontally out of view. Capture and restore unconditionally.
+    var savedScrollLeft = container.scrollLeft;
+    // block:'nearest' scrolls vertically only when the row is not already visible.
+    // inline:'nearest' minimises horizontal movement, but we restore scrollLeft anyway.
+    row.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    container.scrollLeft = savedScrollLeft;
+  }
+
   window.__selectTreeNode__ = function(issueId) {
     if (!issueId) return;
     var row = container.querySelector('[data-issue-id="' + issueId + '"]');
@@ -68,7 +80,7 @@
       parent = parent.parentElement;
     }
     selectNodeRow(row);
-    if (row.scrollIntoView) row.scrollIntoView(false);
+    scrollRowIntoViewVerticalOnly(row);
   };
 
   // Scan error overlay for product error nodes.

--- a/js-tests/tree-runtime.test.mjs
+++ b/js-tests/tree-runtime.test.mjs
@@ -463,6 +463,76 @@ test("window.__selectTreeNode__ expands collapsed ancestor nodes", async () => {
   assert.ok(row.className.includes('selected'), 'issue row should be selected');
 });
 
+test("__selectTreeNode__ preserves container.scrollLeft after programmatic select", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const nodesHtml = productNodeHtml(
+    fileNodeHtml("file-1", { childrenHtml: issueNodeHtml("vuln-1") })
+  );
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 0, nodesHtml, runtimeScript }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+  const { document } = dom.window;
+  const container = document.getElementById("treeContainer");
+  const row = document.querySelector('[data-issue-id="vuln-1"]');
+
+  // Stub scrollIntoView to simulate it shifting scrollLeft (as browsers may do)
+  var scrollIntoViewCalled = false;
+  row.scrollIntoView = function() {
+    scrollIntoViewCalled = true;
+    container.scrollLeft = 0; // simulate browser shifting horizontal scroll
+  };
+  container.scrollLeft = 100;
+
+  dom.window.__selectTreeNode__("vuln-1");
+
+  assert.ok(scrollIntoViewCalled, "scrollIntoView should be called");
+  assert.equal(container.scrollLeft, 100, "scrollLeft must be restored after scrollIntoView");
+});
+
+test("__selectTreeNode__ calls scrollIntoView with block:nearest", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const nodesHtml = productNodeHtml(
+    fileNodeHtml("file-1", { childrenHtml: issueNodeHtml("vuln-1") })
+  );
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 0, nodesHtml, runtimeScript }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+  const { document } = dom.window;
+  const row = document.querySelector('[data-issue-id="vuln-1"]');
+
+  var scrollArgs = null;
+  row.scrollIntoView = function(opts) { scrollArgs = opts; };
+
+  dom.window.__selectTreeNode__("vuln-1");
+
+  assert.ok(scrollArgs !== null, "scrollIntoView should be called");
+  assert.equal(scrollArgs.block, "nearest", "block should be 'nearest' to avoid scrolling when already visible");
+  assert.equal(scrollArgs.inline, "nearest", "inline should be 'nearest' to minimise horizontal movement");
+});
+
+test("__selectTreeNode__ does not throw when scrollIntoView absent", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const nodesHtml = productNodeHtml(
+    fileNodeHtml("file-1", { childrenHtml: issueNodeHtml("vuln-1") })
+  );
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 0, nodesHtml, runtimeScript }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+  const { document } = dom.window;
+  const row = document.querySelector('[data-issue-id="vuln-1"]');
+
+  // Remove scrollIntoView to simulate older environment
+  delete row.scrollIntoView;
+
+  assert.doesNotThrow(() => {
+    dom.window.__selectTreeNode__("vuln-1");
+  }, "should not throw when scrollIntoView is absent");
+  assert.ok(row.className.includes("selected"), "row should still be selected");
+});
+
 test("clicking delta-enabled folder node still toggles expand/collapse", async () => {
   const runtimeScript = await loadRuntimeScript();
   const calls = [];

--- a/js-tests/tree-runtime.test.mjs
+++ b/js-tests/tree-runtime.test.mjs
@@ -508,7 +508,7 @@ test("__selectTreeNode__ calls scrollIntoView with block:nearest", async () => {
   dom.window.__selectTreeNode__("vuln-1");
 
   assert.ok(scrollArgs !== null, "scrollIntoView should be called");
-  assert.equal(scrollArgs.block, "center", "block should be 'center' to scroll the row to the vertical centre of the viewport");
+  assert.equal(scrollArgs.block, "nearest", "block should be 'nearest' — no-op when row is already visible, scrolls minimum otherwise");
   assert.equal(scrollArgs.inline, "nearest", "inline should be 'nearest' to minimise horizontal movement");
 });
 

--- a/js-tests/tree-runtime.test.mjs
+++ b/js-tests/tree-runtime.test.mjs
@@ -508,7 +508,7 @@ test("__selectTreeNode__ calls scrollIntoView with block:nearest", async () => {
   dom.window.__selectTreeNode__("vuln-1");
 
   assert.ok(scrollArgs !== null, "scrollIntoView should be called");
-  assert.equal(scrollArgs.block, "nearest", "block should be 'nearest' to avoid scrolling when already visible");
+  assert.equal(scrollArgs.block, "center", "block should be 'center' to scroll the row to the vertical centre of the viewport");
   assert.equal(scrollArgs.inline, "nearest", "inline should be 'nearest' to minimise horizontal movement");
 });
 


### PR DESCRIPTION
### Description

Fixes [IDE-2077](https://snyksec.atlassian.net/browse/IDE-2077).

Clicking an issue in the tree caused the tree to jump unexpectedly. The user clicks a visible row, the IDE sends `snyk.navigateToRange` to the LS, the LS responds with a `showDocument` callback, the IDE calls `window.__selectTreeNode__` — which unconditionally called `scrollIntoView(false)`, scrolling the tree even when the row was already in view.

**Fix:** replace with `scrollIntoView({block:'nearest', inline:'nearest'})` + restore `container.scrollLeft`. `block:nearest` is a no-op when the row is already visible, scrolls minimally when it isn't. `scrollLeft` restore ensures horizontal position never changes.

No IDE plugin changes required — `__selectTreeNode__(issueId)` signature unchanged.

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

[IDE-2077]: https://snyksec.atlassian.net/browse/IDE-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ