### PR TITLE
fix: use configured CLI release channel instead of runtime version [IDE-2133]

### DIFF
--- a/infrastructure/cli/install/releases.go
+++ b/infrastructure/cli/install/releases.go
@@ -28,9 +28,11 @@ import (
 	"time"
 
 	http2 "github.com/snyk/code-client-go/http"
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 const DefaultBaseURL = "https://downloads.snyk.io"
@@ -126,6 +128,12 @@ func (r *CLIRelease) GetLatestRelease() (*Release, error) {
 
 func getDistributionChannel(engine workflow.Engine) string {
 	logger := engine.GetLogger().With().Str("method", "getDistributionChannel").Logger()
+
+	if configured := engine.GetConfiguration().GetString(configresolver.UserGlobalKey(types.SettingCliReleaseChannel)); configured != "" {
+		logger.Debug().Str("configuredChannel", configured).Msg("using configured release channel")
+		return configured
+	}
+
 	info := engine.GetRuntimeInfo()
 	if info == nil {
 		logger.Debug().Msg("no runtime info, assuming stable")
@@ -145,6 +153,11 @@ func getDistributionChannel(engine workflow.Engine) string {
 	return "stable"
 }
 
+// isKnownChannel reports whether s is a named release channel rather than a pinned CLI version.
+func isKnownChannel(s string) bool {
+	return s == "stable" || s == "rc" || s == "preview"
+}
+
 func GetCLIDownloadURL(engine workflow.Engine, baseURL string, httpClient http2.HTTPClient) string {
 	return GetCLIDownloadURLForProtocol(engine, baseURL, httpClient, config.LsProtocolVersion)
 }
@@ -157,7 +170,13 @@ func GetLSDownloadURL(engine workflow.Engine, httpClient http2.HTTPClient) strin
 func GetCLIDownloadURLForProtocol(engine workflow.Engine, baseURL string, httpClient http2.HTTPClient, protocolVersion string) string {
 	logger := engine.GetLogger().With().Str("method", "getCLIDownloadURLForProtocol").Logger()
 	defaultFallBack := "https://github.com/snyk/cli/releases"
+	discovery := Discovery{}
 	releaseChannel := getDistributionChannel(engine)
+	if !isKnownChannel(releaseChannel) {
+		// releaseChannel is a pinned CLI version (e.g. "v1.1292.0"), not a named channel.
+		pinnedVersion := strings.TrimPrefix(releaseChannel, "v")
+		return fmt.Sprintf("%s/cli/v%s/%s", baseURL, pinnedVersion, discovery.ExecutableName(false))
+	}
 	versionURL := fmt.Sprintf("%s/cli/%s/ls-protocol-version-%s", baseURL, releaseChannel, protocolVersion)
 
 	logger.Debug().Str("versionURL", versionURL).Msg("determined base version URL")
@@ -185,7 +204,6 @@ func GetCLIDownloadURLForProtocol(engine workflow.Engine, baseURL string, httpCl
 	version := string(versionBytes)
 	logger.Debug().Str("version", version).Msg("retrieved version from web")
 
-	discovery := Discovery{}
 	downloadURL := fmt.Sprintf("%s/cli/v%s/%s", baseURL, version, discovery.ExecutableName(false))
 	return downloadURL
 }

--- a/infrastructure/cli/install/releases_test.go
+++ b/infrastructure/cli/install/releases_test.go
@@ -32,11 +32,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/code-client-go/http/mocks"
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 func Test_GetLatestRelease_downloadURLShouldBeNotEmpty(t *testing.T) {
@@ -86,6 +88,32 @@ func Test_getDistributionChannel(t *testing.T) {
 		channel := getDistributionChannel(engine)
 
 		assert.Equal(t, "rc", channel)
+	})
+	t.Run("configured setting overrides runtime version", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		runtimeInfo := runtimeinfo.New(
+			runtimeinfo.WithName("snyk-cli"),
+			runtimeinfo.WithVersion("v1.1234.4-preview."),
+		)
+		engine.SetRuntimeInfo(runtimeInfo)
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliReleaseChannel), "rc")
+
+		channel := getDistributionChannel(engine)
+
+		assert.Equal(t, "rc", channel)
+	})
+	t.Run("configured pinned version overrides runtime version", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		runtimeInfo := runtimeinfo.New(
+			runtimeinfo.WithName("snyk-cli"),
+			runtimeinfo.WithVersion("v1.1234.4"),
+		)
+		engine.SetRuntimeInfo(runtimeInfo)
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliReleaseChannel), "v1.1292.0")
+
+		channel := getDistributionChannel(engine)
+
+		assert.Equal(t, "v1.1292.0", channel)
 	})
 }
 
