### PR TITLE
feat: durable per-finding identity + canonical ContentRoot [IDE-2208][IDE-2207]

### DIFF
--- a/application/codeaction/codeaction.go
+++ b/application/codeaction/codeaction.go
@@ -58,6 +58,12 @@ type CodeActionsService struct {
 type cachedAction struct {
 	issue  types.Issue
 	action types.CodeAction
+	// canonicalRoot is the canonical registered workspace-folder root captured at
+	// GetCodeActions time. It is used at resolve time so the resolved action's
+	// FindingId anchors to the same root publishDiagnostics used, even if the
+	// folder is removed between GetCodeActions and ResolveCodeAction (a
+	// resolve-time workspace lookup would then return nil).
+	canonicalRoot types.FilePath
 }
 
 func NewService(engine workflow.Engine, provider snyk.IssueProvider, fileWatcher dirtyFilesWatcher, notifier noti.Notifier, featureFlagService featureflag.Service, configResolver types.ConfigResolverInterface) *CodeActionsService {
@@ -113,7 +119,7 @@ func (c *CodeActionsService) GetCodeActions(params types.CodeActionParams) []typ
 		c.logger.Debug().Any("path", path).Any("range", r).Msgf("Filtered to %d issues", len(issues))
 	}
 
-	quickFixGroupables := c.getQuickFixGroupablesAndCache(filteredIssues)
+	quickFixGroupables := c.getQuickFixGroupablesAndCache(filteredIssues, folder.Path())
 
 	var updatedIssues []types.Issue
 	if len(quickFixGroupables) != 0 {
@@ -122,7 +128,7 @@ func (c *CodeActionsService) GetCodeActions(params types.CodeActionParams) []typ
 		updatedIssues = filteredIssues
 	}
 
-	actions := converter.ToCodeActions(updatedIssues)
+	actions := converter.ToCodeActions(updatedIssues, folder.Path())
 	c.logger.Debug().Msg(fmt.Sprint("Returning ", len(actions), " code actions"))
 	return actions
 }
@@ -178,24 +184,25 @@ func (c *CodeActionsService) getQuickFixAction(quickFixGroupables []types.Groupa
 	return quickFix
 }
 
