### PR TITLE
fix(treeview): use folder-level IssueViewOptions for info node message [IDE-2123]

### DIFF
--- a/domain/ide/command/toggle_tree_filter.go
+++ b/domain/ide/command/toggle_tree_filter.go
@@ -99,6 +99,9 @@ func (cmd *toggleTreeFilter) applySeverityFilter(value string, enabled bool) err
 }
 
 func (cmd *toggleTreeFilter) applyIssueViewFilter(value string, enabled bool) error {
+	// toggleTreeFilter intentionally writes global IVO: the filter panel is a
+	// workspace-wide concept. Per-folder tree info nodes read folder-level IVO
+	// (see BuildTree / FolderData.IssueViewOptions) — these are separate concerns by design.
 	current := config.GetIssueViewOptions(cmd.engine.GetConfiguration())
 	switch value {
 	case "openIssues":

--- a/domain/ide/treeview/tree_builder.go
+++ b/domain/ide/treeview/tree_builder.go
@@ -62,7 +62,6 @@ type TreeBuilder struct {
 	productScanStates map[types.FilePath]map[product.Product]bool
 	productScanErrors map[types.FilePath]map[product.Product]string
 	pendingAutoExpand map[string]bool // deferred auto-expand writes applied after build
-	issueViewOptions  types.IssueViewOptions
 }
 
 // NewTreeBuilder creates a new TreeBuilder with the given expand state.
@@ -83,11 +82,6 @@ func (b *TreeBuilder) SetProductScanStates(states map[types.FilePath]map[product
 // SetProductScanErrors sets the per-(folder, product) scan error messages.
 func (b *TreeBuilder) SetProductScanErrors(errors map[types.FilePath]map[product.Product]string) {
 	b.productScanErrors = errors
-}
-
-// SetIssueViewOptions sets the current issue view options for building info nodes.
-func (b *TreeBuilder) SetIssueViewOptions(opts types.IssueViewOptions) {
-	b.issueViewOptions = opts
 }
 
 // BuildTree constructs tree view data from a workspace.
@@ -114,7 +108,7 @@ func (b *TreeBuilder) BuildTree(workspace types.Workspace) TreeViewData {
 			AllIssues:           allIssues,
 			FilteredIssues:      filtered,
 			DeltaEnabled:        f.IsDeltaFindingsEnabled(),
-			IssueViewOptions:    b.issueViewOptions,
+			IssueViewOptions:    f.IssueViewOptions(),
 		}
 		if cfg := f.FolderConfigReadOnly(); cfg != nil {
 			fd.ConsistentIgnoresEnabled = cfg.GetFeatureFlag(featureflag.SnykCodeConsistentIgnores)

--- a/domain/ide/treeview/tree_builder.go
+++ b/domain/ide/treeview/tree_builder.go
@@ -101,6 +101,7 @@ func (b *TreeBuilder) BuildTree(workspace types.Workspace) TreeViewData {
 		allIssues := fip.Issues()
 		filtered := fip.FilterIssues(allIssues, supportedTypes)
 
+		cfg := f.FolderConfigReadOnly()
 		fd := FolderData{
 			FolderPath:          f.Path(),
 			FolderName:          f.Name(),
@@ -110,7 +111,7 @@ func (b *TreeBuilder) BuildTree(workspace types.Workspace) TreeViewData {
 			DeltaEnabled:        f.IsDeltaFindingsEnabled(),
 			IssueViewOptions:    f.IssueViewOptions(),
 		}
-		if cfg := f.FolderConfigReadOnly(); cfg != nil {
+		if cfg != nil {
 			fd.ConsistentIgnoresEnabled = cfg.GetFeatureFlag(featureflag.SnykCodeConsistentIgnores)
 			if fd.DeltaEnabled {
 				conf := cfg.Conf()

--- a/domain/ide/treeview/tree_builder.go
+++ b/domain/ide/treeview/tree_builder.go
@@ -97,19 +97,22 @@ func (b *TreeBuilder) BuildTree(workspace types.Workspace) TreeViewData {
 		if !ok {
 			continue
 		}
-		supportedTypes := f.DisplayableIssueTypes()
+		// Fetch FolderConfig once; all derived values are computed from this single call
+		// to avoid repeated storage reads inside DisplayableIssueTypes, IsDeltaFindingsEnabled,
+		// and IssueViewOptions (each would otherwise invoke FolderConfigReadOnly separately).
+		cfg := f.FolderConfigReadOnly()
+		supportedTypes := f.DisplayableIssueTypesFromConfig(cfg)
 		allIssues := fip.Issues()
 		filtered := fip.FilterIssues(allIssues, supportedTypes)
 
-		cfg := f.FolderConfigReadOnly()
 		fd := FolderData{
 			FolderPath:          f.Path(),
 			FolderName:          f.Name(),
 			SupportedIssueTypes: supportedTypes,
 			AllIssues:           allIssues,
 			FilteredIssues:      filtered,
-			DeltaEnabled:        f.IsDeltaFindingsEnabled(),
-			IssueViewOptions:    f.IssueViewOptions(),
+			DeltaEnabled:        f.IsDeltaFindingsEnabledFromConfig(cfg),
+			IssueViewOptions:    f.IssueViewOptionsFromConfig(cfg),
 		}
 		if cfg != nil {
 			fd.ConsistentIgnoresEnabled = cfg.GetFeatureFlag(featureflag.SnykCodeConsistentIgnores)

--- a/domain/ide/treeview/tree_scan_emitter.go
+++ b/domain/ide/treeview/tree_scan_emitter.go
@@ -118,7 +118,6 @@ func (e *TreeScanStateEmitter) renderPending() {
 
 	e.builder.SetProductScanStates(state.ProductScanStates)
 	e.builder.SetProductScanErrors(state.ProductScanErrors)
-	e.builder.SetIssueViewOptions(config.GetIssueViewOptions(e.conf))
 
 	ws := config.GetWorkspace(e.conf)
 	var data TreeViewData

--- a/domain/ide/treeview/tree_scan_emitter.go
+++ b/domain/ide/treeview/tree_scan_emitter.go
@@ -124,6 +124,9 @@ func (e *TreeScanStateEmitter) renderPending() {
 	if ws != nil {
 		data = e.builder.BuildTree(ws)
 	}
+	// FilterState uses global IVO (filter panel scope); individual folder nodes use
+	// folder-level IVO (see BuildTree). These are separate concerns by design: the
+	// IDE filter panel is workspace-wide, while info-node messages reflect per-folder overrides.
 	data.FilterState = TreeViewFilterState{
 		SeverityFilter:   config.GetFilterSeverity(e.conf),
 		IssueViewOptions: config.GetIssueViewOptions(e.conf),

--- a/domain/ide/treeview/tree_scan_emitter_test.go
+++ b/domain/ide/treeview/tree_scan_emitter_test.go
@@ -207,3 +207,55 @@ func TestTreeScanStateEmitter_Dispose_StopsRenderLoop(t *testing.T) {
 	// Emit after Dispose must not block or panic.
 	emitter.Emit(scanstates.StateSnapshot{AnyScanInProgressWorkingDirectory: true})
 }
+
+// TestTreeScanStateEmitter_FolderLevelIssueViewOptions verifies that the info-node message
+// reflects folder-level IssueViewOptions overrides rather than the global setting.
+// Regression for: global open+ignored disabled, folder-level open+ignored enabled →
+// "Open and Ignored issues are disabled!" must NOT appear.
+func TestTreeScanStateEmitter_FolderLevelIssueViewOptions(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	conf := engine.GetConfiguration()
+
+	// Enable products so product nodes (and their info nodes) are rendered.
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+
+	// Global: both open and ignored issues disabled.
+	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewOpenIssues), false)
+	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewIgnoredIssues), false)
+
+	folderPath := types.FilePath("/project-folder-ivo")
+	workspaceutil.SetupWorkspace(t, engine, folderPath)
+
+	// Folder-level override: both enabled (takes precedence over global).
+	folderKey := string(types.PathKey(folderPath))
+	conf.Set(configresolver.UserFolderKey(folderKey, types.SettingIssueViewOpenIssues), &configresolver.LocalConfigField{Value: true, Changed: true})
+	conf.Set(configresolver.UserFolderKey(folderKey, types.SettingIssueViewIgnoredIssues), &configresolver.LocalConfigField{Value: true, Changed: true})
+
+	notif := notification.NewNotifier()
+	var mu sync.Mutex
+	var receivedPayload any
+	notif.CreateListener(func(params any) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedPayload = params
+	})
+	t.Cleanup(func() { notif.DisposeListener() })
+
+	emitter, err := NewTreeScanStateEmitter(conf, engine.GetLogger(), notif)
+	require.NoError(t, err)
+	t.Cleanup(emitter.Dispose)
+
+	emitter.Emit(scanstates.StateSnapshot{})
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return receivedPayload != nil
+	}, 2*time.Second, 50*time.Millisecond)
+
+	mu.Lock()
+	treeView := receivedPayload.(types.TreeView)
+	mu.Unlock()
+	assert.NotContains(t, treeView.TreeViewHtml, "Open and Ignored issues are disabled!",
+		"folder-level enabled override must suppress the disabled info message")
+}

--- a/domain/ide/treeview/tree_scan_emitter_test.go
+++ b/domain/ide/treeview/tree_scan_emitter_test.go
@@ -251,7 +251,13 @@ func TestTreeScanStateEmitter_FolderLevelIssueViewOptions(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(emitter.Dispose)
 
-	emitter.Emit(scanstates.StateSnapshot{})
+	// Mark the Code product scan as completed (false = not in progress) so that info nodes are rendered.
+	// Without a scan-registered entry the product node renders no children and neither assertion would fire.
+	emitter.Emit(scanstates.StateSnapshot{
+		ProductScanStates: map[types.FilePath]map[product.Product]bool{
+			types.PathKey(folderPath): {product.ProductCode: false},
+		},
+	})
 
 	assert.Eventually(t, func() bool {
 		mu.Lock()
@@ -264,4 +270,63 @@ func TestTreeScanStateEmitter_FolderLevelIssueViewOptions(t *testing.T) {
 	mu.Unlock()
 	assert.NotContains(t, treeView.TreeViewHtml, "Open and Ignored issues are disabled!",
 		"folder-level enabled override must suppress the disabled info message")
+	assert.Contains(t, treeView.TreeViewHtml, "Congrats",
+		"product node must still render a non-empty info message so the NotContains above is non-vacuous")
+}
+
+// TestTreeScanStateEmitter_GlobalDisabledIVO_ShowsDisabledMessage is the positive counterpart
+// to TestTreeScanStateEmitter_FolderLevelIssueViewOptions: when SnykCodeConsistentIgnores is
+// enabled but there is NO folder-level override, the global disabled setting must produce the
+// "Open and Ignored issues are disabled!" info-node message.
+func TestTreeScanStateEmitter_GlobalDisabledIVO_ShowsDisabledMessage(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	conf := engine.GetConfiguration()
+
+	// Enable products so product nodes (and their info nodes) are rendered.
+	conf.Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+
+	// Global: both open and ignored issues disabled.
+	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewOpenIssues), false)
+	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewIgnoredIssues), false)
+
+	// SnykCodeConsistentIgnores must be true for the IVO branch in zeroIssuesText to execute.
+	ffSvc := featureflag.NewFakeService()
+	ffSvc.Override(featureflag.SnykCodeConsistentIgnores, true)
+
+	// No folder-level override: global disabled applies.
+	folderPath := types.FilePath("/project-global-disabled-ivo")
+	workspaceutil.SetupWorkspaceWithFeatureFlags(t, engine, ffSvc, folderPath)
+
+	notif := notification.NewNotifier()
+	var mu sync.Mutex
+	var receivedPayload any
+	notif.CreateListener(func(params any) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedPayload = params
+	})
+	t.Cleanup(func() { notif.DisposeListener() })
+
+	emitter, err := NewTreeScanStateEmitter(conf, engine.GetLogger(), notif)
+	require.NoError(t, err)
+	t.Cleanup(emitter.Dispose)
+
+	// Mark the Code product scan as completed so that info nodes are rendered.
+	emitter.Emit(scanstates.StateSnapshot{
+		ProductScanStates: map[types.FilePath]map[product.Product]bool{
+			types.PathKey(folderPath): {product.ProductCode: false},
+		},
+	})
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return receivedPayload != nil
+	}, 2*time.Second, 50*time.Millisecond)
+
+	mu.Lock()
+	treeView := receivedPayload.(types.TreeView)
+	mu.Unlock()
+	assert.Contains(t, treeView.TreeViewHtml, "Open and Ignored issues are disabled!",
+		"global disabled IVO with no folder override must produce the disabled info message")
 }

--- a/domain/ide/treeview/tree_scan_emitter_test.go
+++ b/domain/ide/treeview/tree_scan_emitter_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 
 	"github.com/snyk/snyk-ls/domain/scanstates"
+	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
@@ -223,8 +224,13 @@ func TestTreeScanStateEmitter_FolderLevelIssueViewOptions(t *testing.T) {
 	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewOpenIssues), false)
 	conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewIgnoredIssues), false)
 
+	// SnykCodeConsistentIgnores must be true for the IVO branch in zeroIssuesText to execute.
+	// Without it, zeroIssuesText early-returns "✅ Congrats! No issues found!" regardless of IVO.
+	ffSvc := featureflag.NewFakeService()
+	ffSvc.Override(featureflag.SnykCodeConsistentIgnores, true)
+
 	folderPath := types.FilePath("/project-folder-ivo")
-	workspaceutil.SetupWorkspace(t, engine, folderPath)
+	workspaceutil.SetupWorkspaceWithFeatureFlags(t, engine, ffSvc, folderPath)
 
 	// Folder-level override: both enabled (takes precedence over global).
 	folderKey := string(types.PathKey(folderPath))

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -915,6 +915,12 @@ func (f *Folder) IsDeltaFindingsEnabled() bool {
 	return f.isDeltaFindingsEnabledForFolder(f.FolderConfigReadOnly())
 }
 
+// IsDeltaFindingsEnabledFromConfig is like IsDeltaFindingsEnabled but accepts a pre-fetched
+// FolderConfig to avoid a redundant FolderConfigReadOnly() call.
+func (f *Folder) IsDeltaFindingsEnabledFromConfig(cfg *types.FolderConfig) bool {
+	return f.isDeltaFindingsEnabledForFolder(cfg)
+}
+
 // IsAutoScanEnabled returns whether automatic scanning is enabled for this folder.
 func (f *Folder) IsAutoScanEnabled() bool {
 	return f.isAutoScanEnabledForFolder(f.FolderConfigReadOnly())
@@ -925,9 +931,21 @@ func (f *Folder) DisplayableIssueTypes() map[product.FilterableIssueType]bool {
 	return f.displayableIssueTypesForFolder(f.FolderConfigReadOnly())
 }
 
+// DisplayableIssueTypesFromConfig is like DisplayableIssueTypes but accepts a pre-fetched
+// FolderConfig to avoid a redundant FolderConfigReadOnly() call.
+func (f *Folder) DisplayableIssueTypesFromConfig(cfg *types.FolderConfig) map[product.FilterableIssueType]bool {
+	return f.displayableIssueTypesForFolder(cfg)
+}
+
 // IssueViewOptions returns the issue view options for this folder, respecting folder-level overrides.
 func (f *Folder) IssueViewOptions() types.IssueViewOptions {
 	return f.issueViewOptionsForFolder(f.FolderConfigReadOnly())
+}
+
+// IssueViewOptionsFromConfig is like IssueViewOptions but accepts a pre-fetched FolderConfig
+// to avoid a redundant FolderConfigReadOnly() call.
+func (f *Folder) IssueViewOptionsFromConfig(cfg *types.FolderConfig) types.IssueViewOptions {
+	return f.issueViewOptionsForFolder(cfg)
 }
 
 func (f *Folder) IssuesForRange(path types.FilePath, r types.Range) (matchingIssues []types.Issue) {

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -925,6 +925,11 @@ func (f *Folder) DisplayableIssueTypes() map[product.FilterableIssueType]bool {
 	return f.displayableIssueTypesForFolder(f.FolderConfigReadOnly())
 }
 
+// IssueViewOptions returns the issue view options for this folder, respecting folder-level overrides.
+func (f *Folder) IssueViewOptions() types.IssueViewOptions {
+	return f.issueViewOptionsForFolder(f.FolderConfigReadOnly())
+}
+
 func (f *Folder) IssuesForRange(path types.FilePath, r types.Range) (matchingIssues []types.Issue) {
 	method := "domain.ide.workspace.folder.getCodeActions"
 	if !f.Contains(path) {

--- a/domain/ide/workspace/folder_test.go
+++ b/domain/ide/workspace/folder_test.go
@@ -1535,3 +1535,79 @@ func Test_filterIssuesWithConfig_UsesCachedIsNew(t *testing.T) {
 	require.Len(t, filtered[filePath], 1, "should only return new issues when delta is enabled")
 	assert.Equal(t, "new-issue", filtered[filePath][0].GetID())
 }
+
+// TestFolder_IssueViewOptions covers the three resolution paths for IssueViewOptions():
+//   - nil cfg → falls back to global defaults (open=true, ignored=false)
+//   - cfg with no folder override → returns global setting (e.g. open=false, ignored=false)
+//   - cfg with folder-level override → folder value overrides global (e.g. open=true, ignored=true)
+func TestFolder_IssueViewOptions(t *testing.T) {
+	t.Run("nil cfg returns global defaults", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		// Leave IVO at default (open=true, ignored=false per DefaultIssueViewOptions).
+		f := NewMockFolder(engine, notification.NewMockNotifier())
+
+		got := f.IssueViewOptionsFromConfig(nil)
+
+		// With default GAF config the resolver returns the registered defaults: open=true, ignored=false.
+		assert.True(t, got.OpenIssues, "nil cfg: OpenIssues should be true (global default)")
+		assert.False(t, got.IgnoredIssues, "nil cfg: IgnoredIssues should be false (global default)")
+	})
+
+	t.Run("cfg with no folder override returns global setting", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		conf := engine.GetConfiguration()
+
+		// Override global to both-disabled.
+		conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewOpenIssues), false)
+		conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewIgnoredIssues), false)
+
+		resolver := defaultResolver(engine)
+		folderPath := types.FilePath(t.TempDir())
+		folderConfig := &types.FolderConfig{
+			FolderPath:     folderPath,
+			ConfigResolver: resolver,
+		}
+		f := NewFolder(conf, engine.GetLogger(), folderPath, "test", scanner.NewTestScanner(),
+			hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(),
+			persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator(),
+			featureflag.NewFakeService(), resolver, engine)
+
+		got := f.IssueViewOptionsFromConfig(folderConfig)
+
+		assert.False(t, got.OpenIssues, "no folder override: OpenIssues should follow global (false)")
+		assert.False(t, got.IgnoredIssues, "no folder override: IgnoredIssues should follow global (false)")
+	})
+
+	t.Run("cfg with folder-level override takes precedence over global", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		conf := engine.GetConfiguration()
+
+		// Global: both disabled.
+		conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewOpenIssues), false)
+		conf.Set(configresolver.UserGlobalKey(types.SettingIssueViewIgnoredIssues), false)
+
+		resolver := defaultResolver(engine)
+		folderPath := types.FilePath(t.TempDir())
+
+		// Folder-level override: both enabled via UserFolderKey.
+		folderKey := string(types.PathKey(folderPath))
+		conf.Set(configresolver.UserFolderKey(folderKey, types.SettingIssueViewOpenIssues),
+			&configresolver.LocalConfigField{Value: true, Changed: true})
+		conf.Set(configresolver.UserFolderKey(folderKey, types.SettingIssueViewIgnoredIssues),
+			&configresolver.LocalConfigField{Value: true, Changed: true})
+
+		folderConfig := &types.FolderConfig{
+			FolderPath:     folderPath,
+			ConfigResolver: resolver,
+		}
+		f := NewFolder(conf, engine.GetLogger(), folderPath, "test", scanner.NewTestScanner(),
+			hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(),
+			persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator(),
+			featureflag.NewFakeService(), resolver, engine)
+
+		got := f.IssueViewOptionsFromConfig(folderConfig)
+
+		assert.True(t, got.OpenIssues, "folder override: OpenIssues should be true (folder-level wins)")
+		assert.True(t, got.IgnoredIssues, "folder override: IgnoredIssues should be true (folder-level wins)")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/snyk/cli-extension-secrets v0.0.0-20260305092220-defe1129df99
 	github.com/snyk/code-client-go v1.26.1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
