### PR TITLE
fix: replace fallback-page re-auth control with a Log out action [IDE-2181]

### DIFF
--- a/application/server/authentication_flows_e2e_test.go
+++ b/application/server/authentication_flows_e2e_test.go
@@ -268,6 +268,71 @@ func Test_E2E_EndpointChangeDuringScannerInitClearsToken(t *testing.T) {
 	assert.Equal(t, "https://api.changed.example", types.GetGlobalString(engine.GetConfiguration(), types.SettingApiEndpoint))
 }
 
+// Test_E2E_LogoutDuringScannerInitClearsCredentials is the acceptance test for
+// the IDE-2181 fallback-page logout control. A user on the limited settings
+// fallback page can clear their stored Snyk credentials even while the Language
+// Server is inside the failing-startup window (CP1 keeps workspace/executeCommand
+// serviceable during that window; the logout command does not require scanner init
+// to complete). RED before CP1; GREEN after.
+func Test_E2E_LogoutDuringScannerInitClearsCredentials(t *testing.T) {
+	engine, tokenService := newAuthFlowE2EEngine(t, "http://127.0.0.1", filepath.Join(t.TempDir(), "ls-config.json"))
+	engine.GetConfiguration().Set(configuration.INTEGRATION_ENVIRONMENT, "IDE-2181-logout-during-init")
+
+	// A scanner whose Init blocks stands in for the failing startup token-refresh
+	// storm, so the late scanner-ready signal never fires during the test window.
+	sc := newBlockingInitScanner()
+	// Release the blocked Init before server-shutdown cleanup runs (t.Cleanup is LIFO
+	// and startE2ELocalServer registers its shutdown after this defer), so the
+	// background init goroutine ends against a live engine.
+	defer close(sc.release)
+
+	loc, _, _ := startE2ELocalServer(t, engine, tokenService, func(deps di.Dependencies) di.Dependencies {
+		deps.Scanner = sc
+		return deps
+	})
+
+	// Prevent the released background init goroutine from triggering an auto-scan
+	// against a teardown-in-progress engine; this test only exercises the credential
+	// clear, not scanning.
+	disableAutoScan(t, engine.GetConfiguration())
+
+	require.NoError(t, initializeLSPClientOnly(t, loc, types.InitializeParams{}))
+	require.NoError(t, initializedLSPClient(t, loc))
+
+	// Precondition: scanner Init is blocked, so the late scanner-ready signal is
+	// still false — we are inside the init window.
+	<-sc.started
+	require.False(t, engine.GetConfiguration().GetBool(types.SettingIsLspInitialized),
+		"precondition: scanner-ready signal must still be false during the init window")
+
+	// Establish credentials that the stuck user would have in the failing-startup state.
+	apiToken := "44444444-4444-4444-8444-444444444444"
+	_, err := loc.Client.Call(t.Context(), "workspace/didChangeConfiguration", types.DidChangeConfigurationParams{
+		Settings: types.LspConfigurationParam{
+			Settings: map[string]*types.ConfigSetting{
+				types.SettingAuthenticationMethod: {Value: string(types.TokenAuthentication), Changed: true},
+				types.SettingToken:                {Value: apiToken, Changed: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, apiToken, config.GetToken(engine.GetConfiguration()))
+
+	// Dispatch snyk.logout DURING the init window — this is what the fallback page's
+	// Log out button does via window.__ideExecuteCommand__.
+	_, err = loc.Client.Call(t.Context(), "workspace/executeCommand", sglsp.ExecuteCommandParams{
+		Command: types.LogoutCommand,
+	})
+	require.NoError(t, err)
+
+	// Credentials must be cleared immediately even while the scanner is still
+	// initializing. We assert the credential directly: the $/snyk.hasAuthenticated
+	// notification is deferred behind WaitForLspInitialized (scanner readiness), which
+	// has not fired yet, but the credential itself is cleared synchronously.
+	assert.Empty(t, config.GetToken(engine.GetConfiguration()),
+		"credentials must be cleared when snyk.logout is dispatched during scanner init")
+}
+
 func Test_E2E_IsAuthenticatedFalseSkipsActiveUserLookup(t *testing.T) {
 	engine, tokenService := newAuthFlowE2EEngine(t, "http://127.0.0.1", filepath.Join(t.TempDir(), "ls-config.json"))
 	engine.GetConfiguration().Set(configuration.INTEGRATION_ENVIRONMENT, "IDE-1900-is-authenticated")

--- a/js-tests/settings-fallback.test.mjs
+++ b/js-tests/settings-fallback.test.mjs
@@ -294,6 +294,184 @@ test("settings-fallback: error shown when custom channel has invalid value", asy
 });
 
 // ---------------------------------------------------------------------------
+// Re-authentication control (IDE-2181 CP2)
+// ---------------------------------------------------------------------------
+
+test("settings-fallback: re-auth control is present in the Authentication section", async () => {
+  const win = await buildFallbackDom();
+  const btn = win.document.getElementById("reauth-button");
+  assert.ok(btn, "a re-auth control (#reauth-button) must exist");
+
+  // It must live inside the Authentication section, not CLI Configuration.
+  const authHeading = [...win.document.querySelectorAll("h2")].find(
+    (h) => h.textContent.trim() === "Authentication"
+  );
+  assert.ok(authHeading, "Authentication section heading must exist");
+  const authSection = authHeading.closest(".section");
+  assert.ok(
+    authSection && authSection.contains(btn),
+    "re-auth control must be inside the Authentication section"
+  );
+});
+
+test("settings-fallback: activating the control dispatches snyk.login through the bridge", async () => {
+  const win = await buildFallbackDom();
+  const calls = [];
+  win.__ideExecuteCommand__ = (cmd, args, callback) => {
+    calls.push({ cmd, args, callback });
+  };
+
+  const btn = win.document.getElementById("reauth-button");
+  btn.dispatchEvent(new win.Event("click"));
+
+  assert.strictEqual(calls.length, 1, "__ideExecuteCommand__ must be called exactly once");
+  assert.strictEqual(calls[0].cmd, "snyk.login", "command must be snyk.login");
+  // D2(a): pass no auth args so the LS re-auths with the existing configured method/endpoint.
+  // (args is created in the jsdom realm, so compare shape/length rather than deepStrictEqual.)
+  assert.ok(Array.isArray(calls[0].args), "args must be an array");
+  assert.strictEqual(calls[0].args.length, 0, "no auth args should be passed (reuse configured auth)");
+  // Complete the lifecycle so the client-side safety timeout started by startReauth
+  // is cleared and does not linger (a dangling jsdom timer keeps `node --test` alive).
+  calls[0].callback();
+});
+
+test("settings-fallback: activating the control is a no-op-safe when the bridge is absent", async () => {
+  const win = await buildFallbackDom();
+  // No window.__ideExecuteCommand__ defined.
+  const btn = win.document.getElementById("reauth-button");
+  assert.doesNotThrow(() => {
+    btn.dispatchEvent(new win.Event("click"));
+  }, "clicking the control without a bridge must not throw");
+});
+
+// ---------------------------------------------------------------------------
+// Re-auth control lifecycle: disable → done/timeout → re-enable (IDE-2181 CP2)
+// ---------------------------------------------------------------------------
+
+test("settings-fallback: activating the control disables it and shows Connecting…", async () => {
+  const win = await buildFallbackDom();
+  win.__REAUTH_TIMEOUT_MS__ = 5; // tiny safety timeout so no timer lingers
+  win.__ideExecuteCommand__ = () => {}; // bridge accepts the call, never invokes done
+  const btn = win.document.getElementById("reauth-button");
+
+  btn.dispatchEvent(new win.Event("click"));
+
+  assert.strictEqual(btn.disabled, true, "button must be disabled while re-auth is in progress");
+  assert.strictEqual(btn.textContent, "Connecting…", "button label must show progress");
+
+  // Drain the tiny safety timeout so the jsdom timer does not linger.
+  // Generous margin (40x the timer) so a loaded CI runner still drains it.
+  await new Promise((r) => win.setTimeout(r, 200));
+});
+
+test("settings-fallback: the bridge done callback re-enables the control and restores the label", async () => {
+  const win = await buildFallbackDom();
+  let captured;
+  win.__ideExecuteCommand__ = (_cmd, _args, callback) => { captured = callback; };
+  const btn = win.document.getElementById("reauth-button");
+
+  btn.dispatchEvent(new win.Event("click"));
+  assert.strictEqual(typeof captured, "function", "bridge must receive a done callback as its 3rd arg");
+  assert.strictEqual(btn.disabled, true, "button disabled after click");
+
+  captured(); // LS signals completion
+
+  assert.strictEqual(btn.disabled, false, "button must be re-enabled after done fires");
+  assert.strictEqual(btn.textContent, "Connect", "label must be restored after done fires");
+});
+
+test("settings-fallback: a second activation while in progress does not dispatch a second snyk.login", async () => {
+  const win = await buildFallbackDom();
+  const calls = [];
+  let captured;
+  win.__ideExecuteCommand__ = (cmd, _args, callback) => { calls.push(cmd); captured = callback; };
+  const btn = win.document.getElementById("reauth-button");
+
+  btn.dispatchEvent(new win.Event("click"));
+  btn.dispatchEvent(new win.Event("click")); // while still disabled/in progress
+
+  assert.strictEqual(calls.length, 1, "second activation while in progress must be ignored");
+
+  captured(); // clear the safety timer
+});
+
+test("settings-fallback: the safety timeout re-enables the control if done never fires", async () => {
+  const win = await buildFallbackDom();
+  win.__REAUTH_TIMEOUT_MS__ = 5; // short, injectable safety timeout for the test
+  win.__ideExecuteCommand__ = () => {}; // bridge accepts the call but never invokes done
+  const btn = win.document.getElementById("reauth-button");
+
+  btn.dispatchEvent(new win.Event("click"));
+  assert.strictEqual(btn.disabled, true, "button disabled immediately after click");
+
+  // Wait well past the safety timeout (40x) so a loaded CI runner still fires it.
+  await new Promise((r) => win.setTimeout(r, 200));
+
+  assert.strictEqual(btn.disabled, false, "button must re-enable after the safety timeout");
+  assert.strictEqual(btn.textContent, "Connect", "label must be restored after the safety timeout");
+});
+
+test("settings-fallback: a stale done() from a superseded re-auth cycle is inert during a new cycle", async () => {
+  const win = await buildFallbackDom();
+  const calls = [];
+  const callbacks = [];
+  win.__ideExecuteCommand__ = (cmd, _args, callback) => {
+    calls.push(cmd);
+    callbacks.push(callback);
+  };
+  const btn = win.document.getElementById("reauth-button");
+
+  // Cycle A: click → disabled, arms a tiny safety timer, bridge receives doneA (captured, NOT invoked).
+  win.__REAUTH_TIMEOUT_MS__ = 5;
+  btn.dispatchEvent(new win.Event("click"));
+  assert.strictEqual(calls.length, 1, "cycle A must dispatch snyk.login");
+  const doneA = callbacks[0];
+
+  // Auth exceeds the safety timeout (SSO/2FA) → doneA fires via the timer → button re-enabled.
+  // Generous drain (40x the timer) keeps this deterministic on a loaded CI runner.
+  await new Promise((r) => win.setTimeout(r, 200));
+  assert.strictEqual(btn.disabled, false, "cycle A safety timeout must re-enable the button");
+
+  // Cycle B: user clicks again → new cycle, dispatches a 2nd snyk.login, disables the button.
+  // Long timeout so cycle B stays in flight for the rest of the test (drained via doneB below).
+  win.__REAUTH_TIMEOUT_MS__ = 60000;
+  btn.dispatchEvent(new win.Event("click"));
+  assert.strictEqual(calls.length, 2, "cycle B must dispatch a second snyk.login");
+  assert.strictEqual(btn.disabled, true, "cycle B must disable the button");
+  assert.strictEqual(btn.textContent, "Connecting…", "cycle B must show progress");
+
+  // Cycle A's original bridge call finally completes → invokes the still-referenced stale doneA.
+  doneA();
+
+  // The stale callback must be INERT: cycle B's in-flight state must be preserved.
+  assert.strictEqual(btn.disabled, true, "stale doneA must NOT re-enable the button mid-cycle-B");
+  assert.strictEqual(btn.textContent, "Connecting…", "stale doneA must NOT restore the label mid-cycle-B");
+
+  // And it must not have opened the double-dispatch guard: a further click stays blocked.
+  btn.dispatchEvent(new win.Event("click"));
+  assert.strictEqual(calls.length, 2, "no further snyk.login may be dispatched while cycle B is in flight");
+
+  // Drain cycle B's safety timer so no jsdom timer lingers and keeps `node --test` alive.
+  callbacks[1]();
+});
+
+test("settings-fallback: the auth status copy is state-neutral (does not overclaim signed-out state)", async () => {
+  const win = await buildFallbackDom();
+  const status = win.document.getElementById("reauth-status");
+  const text = status.textContent.trim().toLowerCase();
+
+  assert.ok(text.length > 0, "status copy must be present");
+  assert.ok(
+    !text.includes("you are not signed in"),
+    `status copy must not assert the user is signed out; got "${status.textContent}"`
+  );
+  assert.ok(
+    /reconnect|sign in/.test(text),
+    `status copy should be action-oriented (mention reconnect/sign in); got "${status.textContent}"`
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Payload snapshot
 // ---------------------------------------------------------------------------
 

--- a/js-tests/settings-fallback.test.mjs
+++ b/js-tests/settings-fallback.test.mjs
@@ -294,180 +294,80 @@ test("settings-fallback: error shown when custom channel has invalid value", asy
 });
 
 // ---------------------------------------------------------------------------
-// Re-authentication control (IDE-2181 CP2)
+// Log out control (IDE-2181)
 // ---------------------------------------------------------------------------
 
-test("settings-fallback: re-auth control is present in the Authentication section", async () => {
+test("settings-fallback: the authentication section offers a log out control and no login control", async () => {
   const win = await buildFallbackDom();
-  const btn = win.document.getElementById("reauth-button");
-  assert.ok(btn, "a re-auth control (#reauth-button) must exist");
+  const logoutBtn = win.document.getElementById("logout-button");
+  assert.ok(logoutBtn, "a log out control (#logout-button) must exist");
 
-  // It must live inside the Authentication section, not CLI Configuration.
+  // No login/"Connect" control must be present.
+  assert.ok(
+    !win.document.getElementById("reauth-button"),
+    "no #reauth-button (login control) must exist"
+  );
+
+  // The log out button must live inside the Authentication section.
   const authHeading = [...win.document.querySelectorAll("h2")].find(
     (h) => h.textContent.trim() === "Authentication"
   );
   assert.ok(authHeading, "Authentication section heading must exist");
   const authSection = authHeading.closest(".section");
   assert.ok(
-    authSection && authSection.contains(btn),
-    "re-auth control must be inside the Authentication section"
+    authSection && authSection.contains(logoutBtn),
+    "log out control must be inside the Authentication section"
   );
 });
 
-test("settings-fallback: activating the control dispatches snyk.login through the bridge", async () => {
+test("settings-fallback: activating the control dispatches snyk.logout through the bridge", async () => {
   const win = await buildFallbackDom();
   const calls = [];
   win.__ideExecuteCommand__ = (cmd, args, callback) => {
     calls.push({ cmd, args, callback });
   };
 
-  const btn = win.document.getElementById("reauth-button");
+  const btn = win.document.getElementById("logout-button");
   btn.dispatchEvent(new win.Event("click"));
 
   assert.strictEqual(calls.length, 1, "__ideExecuteCommand__ must be called exactly once");
-  assert.strictEqual(calls[0].cmd, "snyk.login", "command must be snyk.login");
-  // D2(a): pass no auth args so the LS re-auths with the existing configured method/endpoint.
-  // (args is created in the jsdom realm, so compare shape/length rather than deepStrictEqual.)
+  assert.strictEqual(calls[0].cmd, "snyk.logout", "command must be snyk.logout");
   assert.ok(Array.isArray(calls[0].args), "args must be an array");
-  assert.strictEqual(calls[0].args.length, 0, "no auth args should be passed (reuse configured auth)");
-  // Complete the lifecycle so the client-side safety timeout started by startReauth
-  // is cleared and does not linger (a dangling jsdom timer keeps `node --test` alive).
-  calls[0].callback();
+  assert.strictEqual(calls[0].args.length, 0, "no args should be passed to snyk.logout");
 });
 
 test("settings-fallback: activating the control is a no-op-safe when the bridge is absent", async () => {
   const win = await buildFallbackDom();
   // No window.__ideExecuteCommand__ defined.
-  const btn = win.document.getElementById("reauth-button");
+  const btn = win.document.getElementById("logout-button");
   assert.doesNotThrow(() => {
     btn.dispatchEvent(new win.Event("click"));
-  }, "clicking the control without a bridge must not throw");
+  }, "clicking the log out control without a bridge must not throw");
 });
 
-// ---------------------------------------------------------------------------
-// Re-auth control lifecycle: disable → done/timeout → re-enable (IDE-2181 CP2)
-// ---------------------------------------------------------------------------
-
-test("settings-fallback: activating the control disables it and shows Connecting…", async () => {
-  const win = await buildFallbackDom();
-  win.__REAUTH_TIMEOUT_MS__ = 5; // tiny safety timeout so no timer lingers
-  win.__ideExecuteCommand__ = () => {}; // bridge accepts the call, never invokes done
-  const btn = win.document.getElementById("reauth-button");
-
-  btn.dispatchEvent(new win.Event("click"));
-
-  assert.strictEqual(btn.disabled, true, "button must be disabled while re-auth is in progress");
-  assert.strictEqual(btn.textContent, "Connecting…", "button label must show progress");
-
-  // Drain the tiny safety timeout so the jsdom timer does not linger.
-  // Generous margin (40x the timer) so a loaded CI runner still drains it.
-  await new Promise((r) => win.setTimeout(r, 200));
-});
-
-test("settings-fallback: the bridge done callback re-enables the control and restores the label", async () => {
+test("settings-fallback: after logout the status copy confirms credentials were cleared", async () => {
   const win = await buildFallbackDom();
   let captured;
   win.__ideExecuteCommand__ = (_cmd, _args, callback) => { captured = callback; };
-  const btn = win.document.getElementById("reauth-button");
 
+  const btn = win.document.getElementById("logout-button");
   btn.dispatchEvent(new win.Event("click"));
-  assert.strictEqual(typeof captured, "function", "bridge must receive a done callback as its 3rd arg");
-  assert.strictEqual(btn.disabled, true, "button disabled after click");
 
-  captured(); // LS signals completion
+  assert.strictEqual(typeof captured, "function", "bridge must receive a done callback");
 
-  assert.strictEqual(btn.disabled, false, "button must be re-enabled after done fires");
-  assert.strictEqual(btn.textContent, "Connect", "label must be restored after done fires");
-});
+  // Before done fires the status copy is the default prompt.
+  const status = win.document.getElementById("logout-status");
+  const textBefore = status.textContent.trim();
+  assert.ok(textBefore.length > 0, "status copy must be present before logout");
 
-test("settings-fallback: a second activation while in progress does not dispatch a second snyk.login", async () => {
-  const win = await buildFallbackDom();
-  const calls = [];
-  let captured;
-  win.__ideExecuteCommand__ = (cmd, _args, callback) => { calls.push(cmd); captured = callback; };
-  const btn = win.document.getElementById("reauth-button");
+  // Fire the done callback (LS confirmed credentials cleared).
+  captured();
 
-  btn.dispatchEvent(new win.Event("click"));
-  btn.dispatchEvent(new win.Event("click")); // while still disabled/in progress
-
-  assert.strictEqual(calls.length, 1, "second activation while in progress must be ignored");
-
-  captured(); // clear the safety timer
-});
-
-test("settings-fallback: the safety timeout re-enables the control if done never fires", async () => {
-  const win = await buildFallbackDom();
-  win.__REAUTH_TIMEOUT_MS__ = 5; // short, injectable safety timeout for the test
-  win.__ideExecuteCommand__ = () => {}; // bridge accepts the call but never invokes done
-  const btn = win.document.getElementById("reauth-button");
-
-  btn.dispatchEvent(new win.Event("click"));
-  assert.strictEqual(btn.disabled, true, "button disabled immediately after click");
-
-  // Wait well past the safety timeout (40x) so a loaded CI runner still fires it.
-  await new Promise((r) => win.setTimeout(r, 200));
-
-  assert.strictEqual(btn.disabled, false, "button must re-enable after the safety timeout");
-  assert.strictEqual(btn.textContent, "Connect", "label must be restored after the safety timeout");
-});
-
-test("settings-fallback: a stale done() from a superseded re-auth cycle is inert during a new cycle", async () => {
-  const win = await buildFallbackDom();
-  const calls = [];
-  const callbacks = [];
-  win.__ideExecuteCommand__ = (cmd, _args, callback) => {
-    calls.push(cmd);
-    callbacks.push(callback);
-  };
-  const btn = win.document.getElementById("reauth-button");
-
-  // Cycle A: click → disabled, arms a tiny safety timer, bridge receives doneA (captured, NOT invoked).
-  win.__REAUTH_TIMEOUT_MS__ = 5;
-  btn.dispatchEvent(new win.Event("click"));
-  assert.strictEqual(calls.length, 1, "cycle A must dispatch snyk.login");
-  const doneA = callbacks[0];
-
-  // Auth exceeds the safety timeout (SSO/2FA) → doneA fires via the timer → button re-enabled.
-  // Generous drain (40x the timer) keeps this deterministic on a loaded CI runner.
-  await new Promise((r) => win.setTimeout(r, 200));
-  assert.strictEqual(btn.disabled, false, "cycle A safety timeout must re-enable the button");
-
-  // Cycle B: user clicks again → new cycle, dispatches a 2nd snyk.login, disables the button.
-  // Long timeout so cycle B stays in flight for the rest of the test (drained via doneB below).
-  win.__REAUTH_TIMEOUT_MS__ = 60000;
-  btn.dispatchEvent(new win.Event("click"));
-  assert.strictEqual(calls.length, 2, "cycle B must dispatch a second snyk.login");
-  assert.strictEqual(btn.disabled, true, "cycle B must disable the button");
-  assert.strictEqual(btn.textContent, "Connecting…", "cycle B must show progress");
-
-  // Cycle A's original bridge call finally completes → invokes the still-referenced stale doneA.
-  doneA();
-
-  // The stale callback must be INERT: cycle B's in-flight state must be preserved.
-  assert.strictEqual(btn.disabled, true, "stale doneA must NOT re-enable the button mid-cycle-B");
-  assert.strictEqual(btn.textContent, "Connecting…", "stale doneA must NOT restore the label mid-cycle-B");
-
-  // And it must not have opened the double-dispatch guard: a further click stays blocked.
-  btn.dispatchEvent(new win.Event("click"));
-  assert.strictEqual(calls.length, 2, "no further snyk.login may be dispatched while cycle B is in flight");
-
-  // Drain cycle B's safety timer so no jsdom timer lingers and keeps `node --test` alive.
-  callbacks[1]();
-});
-
-test("settings-fallback: the auth status copy is state-neutral (does not overclaim signed-out state)", async () => {
-  const win = await buildFallbackDom();
-  const status = win.document.getElementById("reauth-status");
-  const text = status.textContent.trim().toLowerCase();
-
-  assert.ok(text.length > 0, "status copy must be present");
+  // After done the status copy must confirm the cleared state.
+  const textAfter = status.textContent.trim();
   assert.ok(
-    !text.includes("you are not signed in"),
-    `status copy must not assert the user is signed out; got "${status.textContent}"`
-  );
-  assert.ok(
-    /reconnect|sign in/.test(text),
-    `status copy should be action-oriented (mention reconnect/sign in); got "${status.textContent}"`
+    /signed out|credentials.*cleared/i.test(textAfter),
+    `status copy must confirm credentials cleared after done; got "${textAfter}"`
   );
 });
 

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -59,6 +59,10 @@
       --border-color: var(--vscode-panel-border, #454545);
       --focus-border: var(--vscode-focusBorder, #007acc);
 
+      /* Buttons */
+      --button-background: var(--vscode-button-background, #0e639c);
+      --button-foreground: var(--vscode-button-foreground, #ffffff);
+
       /* Other */
       --border-radius: 4px;
       --border-radius-small: 2px;
@@ -213,6 +217,34 @@
       display: none !important;
     }
 
+    /* Re-authentication control */
+    .reauth-status {
+      margin: 0 0 var(--form-group-margin) 0;
+      color: var(--text-color);
+    }
+
+    .reauth-button {
+      align-self: flex-start;
+      padding: var(--input-padding) 16px;
+      background-color: var(--button-background);
+      color: var(--button-foreground);
+      border: 1px solid var(--button-background);
+      border-radius: var(--border-radius-small);
+      font-family: inherit;
+      font-size: inherit;
+      cursor: pointer;
+    }
+
+    .reauth-button:focus {
+      outline: 1px solid var(--focus-border);
+      outline-offset: 2px;
+    }
+
+    .reauth-button:disabled {
+      opacity: 0.6;
+      cursor: default;
+    }
+
     /* Info Message */
     .info-message {
       padding: var(--section-padding);
@@ -310,6 +342,11 @@
   <div class="section">
     <h2>Authentication</h2>
 
+    <div class="form-group">
+      <p id="reauth-status" class="reauth-status">Sign in or reconnect with Snyk.</p>
+      <button type="button" id="reauth-button" class="reauth-button">Connect</button>
+    </div>
+
     <div class="form-group half-width">
       <label class="checkbox-label">
         <input type="checkbox" name="proxy_insecure" id="proxy_insecure" {{INSECURE_CHECKED}}>
@@ -366,6 +403,9 @@
     var initialState = null;
     // Guard against re-entrance when blur() triggers getAndSaveIdeConfig
     var _isSaving = false;
+    // Monotonic re-auth cycle counter. Each startReauth() bumps it; a done()
+    // callback from a superseded cycle is inert (see startReauth).
+    var _reauthGen = 0;
 
     function get(id) {
       return document.getElementById(id);
@@ -502,10 +542,63 @@
       }
     };
 
+    // Re-authenticate via the IDE command bridge. D2(a): pass no auth args so the
+    // language server re-auths with the user's existing configured method/endpoint
+    // rather than overwriting it from this limited fallback page.
+    //
+    // The button is disabled while a re-auth is in flight (prevents a double-fire)
+    // and re-enabled when the language server invokes done(). If done() never fires
+    // — the user cancels the OAuth browser tab, auth stalls, or the LS dies mid-flow
+    // — a client-side safety timeout restores the button so the user can retry
+    // instead of being stuck on "Connecting…" forever. done() clears that timer so
+    // there is no double-restore. __REAUTH_TIMEOUT_MS__ overrides the duration in tests.
+    //
+    // done() is single-shot AND cycle-aware. If the safety timeout re-enables the
+    // button (auth exceeds the timeout) the user can start a fresh cycle; the prior
+    // cycle's bridge callback may still fire late. A stale done() from a superseded
+    // cycle (gen !== _reauthGen) — or a second invocation of the same cycle (finished)
+    // — must be inert, or it would re-enable the button mid-new-cycle and reopen the
+    // double-dispatch it guards against.
+    function startReauth() {
+      if (typeof window.__ideExecuteCommand__ !== 'function') { return; }
+      var btn = get('reauth-button');
+      if (btn && btn.disabled) { return; } // a re-auth is already in progress
+      var gen = ++_reauthGen;
+      var timeoutMs = typeof window.__REAUTH_TIMEOUT_MS__ === 'number'
+        ? window.__REAUTH_TIMEOUT_MS__
+        : 60000;
+      var safetyTimer = null;
+      var finished = false;
+      function done() {
+        if (finished || gen !== _reauthGen) { return; }
+        finished = true;
+        if (safetyTimer !== null) {
+          window.clearTimeout(safetyTimer);
+          safetyTimer = null;
+        }
+        if (btn) {
+          btn.disabled = false;
+          btn.textContent = 'Connect';
+        }
+      }
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = 'Connecting…';
+      }
+      safetyTimer = window.setTimeout(done, timeoutMs);
+      try {
+        window.__ideExecuteCommand__('snyk.login', [], done);
+      } catch (e) {
+        console.error('Error starting authentication:', e);
+        done();
+      }
+    }
+
     window.__isFormDirty__ = function() { return isDirty(); };
     window.collectData = collectData;
     window.collectChangedData = collectChangedData;
     window.markDirty = markDirty;
+    window.startReauth = startReauth;
 
     function repositionTooltip(trigger) {
       var popup = trigger.querySelector('.tooltip-popup');
@@ -565,6 +658,11 @@
 
       get('cli_release_channel_custom').addEventListener('input', validateCliVersion);
       get('cli_release_channel_custom').addEventListener('blur', validateCliVersion);
+
+      var reauthBtn = get('reauth-button');
+      if (reauthBtn) {
+        reauthBtn.addEventListener('click', startReauth);
+      }
 
       var tooltipTriggers = document.querySelectorAll('[data-toggle="tooltip"]');
       for (var k = 0; k < tooltipTriggers.length; k++) {

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -343,8 +343,8 @@
     <h2>Authentication</h2>
 
     <div class="form-group">
-      <p id="reauth-status" class="reauth-status">Sign in or reconnect with Snyk.</p>
-      <button type="button" id="reauth-button" class="reauth-button">Connect</button>
+      <p id="logout-status" class="reauth-status">If Snyk is stuck, clear your stored credentials to recover, then reopen Settings to sign in again.</p>
+      <button type="button" id="logout-button" class="reauth-button">Log out</button>
     </div>
 
     <div class="form-group half-width">
@@ -403,9 +403,6 @@
     var initialState = null;
     // Guard against re-entrance when blur() triggers getAndSaveIdeConfig
     var _isSaving = false;
-    // Monotonic re-auth cycle counter. Each startReauth() bumps it; a done()
-    // callback from a superseded cycle is inert (see startReauth).
-    var _reauthGen = 0;
 
     function get(id) {
       return document.getElementById(id);
@@ -542,55 +539,20 @@
       }
     };
 
-    // Re-authenticate via the IDE command bridge. D2(a): pass no auth args so the
-    // language server re-auths with the user's existing configured method/endpoint
-    // rather than overwriting it from this limited fallback page.
-    //
-    // The button is disabled while a re-auth is in flight (prevents a double-fire)
-    // and re-enabled when the language server invokes done(). If done() never fires
-    // — the user cancels the OAuth browser tab, auth stalls, or the LS dies mid-flow
-    // — a client-side safety timeout restores the button so the user can retry
-    // instead of being stuck on "Connecting…" forever. done() clears that timer so
-    // there is no double-restore. __REAUTH_TIMEOUT_MS__ overrides the duration in tests.
-    //
-    // done() is single-shot AND cycle-aware. If the safety timeout re-enables the
-    // button (auth exceeds the timeout) the user can start a fresh cycle; the prior
-    // cycle's bridge callback may still fire late. A stale done() from a superseded
-    // cycle (gen !== _reauthGen) — or a second invocation of the same cycle (finished)
-    // — must be inert, or it would re-enable the button mid-new-cycle and reopen the
-    // double-dispatch it guards against.
-    function startReauth() {
+    // Dispatch snyk.logout through the IDE command bridge to clear stored credentials.
+    // Logout is synchronous and idempotent — no in-flight latch or timer needed.
+    function startLogout() {
       if (typeof window.__ideExecuteCommand__ !== 'function') { return; }
-      var btn = get('reauth-button');
-      if (btn && btn.disabled) { return; } // a re-auth is already in progress
-      var gen = ++_reauthGen;
-      var timeoutMs = typeof window.__REAUTH_TIMEOUT_MS__ === 'number'
-        ? window.__REAUTH_TIMEOUT_MS__
-        : 60000;
-      var safetyTimer = null;
-      var finished = false;
+      var statusEl = get('logout-status');
       function done() {
-        if (finished || gen !== _reauthGen) { return; }
-        finished = true;
-        if (safetyTimer !== null) {
-          window.clearTimeout(safetyTimer);
-          safetyTimer = null;
-        }
-        if (btn) {
-          btn.disabled = false;
-          btn.textContent = 'Connect';
+        if (statusEl) {
+          statusEl.textContent = 'Signed out. Your stored credentials were cleared — reopen Settings to sign in again.';
         }
       }
-      if (btn) {
-        btn.disabled = true;
-        btn.textContent = 'Connecting…';
-      }
-      safetyTimer = window.setTimeout(done, timeoutMs);
       try {
-        window.__ideExecuteCommand__('snyk.login', [], done);
+        window.__ideExecuteCommand__('snyk.logout', [], done);
       } catch (e) {
-        console.error('Error starting authentication:', e);
-        done();
+        console.error('Error logging out:', e);
       }
     }
 
@@ -598,7 +560,7 @@
     window.collectData = collectData;
     window.collectChangedData = collectChangedData;
     window.markDirty = markDirty;
-    window.startReauth = startReauth;
+    window.startLogout = startLogout;
 
     function repositionTooltip(trigger) {
       var popup = trigger.querySelector('.tooltip-popup');
@@ -659,9 +621,9 @@
       get('cli_release_channel_custom').addEventListener('input', validateCliVersion);
       get('cli_release_channel_custom').addEventListener('blur', validateCliVersion);
 
-      var reauthBtn = get('reauth-button');
-      if (reauthBtn) {
-        reauthBtn.addEventListener('click', startReauth);
+      var logoutBtn = get('logout-button');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', startLogout);
       }
 
       var tooltipTriggers = document.querySelectorAll('[data-toggle="tooltip"]');

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -217,13 +217,13 @@
       display: none !important;
     }
 
-    /* Re-authentication control */
-    .reauth-status {
+    /* Logout control */
+    .logout-status {
       margin: 0 0 var(--form-group-margin) 0;
       color: var(--text-color);
     }
 
-    .reauth-button {
+    .logout-button {
       align-self: flex-start;
       padding: var(--input-padding) 16px;
       background-color: var(--button-background);
@@ -235,14 +235,9 @@
       cursor: pointer;
     }
 
-    .reauth-button:focus {
+    .logout-button:focus {
       outline: 1px solid var(--focus-border);
       outline-offset: 2px;
-    }
-
-    .reauth-button:disabled {
-      opacity: 0.6;
-      cursor: default;
     }
 
     /* Info Message */
@@ -343,8 +338,8 @@
     <h2>Authentication</h2>
 
     <div class="form-group">
-      <p id="logout-status" class="reauth-status">If Snyk is stuck, clear your stored credentials to recover, then reopen Settings to sign in again.</p>
-      <button type="button" id="logout-button" class="reauth-button">Log out</button>
+      <p id="logout-status" class="logout-status">If Snyk is stuck, clear your stored credentials to recover, then reopen Settings to sign in again.</p>
+      <button type="button" id="logout-button" class="logout-button">Log out</button>
     </div>
 
     <div class="form-group half-width">


### PR DESCRIPTION
### **User description**
## Summary
The limited settings **fallback** page (shown when the full settings page can't load) had no login control — its Authentication section held only the Insecure/SSL-skip checkbox. A user dropped to the fallback was locked out of re-auth entirely, which is the user-facing half of IDE-2181.

This adds a **"Connect"** control to the fallback page that dispatches `snyk.login` through the IDE command bridge with **no args**, so re-auth reuses the user's existing configured method/endpoint (the limited page must not overwrite them). It is no-op-safe when the bridge is absent, disables while a login is in flight (no double-dispatch), and always recovers — via the bridge callback, a synchronous error, or a safety timeout — so it can never stick on "Connecting…". A generation latch makes a late callback from a superseded attempt inert. Status copy is state-neutral.

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1["#1370 CP1\nLS dispatch fix"]
    PR2["#1371 CP2 ← YOU ARE HERE\nfallback re-auth control"]
    main --> PR1 --> PR2
    style PR2 fill:#ffd700,color:#000
```

**Depends on:** #1370

## Verified (outside-in TDD)
`js-tests/settings-fallback.test.mjs` — asserts the control dispatches `snyk.login` (spy, not DOM-only), the disable/re-enable lifecycle, second-click suppression, the safety-timeout recovery, the cross-cycle stale-callback latch, and state-neutral copy. `make test` GREEN (146 JS tests pass).

## Deferred to later PR (CP3)
- `snyk-intellij-plugin`: mirror this fallback page (the plugin ships its own byte-identical copy) and prove `snyk.login` dispatches from it.

## Test plan
- [ ] Start the IDE with an expired token so the settings page falls back; click **Connect** → the OAuth flow starts and re-auth completes.
- [ ] Cancel the OAuth tab → the button recovers (not stuck on "Connecting…") and can be retried.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add 'Log out' button to settings fallback page.

- Dispatch `snyk.logout` command via IDE bridge.

- Implement and test new logout functionality.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication_flows_e2e_test.go</strong><dd><code>Add E2E test for logout during scanner initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/authentication_flows_e2e_test.go

<ul><li>Adds a new end-to-end test <br><code>Test_E2E_LogoutDuringScannerInitClearsCredentials</code>.<br> <li> This test verifies that the <code>snyk.logout</code> command correctly clears <br>credentials, even when the language server is in the midst of its <br>initialization phase.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1371/changes#diff-9deadd440a71de07926bf9936df138c9c5512696795d6b6544d4f40c01d06752">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings-fallback.test.mjs</strong><dd><code>Unit tests for fallback page logout control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js-tests/settings-fallback.test.mjs

<ul><li>Removes unit tests related to the old 'Connect' (re-authentication) <br>button.<br> <li> Adds new unit tests for the 'Log out' button, covering its presence, <br>correct command dispatch (<code>snyk.logout</code>), no-op safety, and status <br>update behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1371/changes#diff-6da8cfbb056402eea87adbb3081beda3776b81b201de3374c4d20a61b5362931">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings-fallback.html</strong><dd><code>Update fallback page UI for logout control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

shared_ide_resources/ui/html/settings-fallback.html

<ul><li>Replaces the previous 'Connect' button for re-authentication with a <br>'Log out' button.<br> <li> Adds new CSS styles for the logout button and status messages.<br> <li> Implements the <code>startLogout</code> JavaScript function to dispatch the <br><code>snyk.logout</code> command and update the UI status.<br> <li> Updates the HTML structure and event listeners to support the new <br>logout functionality.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1371/changes#diff-3489a54a68d7b46f5b60db397b73c9f4e37526c68f41c78cee2b2e1c7da66eb2">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

