### PR TITLE
chore: pre-commit hook to log in to ggshield

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,12 @@ repos:
     rev: v1.43.0
     hooks:
       - id: ggshield
+        alias: ggshield-auth-login
+        name: ggshield auth login
+        language_version: python3
+        stages: [pre-commit]
+        args: ["auth", "login"]
+      - id: ggshield
         language_version: python3
         stages: [pre-commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook


### PR DESCRIPTION
### Description

Before the hook would just fail, now it brings up the browser to log in if you aren't logged in.

Previously you would see:

> ggshield (pre-commit)....................................................Failed
> - hook id: ggshield
> - exit code: 3
> 
> Error: Instance 'https://dashboard.gitguardian.com' authentication expired, 
> please authenticate again.

Then it would be a pain to re-auth if you don't have the CLI installed.

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
