### PR TITLE
feat(settings): propagate Project Default changes to folder panes [IDE-2111]

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -11,3 +11,10 @@ IDE-2078: The tree-view hover style shall set both background and foreground usi
 IDE-2078: The tree-view hover style shall fall back to the list-active-selection variables when no IDE-supplied list-hover-foreground variable is provided.
 IDE-2078: The tree-view CSS shall not hard-code colour values for the hover state; all colours shall come from CSS custom properties bound to `--vscode-*` variables (with sensible neutral fallbacks).
 IDE-2078: Hover styling shall remain correct when the IDE injects its own theme CSS via the `${ideStyle}` placeholder.
+IDE-2111: When a Project Default value changes and is saved successfully, the corresponding folder pane input fields shall update to the new value if they were previously inheriting from the Project Default.
+IDE-2111: Folder fields whose source indicator wrapper carries `source-org` or `source-org-locked` shall not be overwritten by Project Default propagation.
+IDE-2111: Folder fields whose current value differs from the previous Project Default value (user-overridden) shall not be overwritten by Project Default propagation.
+IDE-2111: After Project Default propagation, the form's dirty state shall remain clean — propagated DOM changes shall not be reported as unsaved user edits.
+IDE-2111: Project Default propagation shall identify folder inputs by the `data-setting` attribute, not by parsing the field `name` for a `folder_N_` prefix.
+IDE-2111: Project Default propagation shall ignore changed-field keys whose corresponding Project Defaults input does not exist in `#fallbacks-pane`.
+IDE-2111: Project Default propagation shall correctly read and write checkbox, select, text, and number input types.

--- a/infrastructure/configuration/template/js/features/auto-save.js
+++ b/infrastructure/configuration/template/js/features/auto-save.js
@@ -66,6 +66,12 @@
 				if (window.ConfigApp.authFieldMonitor && window.ConfigApp.authFieldMonitor.resetSavedState) {
 					window.ConfigApp.authFieldMonitor.resetSavedState();
 				}
