### PR TITLE
feat: block unauthenticated Snyk API requests via GAF middleware [IDE-1988]

### DIFF
--- a/application/di/init.go
+++ b/application/di/init.go
@@ -161,6 +161,7 @@ func initDomain(tokenService types.TokenService, conf configuration.Configuratio
 
 func initInfrastructure(tokenService types.TokenService, conf configuration.Configuration, engine workflow.Engine, logger *zerolog.Logger) {
 	gafConfiguration := conf
+	gafConfiguration.Set(configuration.STOP_REQUESTS_WITHOUT_AUTH, true)
 
 	fs := pflag.NewFlagSet("snyk-ls-config", pflag.ContinueOnError)
 	types.RegisterAllConfigurations(fs)

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/snyk/cli-extension-secrets v0.0.0-20260305092220-defe1129df99
 	github.com/snyk/code-client-go v1.26.1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
-	github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5
+	github.com/snyk/go-application-framework v0.3.0
 	github.com/snyk/studio-mcp v1.6.1
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.10

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/snyk/cli-extension-secrets v0.0.0-20260305092220-defe1129df99
 	github.com/snyk/code-client-go v1.26.1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
-	github.com/snyk/go-application-framework v0.3.0
+	github.com/snyk/go-application-framework v0.3.1
 	github.com/snyk/studio-mcp v1.6.1
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5 h1
 github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-application-framework v0.3.0 h1:nUTx6TsIY+l3HA7MFuQqbezJTBLrckxTiSxxseGW/fQ=
 github.com/snyk/go-application-framework v0.3.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.3.1 h1:Yg6XSCsFQkz8AC/SmLR6gRvnXingD6Ubp9U7iqIMDrU=
+github.com/snyk/go-application-framework v0.3.1/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/studio-mcp v1.6.1 h1:rk+3eZDt9hVcdnmCzvK78qzuBzbxAHBf862ABc38t+I=

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,8 @@ github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5 h1:nuHRhOlISEByoqX8CAERY1t+sZrdy7ksMhZhV0f2yeI=
 github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.3.0 h1:nUTx6TsIY+l3HA7MFuQqbezJTBLrckxTiSxxseGW/fQ=
+github.com/snyk/go-application-framework v0.3.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/studio-mcp v1.6.1 h1:rk+3eZDt9hVcdnmCzvK78qzuBzbxAHBf862ABc38t+I=


### PR DESCRIPTION
### Description

Bumps GAF to v0.3.0 which includes the opt-in auth-header middleware and enables `STOP_REQUESTS_WITHOUT_AUTH` on the GAF engine.

Requests to Snyk API URLs without an `Authorization` header are now intercepted in-memory with a synthetic 401 — no wire call, no latency, no log/error-reporter spam during unauthenticated sessions.

Jira: [IDE-1988](https://snyk.atlassian.net/browse/IDE-1988)

### Checklist

- [x] Tests added and all succeed
- [x] Linted (`make lint-fix`)

[IDE-1988]: https://snyksec.atlassian.net/browse/IDE-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