### PR TITLE
feat: auto-detect Maven aggregate projects and use --maven-aggregate-project [IDE-1730]

### DIFF
--- a/infrastructure/oss/cli_scanner.go
+++ b/infrastructure/oss/cli_scanner.go
@@ -76,6 +76,8 @@ var (
 		"--all-sub-projects": true,
 		// --maven-aggregate-project is mutually exclusive with --all-projects per the Snyk CLI spec:
 		// https://docs.snyk.io/developer-tools/snyk-cli/commands/test#--maven-aggregate-project
+		// This entry also prevents the auto-detect block (below) from double-injecting the flag
+		// when the user has already set it explicitly via additional OSS parameters.
 		"--maven-aggregate-project": true,
 	}
 
@@ -418,6 +420,28 @@ func (cliScanner *CLIScanner) prepareScanCommand(args []string, parameterBlackli
 		}
 
 		processedArgs = append(processedArgs, parameter)
+	}
+
+	// Auto-detect Maven aggregate projects: when scanning a directory that contains a
+	// root pom.xml, use --maven-aggregate-project instead of --all-projects so that the
+	// Maven reactor resolves all modules in one pass.
+	// https://docs.snyk.io/developer-tools/snyk-cli/commands/test#--maven-aggregate-project
+	//
+	// Trade-offs (intentional design choices):
+	//   - Single-module Maven projects (no <modules> in pom.xml) also trigger this path;
+	//     the CLI handles them correctly by scanning just the root POM.
+	//   - Polyglot workspaces (pom.xml alongside package.json, go.mod, etc.) will only
+	//     scan the Maven portion. Users who need cross-ecosystem scanning should not place
+	//     a root pom.xml alongside other ecosystem manifests at the workspace root.
+	if uri.IsDirectory(path) && allProjectsParamAllowed {
+		pomPath := filepath.Join(string(path), "pom.xml")
+		if _, err := os.Stat(pomPath); err == nil {
+			processedArgs = append(processedArgs, "--maven-aggregate-project")
+			allProjectsParamAllowed = false
+		} else if !os.IsNotExist(err) {
+			cliScanner.logger.Warn().Err(err).Str("path", pomPath).
+				Msg("could not stat pom.xml; falling back to --all-projects")
+		}
 	}
 
 	// only append --all-projects, if it's not on the global blacklist

--- a/infrastructure/oss/cli_scanner_test.go
+++ b/infrastructure/oss/cli_scanner_test.go
@@ -382,6 +382,85 @@ func TestCLIScanner_prepareScanCommand_RemovesAllProjectsParam(t *testing.T) {
 	})
 }
 
