### PR TITLE
fix(oss): suppress --all-projects when --maven-aggregate-project is set [IDE-1730]

### DIFF
--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -74,6 +74,9 @@ var (
 		"--yarn-workspaces":  true,
 		"--docker":           true,
 		"--all-sub-projects": true,
+		// --maven-aggregate-project is mutually exclusive with --all-projects per the Snyk CLI spec:
+		// https://docs.snyk.io/developer-tools/snyk-cli/commands/test#--maven-aggregate-project
+		"--maven-aggregate-project": true,
 	}
 
 	// Make sure CLIScanner implements the desired interfaces

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -356,6 +356,12 @@ func TestCLIScanner_prepareScanCommand_RemovesAllProjectsParam(t *testing.T) {
 				expectedInCmd:   "--all-sub-projects",
 				expectedMessage: "--all-projects should not be present when --all-sub-projects is present",
 			},
+			{
+				name:            "--maven-aggregate-project",
+				parameter:       "--maven-aggregate-project",
+				expectedInCmd:   "--maven-aggregate-project",
+				expectedMessage: "--all-projects should not be present when --maven-aggregate-project is also present",
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
### **User description**
## Summary
- Adds `--maven-aggregate-project` to `allProjectsParamBlacklist` in `infrastructure/oss/cli_scanner.go`.
- When a user passes this flag as an additional OSS parameter, snyk-ls no longer auto-appends `--all-projects`. The Snyk CLI treats the two flags as mutually exclusive, so combining them is invalid.
- This was the root cause of 4× result duplication for Maven multi-module projects.

## Test plan
- [ ] `go test ./infrastructure/oss/... -run TestCLIScanner_prepareScanCommand_RemovesAllProjectsParam` — covers the new `--maven-aggregate-project` case alongside the existing blacklisted flags.
- [ ] `make test` — full unit suite green.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevent `--all-projects` from being used with `--maven-aggregate-project`.

- Fixes duplicate scan results for multi-module Maven projects.

- Adds a new test case for parameter conflict handling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Scanner Logic"] --> B["Parameter Blacklist"];
  B -- "Includes" --> C["--maven-aggregate-project"];
  C -- "Causes" --> D["--all-projects suppressed"];
  D -- "Solves" --> E["Fixes Duplicate Results"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli_scanner.go</strong><dd><code>Update CLI parameter blacklist for mutual exclusivity</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/cli_scanner.go

<ul><li>Adds <code>--maven-aggregate-project</code> to the <code>allProjectsParamBlacklist</code>.<br> <li> Includes comments explaining the mutual exclusivity with <br><code>--all-projects</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1312/changes#diff-6303c702b1a7d4e9fb6a9f930cfbe2546fa60cced2ba801246cb356bd2a047a6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli_scanner_test.go</strong><dd><code>Add test for Maven aggregate project parameter conflict</code>&nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/cli_scanner_test.go

<ul><li>Adds a new test case to <br><code>TestCLIScanner_prepareScanCommand_RemovesAllProjectsParam</code>.<br> <li> Verifies <code>--all-projects</code> is suppressed when <code>--maven-aggregate-project</code> <br>is present.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1312/changes#diff-2ddb7ef67e4b5be5015a0454ff887c279f4e991c9b7e4b6cdce291a29eb348a0">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

