### PR TITLE
feat: expose stable findingId and RemediationAgentQuickFix kind [IDE-2052]

### DIFF
--- a/application/server/precedence_smoke_test.go
+++ b/application/server/precedence_smoke_test.go
@@ -686,7 +686,7 @@ func waitForScanCompletion(t *testing.T, agg scanstates.Aggregator) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		return agg.StateSnapshot().AllScansFinishedWorkingDirectory
-	}, 120*time.Second, time.Millisecond, "scans did not complete in time")
+	}, maxIntegTestDuration, time.Millisecond, "scans did not complete in time")
 }
 
 // Test_SmokeScanPrecedence_OSSEnabled_CodeDisabled verifies that when OSS is enabled

--- a/domain/ide/converter/converter.go
+++ b/domain/ide/converter/converter.go
@@ -236,6 +236,7 @@ func getOssIssue(issue types.Issue) types.ScanIssue {
 
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
+		FindingId:           issue.GetFindingId(),
 		Title:               additionalData.Title,
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),
@@ -287,6 +288,7 @@ func getIacIssue(issue types.Issue) types.ScanIssue {
 
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
+		FindingId:           issue.GetFindingId(),
 		Title:               additionalData.Title,
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),
@@ -348,6 +350,7 @@ func getCodeIssue(issue types.Issue) types.ScanIssue {
 
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
+		FindingId:           issue.GetFindingId(),
 		Title:               issue.GetMessage(),
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),
@@ -396,6 +399,7 @@ func getSecretIssue(issue types.Issue) types.ScanIssue {
 
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
+		FindingId:           issue.GetFindingId(),
 		Title:               additionalData.Title,
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),

--- a/domain/ide/converter/converter_test.go
+++ b/domain/ide/converter/converter_test.go
@@ -288,3 +288,122 @@ func TestGetCvssCalculatorUrl(t *testing.T) {
 		assert.Equal(t, expected, url)
 	})
 }
