### PR TITLE
feat: route reset confirm dialogs through native IDE UI [IDE-1945]

### DIFF
--- a/docs/configuration-dialog.md
+++ b/docs/configuration-dialog.md
@@ -92,12 +92,14 @@ The HTML does **not** use `__ideLogin__` / `__ideLogout__` — authentication an
 | `window.__IS_IDE_AUTOSAVE_ENABLED__` | If `true`, form changes trigger save via `auto-save.js` | No (default false) |
 | `window.__onFormDirtyChange__(isDirty)` | Dirty-state callback for tab chrome | No |
 | `window.__ideSaveAttemptFinished__(status)` | Save outcome: `success`, `validation_error`, `bridge_missing`, `error` | No |
+| `window.__ideConfirmationDialog__(message, callback)` | Show a native confirmation modal (VSCode sandboxed webview blocks `window.confirm`). The `callback` **must** be invoked with a boolean (`true` = confirmed, `false` = cancelled). Hosts that do not inject this function fall back to `window.confirm`. | No (optional; falls back to `window.confirm`) |
 
 **Calls from `ide/bridge.js`:**
 
 - Login: `__ideExecuteCommand__('snyk.login', [authMethod, endpoint, insecure])`
 - Logout: `__ideExecuteCommand__('snyk.logout', [])`
 - Save: `__saveIdeConfig__(jsonString)` where `jsonString` is **`JSON.stringify`** of the object from `form-handler.collectData()` (not `workspace/didChangeConfiguration` — the IDE maps into LSP config).
+- Confirm: `__ideConfirmationDialog__(message, callback)` — called by `ideBridge.confirm()`; `callback` is always invoked with a strict boolean (fail-closed: non-boolean results are logged as errors and treated as cancel).
 
 **IDE-callable helpers (on `window`):**
 
@@ -117,6 +119,12 @@ webview.window.__saveIdeConfig__ = async (jsonString: string) => {
 };
 webview.window.__IS_IDE_AUTOSAVE_ENABLED__ = true;
 webview.window.__onFormDirtyChange__ = (isDirty: boolean) => { /* update tab title */ };
