### PR TITLE
fix: correct env var typo SNYK_DEBUG_LEVEL to SNYK_LOG_LEVEL in README [IDE-2066]

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,8 +522,8 @@ synchronization. For further information please see [CONTRIBUTING.md](CONTRIBUTI
 `-f <FILE>` allows you to specify a log file instead of logging to the console
 
 `-l <LOGLEVEL>` <allows to specify the log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`). The default log
-level is `info`. This can be overruled by setting the env variable `SNYK_DEBUG_LEVEL`,
-e.g. `export SNYK_DEBUG_LEVEL=debug`
+level is `info`. This can be overruled by setting the env variable `SNYK_LOG_LEVEL`,
+e.g. `export SNYK_LOG_LEVEL=debug`
 
 `-licenses` (running standalone) displays the [licenses](https://github.com/snyk/snyk-ls/tree/main/licenses) used by
 Language Server\


### PR DESCRIPTION
## Summary
- Fix env var reference in README: `SNYK_DEBUG_LEVEL` → `SNYK_LOG_LEVEL` (the actual var read by `application/config/config.go`).

## Why
The README example was broken — running the documented command had no effect because the env var didn't exist. Surfaced by automated backlog triage.

## Test plan
- [x] N/A — docs-only change

Jira: [IDE-2066](https://snyksec.atlassian.net/browse/IDE-2066)
Triage: [Buglist](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4860444692/Buglist)

[IDE-2066]: https://snyksec.atlassian.net/browse/IDE-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