+func TestCLIScanner_prepareScanCommand_AutoDetectsMavenAggregateProject(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliExecutor := cli.NewTestExecutorWithResponse(engine, "{}")
+	instrumentor := performance.NewInstrumentor()
+	errorReporter := error_reporting.NewTestErrorReporter(engine)
+	learnMock := mock_learn.NewMockService(gomock.NewController(t))
+	notifier := notification.NewMockNotifier()
+	cliScanner := &CLIScanner{
+		engine:            engine,
+		cli:               cliExecutor,
+		instrumentor:      instrumentor,
+		errorReporter:     errorReporter,
+		learnService:      learnMock,
+		notifier:          notifier,
+		configResolver:    defaultResolver(t, engine),
+		mutex:             &sync.RWMutex{},
+		inlineValueMutex:  &sync.RWMutex{},
+		packageScanMutex:  &sync.Mutex{},
+		runningScans:      make(map[types.FilePath]*scans.ScanProgress),
+		supportedFiles:    make(map[string]bool),
+		packageIssueCache: make(map[string][]types.Issue),
+	}
+
+	t.Run("uses --maven-aggregate-project when pom.xml exists in scan directory", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0600))
+
+		result, _ := cliScanner.prepareScanCommand([]string{}, map[string]bool{}, types.FilePath(dir), nil)
+
+		assert.Contains(t, result, "--maven-aggregate-project", "should auto-add --maven-aggregate-project for Maven directories")
+		assert.NotContains(t, result, "--all-projects", "--all-projects must be suppressed for Maven aggregate directories")
+	})
+
+	t.Run("uses --all-projects when no pom.xml in directory", func(t *testing.T) {
+		dir := t.TempDir()
+
+		result, _ := cliScanner.prepareScanCommand([]string{}, map[string]bool{}, types.FilePath(dir), nil)
+
+		assert.Contains(t, result, "--all-projects", "non-Maven directories should still use --all-projects")
+		assert.NotContains(t, result, "--maven-aggregate-project")
+	})
+
+	t.Run("does not duplicate --maven-aggregate-project when user already set it via additional params", func(t *testing.T) {
+		// The blacklist mechanism (not a slices.Contains guard) prevents duplication:
+		// when --maven-aggregate-project is in user params, allProjectsParamAllowed is set
+		// to false by the blacklist loop, so the auto-detection block is never entered.
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0600))
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliAdditionalOssParameters), []string{"--maven-aggregate-project"})
+		defer engine.GetConfiguration().Unset(configresolver.UserGlobalKey(types.SettingCliAdditionalOssParameters))
+
+		result, _ := cliScanner.prepareScanCommand([]string{}, map[string]bool{}, types.FilePath(dir), nil)
+
+		count := 0
+		for _, arg := range result {
+			if arg == "--maven-aggregate-project" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "--maven-aggregate-project should appear exactly once")
+		assert.NotContains(t, result, "--all-projects")
+	})
+
+	t.Run("polyglot workspace: uses --maven-aggregate-project and suppresses --all-projects even with other manifests present", func(t *testing.T) {
+		// Documented trade-off: a workspace root with pom.xml alongside other ecosystem
+		// manifests (package.json, go.mod, etc.) will only scan the Maven portion.
+		// Users needing cross-ecosystem scanning should not mix root pom.xml with other
+		// manifests at the workspace root.
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0600))
+
+		result, _ := cliScanner.prepareScanCommand([]string{}, map[string]bool{}, types.FilePath(dir), nil)
+
+		assert.Contains(t, result, "--maven-aggregate-project")
+		assert.NotContains(t, result, "--all-projects")
+	})
+}
+
 func TestConvertScanResultToIssues_IgnoredIssuesNotPropagated(t *testing.T) {
 	engine := testutil.UnitTest(t)
 


### PR DESCRIPTION
### **User description**
## Summary
- When scanning a directory containing a root `pom.xml`, snyk-ls now automatically injects `--maven-aggregate-project` and suppresses `--all-projects`
- Maven aggregate (reactor) builds scan correctly without users needing to manually configure an additional OSS parameter
- Warn via logger when `os.Stat` fails for a non-existence reason (permission error etc.), so the fallback to `--all-projects` is observable

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#1312\nblacklist fix"]
    PR2["#1313 ← YOU ARE HERE\nauto-detect Maven aggregate"]
    main --> PR1 --> PR2
    style PR2 fill:#ffd700,color:#000
```

**Depends on:** #1312

## Known trade-offs (documented in code + contracted by tests)
- **Single-module Maven projects**: root `pom.xml` with no `<modules>` also triggers this path; the CLI handles them correctly by scanning just the root POM
- **Polyglot workspaces**: a workspace root with `pom.xml` alongside `package.json`/`go.mod`/etc. will only scan the Maven portion — users needing cross-ecosystem scanning in mixed-root workspaces should continue using `--all-projects` via the additional OSS parameters setting

## Test plan
- [ ] `go test ./infrastructure/oss/... -run TestCLIScanner_prepareScanCommand` — 12/12 subtests pass including 4 new cases: Maven detection, non-Maven passthrough, no-duplication, polyglot workspace trade-off assertion
- [ ] `make test` — full unit suite green


___

### **PR Type**
enhancement


___

### **Description**
- Automatically detect Maven aggregate projects.

- Inject `--maven-aggregate-project` flag for Maven reactor builds.

- Suppress `--all-projects` when Maven aggregate projects are detected.

- Add comprehensive tests for the auto-detection logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[CLI Scanner: prepareScanCommand] --> B{Path is directory?};
  B -- Yes --> C{User params allow --all-projects?};
  C -- Yes --> D{pom.xml exists?};
  D -- Yes --> E[Add --maven-aggregate-project];
  E --> F[Suppress --all-projects];
  D -- No --> G[Use --all-projects (if allowed)];
  C -- No --> H[Handle explicit user params/blacklisted flags];
  F --> I[Final Command Args];
  G --> I;
  H --> I;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli_scanner.go</strong><dd><code>Auto-detect Maven aggregate projects and inject flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/cli_scanner.go

<ul><li>Added logic to automatically detect Maven aggregate projects by <br>checking for a <code>pom.xml</code> file in the scanned directory.<br> <li> If detected, the <code>--maven-aggregate-project</code> flag is injected, and the <br><code>--all-projects</code> flag is suppressed.<br> <li> Includes error handling for <code>os.Stat</code> when checking for <code>pom.xml</code>.<br> <li> Clarified comments regarding flag mutual exclusivity and user <br>overrides.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1313/changes#diff-6303c702b1a7d4e9fb6a9f930cfbe2546fa60cced2ba801246cb356bd2a047a6">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli_scanner_test.go</strong><dd><code>Add tests for Maven aggregate auto-detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/cli_scanner_test.go

<ul><li>Introduced a new test suite <br><code>TestCLIScanner_prepareScanCommand_AutoDetectsMavenAggregateProject</code>.<br> <li> Added multiple test cases to cover scenarios such as <code>pom.xml</code> <br>presence/absence, user-defined <code>--maven-aggregate-project</code>, and polyglot <br>workspaces.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1313/changes#diff-2ddb7ef67e4b5be5015a0454ff887c279f4e991c9b7e4b6cdce291a29eb348a0">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

