### PR TITLE
fix: make Workspace.Folders() return a deterministic order [IDE-2149]

### DIFF
--- a/domain/ide/command/folder_handler_test.go
+++ b/domain/ide/command/folder_handler_test.go
@@ -375,3 +375,55 @@ func Test_BuildLspConfiguration_PopulatesSourceFromResolver(t *testing.T) {
 	assert.Equal(t, "ldx-sync-locked", lspConfig.Settings[types.SettingApiEndpoint].Source)
 	assert.True(t, lspConfig.Settings[types.SettingApiEndpoint].IsLocked)
 }
+
+// Test_BuildLspConfiguration_FolderConfigsStableOrder verifies that BuildLspConfiguration produces
+// a deterministically ordered FolderConfigs slice regardless of Go map iteration order.
+//
+// Root cause (IDE-2149 follow-up): Workspace.Folders() ranges over a map, so the slice order is
+// randomized each call. reflect.DeepEqual on two consecutive BuildLspConfiguration calls can return
+// false even when nothing changed, causing the $/snyk.configuration guard to fire and re-trigger the
+// infinite IDE settings refresh loop on workspaces with 2+ folders.
+//
+// Fix: FolderConfigs must be sorted by FolderPath before returning so the slice is stable across calls.
+//
+// This test runs 50 consecutive BuildLspConfiguration calls with 8 folders whose paths are in
+// intentionally non-sorted alphabetical order (all under one shared base dir so the full paths are
+// non-sorted) and asserts:
+//  1. The FolderPath slice is sorted ascending on every call.
+//  2. Every call produces a result that is reflect.DeepEqual to the first call.
+func Test_BuildLspConfiguration_FolderConfigsStableOrder(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	engineConfig := engine.GetConfiguration()
+
+	// All folders share a single base dir so the full absolute paths are sorted only by the suffix,
+	// not by any auto-incrementing temp-dir counter. Insert them in non-sorted suffix order to
+	// maximize the chance that randomized map iteration surfaces a different order on each call.
+	base := t.TempDir()
+	suffixes := []string{"h", "a", "f", "b", "g", "c", "e", "d"}
+	folderPaths := make([]types.FilePath, len(suffixes))
+	for i, s := range suffixes {
+		folderPaths[i] = types.FilePath(base + "/workspace-" + s)
+	}
+	_, _ = workspaceutil.SetupWorkspace(t, engine, folderPaths...)
+
+	resolver := newConfigResolverForTest(engine)
+
+	first := BuildLspConfiguration(engineConfig, engine, engine.GetLogger(), resolver)
+	require.Len(t, first.FolderConfigs, len(folderPaths), "all folders must appear in the result")
+
+	// Assert sorted order on the first result.
+	for i := 1; i < len(first.FolderConfigs); i++ {
+		assert.LessOrEqual(t, string(first.FolderConfigs[i-1].FolderPath), string(first.FolderConfigs[i].FolderPath),
+			"FolderConfigs[%d].FolderPath (%q) must be <= FolderConfigs[%d].FolderPath (%q)",
+			i-1, first.FolderConfigs[i-1].FolderPath, i, first.FolderConfigs[i].FolderPath)
+	}
+
+	// Run 50 iterations; a map-order regression will almost certainly produce a different order
+	// within that many iterations, making the DeepEqual guard fail.
+	for iter := 0; iter < 50; iter++ {
+		got := BuildLspConfiguration(engineConfig, engine, engine.GetLogger(), resolver)
+		require.Equal(t, first, got,
+			"iteration %d: BuildLspConfiguration result must be identical to the first call (got ordering mismatch)",
+			iter)
+	}
+}

--- a/domain/ide/workspace/workspace.go
+++ b/domain/ide/workspace/workspace.go
@@ -19,6 +19,7 @@ package workspace
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"sync"
 
 	"github.com/rs/zerolog"
@@ -202,14 +203,19 @@ func (w *Workspace) GetFolderContaining(path types.FilePath) types.Folder {
 	return nil
 }
 
