### PR TITLE
fix(auth): don't hold mutex during OAuth browser wait

### DIFF
--- a/domain/ide/command/login_test.go
+++ b/domain/ide/command/login_test.go
@@ -474,10 +474,10 @@ func TestLoginCommand_Execute_InvalidInsecureArg_ReturnsError(t *testing.T) {
 }
 
 func TestLoginCommand_Execute_CanRestartAuthWhenPreviousInProgress(t *testing.T) {
-	// Regression test: starting a new login while a previous auth is in progress must not
-	// deadlock. The root cause was applyAuthConfig → ConfigureProviders acquiring the same
-	// mutex as the in-progress Authenticate, without first canceling the previous auth.
-	// Execute must call CancelOngoingAuth before applyAuthConfig to unblock the mutex.
+	// Regression test: starting a new login while a previous OAuth auth is in progress
+	// must not block. Authenticate no longer holds a.m for the full browser-wait
+	// duration, so ConfigureProviders and a second Authenticate can proceed immediately
+	// after CancelOngoingAuth() without waiting for the first auth's timeout (120 s).
 	engine, ts := testutil.UnitTestWithEngine(t)
 	conf := engine.GetConfiguration()
 	ctrl := gomock.NewController(t)
@@ -488,19 +488,19 @@ func TestLoginCommand_Execute_CanRestartAuthWhenPreviousInProgress(t *testing.T)
 	blockingProvider := authentication.NewBlockingFakeAuthProvider()
 	authService := authentication.NewAuthenticationService(engine, ts, blockingProvider, error_reporting.NewTestErrorReporter(engine), notification.NewMockNotifier(), testutil.DefaultConfigResolver(engine))
 
-	// Start a blocking auth in the background — it holds a.m.Lock() until canceled.
+	// Start a blocking auth in the background.
 	go authService.Authenticate(context.Background())
 
-	// Wait for the first auth to enter Authenticate (and acquire the lock).
+	// Wait for the first auth to enter the provider's Authenticate call.
 	select {
 	case <-blockingProvider.Started:
 	case <-time.After(5 * time.Second):
 		t.Fatal("first auth did not start in time")
 	}
 
-	// Execute a second login while the first is still in progress. ConfigureProviders (called
-	// inside applyAuthConfig) must not deadlock waiting for the mutex held by the first auth.
-	// CancelOngoingAuth must have been called first to unblock the first auth.
+	// Execute a second login while the first is still in progress. ConfigureProviders and
+	// the second Authenticate must complete quickly because the first auth no longer holds
+	// a.m during the OAuth wait.
 	mockLdxSync := mock_command.NewMockLdxSyncService(ctrl)
 	mockLdxSync.EXPECT().RefreshConfigFromLdxSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -169,29 +169,40 @@ func (a *AuthenticationServiceImpl) provider() AuthenticationProvider {
 func (a *AuthenticationServiceImpl) Authenticate(ctx context.Context) (token string, err error) {
 	a.CancelOngoingAuth()
 
-	a.m.Lock()
-	defer a.m.Unlock()
-
 	a.previousAuthCtxCancelFuncMu.Lock()
 	ctx, a.previousAuthCtxCancelFunc = context.WithCancel(ctx)
 	a.previousAuthCtxCancelFuncMu.Unlock()
-
 	defer a.previousAuthCtxCancelFunc() // need to clean up resources if we weren't interrupted, impl should ensure its safe to double call
-	return a.authenticate(ctx)
-}
 
-func (a *AuthenticationServiceImpl) authenticate(ctx context.Context) (token string, err error) {
-	if a.authProvider == nil {
-		err = errors.New("authentication provider is not configured")
-		a.engine.GetLogger().Warn().Err(err).Msg("Failed to authenticate: auth provider is nil")
+	// Capture the provider under a brief read lock. ConfigureProviders takes a
+	// write lock, so releasing a.m before the slow browser wait lets a concurrent
+	// re-login reconfigure providers without waiting for the OAuth flow to time out.
+	a.m.RLock()
+	provider := a.authProvider
+	a.m.RUnlock()
+
+	if provider == nil {
+		a.engine.GetLogger().Warn().Msg("Failed to authenticate: auth provider is nil")
+		a.m.Lock()
 		a.authCache.RemoveAll()
-		return "", err
+		a.m.Unlock()
+		return "", errors.New("authentication provider is not configured")
 	}
 
-	token, err = a.authProvider.Authenticate(ctx)
+	// Run the auth flow without holding a.m. This lets ConfigureProviders and
+	// Logout proceed while waiting for the OAuth browser callback (up to 2 minutes).
+	// CancelOngoingAuth above signals any concurrent auth to abort.
+	token, err = provider.Authenticate(ctx)
 
+	// Re-acquire the write lock to save results.
+	a.m.Lock()
+	defer a.m.Unlock()
+	return a.authenticate(token, err, provider)
+}
+
+func (a *AuthenticationServiceImpl) authenticate(token string, err error, provider AuthenticationProvider) (string, error) {
 	if token == "" || err != nil {
-		a.engine.GetLogger().Warn().Err(err).Msgf("Failed to authenticate using auth provider %v", reflect.TypeOf(a.authProvider))
+		a.engine.GetLogger().Warn().Err(err).Msgf("Failed to authenticate using auth provider %v", reflect.TypeOf(provider))
 		a.authCache.RemoveAll()
 		return token, err
 	}

--- a/infrastructure/authentication/auth_service_impl.go
+++ b/infrastructure/authentication/auth_service_impl.go
@@ -932,29 +932,9 @@ func (a *AuthenticationServiceImpl) configureProviders(conf configuration.Config
 
 	authMethodChanged := a.provider() == nil || a.provider().AuthenticationMethod() != authMethod
 
-	// always set the provider even if the authentication method didn't change, to make sure that the provider is initialized with current config
-	if authMethodChanged {
-		var p AuthenticationProvider
-		switch authMethod {
-		default:
-			p = Default(a.engine, a)
-			a.setProvider(p)
-		case types.TokenAuthentication:
-			p = Token(a.engine, a.errorReporter, a.configResolver)
-			a.setProvider(p)
-		case types.PatAuthentication:
-			p = Pat(a.engine, a)
-			a.setProvider(p)
-		case types.FakeAuthentication:
-			a.setProvider(NewFakeCliAuthenticationProvider(a.engine))
-		case "":
-			// don't do anything
-		}
-		subLogger.Debug().
-			Str("provider_type", fmt.Sprintf("%T", a.provider())).
-			Msg("auth provider configured")
-	}
-	// Check whether we have a valid token for the current auth method
+	// Check credential mismatch BEFORE replacing the provider so that ClearAuthentication
+	// is called on the provider that owns the stale credentials.
+	// logout internally calls configureProviders, which will create the fresh provider.
 	token := config.GetToken(conf)
 	if token != "" && !config.AuthenticationMethodMatchesCredentials(token, authMethod, logger) {
 		subLogger.Info().
@@ -968,6 +948,31 @@ func (a *AuthenticationServiceImpl) configureProviders(conf configuration.Config
 			subLogger.Info().Msg("detected token change which is incompatible with auth provider.")
 			a.handleInvalidCredentials()
 		}
+		// Provider was replaced by logout → configureProviders. Return to avoid double-replace.
+		return
+	}
+
+	// Always replace the provider, even when the auth method is unchanged. A fresh provider
+	// has an unlocked p.m (OAuth2Provider.Authenticate holds p.m for the entire browser wait),
+	// so a concurrent re-login attempt captures a new provider and starts immediately instead of
+	// blocking on the previous auth flow's in-progress mutex. Provider creation is cheap —
+	// token/config state lives in configuration.Configuration, not in the provider struct.
+	switch authMethod {
+	default:
+		a.setProvider(Default(a.engine, a))
+	case types.TokenAuthentication:
+		a.setProvider(Token(a.engine, a.errorReporter, a.configResolver))
+	case types.PatAuthentication:
+		a.setProvider(Pat(a.engine, a))
+	case types.FakeAuthentication:
+		a.setProvider(NewFakeCliAuthenticationProvider(a.engine))
+	case "":
+		// don't do anything
+	}
+	if authMethod != "" {
+		subLogger.Debug().
+			Str("provider_type", fmt.Sprintf("%T", a.provider())).
+			Msg("auth provider configured")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Authenticate()` held `a.m` for the full OAuth flow (up to 120 s browser wait). Re-clicking Authenticate did nothing until the first flow timed out.
- Root cause traced to GAF commit `d14fa1a` (Abdelrahman, Aug 2025) which added `globalRefreshMutex.Lock()` at the start of `CancelableAuthenticate` — before the `ctx.Done()` goroutine starts — creating a cancellation-blind window. Even past that window, `server.Shutdown(context.Background())` can block on live TCP connections, keeping `a.m` locked for the full 120 s.
- Fix: capture the provider under a brief `RLock`, run `provider.Authenticate` lock-free, re-acquire `a.m` only to save results. `ConfigureProviders` and a concurrent re-login now proceed immediately after `CancelOngoingAuth()`.

## Test plan

- [ ] 382 existing auth + command tests pass (`go test ./infrastructure/authentication/... ./domain/ide/command/...`)
- [ ] `TestLoginCommand_Execute_CanRestartAuthWhenPreviousInProgress` still passes (updated comment to reflect new mechanism)
- [ ] Manual: OAuth login → close browser → click Authenticate again → new browser link opens immediately (no 120 s wait)
- [ ] `make lint-fix` → 0 issues