-	github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5
+	github.com/snyk/go-application-framework v0.3.1
 	github.com/snyk/studio-mcp v1.6.1
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -319,10 +319,6 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h1:MumWzLKiIFhZEk/wP71S/zv2cceygDb3+KNXGBb1hC0=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5 h1:nuHRhOlISEByoqX8CAERY1t+sZrdy7ksMhZhV0f2yeI=
-github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
-github.com/snyk/go-application-framework v0.3.0 h1:nUTx6TsIY+l3HA7MFuQqbezJTBLrckxTiSxxseGW/fQ=
-github.com/snyk/go-application-framework v0.3.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-application-framework v0.3.1 h1:Yg6XSCsFQkz8AC/SmLR6gRvnXingD6Ubp9U7iqIMDrU=
 github.com/snyk/go-application-framework v0.3.1/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/go.sum
+++ b/go.sum
@@ -319,6 +319,10 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h1:MumWzLKiIFhZEk/wP71S/zv2cceygDb3+KNXGBb1hC0=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
+github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5 h1:nuHRhOlISEByoqX8CAERY1t+sZrdy7ksMhZhV0f2yeI=
+github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.3.0 h1:nUTx6TsIY+l3HA7MFuQqbezJTBLrckxTiSxxseGW/fQ=
+github.com/snyk/go-application-framework v0.3.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-application-framework v0.3.1 h1:Yg6XSCsFQkz8AC/SmLR6gRvnXingD6Ubp9U7iqIMDrU=
 github.com/snyk/go-application-framework v0.3.1/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,10 @@ github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5 h1:nuHRhOlISEByoqX8CAERY1t+sZrdy7ksMhZhV0f2yeI=
 github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.3.0 h1:nUTx6TsIY+l3HA7MFuQqbezJTBLrckxTiSxxseGW/fQ=