+webview.window.__ideConfirmationDialog__ = (message: string, callback: (confirmed: boolean) => void) => {
+  // Show a native modal and invoke callback with a boolean.
+  // Only needed in sandboxed environments (e.g. VSCode) where window.confirm is blocked.
+  const confirmed = await vscode.window.showWarningMessage(message, "Yes", "No") === "Yes";
+  callback(confirmed);
+};
 ```
 
 See [Function Injection Flow](#function-injection-flow) for the detailed sequence.
@@ -445,7 +453,7 @@ sequenceDiagram
 - [ ] Execute `snyk.workspace.configuration` command
 - [ ] Use returned string as webview HTML
 - [ ] Create webview/browser component for display
-- [ ] Expose `window.__ideExecuteCommand__`, `window.__saveIdeConfig__`, and optional `__onFormDirtyChange__` / `__ideSaveAttemptFinished__`
+- [ ] Expose `window.__ideExecuteCommand__`, `window.__saveIdeConfig__`, and optional `__onFormDirtyChange__` / `__ideSaveAttemptFinished__` / `__ideConfirmationDialog__`
 - [ ] Display HTML content in webview
 
 ### Configuration Management
@@ -478,6 +486,11 @@ sequenceDiagram
 - [ ] Warn user before closing dialog with unsaved changes using `window.__isFormDirty__()`
 - [ ] Disable save button when form is clean
 - [ ] Enable save button when form is dirty
+
+### Native Confirmation Dialog (Optional, recommended for sandboxed webviews)
+- [ ] Implement `window.__ideConfirmationDialog__(message, callback)` for sandboxed environments (e.g. VSCode) where `window.confirm` is blocked
+- [ ] Invoke `callback` with a **boolean** (`true` = confirmed, `false` = cancelled) — non-boolean results are logged as errors and treated as cancel (fail-closed)
+- [ ] If not implemented, `ideBridge.confirm` falls back to `window.confirm` automatically
 
 ### Auto-Save (Optional)
 - [ ] Set `window.__IS_IDE_AUTOSAVE_ENABLED__ = true` before loading HTML

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -274,6 +274,10 @@ func computeProjectDefaultScopes(resolver types.ConfigResolverInterface) map[str
 // - window.__saveIdeConfig__(jsonString): Save configuration
 // - window.__ideExecuteCommand__(cmd, args, callback): Execute an LSP command (e.g. "snyk.login", "snyk.logout")
 // - window.__onFormDirtyChange__(isDirty): [Optional] Called when form dirty state changes
+// - window.__ideConfirmationDialog__(message, callback): [Optional] Show a native confirmation modal.
+//   The callback MUST be invoked with a boolean (true = confirmed, false = cancelled).
+//   Required in sandboxed webviews (e.g. VSCode) where window.confirm is blocked.
+//   If not injected, ideBridge.confirm falls back to window.confirm automatically.
 // The IDE can optionally set window.__IS_IDE_AUTOSAVE_ENABLED__ = true to enable auto-save on form changes.
 // The IDE can also call window.getAndSaveIdeConfig() to retrieve and save current form values.
 // The IDE can call window.setAuthToken(token, apiUrl) to inject an authentication token and optional API URL.

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -271,13 +271,14 @@ func computeProjectDefaultScopes(resolver types.ConfigResolverInterface) map[str
 
 // GetConfigHtml renders the configuration dialog HTML using the provided settings.
 // The IDE extension must inject JavaScript functions on the window object:
-// - window.__saveIdeConfig__(jsonString): Save configuration
-// - window.__ideExecuteCommand__(cmd, args, callback): Execute an LSP command (e.g. "snyk.login", "snyk.logout")
-// - window.__onFormDirtyChange__(isDirty): [Optional] Called when form dirty state changes
-// - window.__ideConfirmationDialog__(message, callback): [Optional] Show a native confirmation modal.
-//   The callback MUST be invoked with a boolean (true = confirmed, false = cancelled).
-//   Required in sandboxed webviews (e.g. VSCode) where window.confirm is blocked.
-//   If not injected, ideBridge.confirm falls back to window.confirm automatically.
+//   - window.__saveIdeConfig__(jsonString): Save configuration
+//   - window.__ideExecuteCommand__(cmd, args, callback): Execute an LSP command (e.g. "snyk.login", "snyk.logout")
+//   - window.__onFormDirtyChange__(isDirty): [Optional] Called when form dirty state changes
+//   - window.__ideConfirmationDialog__(message, callback): [Optional] Show a native confirmation modal.
+//     The callback MUST be invoked with a boolean (true = confirmed, false = canceled).
+//     Required in sandboxed webviews (e.g. VSCode) where window.confirm is blocked.
+//     If not injected, ideBridge.confirm falls back to window.confirm automatically.
+//
 // The IDE can optionally set window.__IS_IDE_AUTOSAVE_ENABLED__ = true to enable auto-save on form changes.
 // The IDE can also call window.getAndSaveIdeConfig() to retrieve and save current form values.
 // The IDE can call window.setAuthToken(token, apiUrl) to inject an authentication token and optional API URL.

--- a/infrastructure/configuration/template/js/ide/bridge.js
+++ b/infrastructure/configuration/template/js/ide/bridge.js
@@ -103,17 +103,33 @@
 
 	/**
 	 * Show a confirmation dialog via the IDE native UI.
-	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
-	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
-	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this uses the
+	 * dedicated window.__ideConfirmationDialog__(message, callback) bridge injected
+	 * by the IDE. Falls back to window.confirm() in IDEs that do not inject the
+	 * dedicated bridge (JetBrains, Eclipse, etc.).
+	 *
+	 * The callback is always invoked with a strict boolean: only a literal true
+	 * confirms (fail-closed). Non-boolean results are logged as an error and treated
+	 * as cancel.
+	 *
 	 * @param {string} message - Message to display
-	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 * @param {function} callback - Required. Called with true if confirmed, false if cancelled.
+	 * @throws {TypeError} If callback is missing or not a function (programmer error — fail fast).
 	 */
 	ideBridge.confirm = function (message, callback) {
-		if (typeof window.__ideExecuteCommand__ === "function") {
-			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
-		} else if (typeof callback === "function") {
-			callback(window.confirm(message));
+		if (typeof callback !== "function") {
+			throw new TypeError("ideBridge.confirm: callback is required and must be a function");
+		}
+		function done(result) {
+			if (typeof result !== "boolean" && window.console && console.error) {
+				console.error("ideBridge.confirm: expected boolean result, got", result);
+			}
+			callback(result === true); // fail closed: only literal true confirms
+		}
+		if (typeof window.__ideConfirmationDialog__ === "function") {
+			window.__ideConfirmationDialog__(message, done);
+		} else {
+			done(window.confirm(message));
 		}
 	};
 

--- a/infrastructure/configuration/template/js/ide/bridge.js
+++ b/infrastructure/configuration/template/js/ide/bridge.js
@@ -101,6 +101,22 @@
 		}
 	};
 
+	/**
+	 * Show a confirmation dialog via the IDE native UI.
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
+	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
+	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * @param {string} message - Message to display
+	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 */
+	ideBridge.confirm = function (message, callback) {
+		if (typeof window.__ideExecuteCommand__ === "function") {
+			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
+		} else if (typeof callback === "function") {
+			callback(window.confirm(message));
+		}
+	};
+
 	// Expose window-level functions for IDE to call
 
 	/**

--- a/infrastructure/configuration/template/js/ui/reset-handler.js
+++ b/infrastructure/configuration/template/js/ui/reset-handler.js
@@ -65,14 +65,18 @@
 			return;
 		}
 
-		var defaults = sectionDefaults[section];
-		applyDefaults(defaults);
+		window.ConfigApp.ideBridge.confirm("Reset all settings in this section to defaults?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Trigger dirty tracking update
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			var defaults = sectionDefaults[section];
+			applyDefaults(defaults);
+
+			// Trigger dirty tracking update
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+		});
 	}
 
 	// Handle folder override reset button click
@@ -95,20 +99,24 @@
 			return;
 		}
 
-		resetFolderOverrides(folderPath);
+		window.ConfigApp.ideBridge.confirm("Reset all overrides for this folder?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			resetFolderOverrides(folderPath);
 
-		// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
-		// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
-		// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
-		if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
-			window.ConfigApp.autoSave.getAndSaveIdeConfig();
-		}
+			// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+
+			// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
+			// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
+			// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
+			if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
+				window.ConfigApp.autoSave.getAndSaveIdeConfig();
+			}
+		});
 	}
 
 	// Apply default values to form fields

--- a/js-tests/bridge.test.mjs
+++ b/js-tests/bridge.test.mjs
@@ -96,3 +96,178 @@ test("setAuthToken preserves OAuth visibility classes and shows logout", async (
   assert.equal(authBtn.disabled, true, "authenticate button should be disabled after setAuthToken");
   assert.equal(logoutBtn.disabled, false, "logout button should be enabled after setAuthToken");
 });
+
+// ---------------------------------------------------------------------------
+// ideBridge.confirm — dedicated __ideConfirmationDialog__ bridge
+// ---------------------------------------------------------------------------
+
+test("ideBridge.confirm: __ideConfirmationDialog__ called with the message and a function callback", async () => {
+  const win = await buildDom();
+
+  let receivedMessage = null;
+  let receivedCallback = null;
+  win.__ideConfirmationDialog__ = (msg, cb) => { receivedMessage = msg; receivedCallback = cb; };
+
+  win.ConfigApp.ideBridge.confirm("Are you sure?", () => {});
+
+  assert.equal(receivedMessage, "Are you sure?", "message forwarded to __ideConfirmationDialog__");
+  assert.equal(typeof receivedCallback, "function", "__ideConfirmationDialog__ receives a function callback (done wrapper)");
+});
+
+test("ideBridge.confirm: cb(false) → outer callback called with false (cancel → no save)", async () => {
+  const win = await buildDom();
+  win.__IS_IDE_AUTOSAVE_ENABLED__ = true;
+  const saveCalls = [];
+  win.__saveIdeConfig__ = (json) => saveCalls.push(json);
+
+  let capturedCb;
+  win.__ideConfirmationDialog__ = (_msg, cb) => { capturedCb = cb; };
+
+  let confirmedResult = null;
+  win.ConfigApp.ideBridge.confirm("Reset?", (result) => { confirmedResult = result; });
+
+  capturedCb(false);
+
+  assert.equal(confirmedResult, false, "outer callback receives false");
+  assert.equal(saveCalls.length, 0, "no save triggered when cancelled");
+});
+
+test("ideBridge.confirm: cb(true) → outer callback called with true (confirm → proceeds)", async () => {
+  const win = await buildDom();
+  win.__IS_IDE_AUTOSAVE_ENABLED__ = true;
+  const saveCalls = [];
+  win.__saveIdeConfig__ = (json) => saveCalls.push(json);
+
+  let capturedCb;
+  win.__ideConfirmationDialog__ = (_msg, cb) => { capturedCb = cb; };
+
+  let confirmedResult = null;
+  win.ConfigApp.ideBridge.confirm("Reset?", (result) => { confirmedResult = result; });
+
+  capturedCb(true);
+
+  assert.equal(confirmedResult, true, "outer callback receives true");
+});
+
+test("ideBridge.confirm: non-boolean result logs console.error and is treated as cancel (fail-closed)", async () => {
+  const win = await buildDom();
+
+  let capturedCb;
+  win.__ideConfirmationDialog__ = (_msg, cb) => { capturedCb = cb; };
+
+  const errors = [];
+  win.console = { error: (...args) => errors.push(args) };
+
+  let confirmedResult = null;
+  win.ConfigApp.ideBridge.confirm("Reset?", (result) => { confirmedResult = result; });
+
+  // Pass a non-boolean (object) — should log error and coerce to false (fail-closed)
+  capturedCb({ confirmed: true });
+
+  assert.ok(errors.length > 0, "console.error called for non-boolean result");
+  assert.ok(errors[0].join(" ").includes("expected boolean"), "error message mentions expected boolean");
+  assert.equal(confirmedResult, false, "non-boolean result treated as cancel (fail-closed)");
+});
+
+test("ideBridge.confirm: non-boolean string result also fail-closed", async () => {
+  const win = await buildDom();
+
+  let capturedCb;
+  win.__ideConfirmationDialog__ = (_msg, cb) => { capturedCb = cb; };
+
+  const errors = [];
+  win.console = { error: (...args) => errors.push(args) };
+
+  let confirmedResult = null;
+  win.ConfigApp.ideBridge.confirm("Reset?", (result) => { confirmedResult = result; });
+
+  capturedCb("yes");
+
+  assert.ok(errors.length > 0, "console.error called for string result");
+  assert.equal(confirmedResult, false, "string result treated as cancel (fail-closed)");
+});
+
+test("ideBridge.confirm: no-bridge fallback uses window.confirm (returns true)", async () => {
+  const win = await buildDom();
+  // Ensure no dedicated bridge is present
+  delete win.__ideConfirmationDialog__;
+  win.confirm = () => true;
+
+  let confirmedResult = null;
+  win.ConfigApp.ideBridge.confirm("Reset?", (result) => { confirmedResult = result; });
+
+  assert.equal(confirmedResult, true, "fallback window.confirm true → callback called with true");
+});
+
+test("ideBridge.confirm: no-bridge fallback uses window.confirm (returns false)", async () => {
+  const win = await buildDom();
+  delete win.__ideConfirmationDialog__;
+  win.confirm = () => false;
+
+  let confirmedResult = null;
+  win.ConfigApp.ideBridge.confirm("Reset?", (result) => { confirmedResult = result; });
+
+  assert.equal(confirmedResult, false, "fallback window.confirm false → callback called with false");
+});
+
+test("ideBridge.confirm: missing callback throws TypeError (programmer error — fail fast)", async () => {
+  const win = await buildDom();
+
+  win.__ideConfirmationDialog__ = (_msg, _cb) => {};
+
+  // A missing callback is a coding mistake — confirm must throw loudly, not silently no-op.
+  assert.throws(
+    () => win.ConfigApp.ideBridge.confirm("Reset?"),
+    /callback is required and must be a function/,
+    "confirm with no callback must throw TypeError"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// handleSectionReset — gates applyDefaults behind confirm callback
+// ---------------------------------------------------------------------------
+
+test("handleSectionReset: confirmed=false → no defaults applied (fields unchanged)", async () => {
+  const win = await buildDom();
+
+  // Stub ideBridge.confirm to capture the callback and NOT invoke it yet
+  let pendingConfirmCb = null;
+  win.ConfigApp.ideBridge.confirm = (_msg, cb) => { pendingConfirmCb = cb; };
+
+  // Change a field from its default so we can detect if applyDefaults runs
+  const scanOssEl = win.document.querySelector('[name="snyk_oss_enabled"]');
+  assert.ok(scanOssEl, "snyk_oss_enabled element exists");
+  const originalValue = scanOssEl.checked;
+
+  const btn = win.document.querySelector('.reset-section-btn[data-section="scanConfiguration"]');
+  assert.ok(btn, "scanConfiguration reset button exists");
+  btn.click();
+
+  assert.ok(pendingConfirmCb, "confirm was called on reset button click");
+
+  // Cancel: defaults must NOT be applied
+  pendingConfirmCb(false);
+
+  assert.equal(scanOssEl.checked, originalValue, "snyk_oss_enabled unchanged when reset cancelled");
+});
+
+test("handleSectionReset: confirmed=true → defaults applied", async () => {
+  const win = await buildDom();
+  win.__IS_IDE_AUTOSAVE_ENABLED__ = true;
+
+  // Inject dedicated bridge so we control the confirmation
+  let pendingConfirmCb = null;
+  win.__ideConfirmationDialog__ = (_msg, cb) => { pendingConfirmCb = cb; };
+
+  const btn = win.document.querySelector('.reset-section-btn[data-section="scanConfiguration"]');
+  assert.ok(btn, "scanConfiguration reset button exists");
+  btn.click();
+
+  assert.ok(pendingConfirmCb, "ideConfirmationDialog was called on reset button click");
+
+  // Confirm: defaults should be applied (snyk_oss_enabled default is false per sectionDefaults)
+  pendingConfirmCb(true);
+
+  const scanOssEl = win.document.querySelector('[name="snyk_oss_enabled"]');
+  assert.equal(scanOssEl.checked, false, "snyk_oss_enabled reset to default (false) after confirmed=true");
+});

--- a/js-tests/folder-reset.test.mjs
+++ b/js-tests/folder-reset.test.mjs
@@ -40,6 +40,9 @@ function assertAllNull(entry, fields) {
 // Enable auto-save and spy on the IDE save bridge; returns the list of JSON payloads sent.
 function spySave(win) {
 	win.__IS_IDE_AUTOSAVE_ENABLED__ = true;
+	// window.confirm() returns false in JSDOM, so stub it to auto-accept so ideBridge.confirm()
+	// calls its callback with true and the reset/save proceeds.
+	win.confirm = () => true;
 	const calls = [];
 	win.__saveIdeConfig__ = (jsonString) => calls.push(jsonString);
 	return calls;

--- a/scripts/config-dialog/config_output_multi_project.html
+++ b/scripts/config-dialog/config_output_multi_project.html
@@ -3299,17 +3299,33 @@ if (window.cssVars) {
 
 	/**
 	 * Show a confirmation dialog via the IDE native UI.
-	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
-	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
-	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this uses the
+	 * dedicated window.__ideConfirmationDialog__(message, callback) bridge injected
+	 * by the IDE. Falls back to window.confirm() in IDEs that do not inject the
+	 * dedicated bridge (JetBrains, Eclipse, etc.).
+	 *
+	 * The callback is always invoked with a strict boolean: only a literal true
+	 * confirms (fail-closed). Non-boolean results are logged as an error and treated
+	 * as cancel.
+	 *
 	 * @param {string} message - Message to display
-	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 * @param {function} callback - Required. Called with true if confirmed, false if cancelled.
+	 * @throws {TypeError} If callback is missing or not a function (programmer error — fail fast).
 	 */
 	ideBridge.confirm = function (message, callback) {
-		if (typeof window.__ideExecuteCommand__ === "function") {
-			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
-		} else if (typeof callback === "function") {
-			callback(window.confirm(message));
+		if (typeof callback !== "function") {
+			throw new TypeError("ideBridge.confirm: callback is required and must be a function");
+		}
+		function done(result) {
+			if (typeof result !== "boolean" && window.console && console.error) {
+				console.error("ideBridge.confirm: expected boolean result, got", result);
+			}
+			callback(result === true); // fail closed: only literal true confirms
+		}
+		if (typeof window.__ideConfirmationDialog__ === "function") {
+			window.__ideConfirmationDialog__(message, done);
+		} else {
+			done(window.confirm(message));
 		}
 	};
 

--- a/scripts/config-dialog/config_output_multi_project.html
+++ b/scripts/config-dialog/config_output_multi_project.html
@@ -3264,6 +3264,22 @@ if (window.cssVars) {
 		}
 	};
 
+	/**
+	 * Show a confirmation dialog via the IDE native UI.
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
+	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
+	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * @param {string} message - Message to display
+	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 */
+	ideBridge.confirm = function (message, callback) {
+		if (typeof window.__ideExecuteCommand__ === "function") {
+			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
+		} else if (typeof callback === "function") {
+			callback(window.confirm(message));
+		}
+	};
+
 	// Expose window-level functions for IDE to call
 
 	/**
@@ -3709,14 +3725,18 @@ if (window.cssVars) {
 			return;
 		}
 
-		var defaults = sectionDefaults[section];
-		applyDefaults(defaults);
+		window.ConfigApp.ideBridge.confirm("Reset all settings in this section to defaults?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Trigger dirty tracking update
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			var defaults = sectionDefaults[section];
+			applyDefaults(defaults);
+
+			// Trigger dirty tracking update
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+		});
 	}
 
 	// Handle folder override reset button click
@@ -3739,20 +3759,24 @@ if (window.cssVars) {
 			return;
 		}
 
-		resetFolderOverrides(folderPath);
+		window.ConfigApp.ideBridge.confirm("Reset all overrides for this folder?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			resetFolderOverrides(folderPath);
 
-		// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
-		// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
-		// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
-		if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
-			window.ConfigApp.autoSave.getAndSaveIdeConfig();
-		}
+			// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+
+			// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
+			// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
+			// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
+			if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
+				window.ConfigApp.autoSave.getAndSaveIdeConfig();
+			}
+		});
 	}
 
 	// Apply default values to form fields

--- a/scripts/config-dialog/config_output_no_projects.html
+++ b/scripts/config-dialog/config_output_no_projects.html
@@ -2047,6 +2047,22 @@ if (window.cssVars) {
 		}
 	};
 
+	/**
+	 * Show a confirmation dialog via the IDE native UI.
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
+	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
+	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * @param {string} message - Message to display
+	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 */
+	ideBridge.confirm = function (message, callback) {
+		if (typeof window.__ideExecuteCommand__ === "function") {
+			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
+		} else if (typeof callback === "function") {
+			callback(window.confirm(message));
+		}
+	};
+
 	// Expose window-level functions for IDE to call
 
 	/**
@@ -2492,14 +2508,18 @@ if (window.cssVars) {
 			return;
 		}
 
-		var defaults = sectionDefaults[section];
-		applyDefaults(defaults);
+		window.ConfigApp.ideBridge.confirm("Reset all settings in this section to defaults?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Trigger dirty tracking update
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			var defaults = sectionDefaults[section];
+			applyDefaults(defaults);
+
+			// Trigger dirty tracking update
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+		});
 	}
 
 	// Handle folder override reset button click
@@ -2522,20 +2542,24 @@ if (window.cssVars) {
 			return;
 		}
 
-		resetFolderOverrides(folderPath);
+		window.ConfigApp.ideBridge.confirm("Reset all overrides for this folder?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			resetFolderOverrides(folderPath);
 
-		// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
-		// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
-		// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
-		if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
-			window.ConfigApp.autoSave.getAndSaveIdeConfig();
-		}
+			// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+
+			// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
+			// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
+			// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
+			if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
+				window.ConfigApp.autoSave.getAndSaveIdeConfig();
+			}
+		});
 	}
 
 	// Apply default values to form fields

--- a/scripts/config-dialog/config_output_no_projects.html
+++ b/scripts/config-dialog/config_output_no_projects.html
@@ -2082,17 +2082,33 @@ if (window.cssVars) {
 
 	/**
 	 * Show a confirmation dialog via the IDE native UI.
-	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
-	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
-	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this uses the
+	 * dedicated window.__ideConfirmationDialog__(message, callback) bridge injected
+	 * by the IDE. Falls back to window.confirm() in IDEs that do not inject the
+	 * dedicated bridge (JetBrains, Eclipse, etc.).
+	 *
+	 * The callback is always invoked with a strict boolean: only a literal true
+	 * confirms (fail-closed). Non-boolean results are logged as an error and treated
+	 * as cancel.
+	 *
 	 * @param {string} message - Message to display
-	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 * @param {function} callback - Required. Called with true if confirmed, false if cancelled.
+	 * @throws {TypeError} If callback is missing or not a function (programmer error — fail fast).
 	 */
 	ideBridge.confirm = function (message, callback) {
-		if (typeof window.__ideExecuteCommand__ === "function") {
-			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
-		} else if (typeof callback === "function") {
-			callback(window.confirm(message));
+		if (typeof callback !== "function") {
+			throw new TypeError("ideBridge.confirm: callback is required and must be a function");
+		}
+		function done(result) {
+			if (typeof result !== "boolean" && window.console && console.error) {
+				console.error("ideBridge.confirm: expected boolean result, got", result);
+			}
+			callback(result === true); // fail closed: only literal true confirms
+		}
+		if (typeof window.__ideConfirmationDialog__ === "function") {
+			window.__ideConfirmationDialog__(message, done);
+		} else {
+			done(window.confirm(message));
 		}
 	};
 

--- a/scripts/config-dialog/config_output_single_solution.html
+++ b/scripts/config-dialog/config_output_single_solution.html
@@ -2382,17 +2382,33 @@ if (window.cssVars) {
 
 	/**
 	 * Show a confirmation dialog via the IDE native UI.
-	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
-	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
-	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this uses the
+	 * dedicated window.__ideConfirmationDialog__(message, callback) bridge injected
+	 * by the IDE. Falls back to window.confirm() in IDEs that do not inject the
+	 * dedicated bridge (JetBrains, Eclipse, etc.).
+	 *
+	 * The callback is always invoked with a strict boolean: only a literal true
+	 * confirms (fail-closed). Non-boolean results are logged as an error and treated
+	 * as cancel.
+	 *
 	 * @param {string} message - Message to display
-	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 * @param {function} callback - Required. Called with true if confirmed, false if cancelled.
+	 * @throws {TypeError} If callback is missing or not a function (programmer error — fail fast).
 	 */
 	ideBridge.confirm = function (message, callback) {
-		if (typeof window.__ideExecuteCommand__ === "function") {
-			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
-		} else if (typeof callback === "function") {
-			callback(window.confirm(message));
+		if (typeof callback !== "function") {
+			throw new TypeError("ideBridge.confirm: callback is required and must be a function");
+		}
+		function done(result) {
+			if (typeof result !== "boolean" && window.console && console.error) {
+				console.error("ideBridge.confirm: expected boolean result, got", result);
+			}
+			callback(result === true); // fail closed: only literal true confirms
+		}
+		if (typeof window.__ideConfirmationDialog__ === "function") {
+			window.__ideConfirmationDialog__(message, done);
+		} else {
+			done(window.confirm(message));
 		}
 	};
 

--- a/scripts/config-dialog/config_output_single_solution.html
+++ b/scripts/config-dialog/config_output_single_solution.html
@@ -2347,6 +2347,22 @@ if (window.cssVars) {
 		}
 	};
 
+	/**
+	 * Show a confirmation dialog via the IDE native UI.
+	 * In VSCode the sandboxed webview blocks window.confirm(), so this routes through
+	 * the executeCommand bridge to show a native modal. Falls back to window.confirm()
+	 * in IDEs that inject no bridge (JetBrains, Eclipse, etc.).
+	 * @param {string} message - Message to display
+	 * @param {function} callback - Called with true if confirmed, false if cancelled
+	 */
+	ideBridge.confirm = function (message, callback) {
+		if (typeof window.__ideExecuteCommand__ === "function") {
+			window.__ideExecuteCommand__("snyk.showConfirmationDialog", [message], callback);
+		} else if (typeof callback === "function") {
+			callback(window.confirm(message));
+		}
+	};
+
 	// Expose window-level functions for IDE to call
 
 	/**
@@ -2792,14 +2808,18 @@ if (window.cssVars) {
 			return;
 		}
 
-		var defaults = sectionDefaults[section];
-		applyDefaults(defaults);
+		window.ConfigApp.ideBridge.confirm("Reset all settings in this section to defaults?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Trigger dirty tracking update
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			var defaults = sectionDefaults[section];
+			applyDefaults(defaults);
+
+			// Trigger dirty tracking update
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+		});
 	}
 
 	// Handle folder override reset button click
@@ -2822,20 +2842,24 @@ if (window.cssVars) {
 			return;
 		}
 
-		resetFolderOverrides(folderPath);
+		window.ConfigApp.ideBridge.confirm("Reset all overrides for this folder?", function (confirmed) {
+			if (!confirmed) return;
 
-		// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
-		if (window.dirtyTracker) {
-			window.dirtyTracker.runChangeListeners();
-			window.dirtyTracker.checkDirty();
-		}
+			resetFolderOverrides(folderPath);
 
-		// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
-		// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
-		// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
-		if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
-			window.ConfigApp.autoSave.getAndSaveIdeConfig();
-		}
+			// Keep dirty state in sync (a reset changes no DOM input, so no change/blur event fires).
+			if (window.dirtyTracker) {
+				window.dirtyTracker.runChangeListeners();
+				window.dirtyTracker.checkDirty();
+			}
+
+			// Persist the reset immediately on every IDE. We call getAndSaveIdeConfig() directly rather
+			// than formState.triggerChangeHandlers(), which only saves on auto-save IDEs — a reset must
+			// be a commit point everywhere (incl. OK/Cancel IDEs), since no input event would carry it.
+			if (window.ConfigApp.autoSave && window.ConfigApp.autoSave.getAndSaveIdeConfig) {
+				window.ConfigApp.autoSave.getAndSaveIdeConfig();
+			}
+		});
 	}
 
 	// Apply default values to form fields


### PR DESCRIPTION
### Description

VSCode sandboxed webviews block window.confirm() silently (no allow-modals). Add ideBridge.confirm(message, callback) that routes through the existing executeCommand bridge to snyk.showConfirmationDialog in VSCode, falling back to window.confirm() in IDEs with no bridge (JetBrains, Eclipse). Both reset handlers (section and folder override) now gate their work behind this callback.

Only merge if the VSCode side is also mergable (https://github.com/snyk/vscode-extension/pull/771)

### Checklist

- [ ] Tests added and all succeed
  - Not yet!
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
  - N/A
- [ ] License file updated, if new 3rd-party dependency is introduced
  - N/A