+
+// TestToDiagnostics_FindingId verifies that ScanIssue.FindingId is populated from issue.GetFindingId()
+// for each product. A stable FindingId allows clients to correlate the same underlying finding across
+// separate scan invocations without relying on the per-result-set Id field.
+func TestToDiagnostics_FindingId_Code(t *testing.T) {
+	testutil.UnitTest(t)
+
+	const expectedFindingId = "snyk-asset-finding-v1-abc123"
+	testIssue := &snyk.Issue{
+		ID:        "code-rule-id",
+		Severity:  types.High,
+		Product:   product.ProductCode,
+		FindingId: expectedFindingId,
+		AdditionalData: snyk.CodeIssueData{
+			Key: "code-key-1",
+		},
+	}
+
+	diagnostics := ToDiagnostics([]types.Issue{testIssue})
+
+	require.Len(t, diagnostics, 1)
+	assert.Equal(t, expectedFindingId, diagnostics[0].Data.FindingId,
+		"ScanIssue.FindingId must equal issue.GetFindingId() for Code issues")
+}
+
+func TestToDiagnostics_FindingId_OSS(t *testing.T) {
+	testutil.UnitTest(t)
+
+	const expectedFindingId = "oss-introducing-finding-id-xyz"
+	testIssue := &snyk.Issue{
+		ID:        "oss-vuln-id",
+		Severity:  types.Medium,
+		Product:   product.ProductOpenSource,
+		FindingId: expectedFindingId,
+		AdditionalData: snyk.OssIssueData{
+			Key: "oss-key-1",
+		},
+	}
+
+	diagnostics := ToDiagnostics([]types.Issue{testIssue})
+
+	require.Len(t, diagnostics, 1)
+	assert.Equal(t, expectedFindingId, diagnostics[0].Data.FindingId,
+		"ScanIssue.FindingId must equal issue.GetFindingId() for OSS issues")
+}
+
+func TestToDiagnostics_FindingId_Secrets(t *testing.T) {
+	testutil.UnitTest(t)
+
+	const expectedFindingId = "secret-attrs-key-99"
+	testIssue := &snyk.Issue{
+		ID:        "secret-rule-id",
+		Severity:  types.High,
+		Product:   product.ProductSecrets,
+		FindingId: expectedFindingId,
+		AdditionalData: snyk.SecretsIssueData{
+			Key:   "secret-key-99",
+			Title: "Hardcoded Secret",
+		},
+	}
+
+	diagnostics := ToDiagnostics([]types.Issue{testIssue})
+
+	require.Len(t, diagnostics, 1)
+	assert.Equal(t, expectedFindingId, diagnostics[0].Data.FindingId,
+		"ScanIssue.FindingId must equal issue.GetFindingId() for Secrets issues")
+}
+
+// TestToDiagnostics_FindingId_IaC documents that IaC findings currently emit an empty FindingId.
+// The IaC scanner does not yet set FindingId on snyk.Issue, so ScanIssue.FindingId is always "".
+// When the IaC scanner is updated to set FindingId, this test should be updated to assert the
+// expected non-empty value.
+func TestToDiagnostics_FindingId_IaC(t *testing.T) {
+	testutil.UnitTest(t)
+
+	testIssue := &snyk.Issue{
+		ID:       "iac-rule-id",
+		Severity: types.High,
+		Product:  product.ProductInfrastructureAsCode,
+		// FindingId is intentionally not set: the IaC scanner does not yet populate it.
+		AdditionalData: snyk.IaCIssueData{
+			Key:   "iac-key-1",
+			Title: "IaC misconfiguration",
+		},
+	}
+
+	diagnostics := ToDiagnostics([]types.Issue{testIssue})
+
+	require.Len(t, diagnostics, 1)
+	assert.Empty(t, diagnostics[0].Data.FindingId,
+		"IaC issues emit empty FindingId until the IaC scanner populates it")
+}
+
+// TestToDiagnostics_FindingId_DeterministicConversion verifies that ToDiagnostics is a pure
+// function: two calls on the same issue struct produce identical FindingId values.
+func TestToDiagnostics_FindingId_DeterministicConversion(t *testing.T) {
+	testutil.UnitTest(t)
+
+	const stableFindingId = "stable-code-fingerprint-v1"
+	testIssue := &snyk.Issue{
+		ID:        "code-rule-id",
+		Severity:  types.High,
+		Product:   product.ProductCode,
+		FindingId: stableFindingId,
+		AdditionalData: snyk.CodeIssueData{
+			Key: "code-key-stable",
+		},
+	}
+
+	diagnostics1 := ToDiagnostics([]types.Issue{testIssue})
+	diagnostics2 := ToDiagnostics([]types.Issue{testIssue})
+
+	require.Len(t, diagnostics1, 1)
+	require.Len(t, diagnostics2, 1)
+	assert.Equal(t, diagnostics1[0].Data.FindingId, diagnostics2[0].Data.FindingId,
+		"FindingId must be identical across two separate conversions of the same finding")
+	assert.Equal(t, stableFindingId, diagnostics1[0].Data.FindingId,
+		"FindingId must match the value from issue.GetFindingId()")
+}