+github.com/snyk/go-application-framework v0.3.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.3.1 h1:Yg6XSCsFQkz8AC/SmLR6gRvnXingD6Ubp9U7iqIMDrU=
+github.com/snyk/go-application-framework v0.3.1/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/studio-mcp v1.6.1 h1:rk+3eZDt9hVcdnmCzvK78qzuBzbxAHBf862ABc38t+I=

--- a/internal/testutil/workspaceutil/workspace.go
+++ b/internal/testutil/workspaceutil/workspace.go
@@ -40,6 +40,18 @@ import (
 // SetupWorkspace creates a minimal workspace if it doesn't exist and adds the given folder paths to it.
 func SetupWorkspace(t *testing.T, engine workflow.Engine, folderPaths ...types.FilePath) (types.Workspace, *notification.MockNotifier) {
 	t.Helper()
+	return SetupWorkspaceWithFeatureFlags(t, engine, nil, folderPaths...)
+}
+
+// SetupWorkspaceWithFeatureFlags is like SetupWorkspace but uses the provided FakeFeatureFlagService
+// for each folder. Pass nil to use a default empty fake service. Use this when the test needs to
+// control feature flags (e.g. SnykCodeConsistentIgnores) that affect folder-level behavior.
+func SetupWorkspaceWithFeatureFlags(t *testing.T, engine workflow.Engine, ffSvc *featureflag.FakeFeatureFlagService, folderPaths ...types.FilePath) (types.Workspace, *notification.MockNotifier) {
+	t.Helper()
+
+	if ffSvc == nil {
+		ffSvc = featureflag.NewFakeService()
+	}
 
 	notifier := notification.NewMockNotifier()
 
@@ -63,7 +75,7 @@ func SetupWorkspace(t *testing.T, engine workflow.Engine, folderPaths ...types.F
 			notifier,
 			persistence.NewNopScanPersister(),
 			scanstates.NewNoopStateAggregator(),
-			featureflag.NewFakeService(),
+			ffSvc,
 			resolver,
 			engine,
 		)
@@ -87,11 +99,17 @@ func SetupWorkspace(t *testing.T, engine workflow.Engine, folderPaths ...types.F
 			notifier,
 			persistence.NewNopScanPersister(),
 			scanstates.NewNoopStateAggregator(),
-			featureflag.NewFakeService(),
+			ffSvc,
 			resolver,
 			engine,
 		)
 		config.GetWorkspace(gafConf).AddFolder(folder)
+
+		// Populate feature flags into config so FolderConfigReadOnly() picks them up.
+		// This mirrors the production path: processFolderConfigs calls ffSvc.PopulateFolderConfig.
+		if folderCfg := folder.FolderConfigReadOnly(); folderCfg != nil {
+			ffSvc.PopulateFolderConfig(folderCfg)
+		}
 	}
 
 	return config.GetWorkspace(gafConf), notifier

--- a/internal/types/mock_types/workspace_mock.go
+++ b/internal/types/mock_types/workspace_mock.go
@@ -305,6 +305,20 @@ func (mr *MockFolderMockRecorder) DisplayableIssueTypes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisplayableIssueTypes", reflect.TypeOf((*MockFolder)(nil).DisplayableIssueTypes))
 }
 
