### PR TITLE
fix: remove "Closed Beta" label from Snyk Secrets setting [IDE-2116]

### DIFF
--- a/infrastructure/configuration/template/config.html
+++ b/infrastructure/configuration/template/config.html
@@ -237,7 +237,7 @@
                                     <div class="override-indicator-wrapper {{getSourceClass .DefaultsScopes "snyk_secrets_enabled"}}">
                                         <label class="checkbox-label">
                                             <input type="checkbox" name="snyk_secrets_enabled" {{if index .Settings "snyk_secrets_enabled"}}checked{{end}}>
-                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets<span class="deprecated-label">Closed Beta</span></span>
+                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets</span>
                                             <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="snyk_secrets_enabled"></span>
                                         </label>
                                     </div>
@@ -400,7 +400,7 @@
                                     <div class="override-indicator-wrapper {{getSourceClass $folder.EffectiveConfig "snyk_secrets_enabled"}}">
                                         <label class="checkbox-label">
                                             <input type="checkbox" name="folder_{{$index}}_snyk_secrets_enabled" data-setting="snyk_secrets_enabled" {{with getEffectiveValue $folder.EffectiveConfig "snyk_secrets_enabled"}}{{if .Value}}checked{{end}}{{end}} {{if isLocked $folder.EffectiveConfig "snyk_secrets_enabled"}}disabled{{end}}>
-                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets<span class="deprecated-label">Closed Beta</span></span>
+                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets</span>
                                             {{sourceIndicator $folder.EffectiveConfig "snyk_secrets_enabled"}}
                                         </label>
                                     </div>

--- a/scripts/config-dialog/config_output_multi_project.html
+++ b/scripts/config-dialog/config_output_multi_project.html
@@ -1091,7 +1091,7 @@ button.secondary[disabled] {
                                     <div class="override-indicator-wrapper ">
                                         <label class="checkbox-label">
                                             <input type="checkbox" name="snyk_secrets_enabled" >
-                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets<span class="deprecated-label">Closed Beta</span></span>
+                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets</span>
                                             <span class="config-scope-slot" data-config-scope-slot="true" data-setting-key="snyk_secrets_enabled"></span>
                                         </label>
                                     </div>
@@ -1545,7 +1545,7 @@ button.secondary[disabled] {
                                     <div class="override-indicator-wrapper source-org">
                                         <label class="checkbox-label">
                                             <input type="checkbox" name="folder_1_snyk_secrets_enabled" data-setting="snyk_secrets_enabled" checked >
-                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets<span class="deprecated-label">Closed Beta</span></span>
+                                            <span data-toggle="tooltip" title="Detect and prevent secrets from being exposed in your code.">Snyk Secrets</span>
                                             <span class="source-indicator" data-toggle="tooltip" title="Set by your organization settings">🏢</span>
                                         </label>
                                     </div>


### PR DESCRIPTION
## Summary

- Remove `<span class=\"deprecated-label\">Closed Beta</span>` from the Snyk Secrets checkbox label in the settings dialog (global and per-folder views)
- Update generated fixture `config_output_multi_project.html` to match
- Feature flag gates and all other Secrets infrastructure unchanged

## Test plan
- [x] `make test` — all packages pass
- [x] Pre-commit hooks pass
- [x] `rg "Snyk Secrets.*Closed Beta"` returns no matches