+				// Propagate changed Project Default values into folder panes that were
+				// inheriting from PD (i.e. not user-overridden). Must run BEFORE reset()
+				// so the propagated folder values become the new baseline (not dirty).
+				if (window.ConfigApp.projectDefaultPropagator && window.dirtyTracker) {
+					window.ConfigApp.projectDefaultPropagator.propagate(data, window.dirtyTracker.originalData);
+				}
 				// Reset dirty state after successful save (baseline must be the full form state)
 				if (window.dirtyTracker) {
 					window.dirtyTracker.reset();

--- a/infrastructure/configuration/template/js/features/project-default-propagator.js
+++ b/infrastructure/configuration/template/js/features/project-default-propagator.js
@@ -1,0 +1,143 @@
+// ABOUTME: Project Default Propagation — after a successful save, walks all
+// ABOUTME: folder panes and overwrites inputs that were inheriting from
+// ABOUTME: Project Defaults (PD) with the new PD value.
+//
+// Exposed as: window.ConfigApp.projectDefaultPropagator.propagate(changedData, originalPdValues)
+//
+// Algorithm:
+//   For each key in changedData (skipping folderConfigs / trusted_folders):
+//     1. Find the PD input in #fallbacks-pane by name=<key>.
+//        If absent, skip — not a PD-scope field.
+//     2. Read the post-save PD value from the DOM (authoritative after save).
+//     3. For each folder input matched via data-setting=<key>:
+//        a. Skip if wrapper carries source-org or source-org-locked.
+//        b. Skip if folder's current value != old PD value (user override).
+//        c. Otherwise write the new PD value and dispatch a change event.
+
+(function () {
+	'use strict';
+
+	window.ConfigApp = window.ConfigApp || {};
+
+	// ---------------------------------------------------------------------------
+	// Module-private helpers
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Read the effective value from a form element.
+	 * Returns a boolean for checkboxes, a string for everything else.
+	 * @param {HTMLInputElement|HTMLSelectElement} el
+	 * @returns {boolean|string}
+	 */
+	function readValue(el) {
+		if (el.type === 'checkbox') {
+			return el.checked;
+		}
+		return el.value;
+	}
+
+	/**
+	 * Write a value to a form element.
+	 * @param {HTMLInputElement|HTMLSelectElement} el
+	 * @param {boolean|string} value
+	 */
+	function writeValue(el, value) {
+		if (el.type === 'checkbox') {
+			el.checked = !!value;
+		} else {
+			el.value = String(value);
+		}
+	}
+
+	/**
+	 * Compare two values for equality, normalising types consistently.
+	 * Checkboxes produce booleans; text/number/select produce strings.
+	 * We compare with String() on both sides when neither is a pure boolean.
+	 * @param {boolean|string} a
+	 * @param {boolean|string} b
+	 * @returns {boolean}
+	 */
+	function valuesEqual(a, b) {
+		if (typeof a === 'boolean' || typeof b === 'boolean') {
+			return !!a === !!b;
+		}
+		return String(a) === String(b);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Public API
+	// ---------------------------------------------------------------------------
+
+	var projectDefaultPropagator = {};
+
+	/**
+	 * Propagate changed Project Default values into folder panes.
+	 *
+	 * Called inside the saveSuccess branch of auto-save.js, BEFORE
+	 * dirtyTracker.reset(), so that propagated folder values become the
+	 * new baseline (not dirty).
+	 *
+	 * @param {Object} changedData      - The collectChangedData() result (post-save).
+	 * @param {Object} originalPdValues - dirtyTracker.originalData (pre-save baseline).
+	 */
+	projectDefaultPropagator.propagate = function (changedData, originalPdValues) {
+		if (!changedData || !originalPdValues) {
+			return;
+		}
+
+		var keys = Object.keys(changedData);
+
+		for (var i = 0; i < keys.length; i++) {
+			var key = keys[i];
+
+			// Skip structural keys that are not PD settings (UNIT-006b)
+			if (key === 'folderConfigs' || key === 'trusted_folders') {
+				continue;
+			}
+
+			// Look up the PD input by name inside #fallbacks-pane
+			var pdInput = document.querySelector('#fallbacks-pane [name="' + key + '"]');
+			if (!pdInput) {
+				// Not a PD-scope field — skip silently (UNIT-006)
+				continue;
+			}
+
+			// Post-save DOM value is authoritative
+			var newValue = readValue(pdInput);
+
+			// Pre-save baseline value for this key
+			var oldValue = originalPdValues[key];
+
+			// Find all folder inputs for this setting via data-setting attribute (UNIT-002)
+			var folderInputs = document.querySelectorAll('.folder-pane [data-setting="' + key + '"]');
+
+			for (var j = 0; j < folderInputs.length; j++) {
+				var folderInput = folderInputs[j];
+
+				// Skip org-managed inputs (UNIT-005)
+				var wrapper = folderInput.closest('.override-indicator-wrapper');
+				if (wrapper) {
+					if (wrapper.classList.contains('source-org') ||
+						wrapper.classList.contains('source-org-locked')) {
+						continue;
+					}
+				}
+
+				// Skip user-overridden inputs: their current value differs from old PD (UNIT-004)
+				var currentFolderValue = readValue(folderInput);
+				if (!valuesEqual(currentFolderValue, oldValue)) {
+					continue;
+				}
+
+				// Write the new PD value
+				writeValue(folderInput, newValue);
+
+				// Notify other listeners that this input changed
+				var event = new Event('change', { bubbles: true });
+				folderInput.dispatchEvent(event);
+			}
+		}
+	};
+
+	window.ConfigApp.projectDefaultPropagator = projectDefaultPropagator;
+})();

--- a/js-tests/auto-save-propagation.test.mjs
+++ b/js-tests/auto-save-propagation.test.mjs
@@ -1,0 +1,186 @@
+// ABOUTME: Integration tests for auto-save + project-default-propagator wiring.
+// ABOUTME: Verifies that after a successful save, folder values that were
+// ABOUTME: inheriting from Project Defaults are updated and the dirty tracker
+// ABOUTME: considers the form clean.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { JSDOM } from "jsdom";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fully-initialized JSDOM environment from the production HTML fixture
+ * with the project-default-propagator.js script also injected.
+ * The fixture already contains folder panes (generated with -dummy-data).
+ */
+async function buildDomWithPropagator({
+  initialToken = "",
+  initialAuthMethod = "oauth",
+  initialEndpoint = "https://api.snyk.io",
+} = {}) {
+  const html = await readFile(join(__dirname, "fixtures", "config-page.html"), "utf8");
+  const propagatorSrc = await readFile(
+    join(__dirname, "../infrastructure/configuration/template/js/features/project-default-propagator.js"),
+    "utf8"
+  );
+
+  // Inject the propagator script just before </body>
+  const htmlWithPropagator = html.replace("</body>", `<script>${propagatorSrc}</script></body>`);
+
+  const dom = new JSDOM(htmlWithPropagator, { runScripts: "dangerously" });
+  const win = dom.window;
+
+  win.document.getElementById("token").value = initialToken;
+  win.document.getElementById("authentication_method").value = initialAuthMethod;
+  win.document.getElementById("api_endpoint").value = initialEndpoint;
+
+  // Yield to fire the window load event (initializes dirtyTracker etc.)
+  await new Promise((resolve) => win.setTimeout(resolve, 0));
+
+  return win;
+}
+
+/**
+ * Install a __saveIdeConfig__ spy that returns true (success).
+ */
+function spySaveConfigSuccess(win) {
+  const calls = [];
+  win.__saveIdeConfig__ = function (jsonString) {
+    calls.push(jsonString);
+    return true;
+  };
+  return calls;
+}
+
+/**
+ * Filter NodeList to only those inputs whose closest .override-indicator-wrapper
+ * does NOT carry source-org or source-org-locked — i.e. inputs that the propagator
+ * is allowed to update.
+ */
+function propagatableInputs(nodeList) {
+  return Array.from(nodeList).filter((el) => {
+    const wrapper = el.closest(".override-indicator-wrapper");
+    if (!wrapper) return true;
+    return !wrapper.classList.contains("source-org") &&
+           !wrapper.classList.contains("source-org-locked");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// INTEG-001: Full path — PD + folder panes, propagatable folder values updated
+// ---------------------------------------------------------------------------
+
+test("INTEG-001: after successful save, propagatable folder values are updated and dirtyTracker is clean", async () => {
+  const win = await buildDomWithPropagator();
+  const calls = spySaveConfigSuccess(win);
+
+  // Find a PD input and its corresponding folder inputs
+  const pdInput = win.document.querySelector('#fallbacks-pane [name="snyk_oss_enabled"]');
+  assert.ok(pdInput, "snyk_oss_enabled PD input must exist in fixture");
+
+  const allFolderInputs = win.document.querySelectorAll('.folder-pane [data-setting="snyk_oss_enabled"]');
+  assert.ok(allFolderInputs.length > 0, "at least one folder input for snyk_oss_enabled must exist");
+
+  // Propagatable = inputs without source-org or source-org-locked wrapper
+  const propInputs = propagatableInputs(allFolderInputs);
+  assert.ok(propInputs.length > 0, "at least one propagatable folder input must exist");
+
+  // Set propagatable folder inputs to match current PD value (non-overridden state)
+  const pdCurrentValue = pdInput.checked;
+  for (const fi of propInputs) {
+    fi.checked = pdCurrentValue;
+  }
+
+  // Re-initialize dirty tracker baseline to capture this state
+  win.dirtyTracker.reset();
+  assert.equal(win.dirtyTracker.isDirty, false, "precondition: form must be clean before test");
+
+  // Change the PD value
+  const newPdValue = !pdCurrentValue;
+  pdInput.checked = newPdValue;
+  pdInput.dispatchEvent(new win.Event("change", { bubbles: true }));
+
+  // Trigger save
+  win.getAndSaveIdeConfig();
+
+  assert.ok(calls.length > 0, "save must have been called");
+
+  // After save, propagatable folder inputs should have been updated to new PD value
+  for (const fi of propInputs) {
+    assert.equal(fi.checked, newPdValue,
+      `propagatable folder input for snyk_oss_enabled should be updated to ${newPdValue}`);
+  }
+
+  // And the dirty tracker should be clean (propagation ran before reset)
+  assert.equal(win.dirtyTracker.isDirty, false,
+    "dirty tracker must be clean after save + propagation");
+});
+
+// ---------------------------------------------------------------------------
+// INTEG-002: Severity-filter regression — severity_filter_high propagates correctly
+// ---------------------------------------------------------------------------
+
+test("INTEG-002: severity_filter_high change propagates to folder pane correctly", async () => {
+  const win = await buildDomWithPropagator();
+  const calls = spySaveConfigSuccess(win);
+
+  // Get PD severity_filter_high input
+  const pdHighInput = win.document.querySelector('#fallbacks-pane [name="severity_filter_high"]');
+  assert.ok(pdHighInput, "severity_filter_high PD input must exist in fixture");
+
+  // Get folder severity_filter_high inputs
+  const allFolderHighInputs = win.document.querySelectorAll('.folder-pane [data-setting="severity_filter_high"]');
+  assert.ok(allFolderHighInputs.length > 0, "at least one folder severity_filter_high input must exist");
+
+  // Propagatable inputs only (not org-managed)
+  const propHighInputs = propagatableInputs(allFolderHighInputs);
+  assert.ok(propHighInputs.length > 0, "at least one propagatable folder severity_filter_high input must exist");
+
+  // Also get folder severity_filter_critical to verify it is NOT affected
+  const folderCriticalInputs = win.document.querySelectorAll('.folder-pane [data-setting="severity_filter_critical"]');
+
+  // Set propagatable folder high inputs to match current PD value (non-overridden state)
+  const pdHighValue = pdHighInput.checked;
+  for (const fi of propHighInputs) {
+    fi.checked = pdHighValue;
+  }
+
+  // Record critical value before save (should not change)
+  const criticalValuesBefore = Array.from(folderCriticalInputs).map((fi) => fi.checked);
+
+  // Reset baseline
+  win.dirtyTracker.reset();
+
+  // Change PD severity_filter_high
+  const newHighValue = !pdHighValue;
+  pdHighInput.checked = newHighValue;
+  pdHighInput.dispatchEvent(new win.Event("change", { bubbles: true }));
+
+  // Trigger save
+  win.getAndSaveIdeConfig();
+
+  assert.ok(calls.length > 0, "save must have been called");
+
+  // Propagatable folder severity_filter_high inputs should be updated
+  for (const fi of propHighInputs) {
+    assert.equal(fi.checked, newHighValue,
+      "propagatable folder severity_filter_high must be propagated");
+  }
+
+  // Folder severity_filter_critical must NOT be changed
+  const criticalValuesAfter = Array.from(folderCriticalInputs).map((fi) => fi.checked);
+  assert.deepEqual(criticalValuesAfter, criticalValuesBefore,
+    "severity_filter_critical must not be affected by severity_filter_high change");
+
+  // Form clean
+  assert.equal(win.dirtyTracker.isDirty, false, "dirty tracker must be clean after propagation");
+});

--- a/js-tests/propagation.test.mjs
+++ b/js-tests/propagation.test.mjs
@@ -1,0 +1,350 @@
+// ABOUTME: Unit tests for the project-default-propagator module.
+// ABOUTME: Tests that propagateProjectDefaults walks folder panes and overwrites
+// ABOUTME: non-overridden inputs with new PD values after a successful save.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+// ---------------------------------------------------------------------------
+// Minimal DOM factory — builds an isolated JSDOM per test so tests are clean.
+// Does NOT use the full config-page fixture; just the DOM nodes we care about.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal window that contains:
+ *   - #fallbacks-pane  (Project Defaults scope)
+ *   - one or more .folder-pane divs (folder scope)
+ * and loads project-default-propagator.js into it.
+ *
+ * @param {string} html - Body HTML to inject.
+ * @returns {Promise<Window>}
+ */
+async function buildPropagatorDom(html) {
+  const { readFile } = await import("node:fs/promises");
+  const { dirname, join } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  const scriptSrc = await readFile(
+    join(__dirname, "../infrastructure/configuration/template/js/features/project-default-propagator.js"),
+    "utf8"
+  );
+
+  const fullHtml = `<!DOCTYPE html><html><body>${html}</body></html>`;
+  const dom = new JSDOM(fullHtml, { runScripts: "dangerously" });
+  const win = dom.window;
+
+  // Inject the script
+  const scriptEl = win.document.createElement("script");
+  scriptEl.textContent = scriptSrc;
+  win.document.head.appendChild(scriptEl);
+
+  return win;
+}
+
+// ---------------------------------------------------------------------------
+// UNIT-001: propagate walks folder panes and overwrites a non-overridden input
+// ---------------------------------------------------------------------------
+test("UNIT-001: propagates new PD value into non-overridden folder input", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="checkbox" name="snyk_oss_enabled" checked>
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <input type="checkbox" name="folder_0_snyk_oss_enabled" data-setting="snyk_oss_enabled">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { snyk_oss_enabled: true };
+  const originalPdValues = { snyk_oss_enabled: false };
+
+  // Folder input starts unchecked (matches old PD value false)
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="snyk_oss_enabled"]');
+  assert.equal(folderInput.checked, false, "precondition: folder starts with old PD value");
+
+  propagator.propagate(changedData, originalPdValues);
+
+  // After propagation, folder should match new PD value
+  assert.equal(folderInput.checked, true, "folder input should be updated to new PD value");
+});
+
+// ---------------------------------------------------------------------------
+// UNIT-002: PR #1185 regression guard — discovery via data-setting, NOT name parsing
+// ---------------------------------------------------------------------------
+test("UNIT-002: uses data-setting for discovery, not name attribute parsing", async () => {
+  // data-setting differs from the name suffix — propagator must follow data-setting
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="text" name="organization" value="new-org">
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <!-- name suffix would be "organization" but we test with a different-looking name
+             to prove the propagator is NOT parsing the name attribute -->
+        <input type="text" name="folder_0_organization" data-setting="organization" value="old-org">
+      </div>
+    </div>
+    <div class="folder-pane" id="folder-pane-1">
+      <div class="override-indicator-wrapper">
+        <!-- This input has data-setting="organization" but an unusual name to trip name-based logic -->
+        <input type="text" name="folder_1_organization_alias" data-setting="organization" value="old-org">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const pdInput = win.document.querySelector('#fallbacks-pane [name="organization"]');
+  pdInput.value = "new-org";
+
+  const changedData = { organization: "new-org" };
+  const originalPdValues = { organization: "old-org" };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  // Both folder inputs matched via data-setting, regardless of their name attribute
+  const folder0Input = win.document.querySelector('#folder-pane-0 [data-setting="organization"]');
+  const folder1Input = win.document.querySelector('#folder-pane-1 [data-setting="organization"]');
+
+  assert.equal(folder0Input.value, "new-org", "folder-0 updated via data-setting");
+  assert.equal(folder1Input.value, "new-org", "folder-1 updated via data-setting even with unusual name");
+});
+
+// ---------------------------------------------------------------------------
+// UNIT-003: all input type branches (checkbox, select, text/number) propagate correctly
+// ---------------------------------------------------------------------------
+test("UNIT-003: propagates checkbox correctly", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="checkbox" name="severity_filter_high" checked>
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <input type="checkbox" name="folder_0_severity_filter_high" data-setting="severity_filter_high">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { severity_filter_high: true };
+  const originalPdValues = { severity_filter_high: false };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="severity_filter_high"]');
+  assert.equal(folderInput.checked, true, "checkbox propagated correctly");
+});
+
+test("UNIT-003: propagates select correctly", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <select name="scan_automatic">
+        <option value="true">Auto</option>
+        <option value="false" selected>Manual</option>
+      </select>
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <select name="folder_0_scan_automatic" data-setting="scan_automatic">
+          <option value="true" selected>Auto</option>
+          <option value="false">Manual</option>
+        </select>
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  // PD is now "false" (Manual), folder was "true" (Auto) — folder matches old PD "true"
+  const changedData = { scan_automatic: "false" };
+  const originalPdValues = { scan_automatic: "true" };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  const folderSelect = win.document.querySelector('.folder-pane [data-setting="scan_automatic"]');
+  assert.equal(folderSelect.value, "false", "select propagated correctly");
+});
+
+test("UNIT-003: propagates text input correctly", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="text" name="organization" value="new-org-uuid">
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <input type="text" name="folder_0_organization" data-setting="organization" value="old-org-uuid">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { organization: "new-org-uuid" };
+  const originalPdValues = { organization: "old-org-uuid" };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="organization"]');
+  assert.equal(folderInput.value, "new-org-uuid", "text input propagated correctly");
+});
+
+test("UNIT-003: propagates number input correctly", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="number" name="risk_score_threshold" value="500">
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <input type="number" name="folder_0_risk_score_threshold" data-setting="risk_score_threshold" value="200">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { risk_score_threshold: "500" };
+  const originalPdValues = { risk_score_threshold: "200" };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="risk_score_threshold"]');
+  assert.equal(folderInput.value, "500", "number input propagated correctly");
+});
+
+// ---------------------------------------------------------------------------
+// UNIT-004: folder input with user override (value !== old PD) is skipped
+// ---------------------------------------------------------------------------
+test("UNIT-004: skips folder input that has a user override (value differs from old PD)", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="text" name="organization" value="new-org">
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <!-- This folder has a user-set value "user-override-org" — different from old PD -->
+        <input type="text" name="folder_0_organization" data-setting="organization" value="user-override-org">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { organization: "new-org" };
+  const originalPdValues = { organization: "old-org" };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="organization"]');
+  // Must NOT be overwritten — it had a user override
+  assert.equal(folderInput.value, "user-override-org", "user-overridden folder value must not be changed");
+});
+
+// ---------------------------------------------------------------------------
+// UNIT-005: source-org and source-org-locked wrappers are never overwritten
+// ---------------------------------------------------------------------------
+test("UNIT-005: skips folder input whose wrapper has source-org class", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="checkbox" name="snyk_oss_enabled" checked>
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper source-org">
+        <input type="checkbox" name="folder_0_snyk_oss_enabled" data-setting="snyk_oss_enabled">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { snyk_oss_enabled: true };
+  const originalPdValues = { snyk_oss_enabled: false };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="snyk_oss_enabled"]');
+  // Still unchecked — org-managed, must not be changed
+  assert.equal(folderInput.checked, false, "source-org folder must not be overwritten");
+});
+
+test("UNIT-005: skips folder input whose wrapper has source-org-locked class", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <input type="checkbox" name="snyk_code_enabled" checked>
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper source-org-locked">
+        <input type="checkbox" name="folder_0_snyk_code_enabled" data-setting="snyk_code_enabled">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { snyk_code_enabled: true };
+  const originalPdValues = { snyk_code_enabled: false };
+
+  propagator.propagate(changedData, originalPdValues);
+
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="snyk_code_enabled"]');
+  assert.equal(folderInput.checked, false, "source-org-locked folder must not be overwritten");
+});
+
+// ---------------------------------------------------------------------------
+// UNIT-006: changedData key with no matching PD input is silently ignored
+// ---------------------------------------------------------------------------
+test("UNIT-006: key with no matching #fallbacks-pane input is ignored, no error", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+      <!-- no input for "ghost_setting" -->
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+      <div class="override-indicator-wrapper">
+        <input type="text" name="folder_0_ghost_setting" data-setting="ghost_setting" value="old">
+      </div>
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  const changedData = { ghost_setting: "new-value" };
+  const originalPdValues = { ghost_setting: "old" };
+
+  // Must not throw
+  assert.doesNotThrow(() => {
+    propagator.propagate(changedData, originalPdValues);
+  });
+
+  // Folder input untouched
+  const folderInput = win.document.querySelector('.folder-pane [data-setting="ghost_setting"]');
+  assert.equal(folderInput.value, "old", "folder input must not be changed when PD input absent");
+});
+
+// ---------------------------------------------------------------------------
+// UNIT-006b: folderConfigs and trusted_folders keys are skipped
+// ---------------------------------------------------------------------------
+test("UNIT-006b: folderConfigs and trusted_folders keys are skipped", async () => {
+  const html = `
+    <div id="fallbacks-pane">
+    </div>
+    <div class="folder-pane" id="folder-pane-0">
+    </div>
+  `;
+  const win = await buildPropagatorDom(html);
+  const propagator = win.ConfigApp.projectDefaultPropagator;
+
+  // Should not throw even when these special keys are in changedData
+  assert.doesNotThrow(() => {
+    propagator.propagate(
+      { folderConfigs: [{}], trusted_folders: ["/some/path"] },
+      { folderConfigs: [], trusted_folders: [] }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- After saving a Project Default value, walk folder pane inputs (matched via `data-setting=<key>`) and overwrite those that were inheriting from PD.
- Skip folder inputs whose wrapper carries `source-org` / `source-org-locked`, or whose current value differs from the pre-save PD value (user override).
- No `location.reload()` — works in webviews without IDE plugin changes.

Closes [IDE-2111](https://snyksec.atlassian.net/browse/IDE-2111).
Parent epic: [IDE-2029](https://snyksec.atlassian.net/browse/IDE-2029).

## Why prior PR #1185 was reverted

It looked for `folder_N_override_<setting>` — but the template names folder inputs `folder_N_<setting>` with `data-setting="<setting>"`. Severity-filter propagation silently no-op'd. This PR keys off `data-setting`, making that bug structurally impossible.

## Field-name audit

| Scope | Element naming | Container | Wrapper source classes |
|---|---|---|---|
| Project Defaults | `name="<setting>"` | `#fallbacks-pane` | `source-org-locked` / `source-org` / "" |
| Folder pane | `name="folder_N_<setting>"` + `data-setting="<setting>"` | `#folder-pane-N`, `.folder-pane` | `source-org-locked` / `source-org` / "" |

`getSourceClass` (in `config_html.go`) emits only three values; **no `source-override` class exists server-side**. User-override is detected client-side by comparing folder DOM value to `dirtyTracker.originalData[<setting>]` (the pre-save PD baseline).

## Algorithm

For each key in `changedData` (skipping `folderConfigs` / `trusted_folders`):
1. Find PD input in `#fallbacks-pane` by `name=<key>`. Absent → skip (not PD-scope).
2. Read post-save PD value from DOM.
3. For each folder input with `data-setting=<key>`:
   - Skip if wrapper has `source-org` / `source-org-locked`.
   - Skip if folder's current value ≠ pre-save PD value (user override).
   - Otherwise write the new PD value + dispatch `change` event.

Runs inside `auto-save.js` save-success branch, **before** `dirtyTracker.reset()` so propagated DOM values land in the fresh baseline (form stays clean — propagation is invisible to the dirty tracker).

## Files

| File | Change |
|---|---|
| `infrastructure/configuration/template/js/features/project-default-propagator.js` | New, ~140 LOC |
| `infrastructure/configuration/template/js/features/auto-save.js` | 6-line wiring inside `saveSuccess` |
| `js-tests/propagation.test.mjs` | 11 unit tests |
| `js-tests/auto-save-propagation.test.mjs` | 2 integration tests |
| `docs/requirements/requirements.md` | 7 IDE-2111 requirements |

## Test plan

- [x] Unit: walks folder panes, only updates non-overridden fields
- [x] Unit: setting discovery via `data-setting`, not name-parsing (PR #1185 regression guard)
- [x] Unit: checkbox / select / text / number branches each handled
- [x] Unit: `source-org` / `source-org-locked` wrappers skipped
- [x] Unit: keys with no PD-scope input ignored (no error, no propagation)
- [x] Integration: full auto-save → propagation, dirty state remains clean
- [x] Integration: severity_filter_high rename regression guard
- [x] Full `js-tests` suite: 127/127 pass
- [ ] Manual smoke: VS Code
- [ ] Manual smoke: IntelliJ
- [ ] Manual smoke: Eclipse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-2111]: https://snyksec.atlassian.net/browse/IDE-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2029]: https://snyksec.atlassian.net/browse/IDE-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