### PR TITLE
fix: outlined Generate AI fix / Apply Fix buttons with hover fill [IDE-1252]

### DIFF
--- a/infrastructure/code/template/styles.css
+++ b/infrastructure/code/template/styles.css
@@ -483,13 +483,15 @@ button.sn-apply-fix:disabled{
 button.generate-ai-fix,
 button.sn-apply-fix {
   border-radius: 4px;
-  background-color: var(--button-background-color);
-  color: var(--button-text-color);
+  background-color: transparent;
+  color: var(--button-background-color);
+  border: 1px solid var(--button-background-color);
   cursor: pointer;
+  transition: background-color .15s ease-in, color .15s ease-in;
 }
 button.sn-apply-fix{
   padding: 4px 12px;
-  background-color: var(--button-background-color)
+  background-color: transparent;
 }
 button.sn-apply-fix:disabled{
   background-color: var(--disabled-background-color);
@@ -538,9 +540,10 @@ button.sn-apply-fix:disabled{
   color: var(--text-color);
 }
 
-button.generate-ai-fix:hover,
-button.sn-apply-fix:hover {
-  opacity: 0.9;
+button.generate-ai-fix:hover:not(:disabled),
+button.sn-apply-fix:hover:not(:disabled) {
+  background-color: var(--button-background-color);
+  color: var(--button-text-color);
 }
 
 /*AI fix tab */


### PR DESCRIPTION
### **User description**
## Summary
- `infrastructure/code/template/styles.css`: change Generate AI fix and Apply Fix buttons from filled to **outlined** (transparent bg, link-coloured border + text) so they match the Create Ignore button.
- Hover: fill with `--button-background-color`, switch text to `--button-text-color`. Short transition for the affordance.
- Disabled state preserved via `:not(:disabled)` on the hover rule.

## Why
The Create Ignore button is outlined while Generate AI fix and Apply Fix were filled — visually inconsistent across the same panel. Earlier attempt was to override in the Eclipse plugin via injected `<style>` (PR snyk/snyk-eclipse-plugin#409), but the CSP in the LS HTML template blocked it. Better to fix in the LS so all IDEs (VSCode, IntelliJ, VS, Eclipse) inherit the consistent look.

Companion: [snyk/snyk-eclipse-plugin#409](https://github.com/snyk/snyk-eclipse-plugin/pull/409) — Eclipse-side colour key change (`hyperlinkColor` for `--button-background-color`).

## Test plan
- [ ] Open issue details for a Code finding in any IDE plugin
- [ ] Generate AI fix and Apply Fix render outlined (link-coloured border + text, transparent background)
- [ ] On hover, both fill with link colour and switch text to on-link colour
- [ ] Disabled state: no hover fill (cursor:not-allowed honoured)
- [ ] Create Ignore still renders outlined — and the three look consistent

Jira: [IDE-1252](https://snyksec.atlassian.net/browse/IDE-1252)
Triage: [Buglist](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4860444692/Buglist)

[IDE-1252]: https://snyksec.atlassian.net/browse/IDE-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Style `Generate AI fix` and `Apply Fix` buttons to be outlined by default.

- Apply fill and text color changes on button hover.

- Introduce smooth transition animations for hover effects.

- Preserve distinct styling for disabled buttons.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.css</strong><dd><code>Style outlined buttons and implement hover effects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/code/template/styles.css

<ul><li>Modified default styles for <code>button.generate-ai-fix</code> and <br><code>button.sn-apply-fix</code> to be outlined, setting transparent background and <br>using <code>--button-background-color</code> for text and border.<br> <li> Added a CSS transition for <code>background-color</code> and <code>color</code> properties to <br>animate hover effects.<br> <li> Implemented <code>:hover:not(:disabled)</code> states for these buttons to apply <br><code>--button-background-color</code> and <code>--button-text-color</code> on hover.<br> <li> Ensured disabled states remain unaffected by hover styles.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1325/changes#diff-20b624ae1678e149ccdaca27a6effda8ba1cbecc7cfbc3b3876b22254083aea4">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

