### PR TITLE
fix: eliminate data race in fflags.LoadFeatureFlags() [IDE-2103]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ brain/
 .verify-range
 .verify-agent-progress
 .pr-review-*.md
+.verify-metrics-pending

--- a/internal/fflags/features.go
+++ b/internal/fflags/features.go
@@ -20,6 +20,7 @@ package fflags
 import (
 	_ "embed"
 	"encoding/json"
+	"sync"
 )
 
 type FeatureFlag struct {
@@ -29,13 +30,33 @@ type FeatureFlag struct {
 var (
 	//go:embed features.json
 	featuresEmbed []byte
-	featureFlag   FeatureFlag
+
+	once      sync.Once
+	cached    FeatureFlag
+	errCached error
 )
 
-func LoadFeatureFlags() (*FeatureFlag, error) {
-	err := json.Unmarshal(featuresEmbed, &featureFlag)
-	if err != nil {
-		return nil, err
+func parseFeatureFlags(data []byte) (FeatureFlag, error) {
+	var ff FeatureFlag
+	if err := json.Unmarshal(data, &ff); err != nil {
+		return FeatureFlag{}, err
 	}
-	return &featureFlag, nil
+	return ff, nil
+}
+
+// LoadFeatureFlags returns the parsed feature flags. The embedded JSON is
+// unmarshalled exactly once; errCached is non-nil only if the embedded asset
+// is malformed at build time, which TestLoadFeatureFlags would also catch.
+func LoadFeatureFlags() (*FeatureFlag, error) {
+	once.Do(func() {
+		cached, errCached = parseFeatureFlags(featuresEmbed)
+	})
+	if errCached != nil {
+		return nil, errCached
+	}
+	// Shallow copy is safe because FeatureFlag contains only value-typed fields
+	// (strings). If a slice, map, or pointer is ever added, replace this with
+	// an explicit deep copy to avoid sharing mutable state between callers.
+	cp := cached
+	return &cp, nil
 }

--- a/internal/fflags/features_test.go
+++ b/internal/fflags/features_test.go
@@ -17,9 +17,11 @@
 package fflags
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadFeatureFlags(t *testing.T) {
@@ -29,9 +31,42 @@ func TestLoadFeatureFlags(t *testing.T) {
 	assert.Equal(t, "test-feature with value 555", ff.TestFeature)
 }
 
+// TestLoadFeatureFlags_brokenJSON calls parseFeatureFlags directly to verify
+// JSON parse errors are propagated. The errCached branch in LoadFeatureFlags
+// is unreachable in practice: the embedded asset is compiled in at build time,
+// so a malformed features.json would be caught by TestLoadFeatureFlags first.
 func TestLoadFeatureFlags_brokenJSON(t *testing.T) {
-	featuresEmbed = []byte("{{{broken-json")
-
-	_, err := LoadFeatureFlags()
+	_, err := parseFeatureFlags([]byte("{{{broken-json"))
 	assert.Error(t, err)
+}
+
+// TestLoadFeatureFlags_concurrent exercises concurrent calls to LoadFeatureFlags.
+// Package-level state is reset before launching goroutines so the test covers
+// the once.Do initialisation path regardless of which tests ran before it.
+func TestLoadFeatureFlags_concurrent(t *testing.T) {
+	// Reset package-level state so this test exercises the once.Do init path,
+	// not just the cached-read fast path.
+	once = sync.Once{}
+	cached = FeatureFlag{}
+	errCached = nil
+
+	const goroutines = 20
+
+	var wg sync.WaitGroup
+	results := make([]*FeatureFlag, goroutines)
+	errs := make([]error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = LoadFeatureFlags()
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		require.NoError(t, errs[i])
+		assert.Equal(t, "test-feature with value 555", results[i].TestFeature)
+	}
 }


### PR DESCRIPTION
### **User description**
## Summary

- Replaces the mutable package-level `featureFlag` var with `sync.Once` + `cached`/`errOnce` vars so the embedded JSON is parsed exactly once and concurrent callers cannot race on shared mutable state
- `LoadFeatureFlags()` now returns a copy of the cached struct (not a pointer into it), preventing callers from mutating shared state through the returned pointer
- Extracts an unexported `parseFeatureFlags([]byte)` helper so the broken-JSON test no longer needs to mutate the global `featuresEmbed` var (itself a latent race)
- Adds `TestLoadFeatureFlags_concurrent` — 20 goroutines calling `LoadFeatureFlags()` concurrently; fails on the old code under `go test -race`, passes cleanly after the fix

## Test plan

- [ ] `go test -race ./internal/fflags/...` passes (all three tests)
- [ ] `go test -race -run ^TestLoadFeatureFlags_concurrent$ ./internal/fflags/...` passes (exercises first-initialisation race in isolation)
- [ ] `make test` passes

Fixes IDE-2103


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Eliminates data race in `LoadFeatureFlags`.

- Ensures feature flags are parsed only once using `sync.Once`.

- Prevents callers from mutating shared cached state.

- Adds comprehensive concurrent execution tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[LoadFeatureFlags] --> B{sync.Once.Do};
  B --> C{parseFeatureFlags};
  C --> D[cached FeatureFlag];
  C --> E[errCached error];
  D -- return copy --> F[Caller];
  E -- return error --> F;
  B -- already done --> G[Read cached];
  G --> D;
  D -- return copy --> F;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features.go</strong><dd><code>Implement concurrent-safe feature flag loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/fflags/features.go

<ul><li>Introduced <code>sync.Once</code>, <code>cached</code>, and <code>errCached</code> for safe, single <br>initialization.<br> <li> Added <code>parseFeatureFlags</code> helper for unmarshalling logic.<br> <li> Modified <code>LoadFeatureFlags</code> to use <code>once.Do</code> and return a shallow copy of <br>cached flags.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1318/changes#diff-d3173c12dbaffb92cf68cdf7d369c30dd6e601c917b3c0b97082cd5407e2176e">+26/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features_test.go</strong><dd><code>Add concurrent test and refactor broken JSON test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/fflags/features_test.go

<ul><li>Added <code>TestLoadFeatureFlags_concurrent</code> to verify thread-safe access.<br> <li> Refactored <code>TestLoadFeatureFlags_brokenJSON</code> to use the new <br><code>parseFeatureFlags</code> helper.<br> <li> Added necessary imports for <code>sync</code> and <code>require</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1318/changes#diff-98a4808e5476b117b2cf06124eac9aef43f3c9654da967158e8da7f3783aef38">+38/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