+// DisplayableIssueTypesFromConfig mocks base method.
+func (m *MockFolder) DisplayableIssueTypesFromConfig(arg0 *types.FolderConfig) map[product.FilterableIssueType]bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisplayableIssueTypesFromConfig", arg0)
+	ret0, _ := ret[0].(map[product.FilterableIssueType]bool)
+	return ret0
+}
+
+// DisplayableIssueTypesFromConfig indicates an expected call of DisplayableIssueTypesFromConfig.
+func (mr *MockFolderMockRecorder) DisplayableIssueTypesFromConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisplayableIssueTypesFromConfig", reflect.TypeOf((*MockFolder)(nil).DisplayableIssueTypesFromConfig), arg0)
+}
+
 // FilterAndPublishDiagnostics mocks base method.
 func (m *MockFolder) FilterAndPublishDiagnostics(arg0 product.Product) {
 	m.ctrl.T.Helper()
@@ -359,6 +373,20 @@ func (mr *MockFolderMockRecorder) IsDeltaFindingsEnabled() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDeltaFindingsEnabled", reflect.TypeOf((*MockFolder)(nil).IsDeltaFindingsEnabled))
 }
 
+// IsDeltaFindingsEnabledFromConfig mocks base method.
+func (m *MockFolder) IsDeltaFindingsEnabledFromConfig(arg0 *types.FolderConfig) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDeltaFindingsEnabledFromConfig", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDeltaFindingsEnabledFromConfig indicates an expected call of IsDeltaFindingsEnabledFromConfig.
+func (mr *MockFolderMockRecorder) IsDeltaFindingsEnabledFromConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDeltaFindingsEnabledFromConfig", reflect.TypeOf((*MockFolder)(nil).IsDeltaFindingsEnabledFromConfig), arg0)
+}
+
 // IsScanned mocks base method.
 func (m *MockFolder) IsScanned() bool {
 	m.ctrl.T.Helper()
@@ -399,6 +427,20 @@ func (m *MockFolder) IssueViewOptions() types.IssueViewOptions {
 func (mr *MockFolderMockRecorder) IssueViewOptions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueViewOptions", reflect.TypeOf((*MockFolder)(nil).IssueViewOptions))
+}
+
+// IssueViewOptionsFromConfig mocks base method.
+func (m *MockFolder) IssueViewOptionsFromConfig(arg0 *types.FolderConfig) types.IssueViewOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IssueViewOptionsFromConfig", arg0)
+	ret0, _ := ret[0].(types.IssueViewOptions)
+	return ret0
+}
+
+// IssueViewOptionsFromConfig indicates an expected call of IssueViewOptionsFromConfig.
+func (mr *MockFolderMockRecorder) IssueViewOptionsFromConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueViewOptionsFromConfig", reflect.TypeOf((*MockFolder)(nil).IssueViewOptionsFromConfig), arg0)
 }
 
 // Name mocks base method.

