### PR TITLE
fix: stabilize Test_E2E_EndpointChangeAfterInitializationClearsToken flaky on windows [IDE-2179]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ brain/
 .snyk-code-output.json
 .snyk-code-output.err
 .verification-result.*
+.verify-report
+.localtmp

--- a/infrastructure/authentication/auth_configuration.go
+++ b/infrastructure/authentication/auth_configuration.go
@@ -159,6 +159,23 @@ func newOAuthStorageBridgeCallback(authenticationService AuthenticationService) 
 	return func(_ string, value any) {
 		// an empty struct marks an empty token, so we stay with empty string if the cast fails
 		newToken, _ := value.(string)
+		// Drop empty-token storage updates. The bridge exists only to propagate a newly
+		// written/rotated (non-empty) OAuth token from storage to the auth service.
+		// Credential clears are always driven synchronously through updateCredentials /
+		// logout (service → storage), so an empty value arriving here (e.g. the OAuth key
+		// cleared during the init auto-auth logout) is only ever a redundant echo. Queuing
+		// it lets the async worker apply updateCredentials("") after a later, unrelated
+		// synchronous token write (workspace/didChangeConfiguration), clobbering a valid
+		// token with empty — the IDE-2179 credential-loss race. See the regression test
+		// Test_RegisterOAuthStorageBridge_EmptyStorageUpdateDoesNotClearAppliedToken.
+		if newToken == "" {
+			if logger != nil {
+				logger.Debug().
+					Str("oauth_storage_key", auth.CONFIG_KEY_OAUTH_TOKEN).
+					Msg("oauth storage bridge ignoring empty token update")
+			}
+			return
+		}
 		if logger != nil {
 			logger.Debug().
 				Str("oauth_storage_key", auth.CONFIG_KEY_OAUTH_TOKEN).

--- a/infrastructure/authentication/auth_configuration_test.go
+++ b/infrastructure/authentication/auth_configuration_test.go
@@ -410,6 +410,109 @@ func Test_RegisterOAuthStorageBridge_LastWriteWins_WithReentrancy(t *testing.T) 
 	)
 }
 
