### PR TITLE
fix: set prodsec orb back to @1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  prodsec: snyk/prodsec-orb@1.2.20
+  prodsec: snyk/prodsec-orb@1
 
 jobs:
   security-scans:


### PR DESCRIPTION
### Description

We just had too many vulns reported due to the Go version that it upset the runner, since we bumped the Go version we're all good.

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced
