### PR TITLE
fix(treeview): pair hover background and foreground for readability [IDE-2078]

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -7,3 +7,7 @@ IDE-1992: A user's settings shall remain unchanged when the settings panel is di
 IDE-1992: Each behaviour shall apply within the IDE scope stated in the relevant requirement above, covering all supported IDEs: VS Code, Eclipse, IntelliJ, and Visual Studio.
 IDE-1992: The fallback settings HTML page (distributed separately because it is statically bundled in each IDE plugin rather than shipped with the LS binary) shall be automatically distributed to all IDE repos within one CI pipeline run after a change is merged to the main branch of snyk-ls.
 IDE-1992: The fallback HTML page distributed to all IDE repos shall be the version that implements all behaviours described in the requirements above, including auto-save-on-hide for auto-save IDEs and save-on-OK / cancel-discard for IDEs with an explicit OK/Cancel flow.
+IDE-2078: The tree-view hover style shall set both background and foreground using IDE theme variables so that text remains readable across light and dark themes.
+IDE-2078: The tree-view hover style shall fall back to the list-active-selection variables when no IDE-supplied list-hover-foreground variable is provided.
+IDE-2078: The tree-view CSS shall not hard-code colour values for the hover state; all colours shall come from CSS custom properties bound to `--vscode-*` variables (with sensible neutral fallbacks).
+IDE-2078: Hover styling shall remain correct when the IDE injects its own theme CSS via the `${ideStyle}` placeholder.