+// Test_RegisterOAuthStorageBridge_EmptyStorageUpdateDoesNotClearAppliedToken is the
+// deterministic regression test for IDE-2179.
+//
+// Root cause: during the `initialized` handler, the auto-authentication flow calls
+// configureProviders → logout, which clears the OAuth token in storage. The OAuth
+// storage bridge reacts to that empty storage write by enqueuing an asynchronous
+// updateCredentials("") on credentialUpdateChan. That queued empty update is drained by
+// credentialUpdateWorker on a background goroutine with no ordering relationship to the
+// LSP request handlers. On a slow runner it is applied AFTER a later
+// workspace/didChangeConfiguration has synchronously set a token, overwriting the valid
+// token with empty — permanent credential loss until the next config change. This is the
+// fast (non-timeout) assertion failure of
+// Test_E2E_EndpointChangeAfterInitializationClearsToken observed on Windows CI.
+//
+// The bridge exists solely to propagate a newly written/rotated (non-empty) OAuth token
+// from storage to the auth service; credential clears are always driven synchronously
+// through updateCredentials/logout (service → storage), so a storage → service empty is
+// only ever a redundant echo. The bridge must therefore drop empty updates.
+//
+// require.Never polls continuously for 2 seconds: without the empty-guard the worker
+// drains updateCredentials("") within milliseconds and clears the token (reliable RED);
+// with it the empty update is dropped and the token stays stable (reliable GREEN),
+// across -race and all GOMAXPROCS values.
+func Test_RegisterOAuthStorageBridge_EmptyStorageUpdateDoesNotClearAppliedToken(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+
+	storageWithCallbacks, err := storage2.NewStorageWithCallbacks(
+		storage2.WithStorageFile(filepath.Join(t.TempDir(), "testStorage")),
+	)
+	require.NoError(t, err)
+	conf.PersistInStorage(auth.CONFIG_KEY_OAUTH_TOKEN)
+	conf.SetStorage(storageWithCallbacks)
+	conf.Set(configresolver.UserGlobalKey(types.SettingAuthenticationMethod), string(types.OAuthAuthentication))
+
+	service := NewAuthenticationService(
+		engine,
+		tokenService,
+		nil,
+		error_reporting.NewTestErrorReporter(engine),
+		notification.NewNotifier(),
+		testutil.DefaultConfigResolver(engine),
+	)
+	t.Cleanup(func() { service.Shutdown() })
+
+	RegisterOAuthStorageBridge(storageWithCallbacks, service)
+
+	appliedTokenBytes, err := json.Marshal(oauth2.Token{
+		AccessToken:  "applied-access",
+		RefreshToken: "applied-refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	appliedToken := string(appliedTokenBytes)
+
+	// A valid token is applied, as workspace/didChangeConfiguration does synchronously.
+	require.NoError(t, storageWithCallbacks.Set(auth.CONFIG_KEY_OAUTH_TOKEN, appliedToken))
+	require.Eventually(t, func() bool {
+		return config.GetToken(conf) == appliedToken
+	}, 2*time.Second, time.Millisecond, "applied token must be written to user:global:token")
+
+	// A stale empty OAuth storage update (as produced during init auto-auth logout) must
+	// NOT clobber the already-applied token.
+	require.NoError(t, storageWithCallbacks.Set(auth.CONFIG_KEY_OAUTH_TOKEN, ""))
+	require.Never(t,
+		func() bool { return config.GetToken(conf) == "" },
+		2*time.Second, time.Millisecond,
+		"empty oauth storage update must not clear an applied token",
+	)
+}
+
+// Test_oauthStorageBridgeCallback_DropsEmptyToken locks the fix at the unit level: the
+// bridge callback must not drive a credential update for an empty token. An applied
+// token is seeded, the callback is invoked with an empty value, and the token must
+// remain unchanged.
+func Test_oauthStorageBridgeCallback_DropsEmptyToken(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	conf := engine.GetConfiguration()
+	conf.Set(configresolver.UserGlobalKey(types.SettingAuthenticationMethod), string(types.OAuthAuthentication))
+
+	service := NewAuthenticationService(
+		engine,
+		tokenService,
+		nil,
+		error_reporting.NewTestErrorReporter(engine),
+		notification.NewNotifier(),
+		testutil.DefaultConfigResolver(engine),
+	)
+	t.Cleanup(func() { service.Shutdown() })
+
+	tokenService.SetToken(conf, "applied-token")
+	require.Equal(t, "applied-token", config.GetToken(conf))
+
+	newOAuthStorageBridgeCallback(service)("", "")
+
+	require.Never(t,
+		func() bool { return config.GetToken(conf) == "" },
+		time.Second, time.Millisecond,
+		"empty bridge callback must not clear the token",
+	)
+}
+
 func Test_RegisterOAuthStorageBridge_PreInitRefreshIsBufferedForIde(t *testing.T) {
 	engine, tokenService := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()


### PR DESCRIPTION
## Summary
Fixes flaky `Test_E2E_EndpointChangeAfterInitializationClearsToken` (windows-latest integration-tests, IDE-2179).

Root cause: the OAuth storage-bridge callback (`newOAuthStorageBridgeCallback`) propagated empty-token storage echoes through the serialized `credentialUpdateChan`. On slower runners a stale empty update could be drained by the worker *after* a later synchronous token write, clobbering the just-set token to empty and failing the assertion. The `writingToken` re-entrancy guard cannot catch empty echoes (empty is not a valid in-flight token).

Fix: `newOAuthStorageBridgeCallback` now early-returns on an empty token, keeping non-actionable empty echoes off the serialized channel at the boundary — mirroring the existing `updateCredentials` no-op guard. Credential clears remain correct: `logout` drives `updateCredentials("")` synchronously, independent of the bridge, so logout/clear propagation is unaffected. Real root-cause fix — no sleep/timeout/skip/retry workaround.

## Tests
- Two deterministic regression tests added (`auth_configuration_test.go`), confirmed RED before the fix / GREEN after.
- Stress: `go test ./application/server/ -run '^Test_E2E_EndpointChangeAfterInitializationClearsToken$' -race -count=100` → green.
- `go build ./...`, `golangci-lint run` (0 issues), and `make test` (unit) all green at HEAD.

## Known follow-up (non-blocking)
- Reviewers flagged a now-dead `token_empty` debug log field in `auth_configuration.go` (always false after the early return). Cosmetic only; left for a follow-up to keep this fix minimal.

_This fix was produced by an automated flake-fix loop._