-func (c *CodeActionsService) getQuickFixGroupablesAndCache(issues []types.Issue) []types.Groupable {
+func (c *CodeActionsService) getQuickFixGroupablesAndCache(issues []types.Issue, canonicalRoot types.FilePath) []types.Groupable {
 	quickFixGroupables := []types.Groupable{}
 	for _, issue := range issues {
 		for _, action := range issue.GetCodeActions() {
 			if action.GetGroupingType() == types.Quickfix {
 				quickFixGroupables = append(quickFixGroupables, action)
 			}
-			c.cacheCodeAction(action, issue)
+			c.cacheCodeAction(action, issue, canonicalRoot)
 		}
 	}
 	return quickFixGroupables
 }
 
-func (c *CodeActionsService) cacheCodeAction(action types.CodeAction, issue types.Issue) {
+func (c *CodeActionsService) cacheCodeAction(action types.CodeAction, issue types.Issue, canonicalRoot types.FilePath) {
 	if action.GetUuid() != nil {
 		cached := cachedAction{
-			issue:  issue,
-			action: action,
+			issue:         issue,
+			action:        action,
+			canonicalRoot: canonicalRoot,
 		}
 		c.actionsCache[*action.GetUuid()] = cached
 	}
@@ -229,7 +236,15 @@ func (c *CodeActionsService) ResolveCodeAction(action types.LSPCodeAction) (type
 	resolvedAction.SetEdit(edit)
 	elapsed := time.Since(t)
 	elapsedSeconds := int(elapsed.Seconds())
-	codeAction := converter.ToCodeAction(cached.issue, resolvedAction)
+
+	// Use the canonical registered folder root captured at GetCodeActions time so
+	// the resolved action's embedded FindingId matches the one published for the
+	// same finding via publishDiagnostics (both anchor to the folder root). Reading
+	// it from the cache — rather than re-deriving it via a workspace lookup — keeps
+	// the id correct even if the folder was removed between GetCodeActions and this
+	// resolve (the lookup would then return nil and the id would silently fall back
+	// to the issue's sub-path ContentRoot, diverging from what was published).
+	codeAction := converter.ToCodeAction(cached.issue, resolvedAction, cached.canonicalRoot)
 
 	c.logger.Debug().Msg(fmt.Sprint("Resolved code action in ", elapsedSeconds, " seconds:\n", codeAction))
 	return codeAction, nil

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -1133,7 +1133,7 @@ func textDocumentDidOpenHandler(conf configuration.Configuration) jrpc2.Handler 
 			logger.Debug().Msg("Sending cached issues")
 			diagnosticParams := types.PublishDiagnosticsParams{
 				URI:         params.TextDocument.URI,
-				Diagnostics: converter.ToDiagnostics(filteredIssues[filePath]),
+				Diagnostics: converter.ToDiagnosticsForFolder(filteredIssues[filePath], folder.Path(), &logger),
 			}
 			mustNotifierFromContext(ctx).Send(diagnosticParams)
 		}

--- a/application/server/server_multiroot_test.go
+++ b/application/server/server_multiroot_test.go
@@ -1,0 +1,117 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/application/di"
+	"github.com/snyk/snyk-ls/domain/ide/workspace"
+	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/testsupport"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+	"github.com/snyk/snyk-ls/internal/uri"
+)
+
+// contentRootForFile returns the ContentRoot published for the given file's
+// most recent non-empty publishDiagnostics notification, or "" if none is found.
+func contentRootForFile(t *testing.T, jsonRPCRecorder *testsupport.JsonRPCRecorder, file types.FilePath) types.FilePath {
+	t.Helper()
+	want := uri.PathToUri(file)
+	var root types.FilePath
+	for _, n := range jsonRPCRecorder.FindNotificationsByMethod("textDocument/publishDiagnostics") {
+		var params types.PublishDiagnosticsParams
+		if n.UnmarshalParams(&params) != nil {
+			continue
+		}
+		if params.URI != want || len(params.Diagnostics) == 0 {
+			continue
+		}
+		root = params.Diagnostics[0].Data.ContentRoot
+	}
+	return root
+}
+
+// ACC-005: in a workspace with more than one root, every finding's ContentRoot
+// must equal the canonical registered root it physically belongs to. A finding
+// in the second root must NOT be mis-attributed to the first root, even when the
+// finding's own ContentRoot reports the wrong root (as happens today when a
+// sub-path is scanned).
+func TestFinding_RootAttribution_MultiRoot(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, jsonRPCRecorder, _ := setupServer(t, engine, tokenService)
+
+	_, err := loc.Client.Call(t.Context(), "initialize", nil)
+	require.NoError(t, err)
+	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
+
+	rootA := types.FilePath(t.TempDir())
+	rootB := types.FilePath(t.TempDir())
+	fileA := types.FilePath(filepath.Join(string(rootA), "a.go"))
+	fileB := types.FilePath(filepath.Join(string(rootB), "b.go"))
+
+	newFolder := func(root types.FilePath, name string) *workspace.Folder {
+		return workspace.NewFolder(
+			engine.GetConfiguration(), engine.GetLogger(), root, name,
+			di.Scanner(), di.HoverService(), di.ScanNotifier(), di.Notifier(),
+			di.ScanPersister(), di.ScanStateAggregator(), featureflag.NewFakeService(),
+			di.ConfigResolver(), engine,
+		)
+	}
+	folderA := newFolder(rootA, "rootA")
+	folderB := newFolder(rootB, "rootB")
+	ws := config.GetWorkspace(engine.GetConfiguration())
+	ws.AddFolder(folderA)
+	ws.AddFolder(folderB)
+
+	// Both findings carry rootA as their own ContentRoot, simulating the
+	// mis-attribution bug where a finding reports the first/wrong root. Each
+	// folder must publish the finding with its own canonical registered root.
+	issueA := testutil.NewMockIssue("issueA", fileA)
+	issueA.ContentRoot = rootA
+	issueB := testutil.NewMockIssue("issueB", fileB)
+	issueB.ContentRoot = rootA // deliberately wrong: pretends to belong to rootA
+
+	folderA.ProcessResults(t.Context(), types.ScanData{
+		Product:           product.ProductOpenSource,
+		Issues:            []types.Issue{issueA},
+		UpdateGlobalCache: true,
+	})
+	folderB.ProcessResults(t.Context(), types.ScanData{
+		Product:           product.ProductOpenSource,
+		Issues:            []types.Issue{issueB},
+		UpdateGlobalCache: true,
+	})
+
+	require.Eventually(t, func() bool {
+		return contentRootForFile(t, jsonRPCRecorder, fileA) != "" &&
+			contentRootForFile(t, jsonRPCRecorder, fileB) != ""
+	}, 5*time.Second, 10*time.Millisecond, "expected diagnostics published for both roots")
+
+	assert.Equal(t, rootA, contentRootForFile(t, jsonRPCRecorder, fileA),
+		"finding in rootA must be attributed to rootA")
+	assert.Equal(t, rootB, contentRootForFile(t, jsonRPCRecorder, fileB),
+		"finding in rootB must be attributed to its own canonical root, not the first root")
+}

--- a/docs/plans/IDE-2207-2208-durable-finding-and-root-identity.md
+++ b/docs/plans/IDE-2207-2208-durable-finding-and-root-identity.md
@@ -1,0 +1,306 @@
+<!-- sub-plan: non-authoritative mirror of the Confluence master plan (to be published) -->
+# IDE-2207 + IDE-2208 — Durable finding identity & workspace-root identity in snyk-ls scan output
+> Committed per-PR sub-plan mirror. Source of truth = Confluence master (to be published). Working copy = repo-root `IDE-2207-2208_implementation_plan.md` (gitignored).
+> Working copy (gitignored session scratchpad). Source of truth = Confluence master (to be published). Committed mirror = `docs/plans/IDE-2207-2208-durable-finding-and-root-identity.md`.
+
+## SESSION RESUME
+
+| Field | Value |
+|-------|-------|
+| Tickets | [IDE-2207](https://snyksec.atlassian.net/browse/IDE-2207) (stable per-finding route id / D10), [IDE-2208](https://snyksec.atlassian.net/browse/IDE-2208) (multi-root correlation via canonical `ContentRoot`) |
+| Parent epic | [IDE-2052](https://snyksec.atlassian.net/browse/IDE-2052) — Ambient Canary (In Progress) |
+| Traces to | ADR-18 open item #4 (`../ambient-canary/docs/requirements/architecture.md`) — stable finding identifier for before/after correlation across worktree boundaries |
+| Repo (in scope) | `github.com/snyk/snyk-ls` only. Consumer `ambient-canary` is OUT of scope (defines the customer outcome) |
+| Branch | current `feat/IDE-2052-fixfolder-return-diffs`; implementation should start a fresh branch `feat/IDE-2207-2208-durable-finding-identity` off `main` |
+| Status | Planning — awaiting user confirmation |
+| Last updated | 2026-07-13 |
+
+### Current state (what already landed)
+
+Commit `eb6063e` — `feat(codeaction): expose stable findingId and code action kind [IDE-2052]` — added `ScanIssue.FindingId` (`internal/types/lsp.go:1133`) sourced from `issue.GetFindingId()`, distinct from `ScanIssue.Id` (per-result-set key). That work is **stable-across-scans but NOT instance-unique**, and is **not populated consistently across products**. This plan closes those gaps.
+
+### Next actions
+1. User confirms the architecture decision (below) and the two open decisions.
+2. Publish Confluence master + write ACs onto IDE-2207 / IDE-2208 (`customfield_10890`).
+3. Spawn `coder` on CP-1 (foundation) first; CP-2/CP-3 parallelisable after CP-1 freezes the contract.
+
+---
+
+## BDD Offer (optional — confirm before coder starts)
+
+No BDD framework detected (Go project; `go.mod` has no `cucumber/godog`; no `.feature` files). Adding one would:
+- **Framework:** `github.com/cucumber/godog` (detected language: Go) — `go test` compatible via `godog.TestSuite`.
+- **Estimated effort:** 0.5–1d for scaffold + `bdd-coverage-gate` CI job + `CONTRIBUTING.md`.
+- **Approach:** Phase 0 (`.feature` files as docs + CI gate) → Phase 1 (wiring + step defs for these tickets' scenarios) → Phase 2 (`go test ./test/acceptance/` step).
+
+**Confirm Y/N.** If N, mark this section "Declined" and proceed with the standard Go table-test pyramid described in Phase 1.4. Recommendation: **N for this pair** — the acceptance layer here is LSP-protocol roundtrips already well-served by `application/server` integration tests; adding godog now is scope the tickets don't need. Revisit as an epic-level decision.
+
+---
+
+## Phase 1: Planning
+
+### 1.0 Background — why the existing identifiers don't work
+
+> This section derives the conclusions the rest of the plan relies on, so a reviewer who has not read the code can follow the reasoning. All claims verified in source on 2026-07-13.
+
+#### (a) Three identifiers, three different jobs
+
+snyk-ls already carries three id-like values on a finding. They are **not** interchangeable:
+
+| Value | Wire? | Where set | What it is | Job |
+|-------|-------|-----------|------------|-----|
+| `Issue.Fingerprint` | no (internal) | per-product (`SetFingerPrint`) | product-specific grouping hash | delta / `IsNew` fuzzy matching only |
+| `ScanIssue.Id` | `json:"id"` | `domain/ide/converter` (= `additionalData.Key`) | `util.GetIssueKey` = `sha256(ruleId + absPath + startLine+endLine+startCol+endCol)` (`internal/util/identity.go:25`) | per-result-set key within one scan |
+| `ScanIssue.FindingId` | `json:"findingId"` | `domain/ide/converter` (= `issue.GetFindingId()`) | the **intended** stable cross-scan correlation key, added by `eb6063e` | correlate the same finding across scans |
+
+The single fact that drives the worktree failure: **`GetIssueKey` is derived from the absolute path and range.** The same finding scanned in a git-worktree copy sits at a different absolute path → different `Id`. So `Id` can never be worktree-portable by construction.
+
+#### (b) Per-product sourcing today, and why each fails (verified in source)
+
+- **Code** (`getCodeIssue`): `Id` = `CodeIssueData.Key` (abs-path `GetIssueKey`, `convert.go:380/386`); `FindingId` = `Fingerprints.SnykAssetFindingV1` (`convert.go:418`) — an **asset/grouping** key. The treeview groups every location of a finding under one node **by fingerprint** (`tree_builder.go` `buildIssueNodes`: "Issues sharing the same fingerprint are grouped under a single parent issue node with NodeTypeLocation children"). A grouping key by definition **collides** across the distinct instances IDE-2207 must individuate.
+- **OSS** (`getOssIssue`): `Id` = `OssIssueData.Key` (abs-path key, `unified_converter.go:462`); `FindingId` = `introducingFinding.Id.String()` — a **testapi finding UUID** (`unified_converter.go:161`), not guaranteed stable across scans. (OSS `Fingerprint` via `CalculateFingerprintFromAdditionalData` = `packageName|version|depChain|rule` — stable but path-blind/grouping, and delta-only.)
+- **Secrets** (`convert.go`): `Id`, `FindingId`, and `Fingerprint` **all fold `attrs.Key`, a per-scan UUID** (lines 93, 128, 129) → nothing is stable across scans; every re-scan mints new ids.
+- **IaC** (`getIacIssue`): `Id` = `sha256(absPath + line + publicID)` (`iac.go:515`); `FindingId` = **empty** (the scanner never calls `SetFindingId`); `Fingerprint` = `rule|resourcePath` (delta-only).
+
+| Product | stable across scans? | instance-unique? | location-independent? | one value with all three? |
+|---------|:---:|:---:|:---:|:---:|
+| Code | `FindingId` ✅ / `Id` ✅ | `Id` ✅ / `FindingId` ❌ | ❌ | **no** |
+| OSS | `Id` ✅ / `FindingId` ❌ | ✅ | ❌ | **no** |
+| Secrets | ❌ (UUID) | ✅ | ❌ | **no** |
+| IaC | `Id` ✅ | ✅ | ❌ | **no** (`FindingId` empty) |
+
+No product has {stable ∧ instance-unique ∧ location-independent} in a single value. That is the exact gap this plan fills.
+
+#### (c) Why the workspace/folder construct isn't enough (IDE-2208)
+
+`ScanIssue.ContentRoot` is stamped per issue and is already on the wire, so an in-place listing already knows a finding's folder — but today it is **not guaranteed to be the canonical registered root**: when a sub-path is scanned it can report a different value, so the consumer can't reliably rely on it and falls back to `roots[0]`. The fix is not a new opaque key; it is to **guarantee `ContentRoot` is always the canonical registered root path** (identical regardless of which sub-path was scanned) and to make `FindingId` **root-relative** so it is stable across the worktree boundary. The consumer created the worktree, so it already owns the worktree↔origin-root mapping and keys on `ContentRoot` + the root-relative `FindingId`. snyk-ls already relies on an ad-hoc path-prefix remap in the fix path (the daemon "prefix-remap contract" — `runDir` used verbatim/non-canonical — in `domain/snyk/remediation/`); a canonical `ContentRoot` + root-relative `FindingId` removes the need for that brittle workaround.
+
+#### (d) Why fingerprint can't be the identity
+
+Fingerprint solves a **different** problem — fuzzy base-vs-current delta diffing — and is structurally unfit as an identity (`internal/delta/fuzzy_matcher.go`):
+- it is one weighted term (`FingerprintConfidence: 0.5`) in a similarity score with a **fuzzy** accept threshold (`MinimumAcceptableConfidence: 0.4`) — not 1:1 equality;
+- `fingerprintDistance` returns a part-ratio, not equality;
+- the matcher **derives a separate `GlobalIdentity`** (a base-branch UUID via `SetGlobalIdentity`) rather than using the fingerprint as the id;
+- `Match` requires a base list, so it doesn't even exist outside a delta scan;
+- its design goal is position-**blindness** (so a drifted finding still matches) — the exact opposite of the instance individuation IDE-2207 needs;
+- coverage is inconsistent (`CalculateFingerprintFromAdditionalData` handles **OSS + IaC only**; Code uses a SARIF fingerprint; Secrets fp is the per-scan UUID).
+
+**Core tension:** fingerprint optimises *tolerance*; identity optimises *exactness*; one value cannot be both. The fix therefore **reuses the fingerprint/grouping key as the `groupingKey` input** and **adds the root-relative path + range** to individuate — producing a value that is both durable (grouping core) and exact (location discriminator).
+
+### 1.1 Requirements analysis
+
+**Customer outcomes (from the consumer, ambient-canary — the reason this work exists):**
+
+- **R1 (IDE-2207 — durable identity):** The same underlying finding keeps the **same** per-finding identity across repeated scans of the same code.
+- **R2 (IDE-2207 — instance uniqueness):** Two **distinct** findings never receive the same per-finding identity, **even when they share a rule or fingerprint** (e.g. the same rule firing at two locations in one file).
+- **R3 (IDE-2207 — worktree portability):** A finding's identity is **identical** whether the code is scanned in the user's working tree or in a git worktree copy of it, so a consumer can correlate before/after diagnostics across the worktree boundary (ADR-18 #4).
+- **R4 (IDE-2207 — cross-product coverage):** R1–R3 hold for **all four products**: Snyk Code, Open Source, Secrets, IaC. No product emits an empty or per-scan-random identity.
+- **R5 (IDE-2208 — root attribution):** In a workspace with **more than one root/folder**, every finding in the scan output carries a reliable identifier of **which workspace root it belongs to**, so a consumer correlates each finding to the correct root instead of defaulting to the first root.
+- **R6 (backward compat):** The existing `ScanIssue.Id` (per-result-set key) and the existing consumers of published diagnostics keep working unchanged; new/repaired fields are additive or semantics-preserving for current IDE clients.
+
+**Current-state gap analysis (verified in source, 2026-07-13):**
+
+| Product | `ScanIssue.Id` (`additionalData.Key`) | Stable across scans? | Instance-unique? | `ScanIssue.FindingId` | Stable? | Instance-unique? | Worktree-portable? |
+|---------|----------------------------------------|----------------------|------------------|-----------------------|---------|------------------|--------------------|
+| Code | `util.GetIssueKey(ruleID, absPath, range)` (`infrastructure/code/convert.go:380,386`) | ✅ (unchanged code) | ✅ | `Fingerprints.SnykAssetFindingV1` (`convert.go:418`) | ✅ | ❌ **groups instances** | ❌ (abs path in `Id`) |
+| OSS | `util.GetIssueKey(problem.Id, absPath, range)` (`oss/unified_converter.go:462`) | ✅ | ✅ | `introducingFinding.Id.String()` testapi UUID (`unified_converter.go:161`) | ❓ GAF-dependent | ✅-ish | ❌ |
+| Secrets | `util.GetIssueKey(attrs.Key, absPath, range)` — **folds per-scan UUID** (`secrets/convert.go:93,99`) | ❌ **unstable** | ✅ | `attrs.Key` per-scan UUID (`convert.go:128`) | ❌ **unstable** | ✅ | ❌ |
+| IaC | `getIssueKey(absPath, line, publicID)` (`iac/iac.go:515`) | ✅ | ✅ | **empty** (not set) | ❌ | ❌ | ❌ |
+
+**Conclusion:** No single existing field is simultaneously *stable across scans*, *instance-unique*, and *worktree-portable* for all four products. `Id` is instance-unique but absolute-path-based (not worktree-portable) and unstable for Secrets; `FindingId` is stable-ish but groups instances (Code), is empty (IaC), or random per scan (Secrets).
+
+**Files in scope (production):**
+- `internal/types/lsp.go` — `ScanIssue` struct (`FindingId` semantics repaired; `ContentRoot` doc'd as the canonical registered root). No new field.
+- `internal/util/identity.go` — add a deterministic composite-identity helper.
+- `domain/ide/converter/converter.go` — the single conversion layer where `Id`, `FindingId`, and canonical `ContentRoot` are set per product (`getCodeIssue`/`getOssIssue`/`getSecretIssue`/`getIacIssue`).
+- `infrastructure/code/convert.go`, `infrastructure/oss/unified_converter.go`, `infrastructure/secrets/convert.go`, `infrastructure/iac/iac.go` — per-product stable grouping-key sourcing (esp. Secrets: stop using the UUID; IaC: provide grouping key).
+- `domain/snyk/issues.go` — `Issue` finding-id/root accessors if needed.
+- `domain/ide/workspace/*` + wherever `$/snyk.scan` params are built — carry the canonical root identity at scan level.
+
+### 1.2 Architecture design (the decision)
+
+> This section is the ADR for the pair. It answers the user's two framing questions: **where the ids originate** and **how they surface to a consumer**. Persist it via `capture-requirements` (Phase 1.5) as `docs/requirements/architecture.md` ADR entry.
+
+**Decision D-1 — Origin: compute the durable, instance-unique identity in snyk-ls's conversion layer; do NOT block on GAF.**
+All inputs required to compute a stable + instance-unique + worktree-portable identity are already available inside snyk-ls at conversion time:
+- a **stable grouping key** (what makes two observations "the same finding"): Code `SnykAssetFindingV1`, OSS testapi finding id, Secrets rule id/name, IaC `publicID`;
+- an **instance discriminator** (what makes two findings distinct): file path + normalized range;
+- the **workspace root** (to make the path root-relative and hence worktree-portable): the registered folder root (`ContentRoot`).
+
+Therefore neither ticket is *hard*-blocked upstream. The "upstream-blocked" label assumed GAF must mint the id; it need not. Long-term, GAF/testapi should own the durable **asset-finding** grouping identity for every product (Code already emits `SnykAssetFindingV1`; OSS emits a finding id) and snyk-ls should consume it as the grouping core — but instance-uniqueness and root-relativity are conversion-layer concerns that stay in snyk-ls regardless. See "Optional future enhancement" below for the narrow part that remains a GAF ask.
+
+**Decision D-2 — Identity formula (the per-finding id, R1–R4):**
+```
+findingIdentity = shortHash( groupingKey  + " " +
+                             rootRelativePath + " " +
+                             startLine + ":" + startCol + "-" + endLine + ":" + endCol )
+```
+- `groupingKey` = per-product durable key (above); Secrets uses the **rule id/name**, never the per-scan UUID.
+- `rootRelativePath` = `affectedFilePath` expressed **relative to the finding's workspace root** (`ContentRoot`) with forward slashes — this is what makes the id identical in the working tree and in a worktree copy (R3).
+- Range is normalized (0-based, half-open, as already produced by the converter).
+- Deterministic (SHA-256, hex-truncated as `GetIssueKey` already does) → stable across scans for unchanged code (R1), unique per instance because the location discriminates instances that share a grouping key (R2).
+
+**Decision D-3 — Surfacing: repair the existing `FindingId` field in place (recommended); keep `Id` unchanged.**
+- `ScanIssue.FindingId` becomes the D-2 identity, populated identically for **all four products**. The consumer already reads `FindingId`; repairing it in place avoids a consumer field rename. `FindingId` is young (landed in `eb6063e`) and its only consumer is internal (ambient-canary), so redefining its semantics from "grouping fingerprint" to "stable+unique+portable instance id" is low-risk.
+- `ScanIssue.Id` (per-result-set key) is **unchanged** for every product — existing IDE clients (VS Code/IntelliJ/Eclipse/VS) that key on `Id` are unaffected (R6).
+- **DECIDED (2026-07-13):** repair `FindingId` in place; no new field.
+
+**Decision D-4 — Root identity (R5): canonical `ContentRoot`, no new key. DECIDED (2026-07-13).**
+- Guarantee `ScanIssue.ContentRoot` is **always populated** and **always equals the canonical registered workspace-folder root** (not a scan sub-path or file-scan directory) for every product — an identical value regardless of which sub-path was scanned.
+- **No `RootId`** is added (a hashed key was judged over-engineered). The consumer correlates a finding to its root by keying on `ContentRoot` + the root-relative `FindingId`. Because the consumer created the worktree, it already owns the worktree↔origin-root mapping; snyk-ls owes only a canonical, reliable `ContentRoot` and a root-relative `FindingId`.
+
+**Scope: all four products are fixed now, in snyk-ls.** The user has decided OSS/Secrets/IaC are **not** deferred. Every product emits a `FindingId` that is stable across scans, unique per instance, and location-independent (root-relative), computed entirely in snyk-ls's conversion layer from inputs already present. The D-2 composite needs nothing from GAF: it uses each product's existing grouping key (Code `SnykAssetFindingV1`, OSS testapi finding id, Secrets rule id/name, IaC `publicID`) and, where a product has no durable grouping key, degrades gracefully to rule-id — always combined with the root-relative path + range for exactness. **IDE-2207 and IDE-2208 are therefore fully unblocked by this snyk-ls work.**
+
+**Optional future enhancement (NOT a blocker for this delivery):** a *machine-independent, movement-tolerant* asset-finding identity (one that survives the finding physically moving in the file without relying on re-scan delta matching) is the only thing that would additionally require a GAF/testapi asset-finding rollout for OSS/Secrets/IaC. It improves durability under large code drift but is not needed for R1–R6. If pursued, track it as a separate `deferred` child of IDE-2052 — it does not gate shipping a correct, stable, instance-unique `FindingId` per product now.
+
+### 1.3 Flow diagrams
+
+Create `docs/diagrams/IDE-2207-2208_identity_flow.mmd` (gitignored) — sequence: scanner → per-product converter (grouping key) → `domain/ide/converter` (compose FindingId with root-relative path; stamp canonical `ContentRoot`) → `ScanIssue` → `publishDiagnostics.data` → consumer correlates by (`ContentRoot`, `FindingId`). Render to PNG with `make generate-diagrams` if the target exists; otherwise embed the mermaid source in the Confluence master.
+
+### 1.4 Test Scenario Definition (outside-in — defined before any checkpoint)
+
+Acceptance layer for snyk-ls = **LSP-protocol roundtrip** tests in `application/server` (initialize → scan → observe `publishDiagnostics`/`$/snyk.scan` payload) — this is the customer-visible surface the consumer actually reads. Integration = converter + real per-product converters wired together. Unit = the identity helper and per-product grouping-key sourcing.
+
+#### Layer 1 — Acceptance (LSP roundtrip; customer-visible outcomes)
+
+| Test ID | Given | When | Then | File | Test function | Layer |
+|---------|-------|------|------|------|---------------|-------|
+| ACC-001 | a folder with a Code finding | folder scanned twice (unchanged code) | the finding's `FindingId` in `publishDiagnostics.data` is **identical** across both scans | `application/server/server_finding_identity_test.go` | `TestFindingId_StableAcrossScans_Code` | Accept |
+| ACC-002 | a file with the **same rule firing at two different locations** (shared fingerprint) | folder scanned | the two findings have **different** `FindingId` values | same | `TestFindingId_InstanceUnique_SameRuleTwoLocations` | Accept |
+| ACC-003 | a folder with a Code finding, and a git-worktree copy of that folder registered as a separate root | both scanned | the finding's `FindingId` is **identical** in the working tree and the worktree | same | `TestFindingId_WorktreePortable_RootRelative` | Accept |
+| ACC-004a | a folder with a **Code** finding | scanned twice + at two locations of one rule | each Code finding keeps its id across scans and two locations get different ids | same | `TestFindingId_Code_StableUnique` | Accept |
+| ACC-004b | a folder with an **OSS** finding | scanned twice | the OSS finding keeps the same id across scans (no longer a per-scan testapi UUID) | same | `TestFindingId_OSS_StableAcrossScans` | Accept |
+| ACC-004c | a folder with a **Secrets** finding (re-scan mints a new internal UUID) | scanned twice | the Secrets finding keeps the **same** id across scans despite the UUID changing | same | `TestFindingId_Secrets_StableDespiteUUID` | Accept |
+| ACC-004d | a folder with an **IaC** finding | scanned | the IaC finding has a **non-empty**, stable, instance-unique id (was empty before) | same | `TestFindingId_IaC_NonEmptyStableUnique` | Accept |
+| ACC-005 | a workspace with **two roots**, each containing findings | workspace scanned | every finding's `ContentRoot` equals the canonical root it physically belongs to; **no** finding is attributed to the wrong/first root | `application/server/server_multiroot_test.go` | `TestFinding_RootAttribution_MultiRoot` | Accept |
+| ACC-006 | current IDE client keying on `ScanIssue.Id` | folder scanned | `Id` values are unchanged from pre-change behaviour for all four products (golden-value regression) | `application/server/server_finding_identity_test.go` | `TestScanIssueId_Unchanged_BackwardCompat` | Accept |
+
+#### Layer 2 — Integration (converter + real per-product converters)
+
+| Test ID | Scenario | Components wired | Assertion | File | Test function | Layer |
+|---------|----------|------------------|-----------|------|---------------|-------|
+| INT-001 | Code SARIF → issues → `ToDiagnostics` | `code.SarifConverter` + `domain/ide/converter` | `FindingId` = D-2 composite; two same-rule locations differ; re-run identical | `domain/ide/converter/converter_finding_identity_test.go` | `TestToDiagnostics_Code_FindingIdComposite` | Integ |
+| INT-002 | OSS testapi → issues → `ToDiagnostics` | `oss` unified converter + `domain/ide/converter` | `FindingId` composite non-empty, stable, instance-unique | same | `TestToDiagnostics_OSS_FindingIdComposite` | Integ |
+| INT-003 | Secrets testapi (**re-run mints a new `attrs.Key` UUID**) → issues → `ToDiagnostics` | `secrets.FindingsConverter` + `domain/ide/converter` | `FindingId` is **identical** across the two runs despite the UUID changing (proves UUID no longer feeds identity) | same | `TestToDiagnostics_Secrets_FindingIdStable_DespiteUUIDChange` | Integ |
+| INT-004 | IaC issues → `ToDiagnostics` | `iac` converter + `domain/ide/converter` | `FindingId` non-empty and instance-unique (fixes empty-id gap) | same | `TestToDiagnostics_IaC_FindingIdPopulated` | Integ |
+| INT-005 | finding in a sub-path of a root | per-product converter + `domain/ide/converter` | `ContentRoot` = canonical registered root (not the scanned sub-path); `FindingId` uses root-relative path | same | `TestToDiagnostics_CanonicalContentRoot_RootRelativeFindingId` | Integ |
+| INT-006 | worktree copy vs original tree, same file/finding | `domain/ide/converter` | `FindingId` identical; `Id` differs (abs-path based) — documents the contrast | same | `TestToDiagnostics_WorktreePortability` | Integ |
+
+#### Layer 3 — Unit (identity helper + per-product grouping key)
+
+| Test ID | Function under test | Input / state | Expected | File | Test function | Layer |
+|---------|--------------------|---------------|----------|------|---------------|-------|
+| UNIT-001 | `util.ComputeFindingIdentity` | groupingKey + rootRelPath + range | deterministic hex; same inputs → same output | `internal/util/identity_test.go` | `TestComputeFindingIdentity_Deterministic` | Unit |
+| UNIT-002 | `util.ComputeFindingIdentity` | same groupingKey, two different ranges | different outputs | same | `TestComputeFindingIdentity_InstanceUnique` | Unit |
+| UNIT-003 | `util.ComputeFindingIdentity` | same groupingKey+range, abs path vs root-relative caller | root-relative caller yields worktree-identical output | same | `TestComputeFindingIdentity_RootRelative` | Unit |
+| UNIT-004 | Secrets grouping-key selection | `attrs.Key` UUID present + rule id present | grouping key = rule id (UUID ignored) | `infrastructure/secrets/convert_test.go` | `TestSecrets_GroupingKey_IgnoresUUID` | Unit |
+| UNIT-005 | IaC grouping-key selection | issue with `publicID` | grouping key = `publicID` | `infrastructure/iac/iac_test.go` | `TestIaC_GroupingKey_PublicID` | Unit |
+
+#### Layer 4 — Manual
+
+| Test ID | Scenario | Steps | Expected | Layer |
+|---------|----------|-------|----------|-------|
+| MAN-001 | Existing IDE (VS Code) still renders + navigates findings | scan a multi-finding repo in VS Code | tree, navigation, code actions unaffected (no reliance on repaired `FindingId`) | Manual |
+
+**Self-check:**
+- [x] Every R1–R5 outcome has ≥1 ACC row; R6 → ACC-006 + MAN-001.
+- [x] Every boundary (converter) has INT rows; identity helper has UNIT rows not duplicated by INT.
+- [x] Ghost-test check: ACC rows assert **payload field values** in `publishDiagnostics.data`, not that a method was called.
+- [x] Cross-language contract: `FindingId` and `ContentRoot` are consumed by ambient-canary (Rust/Go). Field names/JSON tags cross the language boundary → ACC-004/ACC-005 assert exact JSON field presence + value; the JSON tags (`findingId`, `contentRoot`) are the shared contract. (ambient-canary side is out of scope but the exact-tag assertion lives here.)
+
+  | Value | snyk-ls emitter | Consumer | Test asserting exact wire value |
+  |-------|-----------------|----------|---------------------------------|
+  | `findingId` JSON tag + composite value | `converter.go` → `ScanIssue` | ambient-canary | ACC-004a–d, INT-001..004 |
+  | `contentRoot` JSON tag = canonical root | `converter.go` → `ScanIssue` | ambient-canary | ACC-005, INT-005 |
+
+### 1.5 Requirements capture
+Before Phase 2, run `capture-requirements` to persist R1–R6 to the central store keyed to IDE-2207 and IDE-2208, and persist D-1..D-4 as an ADR in `docs/requirements/architecture.md`. Hard gate: ≥1 requirement per ticket in the store before coding.
+
+---
+
+## Phase 2: Implementation (outside-in TDD, structured for parallelism)
+
+**Foundation-first:** CP-1 freezes the wire contract — repaired `FindingId` (root-relative, all four products) + canonical `ContentRoot` guarantee + the identity helper; **no `RootId`**. CP-2 and CP-3 implement per-product against that frozen contract and are **independent** (different converter files) → parallelisable by two coder agents. CP-4 is the cross-product acceptance sweep and depends on CP-2+CP-3. Every product's `FindingId` is repaired in this delivery — none deferred.
+
+**Checkpoint DAG:**
+```mermaid
+flowchart LR
+  CP1["CP-1 root identity + helper<br/>(IDE-2208) — contract freeze"]
+  CP2["CP-2 FindingId: Code + OSS<br/>(IDE-2207)"]
+  CP3["CP-3 FindingId: Secrets + IaC<br/>(IDE-2207)"]
+  CP4["CP-4 cross-product acceptance<br/>+ backward-compat lock"]
+  CP1 --> CP2
+  CP1 --> CP3
+  CP2 --> CP4
+  CP3 --> CP4
+```
+CP-2 and CP-3 run in parallel once CP-1 merges (or stacks on CP-1).
+
+### CP-1: Root identity foundation + identity helper (IDE-2208 core) — **contract freeze**
+**Goal:** Every finding reliably names its canonical workspace root (`ContentRoot`), and a deterministic root-relative identity helper exists; the wire contract (repaired `FindingId` + canonical `ContentRoot`, **no `RootId`**) is frozen.
+**Child ticket:** IDE-2208 (+ create sub-task if the team wants finer granularity).
+**Architecture decisions:** D-1, D-3, D-4; add `util.ComputeFindingIdentity(groupingKey, rootRelPath string, r types.Range) string`; guarantee `ContentRoot` = canonical registered root in all four `getXxxIssue` converters; compute the root-relative path once in the converter. No `RootId` field, no scan-notification change.
+**Files to create:** `internal/util/identity.go` additions (helper) + `internal/util/identity_test.go`.
+**Files to modify:** `internal/types/lsp.go` (doc `FindingId`; doc `ContentRoot` as canonical registered root); `domain/ide/converter/converter.go` (stamp canonical `ContentRoot`, compute root-relative path once, feed the helper).
+**Tests (outside-in):** ACC-005 (RED) → INT-005 (RED) → UNIT-001..003 (RED) → implement → GREEN.
+**Real-wiring note:** canonical `ContentRoot` + root-relative `FindingId` set in the production converter path that feeds `publishDiagnostics`; ACC-005 exercises the real LSP server, no fakes at the boundary.
+**Commit:** `feat(scan): guarantee canonical ContentRoot + root-relative finding identity [IDE-2208]`
+
+### CP-2: Instance-unique, worktree-portable FindingId for Code + OSS (IDE-2207) — parallel
+**Goal:** Code and OSS findings carry a stable, instance-unique, worktree-portable `FindingId`.
+**Customer outcomes:** *A Code finding keeps the same identity across scans, and the same rule at two locations gets two identities (no collision). An OSS finding keeps the same identity across scans (no longer a per-scan UUID).*
+**Child ticket:** IDE-2207.
+**Architecture decisions:** D-2, D-3; Code grouping key = `SnykAssetFindingV1`; OSS grouping key = testapi finding id; both feed `ComputeFindingIdentity` with the root-relative path from CP-1.
+**Files to modify:** `domain/ide/converter/converter.go` (`getCodeIssue`, `getOssIssue`); if grouping key must be plumbed, `infrastructure/code/convert.go` / `infrastructure/oss/unified_converter.go`.
+**Tests:** ACC-001, ACC-002, ACC-003, ACC-004a, ACC-004b (RED) → INT-001, INT-002, INT-006 (RED) → implement → GREEN.
+**Commit:** `feat(scan): stable instance-unique findingId for Code and OSS [IDE-2207]`
+
+### CP-3: FindingId for Secrets + IaC — drop UUID, fill the empty (IDE-2207) — parallel
+**Goal:** Secrets `FindingId` is stable despite the per-scan UUID; IaC `FindingId` is populated.
+**Customer outcomes:** *A Secrets finding keeps the same identity across scans even though the internal UUID changes each scan. An IaC finding now has a real, stable, instance-unique identity (previously empty).*
+**Child ticket:** IDE-2207 (sibling sub-task to CP-2).
+**Architecture decisions:** D-2; Secrets grouping key = rule id/name (**not** `attrs.Key`); IaC grouping key = `publicID`; both via `ComputeFindingIdentity` + root-relative path.
+**Files to modify:** `domain/ide/converter/converter.go` (`getSecretIssue`, `getIacIssue`); `infrastructure/secrets/convert.go` (source a stable grouping key, stop feeding the UUID into identity); `infrastructure/iac/iac.go` (expose `publicID` as grouping key).
+**Tests:** ACC-004c, ACC-004d (RED) → INT-003, INT-004 (RED) → UNIT-004, UNIT-005 (RED) → implement → GREEN.
+**Commit:** `feat(scan): populate stable findingId for Secrets and IaC [IDE-2207]`
+
+### CP-4: Cross-product acceptance sweep + backward-compat lock
+**Goal:** All four products proven together; `Id` backward-compat locked.
+**Depends on:** CP-2 + CP-3.
+**Tests:** ACC-004a–d (full four-product sweep), ACC-006 (RED→GREEN); run full suite + `make lint`. MAN-001 scheduled.
+**Commit:** `test(scan): cross-product findingId + root attribution acceptance [IDE-2207][IDE-2208]`
+
+**PR sizing:** CP-1 and CP-4 likely one PR each; CP-2/CP-3 one PR each (stacked on CP-1). Each < 700 lines.
+
+---
+
+## Decisions (resolved 2026-07-13)
+
+1. **`FindingId` repaired in place — no new field.** Its only consumer (ambient-canary) is internal and the field is young (`eb6063e`), so redefining its semantics from "grouping fingerprint" to "stable + instance-unique + root-relative id" is low-risk and avoids a consumer rename. (D-3)
+2. **Canonical `ContentRoot` only — no `RootId`.** A hashed root key was judged over-engineered. IDE-2208 is solved by (a) guaranteeing `ContentRoot` is the canonical registered root path (identical regardless of which sub-path was scanned) and (b) the root-relative `FindingId`, which makes a finding correlatable across the worktree boundary. The consumer created the worktree, so it already owns the worktree↔origin-root mapping and keys on `ContentRoot` + root-relative `FindingId`. No new opaque key on the wire. (D-4)
+3. **Not upstream-blocked — proceed in snyk-ls.** All inputs to compute a stable, instance-unique, root-relative id exist in the conversion layer today; the tickets are fully unblocked by this snyk-ls work. The single optional future enhancement is a movement-tolerant, content-based asset identity (GAF/testapi) that survives a finding physically moving — a durability improvement, not a blocker; if pursued, track as a `deferred` child of IDE-2052. (D-1)
+
+---
+
+## Effort estimates
+
+| PR | Scope | Agent dev | PR review | Manual | Total |
+|----|-------|-----------|-----------|--------|-------|
+| PR1 (CP-1) | root identity + helper + contract freeze | 1.0d | 1d | — | 2.0d |
+| PR2 (CP-2) | Code+OSS findingId | 0.75d | 1d | — | 1.75d |
+| PR3 (CP-3) | Secrets+IaC findingId | 0.75d | 1d | — | 1.75d |
+| PR4 (CP-4) | cross-product acceptance + compat | 0.5d | 1d | 0.5d (MAN-001) | 2.0d |
+| **Total** | | **3.0d** | **4d** | **0.5d** | **~7.5d** |
+
+Scope note: all four products (Code, OSS, Secrets, IaC) are in this delivery — CP-2 (Code+OSS) and CP-3 (Secrets+IaC) run in parallel on the CP-1 contract, so widening from "Code-only + defer rest" to "all four now" adds no serial time; the two per-product PRs are concurrent.
+
+---
+
+## Phase 3: Review
+- `make lint` + focused package tests per PR; full suite on CP-4.
+- Run `verification` skill on each PR diff before push; fix all Critical/Should-Fix.
+- Update `docs/requirements/architecture.md` ADR; update Confluence master status table + dual-sync IDE-2207/IDE-2208.
+- Dual-remote push (`origin` + `snyk`).
+
+## Progress tracking
+Dual-sync at every checkpoint/PR: (1) IDE-2207/IDE-2208 status + progress comment, (2) Confluence master status table. Deferred GAF asset-finding item → new `deferred` child of IDE-2052.

--- a/domain/ide/converter/converter.go
+++ b/domain/ide/converter/converter.go
@@ -18,10 +18,12 @@
 package converter
 
 import (
+	"path/filepath"
 	"regexp"
 	"strconv"
 
 	"github.com/gomarkdown/markdown"
+	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	stripmd "github.com/writeas/go-strip-markdown"
 
@@ -34,6 +36,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
+	"github.com/snyk/snyk-ls/internal/util"
 )
 
 var htmlEndingRegExp = regexp.MustCompile(`<br\s?/?>`)
@@ -52,12 +55,12 @@ func FromPosition(pos sglsp.Position) types.Position {
 	}
 }
 
-func ToCodeActions(issues []types.Issue) (actions []types.LSPCodeAction) {
+func ToCodeActions(issues []types.Issue, canonicalRoot types.FilePath) (actions []types.LSPCodeAction) {
 	dedupMap := map[string]bool{}
 	for _, issue := range issues {
 		for _, action := range issue.GetCodeActions() {
 			if !dedupMap[action.GetTitle()] {
-				codeAction := ToCodeAction(issue, action)
+				codeAction := ToCodeAction(issue, action, canonicalRoot)
 				actions = append(actions, codeAction)
 				dedupMap[action.GetTitle()] = true
 			}
@@ -66,7 +69,11 @@ func ToCodeActions(issues []types.Issue) (actions []types.LSPCodeAction) {
 	return actions
 }
 
-func ToCodeAction(issue types.Issue, action types.CodeAction) types.LSPCodeAction {
+// ToCodeAction converts a single issue+action to an LSP code action. canonicalRoot
+// is the canonical registered workspace-folder root; it is threaded into the
+// embedded diagnostics so the code action's FindingId matches the one emitted for
+// the same finding by publishDiagnostics (which also anchors to the folder root).
+func ToCodeAction(issue types.Issue, action types.CodeAction, canonicalRoot types.FilePath) types.LSPCodeAction {
 	var id *types.CodeActionData = nil
 	if action.GetUuid() != nil {
 		i := types.CodeActionData(*action.GetUuid())
@@ -76,7 +83,7 @@ func ToCodeAction(issue types.Issue, action types.CodeAction) types.LSPCodeActio
 	return types.LSPCodeAction{
 		Title:       action.GetTitle(),
 		Kind:        kind,
-		Diagnostics: ToDiagnostics([]types.Issue{issue}),
+		Diagnostics: ToDiagnosticsForFolder([]types.Issue{issue}, canonicalRoot, nil),
 		IsPreferred: action.GetIsPreferred(),
 		Edit:        ToWorkspaceEdit(action.GetEdit()),
 		Command:     ToCommand(action.GetCommand()),
@@ -166,7 +173,19 @@ func ToPosition(p types.Position) sglsp.Position {
 	}
 }
 
+// ToDiagnostics converts issues to LSP diagnostics without a known canonical
+// workspace root. Prefer ToDiagnosticsForFolder from a folder context so that
+// ContentRoot and FindingId are anchored to the canonical registered root.
 func ToDiagnostics(issues []types.Issue) []types.Diagnostic {
+	return ToDiagnosticsForFolder(issues, "", nil)
+}
+
+// ToDiagnosticsForFolder converts issues to LSP diagnostics, stamping every
+// resulting ScanIssue with the canonical registered workspace-folder root and a
+// root-relative FindingId. canonicalRoot is the registered folder root; when it
+// is empty the issue's own ContentRoot is used as a fallback (e.g. for the
+// single-issue code-action path where no folder context is available).
+func ToDiagnosticsForFolder(issues []types.Issue, canonicalRoot types.FilePath, logger *zerolog.Logger) []types.Diagnostic {
 	// In JSON, `nil` serializes to `null`, while an empty slice serializes to `[]`.
 	// Sending null instead of an empty array leads to stored diagnostics not being cleared.
 	// Do not prefer nil over an empty slice in this case. The next line ensures that even if issues is empty,
@@ -187,24 +206,108 @@ func ToDiagnostics(issues []types.Issue) []types.Diagnostic {
 			CodeDescription: types.CodeDescription{Href: types.Uri(s)},
 		}
 		if issue.GetProduct() == product.ProductInfrastructureAsCode {
-			diagnostic.Data = getIacIssue(issue)
+			diagnostic.Data = getIacIssue(issue, canonicalRoot, logger)
 		} else if issue.GetProduct() == product.ProductCode {
-			diagnostic.Data = getCodeIssue(issue)
+			diagnostic.Data = getCodeIssue(issue, canonicalRoot, logger)
 		} else if issue.GetProduct() == product.ProductOpenSource {
-			diagnostic.Data = getOssIssue(issue)
+			diagnostic.Data = getOssIssue(issue, canonicalRoot, logger)
 		} else if issue.GetProduct() == product.ProductSecrets {
-			diagnostic.Data = getSecretIssue(issue)
+			diagnostic.Data = getSecretIssue(issue, canonicalRoot, logger)
 		}
 		diagnostics = append(diagnostics, diagnostic)
 	}
 	return diagnostics
 }
 
-func getOssIssue(issue types.Issue) types.ScanIssue {
+// canonicalContentRoot returns the canonical registered workspace-folder root to
+// stamp on a ScanIssue. It prefers the folder root passed by the caller and
+// falls back to the issue's own ContentRoot when no folder context is available.
+func canonicalContentRoot(issue types.Issue, canonicalRoot types.FilePath) types.FilePath {
+	if canonicalRoot != "" {
+		return canonicalRoot
+	}
+	return issue.GetContentRoot()
+}
+
+// rootRelativePath expresses filePath relative to root using forward slashes, so
+// the value is identical across a git-worktree copy of the same tree. If a
+// relative path cannot be derived (e.g. root is empty), the forward-slashed
+// input path is returned unchanged.
+func rootRelativePath(root types.FilePath, filePath types.FilePath, logger *zerolog.Logger) string {
+	// No folder context: there is nothing to make the path relative to. Return the
+	// forward-slashed path as-is. This is an expected degenerate case (e.g. the
+	// code-action path with no folder), not an error, so it is handled before Rel
+	// and never logs.
+	if root == "" {
+		return filepath.ToSlash(string(filePath))
+	}
+	rel, err := filepath.Rel(string(root), string(filePath))
+	if err != nil {
+		// A non-empty root that cannot be related to the file yields a
+		// non-portable (absolute-ish) id; surface it rather than failing silently.
+		if logger != nil {
+			logger.Warn().Err(err).
+				Str("root", string(root)).
+				Str("filePath", string(filePath)).
+				Msg("could not derive root-relative path for finding identity; falling back to the file path")
+		}
+		return filepath.ToSlash(string(filePath))
+	}
+	return filepath.ToSlash(rel)
+}
+
+// computeFindingIdentity builds the stable, instance-unique, worktree-portable
+// FindingId for an issue from its durable grouping key (issue.GetFindingId())
+// combined with the root-relative path and normalized range. This is the single
+// product-agnostic seam; per-product grouping-key sourcing is layered upstream.
+//
+// Products whose per-result-set key is location-independent can use this directly.
+// IaC must NOT: its GetKey() bakes the absolute affected path in, so it computes
+// its identity via computeFindingIdentityForKey with the location-independent
+// publicID instead (see getIacIssue).
+func computeFindingIdentity(issue types.Issue, contentRoot types.FilePath, logger *zerolog.Logger) string {
+	// The grouping key is the product's durable finding id. Products that do not
+	// (yet) emit one return an empty string; fall back to the issue's per-instance
+	// key so instance uniqueness holds. When a product later supplies a real
+	// finding id, that takes precedence.
+	groupingKey := issue.GetFindingId()
+	if groupingKey == "" {
+		if ad := issue.GetAdditionalData(); ad != nil {
+			groupingKey = ad.GetKey()
+		}
+	}
+	return computeFindingIdentityForKey(groupingKey, issue, contentRoot, logger)
+}
+
+// computeFindingIdentityForKey composes the FindingId from an explicit grouping
+// key plus the issue's root-relative path and normalized range. It lets a product
+// supply a grouping key other than issue.GetFindingId()/GetKey() (IaC uses its
+// location-independent publicID). When the resolved grouping key is empty, the
+// composite reduces to path+range, so two distinct findings at the same location
+// would collide; a warning is logged so that condition is diagnosable.
+func computeFindingIdentityForKey(groupingKey string, issue types.Issue, contentRoot types.FilePath, logger *zerolog.Logger) string {
+	if groupingKey == "" && logger != nil {
+		logger.Warn().
+			Str("filePath", string(issue.GetAffectedFilePath())).
+			Str("product", string(issue.GetProduct())).
+			Msg("computing finding identity with an empty grouping key; distinct findings at the same location may collide")
+	}
+	rel := rootRelativePath(contentRoot, issue.GetAffectedFilePath(), logger)
+	r := issue.GetRange()
+	return util.ComputeFindingIdentity(
+		groupingKey,
+		rel,
+		r.Start.Line, r.Start.Character, r.End.Line, r.End.Character,
+	)
+}
+
+func getOssIssue(issue types.Issue, canonicalRoot types.FilePath, logger *zerolog.Logger) types.ScanIssue {
 	additionalData, ok := issue.GetAdditionalData().(snyk.OssIssueData)
 	if !ok {
 		return types.ScanIssue{}
 	}
+
+	contentRoot := canonicalContentRoot(issue, canonicalRoot)
 
 	matchingIssues := make([]types.OssIssueData, len(additionalData.MatchingIssues))
 	for i, matchingIssue := range additionalData.MatchingIssues {
@@ -237,11 +340,11 @@ func getOssIssue(issue types.Issue) types.ScanIssue {
 
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
-		FindingId:           issue.GetFindingId(),
+		FindingId:           computeFindingIdentity(issue, contentRoot, logger),
 		Title:               additionalData.Title,
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),
-		ContentRoot:         issue.GetContentRoot(),
+		ContentRoot:         contentRoot,
 		Range:               ToRange(issue.GetRange()),
 		IsIgnored:           issue.GetIsIgnored(),
 		IsNew:               issue.GetIsNew(),
@@ -281,19 +384,27 @@ func getOssIssue(issue types.Issue) types.ScanIssue {
 	return scanIssue
 }
 
-func getIacIssue(issue types.Issue) types.ScanIssue {
+func getIacIssue(issue types.Issue, canonicalRoot types.FilePath, logger *zerolog.Logger) types.ScanIssue {
 	additionalData, ok := issue.GetAdditionalData().(snyk.IaCIssueData)
 	if !ok {
 		return types.ScanIssue{}
 	}
 
+	contentRoot := canonicalContentRoot(issue, canonicalRoot)
+
+	// IaC has no GetFindingId(), and its per-result-set Key bakes the ABSOLUTE
+	// affected path in, so keying identity off it would give the same finding a
+	// different FindingId in a git-worktree copy. Use the location-independent
+	// publicID as the grouping key so the identity is worktree-portable; the
+	// root-relative path + range still individuate distinct instances that share a
+	// publicID (e.g. the same rule firing at two locations).
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
-		FindingId:           issue.GetFindingId(),
+		FindingId:           computeFindingIdentityForKey(additionalData.PublicId, issue, contentRoot, logger),
 		Title:               additionalData.Title,
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),
-		ContentRoot:         issue.GetContentRoot(),
+		ContentRoot:         contentRoot,
 		Range:               ToRange(issue.GetRange()),
 		IsIgnored:           issue.GetIsIgnored(),
 		IsNew:               issue.GetIsNew(),
@@ -314,11 +425,13 @@ func getIacIssue(issue types.Issue) types.ScanIssue {
 	return scanIssue
 }
 
-func getCodeIssue(issue types.Issue) types.ScanIssue {
+func getCodeIssue(issue types.Issue, canonicalRoot types.FilePath, logger *zerolog.Logger) types.ScanIssue {
 	additionalData, ok := issue.GetAdditionalData().(snyk.CodeIssueData)
 	if !ok {
 		return types.ScanIssue{}
 	}
+
+	contentRoot := canonicalContentRoot(issue, canonicalRoot)
 
 	markers := make([]types.Marker, 0, len(additionalData.Markers))
 	for _, marker := range additionalData.Markers {
@@ -351,11 +464,11 @@ func getCodeIssue(issue types.Issue) types.ScanIssue {
 
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
-		FindingId:           issue.GetFindingId(),
+		FindingId:           computeFindingIdentity(issue, contentRoot, logger),
 		Title:               issue.GetMessage(),
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),
-		ContentRoot:         issue.GetContentRoot(),
+		ContentRoot:         contentRoot,
 		Range:               ToRange(issue.GetRange()),
 		IsIgnored:           issue.GetIsIgnored(),
 		IsNew:               issue.GetIsNew(),
@@ -392,19 +505,21 @@ func getCodeIssue(issue types.Issue) types.ScanIssue {
 	return scanIssue
 }
 
-func getSecretIssue(issue types.Issue) types.ScanIssue {
+func getSecretIssue(issue types.Issue, canonicalRoot types.FilePath, logger *zerolog.Logger) types.ScanIssue {
 	additionalData, ok := issue.GetAdditionalData().(snyk.SecretsIssueData)
 	if !ok {
 		return types.ScanIssue{}
 	}
 
+	contentRoot := canonicalContentRoot(issue, canonicalRoot)
+
 	scanIssue := types.ScanIssue{
 		Id:                  additionalData.Key,
-		FindingId:           issue.GetFindingId(),
+		FindingId:           computeFindingIdentity(issue, contentRoot, logger),
 		Title:               additionalData.Title,
 		Severity:            issue.GetSeverity().String(),
 		FilePath:            issue.GetAffectedFilePath(),
-		ContentRoot:         issue.GetContentRoot(),
+		ContentRoot:         contentRoot,
 		Range:               ToRange(issue.GetRange()),
 		IsIgnored:           issue.GetIsIgnored(),
 		IsNew:               issue.GetIsNew(),

--- a/domain/ide/converter/converter_finding_identity_test.go
+++ b/domain/ide/converter/converter_finding_identity_test.go
@@ -1,0 +1,348 @@
+/*
+ * © 2024-2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package converter
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+	"github.com/snyk/snyk-ls/internal/util"
+)
+
+// realIacKey reproduces infrastructure/iac.getIssueKey exactly: the per-result-set
+// Key is sha256(absoluteFilePath + lineNumber + publicID). It bakes the ABSOLUTE
+// affected file path in, so the same finding scanned in a git-worktree copy (a
+// different absolute path) gets a different Key. That is precisely why the Key
+// cannot be the IaC grouping key; the location-independent publicID must be.
+func realIacKey(absPath types.FilePath, lineNumber int, publicID string) string {
+	sum := sha256.Sum256([]byte(string(absPath) + strconv.Itoa(lineNumber) + publicID))
+	return hex.EncodeToString(sum[:16])
+}
+
+// Fix 2: when root!="" but filepath.Rel cannot relate the file to it, the fallback
+// must log a warning (previously it returned the path silently, yielding a
+// non-portable id with no diagnostic signal).
+func TestRootRelativePath_LogsWarningOnRelError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+
+	// A relative filePath cannot be made relative to an absolute root → Rel errors.
+	rel := rootRelativePath(types.FilePath("/project"), types.FilePath("relative/x.go"), &logger)
+
+	assert.Equal(t, "relative/x.go", rel, "on Rel error the forward-slashed path is returned")
+	assert.Contains(t, buf.String(), "\"level\":\"warn\"", "a warning must be logged when Rel fails for a non-empty root")
+}
+
+// Fix 2: root=="" is an expected degenerate case (no folder context), handled
+// before filepath.Rel — so it never logs, even for an absolute path.
+func TestRootRelativePath_EmptyRoot_NoWarning(t *testing.T) {
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+
+	rel := rootRelativePath(types.FilePath(""), types.FilePath("/abs/pkg/server.go"), &logger)
+
+	assert.Equal(t, "/abs/pkg/server.go", rel)
+	assert.Empty(t, buf.String(), "root=='' is not an error and must not emit a warning")
+}
+
+// Fix 2: root=="" with a relative input returns it unchanged (forward-slashed),
+// embedding no absolute path.
+func TestRootRelativePath_EmptyRoot_RelativeInput_NoAbsolutePath(t *testing.T) {
+	rel := rootRelativePath(types.FilePath(""), types.FilePath("pkg/server.go"), nil)
+
+	assert.Equal(t, "pkg/server.go", rel, "relative input must be returned unchanged, no absolute path embedded")
+}
+
+// IaC findings have an empty GetFindingId() (the scanner never sets one), so the
+// converter uses the location-independent publicID as the grouping key. Two
+// distinct rules at the SAME file+range have different publicIDs, so their
+// composite identities differ — proving instance-uniqueness holds.
+func TestToDiagnostics_IaC_UsesPublicIdGroupingKey_InstanceUnique(t *testing.T) {
+	testutil.UnitTest(t)
+
+	root := types.FilePath("/project")
+	filePath := types.FilePath("/project/main.tf")
+	r := types.Range{
+		Start: types.Position{Line: 3, Character: 0},
+		End:   types.Position{Line: 3, Character: 10},
+	}
+
+	issueA := &snyk.Issue{
+		ID:               "iac-rule-A",
+		Severity:         types.High,
+		Product:          product.ProductInfrastructureAsCode,
+		FindingId:        "", // IaC: never set by the scanner
+		AffectedFilePath: filePath,
+		ContentRoot:      root,
+		Range:            r,
+		AdditionalData:   snyk.IaCIssueData{Key: "key-publicid-A", PublicId: "SNYK-CC-A"},
+	}
+	issueB := &snyk.Issue{
+		ID:               "iac-rule-B",
+		Severity:         types.High,
+		Product:          product.ProductInfrastructureAsCode,
+		FindingId:        "", // same empty finding id, same file + range
+		AffectedFilePath: filePath,
+		ContentRoot:      root,
+		Range:            r,
+		AdditionalData:   snyk.IaCIssueData{Key: "key-publicid-B", PublicId: "SNYK-CC-B"},
+	}
+
+	diags := ToDiagnosticsForFolder([]types.Issue{issueA, issueB}, root, nil)
+	require.Len(t, diags, 2)
+
+	assert.NotEmpty(t, diags[0].Data.FindingId, "IaC FindingId must be non-empty")
+	assert.NotEmpty(t, diags[1].Data.FindingId, "IaC FindingId must be non-empty")
+	assert.NotEqual(t, diags[0].Data.FindingId, diags[1].Data.FindingId,
+		"two distinct IaC rules at the same file+range must get different FindingIds")
+}
+
+// IaC identity must be worktree-portable (R3): the same finding scanned in the
+// working tree and in a git-worktree copy of it must get the IDENTICAL FindingId.
+// IaC has an empty GetFindingId(), and its per-result-set Key bakes the absolute
+// path in, so using the Key as the grouping key gave the same finding a different
+// FindingId across the worktree boundary. The grouping key must be the
+// location-independent publicID; the root-relative path + range still individuate
+// distinct instances.
+func TestToDiagnostics_IaC_WorktreePortable_ViaPublicId(t *testing.T) {
+	testutil.UnitTest(t)
+
+	const publicID = "SNYK-CC-TF-1"
+	const lineNumber = 3
+	r := types.Range{
+		Start: types.Position{Line: 3, Character: 0},
+		End:   types.Position{Line: 3, Character: 12},
+	}
+
+	// Same finding, same relative path (main.tf), same range, same publicID —
+	// scanned once in the working tree and once in a git-worktree copy mounted at a
+	// different absolute root. The abs-path-baked Key differs between the two.
+	origRoot := types.FilePath("/project")
+	origFile := types.FilePath("/project/main.tf")
+	origIssue := &snyk.Issue{
+		ID:               "iac-rule",
+		Severity:         types.High,
+		Product:          product.ProductInfrastructureAsCode,
+		FindingId:        "", // IaC never sets a finding id
+		AffectedFilePath: origFile,
+		ContentRoot:      origRoot,
+		Range:            r,
+		AdditionalData:   snyk.IaCIssueData{Key: realIacKey(origFile, lineNumber, publicID), PublicId: publicID},
+	}
+
+	wtRoot := types.FilePath("/tmp/worktree-abc")
+	wtFile := types.FilePath("/tmp/worktree-abc/main.tf")
+	wtIssue := &snyk.Issue{
+		ID:               "iac-rule",
+		Severity:         types.High,
+		Product:          product.ProductInfrastructureAsCode,
+		FindingId:        "",
+		AffectedFilePath: wtFile,
+		ContentRoot:      wtRoot,
+		Range:            r,
+		AdditionalData:   snyk.IaCIssueData{Key: realIacKey(wtFile, lineNumber, publicID), PublicId: publicID},
+	}
+
+	// Precondition: the abs-path-baked keys really do differ across the boundary,
+	// so this test would pass trivially only if the Key had (wrongly) been ignored.
+	require.NotEqual(t, origIssue.GetAdditionalData().GetKey(), wtIssue.GetAdditionalData().GetKey(),
+		"precondition: IaC Key must differ across the worktree boundary (it bakes the abs path)")
+
+	origDiags := ToDiagnosticsForFolder([]types.Issue{origIssue}, origRoot, nil)
+	wtDiags := ToDiagnosticsForFolder([]types.Issue{wtIssue}, wtRoot, nil)
+	require.Len(t, origDiags, 1)
+	require.Len(t, wtDiags, 1)
+
+	assert.NotEmpty(t, origDiags[0].Data.FindingId, "IaC FindingId must be non-empty")
+	assert.Equal(t, origDiags[0].Data.FindingId, wtDiags[0].Data.FindingId,
+		"IaC FindingId must be identical across the worktree boundary (grouping key = location-independent publicID)")
+
+	// Instance-uniqueness still holds: a different publicID at the same location,
+	// and the same publicID at a different range, both yield different identities.
+	diffPublicID := &snyk.Issue{
+		ID: "iac-rule-2", Severity: types.High, Product: product.ProductInfrastructureAsCode,
+		AffectedFilePath: origFile, ContentRoot: origRoot, Range: r,
+		AdditionalData: snyk.IaCIssueData{Key: realIacKey(origFile, lineNumber, "SNYK-CC-TF-2"), PublicId: "SNYK-CC-TF-2"},
+	}
+	r2 := types.Range{Start: types.Position{Line: 9, Character: 0}, End: types.Position{Line: 9, Character: 12}}
+	samePublicIDDiffRange := &snyk.Issue{
+		ID: "iac-rule", Severity: types.High, Product: product.ProductInfrastructureAsCode,
+		AffectedFilePath: origFile, ContentRoot: origRoot, Range: r2,
+		AdditionalData: snyk.IaCIssueData{Key: realIacKey(origFile, 9, publicID), PublicId: publicID},
+	}
+	otherDiags := ToDiagnosticsForFolder([]types.Issue{diffPublicID, samePublicIDDiffRange}, origRoot, nil)
+	require.Len(t, otherDiags, 2)
+	assert.NotEqual(t, origDiags[0].Data.FindingId, otherDiags[0].Data.FindingId,
+		"different publicID must yield a different FindingId")
+	assert.NotEqual(t, origDiags[0].Data.FindingId, otherDiags[1].Data.FindingId,
+		"same publicID at a different range must yield a different FindingId")
+}
+
+// Fix 1: the code-action path must emit the SAME composite FindingId as the folder
+// publishDiagnostics path for the same finding. Previously ToCodeAction ignored the
+// folder root (using the issue's own sub-path ContentRoot), so a fixable finding's
+// code-action FindingId diverged from the one published for it, breaking correlation.
+func TestToCodeAction_FindingIdMatchesFolderPublishDiagnostics(t *testing.T) {
+	testutil.UnitTest(t)
+
+	canonicalRoot := types.FilePath("/project")
+	subPath := types.FilePath("/project/src") // non-canonical: as produced by a sub-dir scan
+	filePath := types.FilePath("/project/src/main.go")
+	r := types.Range{
+		Start: types.Position{Line: 10, Character: 4},
+		End:   types.Position{Line: 10, Character: 20},
+	}
+
+	newIssue := func() *snyk.Issue {
+		return &snyk.Issue{
+			ID:               "code-rule-xss",
+			Severity:         types.High,
+			Product:          product.ProductCode,
+			FindingId:        "asset-finding-v1-abc",
+			AffectedFilePath: filePath,
+			ContentRoot:      subPath,
+			Range:            r,
+			AdditionalData:   snyk.CodeIssueData{Key: "code-key-1"},
+		}
+	}
+
+	// Folder publishDiagnostics path anchors to the canonical registered root.
+	folderDiags := ToDiagnosticsForFolder([]types.Issue{newIssue()}, canonicalRoot, nil)
+	require.Len(t, folderDiags, 1)
+	folderFindingId := folderDiags[0].Data.FindingId
+
+	// Code-action path must anchor to the SAME canonical root so the ids correlate.
+	action := &snyk.CodeAction{Title: "Fix", OriginalTitle: "Fix"}
+	lspAction := ToCodeAction(newIssue(), action, canonicalRoot)
+	require.Len(t, lspAction.Diagnostics, 1)
+	caFindingId := lspAction.Diagnostics[0].Data.FindingId
+
+	assert.NotEmpty(t, caFindingId)
+	assert.Equal(t, folderFindingId, caFindingId,
+		"FindingId must be identical via the code-action path and the folder publishDiagnostics path")
+}
+
+// INT-005: when the issue's ContentRoot is a sub-path of the registered workspace folder,
+// ToDiagnosticsForFolder must normalise ContentRoot to the canonical registered root and
+// compute FindingId using the root-relative file path so the identity is worktree-portable.
+func TestToDiagnostics_CanonicalContentRoot_RootRelativeFindingId(t *testing.T) {
+	testutil.UnitTest(t)
+
+	canonicalRoot := types.FilePath("/project")
+	// The issue's ContentRoot is a sub-path (e.g. produced when a sub-directory is scanned).
+	subPath := types.FilePath("/project/src")
+	filePath := types.FilePath("/project/src/main.go")
+
+	r := types.Range{
+		Start: types.Position{Line: 10, Character: 4},
+		End:   types.Position{Line: 10, Character: 20},
+	}
+
+	testIssue := &snyk.Issue{
+		ID:               "code-rule-xss",
+		Severity:         types.High,
+		Product:          product.ProductCode,
+		FindingId:        "asset-finding-v1-abc",
+		AffectedFilePath: filePath,
+		ContentRoot:      subPath, // deliberately set to sub-path to test normalisation
+		Range:            r,
+		AdditionalData: snyk.CodeIssueData{
+			Key: "code-key-1",
+		},
+	}
+
+	diagnostics := ToDiagnosticsForFolder([]types.Issue{testIssue}, canonicalRoot, nil)
+
+	require.Len(t, diagnostics, 1)
+	scanIssue := diagnostics[0].Data
+
+	// ContentRoot must be the canonical registered root, not the sub-path.
+	assert.Equal(t, canonicalRoot, scanIssue.ContentRoot,
+		"ContentRoot must equal the canonical registered workspace folder root, not the scan sub-path")
+
+	// FindingId must use the root-relative path (src/main.go) not the absolute path.
+	// The expected identity is ComputeFindingIdentity using the root-relative path.
+	rootRelPath := "src/main.go"
+	expectedFindingId := util.ComputeFindingIdentity(
+		"asset-finding-v1-abc",
+		rootRelPath,
+		r.Start.Line, r.Start.Character, r.End.Line, r.End.Character,
+	)
+	assert.Equal(t, expectedFindingId, scanIssue.FindingId,
+		"FindingId must be computed from the root-relative file path for worktree portability")
+
+	// Ensure FindingId is non-empty.
+	assert.NotEmpty(t, scanIssue.FindingId, "FindingId must be non-empty")
+}
+
+// INT-005b: same finding scanned in a worktree copy and the original root gets the same
+// FindingId when both are converted with their respective canonical roots, because the
+// root-relative path is identical.
+func TestToDiagnostics_CanonicalContentRoot_WorktreePortable(t *testing.T) {
+	testutil.UnitTest(t)
+
+	r := types.Range{
+		Start: types.Position{Line: 5, Character: 2},
+		End:   types.Position{Line: 5, Character: 15},
+	}
+
+	// Original workspace: /project/src/file.go
+	originalRoot := types.FilePath("/project")
+	originalIssue := &snyk.Issue{
+		ID:               "rule/SQLi",
+		Severity:         types.High,
+		Product:          product.ProductCode,
+		FindingId:        "asset-v1-sqli",
+		AffectedFilePath: types.FilePath("/project/src/file.go"),
+		ContentRoot:      originalRoot,
+		Range:            r,
+		AdditionalData:   snyk.CodeIssueData{Key: "key-1"},
+	}
+
+	// Worktree copy: /worktree/src/file.go (same relative path, different mount)
+	worktreeRoot := types.FilePath("/worktree")
+	worktreeIssue := &snyk.Issue{
+		ID:               "rule/SQLi",
+		Severity:         types.High,
+		Product:          product.ProductCode,
+		FindingId:        "asset-v1-sqli",
+		AffectedFilePath: types.FilePath("/worktree/src/file.go"),
+		ContentRoot:      worktreeRoot,
+		Range:            r,
+		AdditionalData:   snyk.CodeIssueData{Key: "key-1"},
+	}
+
+	originalDiags := ToDiagnosticsForFolder([]types.Issue{originalIssue}, originalRoot, nil)
+	worktreeDiags := ToDiagnosticsForFolder([]types.Issue{worktreeIssue}, worktreeRoot, nil)
+
+	require.Len(t, originalDiags, 1)
+	require.Len(t, worktreeDiags, 1)
+
+	assert.Equal(t, originalDiags[0].Data.FindingId, worktreeDiags[0].Data.FindingId,
+		"FindingId must be identical across worktree boundary when root-relative path is the same")
+}

--- a/domain/ide/converter/converter_test.go
+++ b/domain/ide/converter/converter_test.go
@@ -20,14 +20,17 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/domain/snyk/mock_snyk"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/types/mock_types"
+	"github.com/snyk/snyk-ls/internal/util"
 )
 
 func TestToHovers(t *testing.T) {
@@ -289,96 +292,70 @@ func TestGetCvssCalculatorUrl(t *testing.T) {
 	})
 }
 
-// TestToDiagnostics_FindingId verifies that ScanIssue.FindingId is populated from issue.GetFindingId()
-// for each product. A stable FindingId allows clients to correlate the same underlying finding across
-// separate scan invocations without relying on the per-result-set Id field.
-func TestToDiagnostics_FindingId_Code(t *testing.T) {
+// TestToDiagnostics_FindingId_Composite verifies that ScanIssue.FindingId is the CP-1 composite
+// identity — util.ComputeFindingIdentity(groupingKey, rootRelativePath, range) — for every
+// product. The grouping key is issue.GetFindingId(), except IaC, which never populates it and
+// instead uses its location-independent publicID (its per-result-set Key bakes the absolute
+// path in and so is not worktree-portable). The composite is stable across scans, instance-unique
+// (the range discriminates two findings sharing a grouping key), and root-relative (portable
+// across a worktree copy), unlike the per-result-set Id field.
+//
+// NOTE: this test drives ToDiagnostics (no canonical folder root supplied), so it exercises the
+// issue-ContentRoot fallback path (canonicalContentRoot falls back to issue.GetContentRoot()).
+// The canonical-override path (a folder root supplied to ToDiagnosticsForFolder) is covered in
+// converter_finding_identity_test.go.
+func TestToDiagnostics_FindingId_Composite(t *testing.T) {
 	testutil.UnitTest(t)
 
-	const expectedFindingId = "snyk-asset-finding-v1-abc123"
-	testIssue := &snyk.Issue{
-		ID:        "code-rule-id",
-		Severity:  types.High,
-		Product:   product.ProductCode,
-		FindingId: expectedFindingId,
-		AdditionalData: snyk.CodeIssueData{
-			Key: "code-key-1",
-		},
+	r := types.Range{
+		Start: types.Position{Line: 4, Character: 2},
+		End:   types.Position{Line: 4, Character: 20},
 	}
 
-	diagnostics := ToDiagnostics([]types.Issue{testIssue})
-
-	require.Len(t, diagnostics, 1)
-	assert.Equal(t, expectedFindingId, diagnostics[0].Data.FindingId,
-		"ScanIssue.FindingId must equal issue.GetFindingId() for Code issues")
-}
-
-func TestToDiagnostics_FindingId_OSS(t *testing.T) {
-	testutil.UnitTest(t)
-
-	const expectedFindingId = "oss-introducing-finding-id-xyz"
-	testIssue := &snyk.Issue{
-		ID:        "oss-vuln-id",
-		Severity:  types.Medium,
-		Product:   product.ProductOpenSource,
-		FindingId: expectedFindingId,
-		AdditionalData: snyk.OssIssueData{
-			Key: "oss-key-1",
-		},
+	cases := []struct {
+		name        string
+		product     product.Product
+		groupingKey string
+		// expectedGroupingKey is the grouping key the converter actually uses. It
+		// equals groupingKey except for IaC, whose GetFindingId() is empty and which
+		// uses its location-independent publicID (never the abs-path-based Key).
+		expectedGroupingKey string
+		filePath            types.FilePath
+		contentRoot         types.FilePath
+		expectedRelate      string
+		additionalData      types.IssueAdditionalData
+	}{
+		{"Code", product.ProductCode, "snyk-asset-finding-v1-abc123", "snyk-asset-finding-v1-abc123", "/repo/src/a.go", "/repo", "src/a.go", snyk.CodeIssueData{Key: "code-key-1"}},
+		{"OSS", product.ProductOpenSource, "oss-introducing-finding-id-xyz", "oss-introducing-finding-id-xyz", "/repo/package.json", "/repo", "package.json", snyk.OssIssueData{Key: "oss-key-1"}},
+		{"Secrets", product.ProductSecrets, "secret-attrs-key-99", "secret-attrs-key-99", "/repo/config.yml", "/repo", "config.yml", snyk.SecretsIssueData{Key: "secret-key-99", Title: "Hardcoded Secret"}},
+		// IaC: GetFindingId() is empty (scanner never sets it); the converter uses the
+		// location-independent publicID as the grouping key, not the abs-path-based Key.
+		{"IaC", product.ProductInfrastructureAsCode, "", "SNYK-CC-TF-1", "/repo/main.tf", "/repo", "main.tf", snyk.IaCIssueData{Key: "iac-key-1", PublicId: "SNYK-CC-TF-1", Title: "IaC misconfiguration"}},
 	}
 
-	diagnostics := ToDiagnostics([]types.Issue{testIssue})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testIssue := &snyk.Issue{
+				ID:               tc.name + "-rule-id",
+				Severity:         types.High,
+				Product:          tc.product,
+				FindingId:        tc.groupingKey,
+				AffectedFilePath: tc.filePath,
+				ContentRoot:      tc.contentRoot,
+				Range:            r,
+				AdditionalData:   tc.additionalData,
+			}
 
-	require.Len(t, diagnostics, 1)
-	assert.Equal(t, expectedFindingId, diagnostics[0].Data.FindingId,
-		"ScanIssue.FindingId must equal issue.GetFindingId() for OSS issues")
-}
+			diagnostics := ToDiagnostics([]types.Issue{testIssue})
 
-func TestToDiagnostics_FindingId_Secrets(t *testing.T) {
-	testutil.UnitTest(t)
-
-	const expectedFindingId = "secret-attrs-key-99"
-	testIssue := &snyk.Issue{
-		ID:        "secret-rule-id",
-		Severity:  types.High,
-		Product:   product.ProductSecrets,
-		FindingId: expectedFindingId,
-		AdditionalData: snyk.SecretsIssueData{
-			Key:   "secret-key-99",
-			Title: "Hardcoded Secret",
-		},
+			require.Len(t, diagnostics, 1)
+			expected := util.ComputeFindingIdentity(tc.expectedGroupingKey, tc.expectedRelate,
+				r.Start.Line, r.Start.Character, r.End.Line, r.End.Character)
+			assert.Equal(t, expected, diagnostics[0].Data.FindingId,
+				"ScanIssue.FindingId must be the composite identity for %s issues", tc.name)
+			assert.NotEmpty(t, diagnostics[0].Data.FindingId, "FindingId must be non-empty for %s", tc.name)
+		})
 	}
-
-	diagnostics := ToDiagnostics([]types.Issue{testIssue})
-
-	require.Len(t, diagnostics, 1)
-	assert.Equal(t, expectedFindingId, diagnostics[0].Data.FindingId,
-		"ScanIssue.FindingId must equal issue.GetFindingId() for Secrets issues")
-}
-
-// TestToDiagnostics_FindingId_IaC documents that IaC findings currently emit an empty FindingId.
-// The IaC scanner does not yet set FindingId on snyk.Issue, so ScanIssue.FindingId is always "".
-// When the IaC scanner is updated to set FindingId, this test should be updated to assert the
-// expected non-empty value.
-func TestToDiagnostics_FindingId_IaC(t *testing.T) {
-	testutil.UnitTest(t)
-
-	testIssue := &snyk.Issue{
-		ID:       "iac-rule-id",
-		Severity: types.High,
-		Product:  product.ProductInfrastructureAsCode,
-		// FindingId is intentionally not set: the IaC scanner does not yet populate it.
-		AdditionalData: snyk.IaCIssueData{
-			Key:   "iac-key-1",
-			Title: "IaC misconfiguration",
-		},
-	}
-
-	diagnostics := ToDiagnostics([]types.Issue{testIssue})
-
-	require.Len(t, diagnostics, 1)
-	assert.Empty(t, diagnostics[0].Data.FindingId,
-		"IaC issues emit empty FindingId until the IaC scanner populates it")
 }
 
 // TestToDiagnostics_FindingId_DeterministicConversion verifies that ToDiagnostics is a pure
@@ -386,12 +363,17 @@ func TestToDiagnostics_FindingId_IaC(t *testing.T) {
 func TestToDiagnostics_FindingId_DeterministicConversion(t *testing.T) {
 	testutil.UnitTest(t)
 
-	const stableFindingId = "stable-code-fingerprint-v1"
 	testIssue := &snyk.Issue{
-		ID:        "code-rule-id",
-		Severity:  types.High,
-		Product:   product.ProductCode,
-		FindingId: stableFindingId,
+		ID:               "code-rule-id",
+		Severity:         types.High,
+		Product:          product.ProductCode,
+		FindingId:        "stable-code-fingerprint-v1",
+		AffectedFilePath: "/repo/src/stable.go",
+		ContentRoot:      "/repo",
+		Range: types.Range{
+			Start: types.Position{Line: 2, Character: 1},
+			End:   types.Position{Line: 2, Character: 9},
+		},
 		AdditionalData: snyk.CodeIssueData{
 			Key: "code-key-stable",
 		},
@@ -404,6 +386,176 @@ func TestToDiagnostics_FindingId_DeterministicConversion(t *testing.T) {
 	require.Len(t, diagnostics2, 1)
 	assert.Equal(t, diagnostics1[0].Data.FindingId, diagnostics2[0].Data.FindingId,
 		"FindingId must be identical across two separate conversions of the same finding")
-	assert.Equal(t, stableFindingId, diagnostics1[0].Data.FindingId,
-		"FindingId must match the value from issue.GetFindingId()")
+	assert.NotEmpty(t, diagnostics1[0].Data.FindingId, "FindingId must be non-empty")
+}
+
+// TestFromRange verifies that sglsp.Range is correctly converted to types.Range.
+func TestFromRange(t *testing.T) {
+	testutil.UnitTest(t)
+
+	lspRange := sglsp.Range{
+		Start: sglsp.Position{Line: 3, Character: 7},
+		End:   sglsp.Position{Line: 5, Character: 12},
+	}
+
+	got := FromRange(lspRange)
+
+	assert.Equal(t, 3, got.Start.Line)
+	assert.Equal(t, 7, got.Start.Character)
+	assert.Equal(t, 5, got.End.Line)
+	assert.Equal(t, 12, got.End.Character)
+}
+
+// TestFromPosition verifies that sglsp.Position is correctly converted to types.Position.
+func TestFromPosition(t *testing.T) {
+	testutil.UnitTest(t)
+
+	pos := sglsp.Position{Line: 10, Character: 4}
+	got := FromPosition(pos)
+
+	assert.Equal(t, 10, got.Line)
+	assert.Equal(t, 4, got.Character)
+}
+
+// TestToTextEdit verifies that a types.TextEdit is converted to sglsp.TextEdit.
+func TestToTextEdit(t *testing.T) {
+	testutil.UnitTest(t)
+
+	te := types.TextEdit{
+		Range: types.Range{
+			Start: types.Position{Line: 1, Character: 0},
+			End:   types.Position{Line: 2, Character: 0},
+		},
+		NewText: "replacement\n",
+	}
+
+	got := ToTextEdit(te)
+
+	assert.Equal(t, "replacement\n", got.NewText)
+	assert.Equal(t, 1, got.Range.Start.Line)
+	assert.Equal(t, 2, got.Range.End.Line)
+}
+
+// TestToTextEdits verifies that a slice of types.TextEdit is converted to sglsp.TextEdit slice.
+func TestToTextEdits(t *testing.T) {
+	testutil.UnitTest(t)
+
+	edits := []types.TextEdit{
+		{
+			Range:   types.Range{Start: types.Position{Line: 0}, End: types.Position{Line: 1}},
+			NewText: "first\n",
+		},
+		{
+			Range:   types.Range{Start: types.Position{Line: 2}, End: types.Position{Line: 3}},
+			NewText: "second\n",
+		},
+	}
+
+	got := ToTextEdits(edits)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "first\n", got[0].NewText)
+	assert.Equal(t, "second\n", got[1].NewText)
+}
+
+// TestToCodeActions_MainPath verifies that ToCodeActions iterates issues and
+// produces one LSPCodeAction per code action, deduplicating by title.
+func TestToCodeActions_MainPath(t *testing.T) {
+	testutil.UnitTest(t)
+
+	action := &snyk.CodeAction{
+		Title:         "Fix with AI",
+		OriginalTitle: "Fix with AI",
+	}
+	issue := &snyk.Issue{
+		CodeActions: []types.CodeAction{action},
+	}
+
+	actions := ToCodeActions([]types.Issue{issue}, "")
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, "Fix with AI", actions[0].Title)
+}
+
+// TestToCodeActions_Dedup verifies that two issues sharing the same action title
+// produce only one LSPCodeAction (dedup by title).
+func TestToCodeActions_Dedup(t *testing.T) {
+	testutil.UnitTest(t)
+
+	action1 := &snyk.CodeAction{Title: "Shared Action", OriginalTitle: "Shared Action"}
+	action2 := &snyk.CodeAction{Title: "Shared Action", OriginalTitle: "Shared Action"}
+	issue1 := &snyk.Issue{CodeActions: []types.CodeAction{action1}}
+	issue2 := &snyk.Issue{CodeActions: []types.CodeAction{action2}}
+
+	actions := ToCodeActions([]types.Issue{issue1, issue2}, "")
+
+	assert.Len(t, actions, 1, "duplicate titles must be deduplicated")
+}
+
+// TestToInlineValue verifies that a snyk.InlineValue is converted to types.InlineValue.
+func TestToInlineValue(t *testing.T) {
+	testutil.UnitTest(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedRange := types.Range{
+		Start: types.Position{Line: 4, Character: 2},
+		End:   types.Position{Line: 4, Character: 10},
+	}
+	mockVal := mock_snyk.NewMockInlineValue(ctrl)
+	mockVal.EXPECT().Range().Return(expectedRange)
+	mockVal.EXPECT().Text().Return("myVar = 42")
+
+	got := ToInlineValue(mockVal)
+
+	assert.Equal(t, "myVar = 42", got.Text)
+	assert.Equal(t, 4, got.Range.Start.Line)
+	assert.Equal(t, 2, got.Range.Start.Character)
+}
+
+// TestToInlineValues verifies that a slice of snyk.InlineValue is converted correctly.
+func TestToInlineValues(t *testing.T) {
+	testutil.UnitTest(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r1 := types.Range{Start: types.Position{Line: 1}, End: types.Position{Line: 1}}
+	r2 := types.Range{Start: types.Position{Line: 5}, End: types.Position{Line: 5}}
+
+	v1 := mock_snyk.NewMockInlineValue(ctrl)
+	v1.EXPECT().Range().Return(r1)
+	v1.EXPECT().Text().Return("a = 1")
+
+	v2 := mock_snyk.NewMockInlineValue(ctrl)
+	v2.EXPECT().Range().Return(r2)
+	v2.EXPECT().Text().Return("b = 2")
+
+	got := ToInlineValues([]snyk.InlineValue{v1, v2})
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "a = 1", got[0].Text)
+	assert.Equal(t, "b = 2", got[1].Text)
+}
+
+// TestToHoversDocument verifies that ToHoversDocument returns a DocumentHovers
+// with the correct path and product, delegating hover conversion to ToHovers.
+func TestToHoversDocument(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockResolver := mock_types.NewMockConfigResolverInterface(ctrl)
+	mockResolver.EXPECT().GetInt(types.SettingHoverVerbosity, nil).Return(1).AnyTimes()
+	mockResolver.EXPECT().GetString(types.SettingFormat, nil).Return("md").AnyTimes()
+
+	testIssue := &snyk.Issue{Message: "test message"}
+	path := types.FilePath("/repo/src/main.go")
+	p := product.ProductCode
+
+	doc := ToHoversDocument(engine, mockResolver, p, path, []types.Issue{testIssue}, nil)
+
+	assert.Equal(t, path, doc.Path)
+	assert.Equal(t, p, doc.Product)
+	require.Len(t, doc.Hover, 1)
+	assert.Equal(t, "test message", doc.Hover[0].Message)
 }

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -875,7 +875,7 @@ func (f *Folder) sendDiagnosticsForFile(path types.FilePath, issues []types.Issu
 
 	f.notifier.Send(types.PublishDiagnosticsParams{
 		URI:         uri.PathToUri(path),
-		Diagnostics: converter.ToDiagnostics(issues),
+		Diagnostics: converter.ToDiagnosticsForFolder(issues, f.path, f.logger),
 	})
 }
 

--- a/internal/types/lsp.go
+++ b/internal/types/lsp.go
@@ -1123,13 +1123,23 @@ type SnykScanParams struct {
 type ScanIssue struct { // TODO - convert this to a generic type
 	// Unique key identifying an issue in the whole result set. Not the same as the Snyk issue ID.
 	Id string `json:"id"`
-	// FindingId is stable across scans for the same underlying finding; sourced from Issue.GetFindingId().
-	// Unlike Id (which is per-result-set), this value is consistent between separate scan invocations
-	// and allows clients to correlate or deduplicate findings over time.
-	FindingId           string                      `json:"findingId"`
-	Title               string                      `json:"title"`
-	Severity            string                      `json:"severity"`
-	FilePath            FilePath                    `json:"filePath"`
+	// FindingId is the composite WIRE correlation id for the finding: a stable,
+	// instance-unique, root-relative identity. It is identical across repeated
+	// scans of unchanged code — including across a git-worktree copy of the same
+	// tree — yet distinct for two findings that share a grouping key at different
+	// locations. Unlike Id (which folds the absolute path and so cannot survive a
+	// worktree boundary), FindingId is derived from the root-relative path, making
+	// it correlatable across the working tree and a worktree copy.
+	//
+	// This composite value is for consumer correlation on the wire, not for fix lookup.
+	FindingId string   `json:"findingId"`
+	Title     string   `json:"title"`
+	Severity  string   `json:"severity"`
+	FilePath  FilePath `json:"filePath"`
+	// ContentRoot is the canonical registered workspace-folder root the finding
+	// belongs to. It is always the registered root — identical regardless of which
+	// sub-path was scanned — so a consumer can reliably attribute every finding to
+	// the correct root instead of defaulting to the first root.
 	ContentRoot         FilePath                    `json:"contentRoot"`
 	Range               sglsp.Range                 `json:"range"`
 	IsIgnored           bool                        `json:"isIgnored"`

--- a/internal/util/identity.go
+++ b/internal/util/identity.go
@@ -22,7 +22,42 @@ import (
 	"strconv"
 )
 
+// GetIssueKey returns the per-result-set key for an issue.
+//
+// WARNING: the coordinate parameter order here is (startLine, endLine, startCol,
+// endCol) — lines first, then columns. This DIFFERS from
+// ComputeFindingIdentity, whose order is (startLine, startCol, endLine, endCol).
+// The two are not interchangeable; transposing them silently produces a wrong,
+// still-valid-looking hex id. Match the parameter names, not the position, when
+// calling either function.
 func GetIssueKey(ruleId string, path string, startLine int, endLine int, startCol int, endCol int) string {
 	id := sha256.Sum256([]byte(ruleId + path + strconv.Itoa(startLine) + strconv.Itoa(endLine) + strconv.Itoa(startCol) + strconv.Itoa(endCol)))
+	return hex.EncodeToString(id[:16])
+}
+
+// ComputeFindingIdentity returns a deterministic, hex-truncated identity for a
+// finding that is stable across scans, unique per instance, and portable across
+// a git-worktree copy of the same tree.
+//
+//   - groupingKey is the product's durable grouping key (what makes two
+//     observations "the same finding"); the range discriminates two findings
+//     that share a grouping key at different locations.
+//   - rootRelPath must be the affected file path expressed relative to the
+//     finding's workspace root, with forward slashes. Passing the root-relative
+//     path is what makes the identity identical in the working tree and in a
+//     worktree copy; passing an absolute path yields a machine-specific,
+//     non-portable identity.
+//
+// Range coordinates are taken as plain ints so this package does not depend on
+// internal/types (which itself depends on internal/util).
+func ComputeFindingIdentity(groupingKey string, rootRelPath string, startLine int, startCol int, endLine int, endCol int) string {
+	// Fields are separated by a NUL byte, which cannot appear in a grouping key
+	// or a file path, so the preimage is unambiguous. A printable delimiter (e.g.
+	// a space) would let ("a b", "c") and ("a", "b c") collide onto the same
+	// preimage.
+	const sep = "\x00"
+	id := sha256.Sum256([]byte(groupingKey + sep + rootRelPath + sep +
+		strconv.Itoa(startLine) + sep + strconv.Itoa(startCol) + sep +
+		strconv.Itoa(endLine) + sep + strconv.Itoa(endCol)))
 	return hex.EncodeToString(id[:16])
 }

--- a/internal/util/identity_test.go
+++ b/internal/util/identity_test.go
@@ -26,3 +26,63 @@ func Test_GetIssueKey(t *testing.T) {
 	id := GetIssueKey("java/DontUsePrintStackTrace", "file/path.java", 15, 17, 15, 35)
 	assert.Equal(t, "8423559307c17d15f5617ae2e29dbf02", id)
 }
+
+// UNIT-001: same inputs always yield the same hex digest, and that digest is a
+// fixed golden value. The golden assertion locks the exact NUL-delimited preimage
+// formula (Fix 4) so any accidental change to the wire identity is caught.
+func TestComputeFindingIdentity_Deterministic(t *testing.T) {
+	id1 := ComputeFindingIdentity("rule/XSS", "src/main.go", 5, 2, 5, 20)
+	id2 := ComputeFindingIdentity("rule/XSS", "src/main.go", 5, 2, 5, 20)
+
+	assert.NotEmpty(t, id1, "identity must not be empty")
+	assert.Equal(t, id1, id2, "same inputs must produce identical identity")
+	// Golden value. Reproducible preimage: the fields below joined by a NUL byte
+	// (shown here as \x00), then SHA-256, then the first 16 bytes hex-encoded:
+	//   "rule/XSS\x00src/main.go\x005\x002\x005\x0020"
+	// i.e. groupingKey \x00 rootRelPath \x00 startLine \x00 startCol \x00 endLine \x00 endCol.
+	// A human can verify with:
+	//   printf 'rule/XSS\x00src/main.go\x005\x002\x005\x0020' | sha256sum | cut -c1-32
+	assert.Equal(t, "b34b8ec7d659575b7917ca60f1bbaee9", id1,
+		"identity formula must remain stable; a change here changes the wire FindingId for every finding")
+}
+
+// Fix 4: the preimage must be delimited so that two distinct field tuples cannot
+// map to the same byte sequence. With a space delimiter, ("a b", "c") and
+// ("a", "b c") both produce "a b c ..." and collide. A NUL separator keeps them
+// distinct.
+func TestComputeFindingIdentity_FieldDelimiterNoCollision(t *testing.T) {
+	id1 := ComputeFindingIdentity("a b", "c", 0, 0, 0, 0)
+	id2 := ComputeFindingIdentity("a", "b c", 0, 0, 0, 0)
+
+	assert.NotEqual(t, id1, id2,
+		"distinct (groupingKey, rootRelPath) tuples must not share a preimage")
+}
+
+// UNIT-002: same groupingKey and path but different ranges produce different identities,
+// ensuring two findings at distinct locations individuate even when they share a rule.
+func TestComputeFindingIdentity_InstanceUnique(t *testing.T) {
+	id1 := ComputeFindingIdentity("rule/SQLi", "db/query.go", 3, 0, 3, 10)
+	id2 := ComputeFindingIdentity("rule/SQLi", "db/query.go", 7, 0, 7, 10)
+
+	assert.NotEqual(t, id1, id2, "different ranges must produce different identities")
+}
+
+// UNIT-003: a root-relative path and an absolute path for the same file produce different
+// outputs, demonstrating that callers must normalise to root-relative before calling.
+// Worktree portability comes from the CALLER computing the same root-relative string
+// regardless of where the tree is mounted.
+func TestComputeFindingIdentity_RootRelative(t *testing.T) {
+	// Root-relative path – the correct input for a portable identity.
+	relId := ComputeFindingIdentity("rule/SSRF", "pkg/server.go", 1, 0, 1, 5)
+	// Absolute path – what a caller would pass without root-relative normalisation.
+	absId := ComputeFindingIdentity("rule/SSRF", "/project/pkg/server.go", 1, 0, 1, 5)
+
+	assert.NotEmpty(t, relId)
+	assert.NotEmpty(t, absId)
+	assert.NotEqual(t, relId, absId,
+		"root-relative and absolute paths must produce different identities; worktree portability requires the caller to pass the root-relative path consistently")
+
+	// Verify determinism: the same relative path always gives the same id (worktree invariant).
+	relId2 := ComputeFindingIdentity("rule/SSRF", "pkg/server.go", 1, 0, 1, 5)
+	assert.Equal(t, relId, relId2, "same root-relative input must always produce the same identity")
+}


### PR DESCRIPTION
## Summary
- Add `util.ComputeFindingIdentity` (NUL-delimited, plain-int signature to avoid an `internal/util`→`internal/types` cycle) and repair `ScanIssue.FindingId` **in place** to a stable, instance-unique, worktree-portable composite (grouping key + root-relative path + range) for all four products via `ToDiagnosticsForFolder`.
- Guarantee `ScanIssue.ContentRoot` is the **canonical registered workspace-folder root** so a consumer correlates findings to the right root in multi-root workspaces (IDE-2208) — **no** new `RootId` field.
- `ScanIssue.Id` unchanged (backward compatible). Code-action `FindingId` matches `publishDiagnostics` via a cached canonical root.

Contract-freeze checkpoint; CP-2+3 (OSS/Secrets grouping keys) stacks on top.

## PR Stack — Merge Order
\`\`\`mermaid
flowchart LR
    main(["main"])
    PR1366["#1366 remediation follow-ups"]
    CP1["CP-1 ← YOU ARE HERE\ndurable finding identity + canonical ContentRoot"]
    CP23["CP-2+3\nOSS + Secrets grouping keys"]
    main --> PR1366 --> CP1 --> CP23
    style CP1 fill:#ffd700,color:#000
\`\`\`

**Depends on:** #1366

## Test plan
- [x] `go test -race` green (internal/util, domain/ide/converter, application/server)
- [x] `make test` recorded; `make lint` 0 issues
- [x] Passed A+B verification gate (2 rounds)

Plan: https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4972839013