-func (w *Workspace) Folders() (folder []types.Folder) {
-	w.mutex.RLock()
-	defer w.mutex.RUnlock()
-	folders := make([]types.Folder, 0, len(w.folders))
-	for _, folder := range w.folders {
-		folders = append(folders, folder)
-	}
-
+func (w *Workspace) Folders() []types.Folder {
+	folders := func() []types.Folder {
+		w.mutex.RLock()
+		defer w.mutex.RUnlock()
+		result := make([]types.Folder, 0, len(w.folders))
+		for _, folder := range w.folders {
+			result = append(result, folder)
+		}
+		return result
+	}()
+	sort.Slice(folders, func(i, j int) bool {
+		return folders[i].Path() < folders[j].Path()
+	})
 	return folders
 }
 

--- a/domain/ide/workspace/workspace_test.go
+++ b/domain/ide/workspace/workspace_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
@@ -120,4 +121,61 @@ func Test_AddAndRemoveFoldersAndReturnFolderList(t *testing.T) {
 	assert.Nil(t, w.GetFolderContaining(toBeRemoved))
 
 	assert.Len(t, folderList, 2)
+}
+
+// Test_Folders_ReturnsSortedOrder verifies that Workspace.Folders() always returns a deterministically
+// ordered slice sorted by folder.Path() ascending, regardless of Go map iteration order.
+//
+// Root cause (IDE-2149 follow-up): Workspace.Folders() ranges over a map, so the returned slice
+// order is randomized per call. Any consumer that compares two consecutive results — notably the
+// reflect.DeepEqual guard that suppresses the $/snyk.configuration infinite refresh loop — can see
+// a spurious difference and misfire. Fixing at the source makes every Folders() consumer deterministic.
+//
+// This test adds 8 folders in intentionally non-sorted path order and asserts:
+//  1. The returned slice is sorted by Path() ascending on every call.
+//  2. Fifty consecutive calls all produce a reflect.DeepEqual result.
+func Test_Folders_ReturnsSortedOrder(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	conf := engine.GetConfiguration()
+	logger := engine.GetLogger()
+	sc := &scanner.TestScanner{}
+	scanNotifier := scanner.NewMockScanNotifier()
+	notifier := notification.NewNotifier()
+	scanStateAggregator := scanstates.NewNoopStateAggregator()
+
+	w := New(conf, logger, performance.NewInstrumentor(), sc, nil, scanNotifier, notifier, nil, scanStateAggregator, featureflag.NewFakeService(), defaultResolver(engine), engine)
+
+	// Insert paths in intentionally non-sorted order so randomized map iteration is likely to
+	// expose a different ordering on repeated calls if the source is not sorted.
+	paths := []types.FilePath{
+		"/workspace/h",
+		"/workspace/a",
+		"/workspace/f",
+		"/workspace/b",
+		"/workspace/g",
+		"/workspace/c",
+		"/workspace/e",
+		"/workspace/d",
+	}
+	for _, p := range paths {
+		w.AddFolder(NewFolder(conf, logger, p, string(p), sc, nil, scanNotifier, notifier, nil, scanStateAggregator, featureflag.NewFakeService(), defaultResolver(engine), engine))
+	}
+
+	first := w.Folders()
+	require.Len(t, first, len(paths), "all folders must be returned")
+
+	// Assert sorted ascending order.
+	for i := 1; i < len(first); i++ {
+		assert.LessOrEqual(t, string(first[i-1].Path()), string(first[i].Path()),
+			"Folders()[%d].Path() (%q) must be <= Folders()[%d].Path() (%q)",
+			i-1, first[i-1].Path(), i, first[i].Path())
+	}
+
+	// 50 consecutive calls must all be reflect.DeepEqual to the first call.
+	for iter := 0; iter < 50; iter++ {
+		got := w.Folders()
+		require.Equal(t, first, got,
+			"iteration %d: Folders() result must be identical to the first call (path order mismatch)",
+			iter)
+	}
 }

--- a/infrastructure/analytics/config_analytics_test.go
+++ b/infrastructure/analytics/config_analytics_test.go
@@ -178,7 +178,7 @@ func TestSendConfigChangedAnalytics_OrgSelection(t *testing.T) {
 				mockFolder2.EXPECT().Path().Return(folder2Path).AnyTimes()
 
 				mockWorkspace := mock_types.NewMockWorkspace(ctrl)
-				// FYI, mock returns deterministic slice order, but real Workspace.Folders() returns the slice in a random order
+				// FYI, both the mock and the real Workspace.Folders() now return a deterministic, ascending path-sorted slice
 				mockWorkspace.EXPECT().Folders().Return([]types.Folder{mockFolder1, mockFolder2}).AnyTimes()
 
 				return mockWorkspace

--- a/infrastructure/authentication/auth_service_impl_test.go
+++ b/infrastructure/authentication/auth_service_impl_test.go
@@ -121,7 +121,7 @@ func TestAuthenticationAnalytics_OrgSelection(t *testing.T) {
 				mockFolder2.EXPECT().Path().Return(folder2Path).AnyTimes()
 
 				mockWorkspace := mock_types.NewMockWorkspace(ctrl)
-				// FYI, mock returns deterministic slice order, but real Workspace.Folders() returns the slice in a random order
+				// FYI, both the mock and the real Workspace.Folders() now return a deterministic, ascending path-sorted slice
 				mockWorkspace.EXPECT().Folders().Return([]types.Folder{mockFolder1, mockFolder2}).AnyTimes()
 
 				return mockWorkspace


### PR DESCRIPTION
### **User description**
## Summary
Follow-up to #1348. `Workspace.Folders()` built its slice by ranging over the internal `folders` map, so element order was randomized per call. The `reflect.DeepEqual(beforeLspConfig, afterLspConfig)` guard in `processConfigSettings` — added in #1348 to suppress no-op `$/snyk.configuration` sends — saw spurious inequality on workspaces with two or more folders, re-triggering the infinite IDE settings refresh loop the guard was meant to prevent (IDE-2149).

## Fix
- `domain/ide/workspace/workspace.go` — `Folders()` now returns a deterministic, `Path()`-ascending slice. The map snapshot is taken under `RLock` inside a defer-protected closure and sorted **outside** the lock, so the read lock is released even on panic and is not held during the sort. Fixing at the source makes all `Folders()` callers deterministic, not just the one feeding the guard.
- Tests — added a workspace-layer unit test (`Test_Folders_ReturnsSortedOrder`) asserting sorted, stable order across consecutive calls; retained the command-layer `BuildLspConfiguration` stability test. Corrected two now-stale comments that described `Folders()` as returning random order.

## Test plan
- [x] `make test` (full unit + JS suites) green locally; stage recorded for the commit
- [x] `make lint` — 0 issues
- [x] Targeted `-race` runs of both stability tests pass across repeated iterations

## Deferred (pre-existing, out of scope)
- `GetFolderTrust`, `GetFolderContaining`, and `Issues()`/`Issue()` read `w.folders` without holding the mutex — pre-existing latent data races, worth a separate hardening PR.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Ensure deterministic order for `Workspace.Folders()`.

- Fixes infinite IDE settings refresh loops.

- Adds new unit tests for deterministic ordering.

- Updates related tests to reflect ordering changes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Workspace.Folders() map iteration] --> B(Original: Random Order);
  B --> C{Spurious Diffs};
  C --> D[Infinite Settings Loop];
  A --> E[Modified: Sort by Path];
  E --> F(Deterministic Order);
  F --> G[Stability];
  G --> H(New Tests: Folders() & BuildLspConfiguration);
  G --> I(Updated Comments);
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.go</strong><dd><code>Sort Workspace.Folders() output by path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/ide/workspace/workspace.go

<ul><li>Implemented sorting of the folder slice by path before returning from <br><code>Folders()</code>.<br> <li> The read lock is now held only during the map snapshot, not during <br>sorting.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1361/changes#diff-94caf15aa8dbede6c14076876272de2f4156d51238e7862b553fbf6cca8d9a25">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>folder_handler_test.go</strong><dd><code>Add test for stable BuildLspConfiguration folder order</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/ide/command/folder_handler_test.go

<ul><li>Added <code>Test_BuildLspConfiguration_FolderConfigsStableOrder</code> to verify <br>deterministic folder config ordering.<br> <li> This test asserts stable output over multiple calls to <br><code>BuildLspConfiguration</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1361/changes#diff-657ad7fa06e97a16b4e8eb7cddc64cd5e53343e6513ef874563e83ffd694416b">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace_test.go</strong><dd><code>Add test for deterministic Workspace.Folders() output</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/ide/workspace/workspace_test.go

<ul><li>Added <code>Test_Folders_ReturnsSortedOrder</code> to directly test <br><code>Workspace.Folders()</code>.<br> <li> The new test verifies consistent sorted output and stability across <br>multiple calls.<br> <li> Updated comments to reflect the deterministic ordering fix.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1361/changes#diff-8b15a4314c4b8fec249174af4d164a17c6e0f8686690a5a03db609fc40cb9afd">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_analytics_test.go</strong><dd><code>Update comment about folder order determinism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/analytics/config_analytics_test.go

<ul><li>Updated a comment in <code>TestSendConfigChangedAnalytics_OrgSelection</code>.<br> <li> The comment now correctly states that <code>Workspace.Folders()</code> returns a <br>deterministic, sorted slice.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1361/changes#diff-c934e75afbe1227a96324d77f8588c3bbc123dd6c7aa6ca5a4e26ab29dddd48b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth_service_impl_test.go</strong><dd><code>Update comment on Workspace.Folders() deterministic return</code></dd></summary>
<hr>

infrastructure/authentication/auth_service_impl_test.go

<ul><li>Updated a comment in <code>TestAuthenticationAnalytics_OrgSelection</code>.<br> <li> The comment now reflects that <code>Workspace.Folders()</code> returns a <br>deterministic, path-sorted slice.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1361/changes#diff-33e0f870d9c9bdfd37c19b41becbbf26cf91138dc595504836ca8d5d5638b770">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