@@ -166,6 +194,18 @@ func Test_GetCLIDownloadURL(t *testing.T) {
 		actual := GetCLIDownloadURL(engine, DefaultBaseURL, httpClient)
 
 		assert.Equal(t, "https://downloads.snyk.io/cli/v1.234-preview./"+name, actual)
+	})
+	t.Run("CLI, pinned version, skips protocol lookup", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliReleaseChannel), "v1.1292.0")
+		ctrl := gomock.NewController(t)
+		httpClient := mocks.NewMockHTTPClient(ctrl)
+		httpClient.EXPECT().Do(gomock.Any()).Times(0)
+		discovery := Discovery{}
+
+		actual := GetCLIDownloadURL(engine, DefaultBaseURL, httpClient)
+
+		assert.Equal(t, "https://downloads.snyk.io/cli/v1.1292.0/"+discovery.ExecutableName(false), actual)
 	})
 }
 

--- a/infrastructure/configuration/config_html.go
+++ b/infrastructure/configuration/config_html.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/snyk-ls/application/config"
@@ -307,8 +308,8 @@ func (r *ConfigHtmlRenderer) GetConfigHtml(settings map[string]any, folderConfig
 		}
 	}
 
-	// Get CLI release channel from runtime version
-	cliReleaseChannel := getCliReleaseChannel(r.engine)
+	// Get CLI release channel from the configured setting, falling back to runtime version
+	cliReleaseChannel := getCliReleaseChannel(conf, r.engine)
 
 	// Build DefaultsScopes for project default indicator rendering
 	defaultsScopes := computeProjectDefaultScopes(r.configResolver)
@@ -379,8 +380,13 @@ func isEclipse(integrationName string) bool {
 	return integrationName == "ECLIPSE"
 }
 
-// getCliReleaseChannel derives the CLI release channel from the runtime version
-func getCliReleaseChannel(engine workflow.Engine) string {
+// getCliReleaseChannel returns the configured CLI release channel, falling back to a
+// runtime-version-derived value only when the setting has never been configured.
+func getCliReleaseChannel(conf configuration.Configuration, engine workflow.Engine) string {
+	if configured := conf.GetString(configresolver.UserGlobalKey(types.SettingCliReleaseChannel)); configured != "" {
+		return configured
+	}
+
 	info := engine.GetRuntimeInfo()
 	if info == nil {
 		return "stable"

--- a/infrastructure/configuration/config_html_test.go
+++ b/infrastructure/configuration/config_html_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	gafconfiguration "github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
+	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -939,4 +940,35 @@ func TestConfigHtml_FormFieldNamesMatchRegisteredSettings(t *testing.T) {
 		t.Errorf("Found %d HTML form field name(s) that don't match registered pflag settings:\n%s",
 			len(violations), strings.Join(violations, "\n"))
 	}
+}
+
+func TestGetCliReleaseChannel(t *testing.T) {
+	t.Run("falls back to runtime version when unconfigured", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		engine.SetRuntimeInfo(runtimeinfo.New(runtimeinfo.WithVersion("v1.1234.4-preview.")))
+
+		channel := getCliReleaseChannel(engine.GetConfiguration(), engine)
+
+		assert.Equal(t, "preview", channel)
+	})
+
+	t.Run("prefers configured channel over runtime version", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		engine.SetRuntimeInfo(runtimeinfo.New(runtimeinfo.WithVersion("v1.1234.4-preview.")))
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliReleaseChannel), "stable")
+
+		channel := getCliReleaseChannel(engine.GetConfiguration(), engine)
+
+		assert.Equal(t, "stable", channel)
+	})
+
+	t.Run("prefers configured pinned version over runtime version", func(t *testing.T) {
+		engine := testutil.UnitTest(t)
+		engine.SetRuntimeInfo(runtimeinfo.New(runtimeinfo.WithVersion("v1.1234.4")))
+		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliReleaseChannel), "v1.1292.0")
+
+		channel := getCliReleaseChannel(engine.GetConfiguration(), engine)
+
+		assert.Equal(t, "v1.1292.0", channel)
+	})
 }


### PR DESCRIPTION
## Summary
- HTML settings page and CLI download logic both derived the release channel from the running binary's version instead of reading the user-configured `cli_release_channel` setting, so changes to the setting silently reverted after restart.
- CLI download path now also handles a pinned CLI version (not just named channels: `stable`/`rc`/`preview`) by building the download URL directly instead of routing it through the channel-keyed protocol-lookup endpoint.

## Test plan
- [x] `make test` passing at this commit
- [x] New unit tests: configured channel/pinned-version override runtime-derived value (both `config_html.go` and `releases.go`)
- [x] `make lint-fix` clean