### PR TITLE
refactor: panic on feature flag access without ConfigResolver [IDE-1974]

### DIFF
--- a/domain/ide/command/logout_test.go
+++ b/domain/ide/command/logout_test.go
@@ -59,7 +59,7 @@ func TestLogoutCommand_Execute_ClearsIssues(t *testing.T) {
 
 	sc := scanner.NewTestScanner()
 
-	resolver := types.NewConfigResolver(engine.GetLogger())
+	resolver := testutil.DefaultConfigResolver(engine)
 	w := workspace.New(engine.GetConfiguration(), engine.GetLogger(), performance.NewInstrumentor(), sc, hoverService, scanNotifier, notifier, scanPersister, scanStateAggregator, fakeFeatureFlagService, resolver, engine)
 	folder := workspace.NewFolder(
 		engine.GetConfiguration(),

--- a/domain/scanstates/summary_html_external_test.go
+++ b/domain/scanstates/summary_html_external_test.go
@@ -45,7 +45,7 @@ func Test_Summary_Html_DeduplicatesIssuesByFingerprint(t *testing.T) {
 
 	folderPath := types.FilePath(t.TempDir())
 	notifier := notification.NewMockNotifier()
-	resolver := types.NewConfigResolver(logger)
+	resolver := testutil.DefaultConfigResolver(engine)
 
 	w := workspace.New(
 		conf,

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -54,7 +54,7 @@ func TestConfigHtmlRenderer_GetConfigHtml(t *testing.T) {
 		types.SettingAuthenticationMethod: "oauth",
 	}
 	folderConfigs := []types.FolderConfig{
-		{FolderPath: folderPath},
+		{FolderPath: folderPath, ConfigResolver: testutil.DefaultConfigResolver(engine)},
 	}
 
 	html := renderer.GetConfigHtml(settings, folderConfigs)
@@ -137,7 +137,8 @@ func TestConfigHtmlRenderer_LdxSyncConfigAlwaysRendered(t *testing.T) {
 	settings := map[string]any{}
 	folderConfigs := []types.FolderConfig{
 		{
-			FolderPath: folderPath,
+			FolderPath:     folderPath,
+			ConfigResolver: testutil.DefaultConfigResolver(engine),
 			EffectiveConfig: map[string]types.EffectiveValue{
 				"scan_automatic": {Value: "auto", Source: "global"},
 			},
@@ -297,7 +298,7 @@ func TestConfigHtmlRenderer_SingleFolderShowsDirectTab(t *testing.T) {
 		types.SettingApiEndpoint: "https://test.snyk.io",
 	}
 	folderConfigs := []types.FolderConfig{
-		{FolderPath: folderPath},
+		{FolderPath: folderPath, ConfigResolver: testutil.DefaultConfigResolver(engine)},
 	}
 
 	html := renderer.GetConfigHtml(settings, folderConfigs)
@@ -335,7 +336,7 @@ func TestConfigHtmlRenderer_FolderNameDiffersFromBasename(t *testing.T) {
 
 	settings := map[string]any{}
 	folderConfigs := []types.FolderConfig{
-		{FolderPath: folderPath},
+		{FolderPath: folderPath, ConfigResolver: testutil.DefaultConfigResolver(engine)},
 	}
 
 	html := renderer.GetConfigHtml(settings, folderConfigs)
@@ -367,7 +368,7 @@ func TestConfigHtmlRenderer_EmptyNameFallsBackToBasename(t *testing.T) {
 
 	settings := map[string]any{}
 	folderConfigs := []types.FolderConfig{
-		{FolderPath: folderPath},
+		{FolderPath: folderPath, ConfigResolver: testutil.DefaultConfigResolver(engine)},
 	}
 
 	html := renderer.GetConfigHtml(settings, folderConfigs)
@@ -406,8 +407,8 @@ func TestConfigHtmlRenderer_MultiFolderShowsDropdown(t *testing.T) {
 		types.SettingApiEndpoint: "https://test.snyk.io",
 	}
 	folderConfigs := []types.FolderConfig{
-		{FolderPath: folderPath1},
-		{FolderPath: folderPath2},
+		{FolderPath: folderPath1, ConfigResolver: testutil.DefaultConfigResolver(engine)},
+		{FolderPath: folderPath2, ConfigResolver: testutil.DefaultConfigResolver(engine)},
 	}
 
 	html := renderer.GetConfigHtml(settings, folderConfigs)
@@ -462,8 +463,8 @@ func TestConfigHtmlRenderer_FolderNamesAlignWithStoredFolderConfigs(t *testing.T
 	// folderConfigs in REVERSED order: beta first, alpha second
 	settings := map[string]any{}
 	folderConfigs := []types.FolderConfig{
-		{FolderPath: betaPath},
-		{FolderPath: alphaPath},
+		{FolderPath: betaPath, ConfigResolver: testutil.DefaultConfigResolver(engine)},
+		{FolderPath: alphaPath, ConfigResolver: testutil.DefaultConfigResolver(engine)},
 	}
 
 	html := renderer.GetConfigHtml(settings, folderConfigs)
@@ -509,7 +510,7 @@ func TestConfigHtmlRenderer_EclipseShowsProjectSettings(t *testing.T) {
 		types.SettingSnykCodeEnabled: true,
 	}
 	folderConfigs := []types.FolderConfig{
-		{FolderPath: folderPath},
+		{FolderPath: folderPath, ConfigResolver: testutil.DefaultConfigResolver(engine)},
 	}
 
 	html := renderer.GetConfigHtml(settings, folderConfigs)
@@ -664,7 +665,8 @@ func TestConfigHtmlRenderer_SourceIndicatorsInOutput(t *testing.T) {
 	settings := map[string]any{}
 	folderConfigs := []types.FolderConfig{
 		{
-			FolderPath: folderPath,
+			FolderPath:     folderPath,
+			ConfigResolver: testutil.DefaultConfigResolver(engine),
 			EffectiveConfig: map[string]types.EffectiveValue{
 				"snyk_oss_enabled":     {Value: true, Source: "ldx-sync-locked"},
 				"snyk_code_enabled":    {Value: true, Source: "ldx-sync"},
@@ -778,7 +780,8 @@ func TestConfigHtml_FormFieldNamesMatchRegisteredSettings(t *testing.T) {
 	}
 	folderConfigs := []types.FolderConfig{
 		{
-			FolderPath: "/path/to/folder",
+			FolderPath:     "/path/to/folder",
+			ConfigResolver: testutil.DefaultConfigResolver(engine),
 			EffectiveConfig: map[string]types.EffectiveValue{
 				types.SettingScanAutomatic:          {Value: true, Source: "global"},
 				types.SettingScanNetNew:             {Value: false, Source: "global"},

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -717,7 +717,7 @@ func TestCLIScanner_ostestScan_AddsFlagSetAndAllowsUnknownFlags(t *testing.T) {
 	}
 
 	workDir := types.FilePath(t.TempDir())
-	folderConfig := &types.FolderConfig{FolderPath: workDir}
+	folderConfig := &types.FolderConfig{FolderPath: workDir, ConfigResolver: testutil.DefaultConfigResolver(engine)}
 	path := types.FilePath(filepath.Join(string(workDir), "package.json"))
 
 	cmdWithoutFlag := []string{"snyk", "test"}
@@ -762,7 +762,7 @@ func TestCLIScanner_ostestScan_SetsSubprocessEnvironment(t *testing.T) {
 	}
 
 	workDir := types.FilePath(t.TempDir())
-	folderConfig := &types.FolderConfig{FolderPath: workDir}
+	folderConfig := &types.FolderConfig{FolderPath: workDir, ConfigResolver: testutil.DefaultConfigResolver(engine)}
 	targetPath := types.FilePath(filepath.Join(string(workDir), "package.json"))
 	cmd := []string{"snyk", "test"}
 	inputEnv := gotenv.Env{

--- a/internal/types/folder_config.go
+++ b/internal/types/folder_config.go
@@ -145,7 +145,7 @@ func (fc *FolderConfig) SetFeatureFlag(flag string, value bool) {
 }
 
 // Conf returns the configuration for prefix key access.
-// Delegates to ConfigResolver.Configuration() when available.
+// Returns nil if the ConfigResolver is nil.
 func (fc *FolderConfig) Conf() configuration.Configuration {
 	if fc.ConfigResolver != nil {
 		return fc.ConfigResolver.Configuration()

--- a/internal/types/folder_config.go
+++ b/internal/types/folder_config.go
@@ -128,12 +128,8 @@ func (fc *FolderConfig) GetFeatureFlag(flag string) bool {
 	if fc == nil {
 		return false
 	}
-	conf := fc.Conf()
-	if conf == nil {
-		return false
-	}
 	key := configresolver.FolderMetadataKey(string(PathKey(fc.FolderPath)), FeatureFlagPrefix+flag)
-	return conf.GetBool(key)
+	return fc.Conf().GetBool(key)
 }
 
 // SetFeatureFlag writes a feature flag value to configuration under the folder metadata prefix.
@@ -144,12 +140,8 @@ func (fc *FolderConfig) SetFeatureFlag(flag string, value bool) {
 	if fc == nil {
 		return
 	}
-	conf := fc.Conf()
-	if conf == nil {
-		return
-	}
 	key := configresolver.FolderMetadataKey(string(PathKey(fc.FolderPath)), FeatureFlagPrefix+flag)
-	conf.Set(key, value)
+	fc.Conf().Set(key, value)
 }
 
 // Conf returns the configuration for prefix key access.

--- a/internal/types/folder_config_test.go
+++ b/internal/types/folder_config_test.go
@@ -91,9 +91,9 @@ func TestFolderConfig_GetFeatureFlag(t *testing.T) {
 		assert.False(t, fc.GetFeatureFlag("missing"))
 	})
 
-	t.Run("returns false when ConfigResolver is nil", func(t *testing.T) {
+	t.Run("panics when ConfigResolver is nil", func(t *testing.T) {
 		fc := &FolderConfig{}
-		assert.False(t, fc.GetFeatureFlag("myFlag"))
+		assert.Panics(t, func() { fc.GetFeatureFlag("myFlag") })
 	})
 
 	t.Run("returns false for nil receiver", func(t *testing.T) {


### PR DESCRIPTION
### Description

Remove silent false/no-op when FolderConfig has no ConfigResolver in GetFeatureFlag and SetFeatureFlag.
Wire ConfigResolver in tests that were constructing incomplete FolderConfigs and not exercising flag reads.

Safe in prod code due to everything going through `wireConfigResolver`.
I did not do the rest of the functions in the file, this was enough for now.

FYI, this change is unrelated to the ticket, just the silent fail caused me some issues when I was adding tests for #1236.

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
 - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
 - N/A