--- a/domain/ide/treeview/template/styles.css
+++ b/domain/ide/treeview/template/styles.css
@@ -19,6 +19,7 @@
   --info-background: var(--vscode-inputValidation-infoBackground, #e6f3ff);
 
   --list-hover-background: var(--vscode-list-hoverBackground, #8080801a);
+  --list-hover-foreground: var(--vscode-list-hoverForeground, var(--list-active-selection-foreground));
   --list-active-selection-background: var(--vscode-list-activeSelectionBackground, #0066cc1f);
   --list-active-selection-foreground: var(--vscode-list-activeSelectionForeground, #0066cc);
 
@@ -77,6 +78,9 @@ body {
 
 .tree-node-row:hover {
   background-color: var(--list-hover-background);
+  color: var(--list-hover-foreground);
+  outline: 1px solid var(--focus-border);
+  outline-offset: -1px;
 }
 
 .tree-node-row.selected {
@@ -278,10 +282,6 @@ body {
   cursor: pointer;
 }
 
-.tree-node-issue .tree-node-row:hover {
-  background-color: var(--list-hover-background);
-}
-
 /* Issue group node (multi-location container) — expand/collapse like file node */
 .tree-node-issue-group .tree-node-row {
   cursor: pointer;
@@ -290,10 +290,6 @@ body {
 /* Location node — clickable like issue leaf */
 .tree-node-location .tree-node-row {
   cursor: pointer;
-}
-
-.tree-node-location .tree-node-row:hover {
-  background-color: var(--list-hover-background);
 }
 
 /* Filter toolbar */

--- a/domain/ide/treeview/template/styles.css
+++ b/domain/ide/treeview/template/styles.css
@@ -21,7 +21,7 @@
   --list-hover-background: var(--vscode-list-hoverBackground, #8080801a);
   --list-hover-foreground: var(--vscode-list-hoverForeground, var(--list-active-selection-foreground));
   --list-active-selection-background: var(--vscode-list-activeSelectionBackground, #0066cc1f);
-  --list-active-selection-foreground: var(--vscode-list-activeSelectionForeground, #0066cc);
+  --list-active-selection-foreground: var(--vscode-list-activeSelectionForeground, inherit);
 
   --tree-indent-guides-stroke: var(--vscode-tree-indentGuidesStroke, #80808099);
 
@@ -79,8 +79,6 @@ body {
 .tree-node-row:hover {
   background-color: var(--list-hover-background);
   color: var(--list-hover-foreground);
-  outline: 1px solid var(--focus-border);
-  outline-offset: -1px;
 }
 
 .tree-node-row.selected {
@@ -410,6 +408,7 @@ body {
 
 .tree-node-row-info:hover {
   background-color: transparent;
+  color: inherit;
 }
 
 /* Disabled product nodes — greyed out */

--- a/domain/ide/treeview/tree_html_test.go
+++ b/domain/ide/treeview/tree_html_test.go
@@ -709,7 +709,7 @@ func TestTreeHtmlRenderer_TreeHoverRow_PairsBackgroundAndForeground(t *testing.T
 	html := renderer.RenderTreeView(TreeViewData{})
 
 	// The embedded CSS must define the hover-foreground variable so that hover
-	// text colour is paired with the hover background across IDE themes (IDE-2078).
+	// text color is paired with the hover background across IDE themes (IDE-2078).
 	assert.Contains(t, html, "--list-hover-foreground", "CSS must define --list-hover-foreground variable")
 
 	// The .tree-node-row:hover block must set BOTH background-color AND color so

--- a/domain/ide/treeview/tree_html_test.go
+++ b/domain/ide/treeview/tree_html_test.go
@@ -700,27 +700,3 @@ func TestTreeHtmlRenderer_FileNode_EmptyFileIconHTML_RendersGenericSVG(t *testin
 	assert.NotContains(t, html, "📄", "empty FileIconHTML should not fall back to emoji")
 	assert.Contains(t, html, `<svg`, "empty FileIconHTML should render the generic file SVG")
 }
-
-func TestTreeHtmlRenderer_TreeHoverRow_PairsBackgroundAndForeground(t *testing.T) {
-	engine := testutil.UnitTest(t)
-	renderer, err := NewTreeHtmlRenderer(engine.GetLogger())
-	require.NoError(t, err)
-
-	html := renderer.RenderTreeView(TreeViewData{})
-
-	// The embedded CSS must define the hover-foreground variable so that hover
-	// text color is paired with the hover background across IDE themes (IDE-2078).
-	assert.Contains(t, html, "--list-hover-foreground", "CSS must define --list-hover-foreground variable")
-
-	// The .tree-node-row:hover block must set BOTH background-color AND color so
-	// that an opaque IDE-injected hover background does not leave text unreadable.
-	hoverBlockStart := strings.Index(html, ".tree-node-row:hover")
-	require.Greater(t, hoverBlockStart, 0, ".tree-node-row:hover rule must be present")
-	hoverBlock := html[hoverBlockStart:]
-	closingBrace := strings.Index(hoverBlock, "}")
-	require.Greater(t, closingBrace, 0, ".tree-node-row:hover block must have a closing brace")
-	hoverRule := hoverBlock[:closingBrace]
-
-	assert.Contains(t, hoverRule, "background-color", ".tree-node-row:hover must set background-color")
-	assert.Contains(t, hoverRule, "color", ".tree-node-row:hover must set color")
-}

--- a/domain/ide/treeview/tree_html_test.go
+++ b/domain/ide/treeview/tree_html_test.go
@@ -700,3 +700,27 @@ func TestTreeHtmlRenderer_FileNode_EmptyFileIconHTML_RendersGenericSVG(t *testin
 	assert.NotContains(t, html, "📄", "empty FileIconHTML should not fall back to emoji")
 	assert.Contains(t, html, `<svg`, "empty FileIconHTML should render the generic file SVG")
 }
+
+func TestTreeHtmlRenderer_TreeHoverRow_PairsBackgroundAndForeground(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	renderer, err := NewTreeHtmlRenderer(engine.GetLogger())
+	require.NoError(t, err)
+
+	html := renderer.RenderTreeView(TreeViewData{})
+
+	// The embedded CSS must define the hover-foreground variable so that hover
+	// text colour is paired with the hover background across IDE themes (IDE-2078).
+	assert.Contains(t, html, "--list-hover-foreground", "CSS must define --list-hover-foreground variable")
+
+	// The .tree-node-row:hover block must set BOTH background-color AND color so
+	// that an opaque IDE-injected hover background does not leave text unreadable.
+	hoverBlockStart := strings.Index(html, ".tree-node-row:hover")
+	require.Greater(t, hoverBlockStart, 0, ".tree-node-row:hover rule must be present")
+	hoverBlock := html[hoverBlockStart:]
+	closingBrace := strings.Index(hoverBlock, "}")
+	require.Greater(t, closingBrace, 0, ".tree-node-row:hover block must have a closing brace")
+	hoverRule := hoverBlock[:closingBrace]
+
+	assert.Contains(t, hoverRule, "background-color", ".tree-node-row:hover must set background-color")
+	assert.Contains(t, hoverRule, "color", ".tree-node-row:hover must set color")
+}


### PR DESCRIPTION
### **User description**
## Summary

- Tree-node hover text becomes unreadable in IntelliJ light mode (and is fragile in dark) because `.tree-node-row:hover` only sets `background-color` — the foreground stays inherited and clashes with IntelliJ's opaque hover background.
- Fix: introduce `--list-hover-foreground` (sourced from `--vscode-list-hoverForeground`, falling back to `--list-active-selection-foreground`) and apply it alongside the existing hover background. Adds a 1px `outline` using `--focus-border` to satisfy the "border" AC without shifting layout.
- Removed redundant `.tree-node-issue .tree-node-row:hover` / `.tree-node-location .tree-node-row:hover` rules — they only repeated the base hover background, which still matches via the base selector.

Ticket: [IDE-2078](https://snyksec.atlassian.net/browse/IDE-2078)

IntelliJ
<img width="468" height="321" alt="image" src="https://github.com/user-attachments/assets/a9004051-6106-4eb2-ab3b-239ec0f197d0" />
<img width="560" height="374" alt="image" src="https://github.com/user-attachments/assets/68db8fd7-f436-4b5d-b15b-54273ffc82a0" />

Visual Studio Code
<img width="385" height="476" alt="image" src="https://github.com/user-attachments/assets/69f6723c-e6bc-45a5-b209-268d182c7679" />



## Scope

**In scope:** `domain/ide/treeview/template/styles.css` (CSS-only). One Go test added in `domain/ide/treeview/tree_html_test.go`. 4 atomic requirements appended to `docs/requirements/requirements.md`.

**Out of scope (intentionally untouched):** `.filter-btn:hover`, `.action-btn:hover`, `.ref-picker-*:hover`, `.error-overlay-close:hover`, and the config-page CSS — different hover sites, not what the ticket reports.

## Test plan

- [x] `go test ./domain/ide/treeview/...` — 28 pass (new `TestTreeHtmlRenderer_TreeHoverRow_PairsBackgroundAndForeground` included)
- [ ] Manual IDE matrix (still pending — required before un-drafting):
  - [ ] IntelliJ light (IntelliJ Light + macOS Light)
  - [ ] IntelliJ dark (Darcula + High Contrast)
  - [ ] VS Code light + dark
  - [ ] Eclipse default
- [ ] Before/after screenshots from IntelliJ light to be attached

## Rollback

Trivial. The change is additive (one new CSS custom property + a `color` line on the existing `:hover` block). `git revert <sha>` is safe — no schema, protocol, or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-2078]: https://snyksec.atlassian.net/browse/IDE-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixes tree-view hover readability by pairing colors.

- Introduces theme variables for hover foreground.

- Documents hover styling requirements for IDEs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSS Theme Variables"] -- "define hover foreground" --> B["Treeview CSS Rules"]
  B -- "apply background & color" --> C["Treeview UI Readability"]
  D["Documentation"] -- "capture requirements" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.css</strong><dd><code>Enhance treeview hover color pairing with theme variables</code></dd></summary>
<hr>

domain/ide/treeview/template/styles.css

<ul><li>Defines <code>--list-hover-foreground</code> variable sourced from theme variables.<br> <li> Applies the new foreground color to the <code>.tree-node-row:hover</code> state.<br> <li> Removes redundant specific hover rules for issue and location rows.<br> <li> Ensures <code>.tree-node-row-info:hover</code> has inherited color.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1314/changes#diff-60771d9f4d356e11613ba1f9e235b885aa5f0e120e46f8c2b10e6497c6429b6a">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.md</strong><dd><code>Document tree-view hover readability requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/requirements/requirements.md

<ul><li>Appends four new requirements related to tree-view hover styling.<br> <li> Requirements cover theme variable usage, fallbacks, and IDE injection.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1314/changes#diff-3d7fa82db2df9bfc78cb214da6015ec71b61922b3c7dfa9aedd58489833216ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