--- a/internal/types/lsp.go
+++ b/internal/types/lsp.go
@@ -1122,7 +1122,11 @@ type SnykScanParams struct {
 
 type ScanIssue struct { // TODO - convert this to a generic type
 	// Unique key identifying an issue in the whole result set. Not the same as the Snyk issue ID.
-	Id                  string                      `json:"id"`
+	Id string `json:"id"`
+	// FindingId is stable across scans for the same underlying finding; sourced from Issue.GetFindingId().
+	// Unlike Id (which is per-result-set), this value is consistent between separate scan invocations
+	// and allows clients to correlate or deduplicate findings over time.
+	FindingId           string                      `json:"findingId"`
 	Title               string                      `json:"title"`
 	Severity            string                      `json:"severity"`
 	FilePath            FilePath                    `json:"filePath"`


### PR DESCRIPTION
### **User description**
## Summary
- Add `FindingId` field to `snyk.Issue` and `types.Issue` with stable cross-scan identifier (`Fingerprints.SnykAssetFindingV1`)
- Add `RemediationAgentQuickFix` LSP code action kind constant (`quickfix.snyk.remediationAgent`)
- Wire `FindingId` through Code/OSS/Secrets/IaC converters
- Add `GetFindingId()` accessor to issue interface

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#? PR-1 ← YOU ARE HERE\nfindingId + kind"]
    PR2["#? PR-2\nCA provider"]
    PR3["#? PR-3\nremy initial"]
    PR4["#? PR-4\nworktree impl"]
    PR5["#? PR-5\nunit tests"]
    PR6["#? PR-6\ninteg+smoke tests"]
    main --> PR1 --> PR2 --> PR3 --> PR4 --> PR5 --> PR6
    style PR1 fill:#ffd700,color:#000
```

## Deferred to later PRs
- Remediation provider implementation (PR-3+)
- Tests (PR-5, PR-6)

## Test plan
- [ ] `make test` passes
- [ ] Converter tests verify FindingId population for all 4 products


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add stable `FindingId` to `ScanIssue`.

- Introduce `RemediationAgentQuickFix` LSP kind.

- Propagate `FindingId` through converters.

- Add tests for new `FindingId` and `CodeActionKind`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Issue Interface] -- GetFindingId() --> B(ScanIssue);
  C[CodeAction Struct] -- GetKind() --> D(LSP CodeAction);
  B -- FindingId --> E(Client);
  D -- Kind --> F(Client);
  subgraph Domain/Types
    A
    C
  end
  subgraph Domain/Converter
    B
    D
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter.go</strong><dd><code>Propagate FindingId and handle CodeAction Kind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/ide/converter/converter.go

<ul><li>Modified <code>ToCodeAction</code> to correctly use the <code>action.GetKind()</code> which can <br>now be <code>RemediationAgentQuickFix</code>.<br> <li> Fallback to <code>types.QuickFix</code> if <code>action.GetKind()</code> is <code>types.Empty</code>.<br> <li> Added <code>FindingId: issue.GetFindingId()</code> to <code>ScanIssue</code> when converting <br>issues for OSS, IaC, Code, and Secrets products.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-906b744a0a633abffa7bc1bfd39886eb37836f675579617c61d13e96c32a4fe9">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codeaction.go</strong><dd><code>Add Kind field to CodeAction struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/snyk/codeaction.go

<ul><li>Added a <code>Kind</code> field of type <code>types.CodeActionKind</code> to the <code>CodeAction</code> <br>struct.<br> <li> Introduced a <code>GetKind()</code> method to access the new <code>Kind</code> field.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-c36818ffaebdf71e9fdc539536a452dbd79bef24c0ba1ee91c479a07bb69a73b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issues.go</strong><dd><code>Update CodeAction interface with GetKind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/types/issues.go

<ul><li>Extended the <code>CodeAction</code> interface to include a <code>GetKind()</code> method, <br>enabling access to the code action's kind.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-63ef754c962ab2c2fa558b3f65bf88663612eb2e405b754eb7d5a18b5a5662df">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lsp.go</strong><dd><code>Define RemediationAgentQuickFix and document FindingId</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/types/lsp.go

<ul><li>Defined a new constant <code>RemediationAgentQuickFix</code> for the LSP <br><code>CodeActionKind</code>.<br> <li> Added a detailed comment to <code>ScanIssue.FindingId</code> explaining its purpose <br>as a stable, cross-scan identifier.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-c16b9b2fc8b4479b07708b28ebdaa473e8f3a73eb62d9402538790b2aed3f978">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter_test.go</strong><dd><code>Test FindingId propagation and CodeAction Kind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/ide/converter/converter_test.go

<ul><li>Added multiple tests to verify <code>ScanIssue.FindingId</code> population for <br>Code, OSS, Secrets, and IaC issues.<br> <li> Included tests for deterministic conversion of <code>FindingId</code>.<br> <li> Added tests to ensure <code>CodeActionKind</code> is correctly derived, including <br>the new <code>RemediationAgentQuickFix</code> and fallback logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-aefddc62a88eee50767d306e120604a7f240ee4a5aaf3382b21cd4aeac5036d9">+172/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

