### PR TITLE
fix: change filter icon colour and saturation to reflect filter state [IDE-2168]

### DIFF
--- a/domain/ide/treeview/template/styles.css
+++ b/domain/ide/treeview/template/styles.css
@@ -408,26 +408,31 @@ body {
   vertical-align: middle;
 }
 
-.filter-btn-icon:not(.filter-active) {
-  opacity: 0.4;
-}
-
+/* The filter icons have three states:
+  - Enabled for all folders (solid colour)
+  - Mixed (some folders enabled, some disabled) (dimmed colour)
+  - Disabled for all folders (greyed-out colour)
+ */
 .filter-btn-icon.filter-active {
+  opacity: 1;
+  filter: none;
   background-color: transparent;
   border-color: transparent;
   color: inherit;
-  opacity: 1;
 }
-/* "Mixed" state — the open folders disagree on this severity (some show it,
-   some hide it), which a single workspace-wide toolbar button can't render as a
-   plain on/off. Shown translucent with a dashed accent border so it reads as
-   indeterminate, distinct from both the solid active and the dim inactive states.
-   The explanatory tooltip comes from the button's title attribute. Clicking it
-   resolves the mismatch by enabling the severity for all folders (see tree.js). */
+
 .filter-btn-icon.filter-mixed {
   opacity: 0.65;
-  border-color: var(--focus-border);
-  border-style: dashed;
+  filter: none;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.filter-btn-icon:not(.filter-active):not(.filter-mixed) {
+  opacity: 0.4;
+  filter: grayscale(1);
+  background-color: transparent;
+  border-color: transparent;
 }
 
 /* Action buttons (expand/collapse all) */

--- a/domain/ide/treeview/template/styles.css
+++ b/domain/ide/treeview/template/styles.css
@@ -422,14 +422,14 @@ body {
 }
 
 .filter-btn-icon.filter-mixed {
-  opacity: 0.65;
+  opacity: 0.7;
   filter: none;
   background-color: transparent;
   border-color: transparent;
 }
 
 .filter-btn-icon:not(.filter-active):not(.filter-mixed) {
-  opacity: 0.4;
+  opacity: 0.3;
   filter: grayscale(1);
   background-color: transparent;
   border-color: transparent;


### PR DESCRIPTION
### Description

Providing feedback from Tars on visual presentation of Severity Filters in the tree view.

Enabled filters are unchanged.
Disabled filters are now desaturated.
Mixed severities are indicated by dimming the filter toggle.



### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