--- a/internal/types/mock_types/workspace_mock.go
+++ b/internal/types/mock_types/workspace_mock.go
@@ -387,6 +387,20 @@ func (mr *MockFolderMockRecorder) IsTrusted() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTrusted", reflect.TypeOf((*MockFolder)(nil).IsTrusted))
 }
 
+// IssueViewOptions mocks base method.
+func (m *MockFolder) IssueViewOptions() types.IssueViewOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IssueViewOptions")
+	ret0, _ := ret[0].(types.IssueViewOptions)
+	return ret0
+}
+
+// IssueViewOptions indicates an expected call of IssueViewOptions.
+func (mr *MockFolderMockRecorder) IssueViewOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueViewOptions", reflect.TypeOf((*MockFolder)(nil).IssueViewOptions))
+}
+
 // Name mocks base method.
 func (m *MockFolder) Name() string {
 	m.ctrl.T.Helper()

--- a/internal/types/workspace.go
+++ b/internal/types/workspace.go
@@ -80,4 +80,6 @@ type Folder interface {
 	IsAutoScanEnabled() bool
 	// DisplayableIssueTypes returns which issue types are enabled for this folder.
 	DisplayableIssueTypes() map[product.FilterableIssueType]bool
+	// IssueViewOptions returns the issue view options for this folder, respecting folder-level overrides.
+	IssueViewOptions() IssueViewOptions
 }

--- a/internal/types/workspace.go
+++ b/internal/types/workspace.go
@@ -76,10 +76,19 @@ type Folder interface {
 	FolderConfigReadOnly() *FolderConfig
 	// IsDeltaFindingsEnabled returns whether delta findings is enabled for this folder.
 	IsDeltaFindingsEnabled() bool
+	// IsDeltaFindingsEnabledFromConfig is like IsDeltaFindingsEnabled but accepts a pre-fetched
+	// FolderConfig to avoid a redundant FolderConfigReadOnly() call.
+	IsDeltaFindingsEnabledFromConfig(cfg *FolderConfig) bool
 	// IsAutoScanEnabled returns whether automatic scanning is enabled for this folder.
 	IsAutoScanEnabled() bool
 	// DisplayableIssueTypes returns which issue types are enabled for this folder.
 	DisplayableIssueTypes() map[product.FilterableIssueType]bool
+	// DisplayableIssueTypesFromConfig is like DisplayableIssueTypes but accepts a pre-fetched
+	// FolderConfig to avoid a redundant FolderConfigReadOnly() call.
+	DisplayableIssueTypesFromConfig(cfg *FolderConfig) map[product.FilterableIssueType]bool
 	// IssueViewOptions returns the issue view options for this folder, respecting folder-level overrides.
 	IssueViewOptions() IssueViewOptions
+	// IssueViewOptionsFromConfig is like IssueViewOptions but accepts a pre-fetched FolderConfig
+	// to avoid a redundant FolderConfigReadOnly() call.
+	IssueViewOptionsFromConfig(cfg *FolderConfig) IssueViewOptions
 }


### PR DESCRIPTION
### Description

The "Open and Ignored issues are disabled!" info node in the tree view always reflected the **global** `IssueViewOptions`, ignoring folder-level overrides. Users who enabled open/ignored issues at the folder level still saw the disabled message, even though the issue list itself rendered correctly.

Root cause: `BuildTree` populated `fd.IssueViewOptions` from a builder-wide field (`b.issueViewOptions`) set once from global config. The folder-aware resolver (`IssueViewOptionsForFolder`) was never consulted for the message path.

Fix: expose `IssueViewOptions()` on the `Folder` interface (matching `IsDeltaFindingsEnabled` / `DisplayableIssueTypes` pattern), delegate to the existing `IssueViewOptionsForFolder` resolver, and use it in `BuildTree`. Remove the now-dead `SetIssueViewOptions` setter and `issueViewOptions` field from `TreeBuilder`.

Jira: https://snyksec.atlassian.net/browse/IDE-2123

### Checklist

- [x] Tests added and all succeed
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced