### PR TITLE
feat: stable per-product finding-id grouping keys for OSS and Secrets [IDE-2207]

### DIFF
--- a/domain/ide/converter/converter_finding_identity_test.go
+++ b/domain/ide/converter/converter_finding_identity_test.go
@@ -23,11 +23,14 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
+	"github.com/snyk/snyk-ls/infrastructure/secrets"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -42,6 +45,78 @@ import (
 func realIacKey(absPath types.FilePath, lineNumber int, publicID string) string {
 	sum := sha256.Sum256([]byte(string(absPath) + strconv.Itoa(lineNumber) + publicID))
 	return hex.EncodeToString(sum[:16])
+}
+
+// INT-003: the Secrets grouping key must be the stable rule identity, never the
+// per-scan UUID (attrs.Key). The backend mints a NEW attrs.Key for every scan, so
+// folding it into the identity made the same finding change identity each scan
+// (violating R1). This wires the REAL secrets converter (infrastructure/secrets)
+// to the REAL domain converter and proves the composite FindingId is IDENTICAL
+// across two scans whose UUID differs, and instance-unique across rules/locations.
+func TestToDiagnostics_Secrets_FindingIdStable_DespiteUUIDChange(t *testing.T) {
+	testutil.UnitTest(t)
+
+	root := types.FilePath("/project")
+	logger := zerolog.Nop()
+	ip := func(v int) *int { return &v }
+
+	// Builds a testapi secrets finding for one rule at one location, with a
+	// caller-supplied per-scan Key (UUID) so it can be varied between scans.
+	newSecretFinding := func(scanUUID, ruleID, ruleName, file string, fromLine int) testapi.FindingData {
+		id := uuid.New()
+		var loc testapi.FindingLocation
+		_ = loc.FromSourceLocation(testapi.SourceLocation{
+			FilePath: file, FromLine: fromLine,
+			FromColumn: ip(1), ToLine: ip(fromLine), ToColumn: ip(20),
+		})
+		var prob testapi.Problem
+		_ = prob.FromSecretsRuleProblem(testapi.SecretsRuleProblem{Id: ruleID, Name: ruleName})
+		return testapi.FindingData{
+			Id: &id,
+			Attributes: &testapi.FindingAttributes{
+				Key:         scanUUID,
+				Title:       "Secret",
+				Description: "d",
+				Rating:      testapi.Rating{Severity: testapi.SeverityHigh},
+				Locations:   []testapi.FindingLocation{loc},
+				Problems:    []testapi.Problem{prob},
+			},
+		}
+	}
+
+	sc := secrets.NewFindingsConverter(&logger)
+
+	scan1 := sc.ToIssues([]testapi.FindingData{newSecretFinding("uuid-scan-1", "aws-access-key", "AWS Access Key", "src/config.yml", 10)}, "", root)
+	scan2 := sc.ToIssues([]testapi.FindingData{newSecretFinding("uuid-scan-2-DIFFERENT", "aws-access-key", "AWS Access Key", "src/config.yml", 10)}, "", root)
+	require.Len(t, scan1, 1)
+	require.Len(t, scan2, 1)
+
+	// Precondition: the per-scan UUID (surfaced as the fingerprint) really differs
+	// across the two scans, so the stability assertion below cannot pass trivially.
+	require.NotEqual(t, scan1[0].GetFingerprint(), scan2[0].GetFingerprint(),
+		"precondition: attrs.Key (fingerprint) must differ across scans")
+
+	d1 := ToDiagnosticsForFolder(scan1, root, &logger)
+	d2 := ToDiagnosticsForFolder(scan2, root, &logger)
+	require.Len(t, d1, 1)
+	require.Len(t, d2, 1)
+
+	assert.NotEmpty(t, d1[0].Data.FindingId, "Secrets FindingId must be non-empty")
+	assert.Equal(t, d1[0].Data.FindingId, d2[0].Data.FindingId,
+		"Secrets FindingId must be identical across scans despite the per-scan UUID changing")
+
+	// Instance-uniqueness: a different rule at the same location, and the same rule
+	// at a different location, must both differ from the first finding's identity.
+	dDiffRule := ToDiagnosticsForFolder(
+		sc.ToIssues([]testapi.FindingData{newSecretFinding("uuid-x", "github-token", "GitHub Token", "src/config.yml", 10)}, "", root), root, &logger)
+	dDiffLoc := ToDiagnosticsForFolder(
+		sc.ToIssues([]testapi.FindingData{newSecretFinding("uuid-y", "aws-access-key", "AWS Access Key", "src/config.yml", 42)}, "", root), root, &logger)
+	require.Len(t, dDiffRule, 1)
+	require.Len(t, dDiffLoc, 1)
+	assert.NotEqual(t, d1[0].Data.FindingId, dDiffRule[0].Data.FindingId,
+		"a different secret rule at the same location must yield a different FindingId")
+	assert.NotEqual(t, d1[0].Data.FindingId, dDiffLoc[0].Data.FindingId,
+		"the same secret rule at a different location must yield a different FindingId")
 }
 
 // Fix 2: when root!="" but filepath.Rel cannot relate the file to it, the fallback

--- a/infrastructure/code/convert_finding_identity_test.go
+++ b/infrastructure/code/convert_finding_identity_test.go
@@ -1,0 +1,112 @@
+/*
+ * © 2025 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"testing"
+
+	codeClientSarif "github.com/snyk/code-client-go/sarif"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// sarifResponseWithAssetFingerprint builds a minimal SARIF response for a single
+// Code finding whose durable server-computed asset fingerprint
+// (snyk/asset/finding/v1) is assetFp. The asset fingerprint is stable across
+// scans of unchanged code, which is what makes it a valid grouping key.
+func sarifResponseWithAssetFingerprint(assetFp string) codeClientSarif.SarifResponse {
+	return codeClientSarif.SarifResponse{
+		Sarif: codeClientSarif.SarifDocument{
+			Runs: []codeClientSarif.Run{
+				{
+					Tool: codeClientSarif.Tool{
+						Driver: codeClientSarif.Driver{
+							Rules: []codeClientSarif.Rule{
+								{
+									ID:   "javascript/rule1",
+									Name: "rule1",
+									Properties: codeClientSarif.RuleProperties{
+										Categories: []string{"Security"},
+									},
+								},
+							},
+						},
+					},
+					Results: []codeClientSarif.Result{
+						{
+							RuleID: "javascript/rule1",
+							Level:  "warning",
+							Message: codeClientSarif.ResultMessage{
+								Text: "some finding",
+							},
+							Locations: []codeClientSarif.Location{
+								{
+									PhysicalLocation: codeClientSarif.PhysicalLocation{
+										ArtifactLocation: codeClientSarif.ArtifactLocation{URI: "main.js"},
+										Region: codeClientSarif.Region{
+											StartLine: 10, EndLine: 10, StartColumn: 5, EndColumn: 15,
+										},
+									},
+								},
+							},
+							Fingerprints: codeClientSarif.Fingerprints{
+								SnykAssetFindingV1: assetFp,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestCode_FindingId_IsAssetFingerprint_StableAcrossScans confirms that the Code
+// converter sources issue.FindingId from the durable Snyk asset fingerprint
+// (snyk/asset/finding/v1), which is stable across separate scans of unchanged
+// code. This is a regression lock: the grouping key must remain the asset
+// fingerprint so the conversion layer produces a stable per-finding identity
+// (IDE-2207 R1/R4). No production change is required — Code was already stable.
+func TestCode_FindingId_IsAssetFingerprint_StableAcrossScans(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	baseDir := types.FilePath(t.TempDir())
+	const assetFp = "asset-finding-fingerprint-abc123"
+
+	convert := func() []types.Issue {
+		sc := SarifConverter{
+			sarif:  sarifResponseWithAssetFingerprint(assetFp),
+			logger: engine.GetLogger(),
+			engine: engine,
+		}
+		issues, err := sc.toIssues(baseDir)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		return issues
+	}
+
+	// Two independent conversions represent two separate scans of unchanged code:
+	// the backend returns the same asset fingerprint each time.
+	scan1 := convert()
+	scan2 := convert()
+
+	assert.Equal(t, assetFp, scan1[0].GetFindingId(),
+		"Code FindingId grouping key must be the durable snyk/asset/finding/v1 fingerprint")
+	assert.Equal(t, scan1[0].GetFindingId(), scan2[0].GetFindingId(),
+		"the same Code finding must keep the same grouping key across scans of unchanged code")
+}

--- a/infrastructure/oss/unified_converter.go
+++ b/infrastructure/oss/unified_converter.go
@@ -58,7 +58,13 @@ func convertTestResultToIssues(ctx context.Context, testResult testapi.TestResul
 	issues := []types.Issue{}
 	for _, trIssue := range issuesFromTestResult {
 		issue := processIssue(ctx, trIssue, logger, affectedFilePath, workDir)
-		issues = append(issues, issue)
+		// processIssue returns a nil *snyk.Issue for findings it cannot convert
+		// (e.g. unusable attributes, unresolved ecosystem). Guard the append on the
+		// concrete pointer: appending a typed-nil pointer into a []types.Issue would
+		// yield a non-nil interface wrapping a nil pointer, which later panics.
+		if issue != nil {
+			issues = append(issues, issue)
+		}
 	}
 	return issues, nil
 }
@@ -109,7 +115,12 @@ func processIssue(ctx context.Context, trIssue testapi.Issue, logger zerolog.Log
 	title := trIssue.GetTitle()
 	introducingOssIssueData, err := buildOssIssueData(ctx, trIssue, problem, introducingFinding, affectedFilePath, myRange, ecosystemStr, dependencyPath)
 	if err != nil {
+		// The introducing finding is unusable, so we cannot produce a
+		// content-bearing issue. Skip it rather than emitting a finding whose
+		// grouping key would be derived from empty attributes and collide with
+		// other degenerate findings at the same location.
 		logger.Warn().Err(err).Msg("failed to build oss issue data")
+		return nil
 	}
 
 	introducingOssIssueData.MatchingIssues = populateMatchingIssues(ctx, trIssue, problem, affectedFilePath, myRange, ecosystemStr, logger)
@@ -158,7 +169,6 @@ func processIssue(ctx context.Context, trIssue testapi.Issue, logger zerolog.Log
 		CVEs:                introducingOssIssueData.Identifiers.CVE,
 		AdditionalData:      introducingOssIssueData,
 		LessonUrl:           introducingOssIssueData.Lesson,
-		FindingId:           introducingFinding.Id.String(),
 	}
 
 	// add code actions
@@ -169,6 +179,14 @@ func processIssue(ctx context.Context, trIssue testapi.Issue, logger zerolog.Log
 	// Calculate fingerprint
 	fingerprint := utils.CalculateFingerprintFromAdditionalData(issue)
 	issue.SetFingerPrint(fingerprint)
+	// The durable grouping key for an OSS finding is derived from stable
+	// vulnerability attributes (package name, version, dependency chain, rule
+	// id) rather than the per-scan testapi finding UUID, which the backend mints
+	// afresh on every scan. Using the fingerprint inputs keeps the finding
+	// identity identical across repeated scans of the same dependency graph; the
+	// conversion layer then adds the root-relative path and range to individuate
+	// multiple occurrences.
+	issue.FindingId = fingerprint
 	return issue
 }
 
@@ -456,6 +474,14 @@ func buildOssIssueData(
 ) (snyk.OssIssueData, error) {
 	logger := ctx2.LoggerFromContext(ctx).With().Str("method", "buildOssIssueData").Logger()
 	logger.Debug().Interface("problem", problem.Id).Interface("finding", finding.Id).Msg("building oss issue data")
+
+	if finding.Attributes == nil {
+		// Without attributes there is no package name, version or dependency
+		// chain to build from. Continuing would produce a content-less issue
+		// whose grouping key is derived from empty fields, so signal the caller
+		// to skip it entirely.
+		return snyk.OssIssueData{}, fmt.Errorf("finding has no attributes; cannot build OSS issue data")
+	}
 
 	attrs := finding.Attributes
 

--- a/infrastructure/oss/unified_converter_finding_identity_test.go
+++ b/infrastructure/oss/unified_converter_finding_identity_test.go
@@ -1,0 +1,293 @@
+/*
+ * © 2025 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oss
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+
+	"github.com/snyk/snyk-ls/infrastructure/utils"
+	ctx2 "github.com/snyk/snyk-ls/internal/context"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// newVulnIssueForTest builds a real testapi.Issue for a single OSS vulnerability,
+// parameterised only by the per-scan finding UUID. Everything else (vuln id,
+// package name/version, dependency path) is identical, so two issues built with
+// two different findingID values represent the SAME finding observed in two
+// separate scans (the backend mints a fresh finding UUID each scan).
+func newVulnIssueForTest(t *testing.T, findingID uuid.UUID) testapi.Issue {
+	t.Helper()
+
+	var eco testapi.SnykvulndbPackageEcosystem
+	require.NoError(t, eco.FromSnykvulndbBuildPackageEcosystem(testapi.SnykvulndbBuildPackageEcosystem{
+		Language:       "js",
+		PackageManager: "npm",
+	}))
+
+	var problem testapi.Problem
+	require.NoError(t, problem.FromSnykVulnProblem(testapi.SnykVulnProblem{
+		Id:          "SNYK-JS-LODASH-1",
+		PackageName: "lodash",
+		Ecosystem:   eco,
+	}))
+
+	var depEvidence testapi.Evidence
+	require.NoError(t, depEvidence.FromDependencyPathEvidence(testapi.DependencyPathEvidence{
+		Path: []testapi.Package{
+			{Name: "goof", Version: "1.0.0"},
+			{Name: "lodash", Version: "4.17.4"},
+		},
+	}))
+
+	id := findingID
+	finding := &testapi.FindingData{
+		Id: &id,
+		Attributes: &testapi.FindingAttributes{
+			FindingType: testapi.FindingTypeSca,
+			Key:         "aggregation-key",
+			Title:       "Prototype Pollution",
+			Description: "Prototype Pollution in lodash",
+			Problems:    []testapi.Problem{problem},
+			Evidence:    []testapi.Evidence{depEvidence},
+		},
+	}
+
+	issue, err := testapi.NewIssueFromFindings([]*testapi.FindingData{finding})
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	return issue
+}
+
+// TestProcessIssue_OSS_FindingIdStable_DespiteChangedFindingUUID proves that the
+// same OSS vulnerability converted across two separate scans yields the SAME
+// issue.FindingId, even though the backend mints a fresh per-scan finding UUID
+// each time. Before this change FindingId was the per-scan finding UUID, so the
+// two scans produced different identities (IDE-2207 R1/R4).
+func TestProcessIssue_OSS_FindingIdStable_DespiteChangedFindingUUID(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	workDir := types.FilePath(t.TempDir())
+	affectedFilePath := workDir + "/package.json"
+
+	buildCtx := func() context.Context {
+		ctx := ctx2.NewContextWithEngine(context.Background(), engine)
+		ctx = EnrichContextForTest(t, ctx, engine, string(workDir))
+		return ctx
+	}
+
+	uuid1 := uuid.New()
+	uuid2 := uuid.New()
+	require.NotEqual(t, uuid1, uuid2, "the two scans must have different finding UUIDs to prove stability")
+
+	issue1 := processIssue(buildCtx(), newVulnIssueForTest(t, uuid1), engine.GetLogger().With().Logger(), affectedFilePath, workDir)
+	issue2 := processIssue(buildCtx(), newVulnIssueForTest(t, uuid2), engine.GetLogger().With().Logger(), affectedFilePath, workDir)
+
+	require.NotNil(t, issue1)
+	require.NotNil(t, issue2)
+
+	assert.NotEmpty(t, issue1.GetFindingId(), "FindingId must not be empty")
+	assert.Equal(t, issue1.GetFindingId(), issue2.GetFindingId(),
+		"the same OSS vuln must keep the same FindingId across scans despite a changed finding UUID")
+
+	// FindingId must no longer be the per-scan finding UUID.
+	assert.NotEqual(t, uuid1.String(), issue1.GetFindingId(), "FindingId must not be the per-scan finding UUID")
+	assert.NotEqual(t, uuid2.String(), issue2.GetFindingId(), "FindingId must not be the per-scan finding UUID")
+
+	// FindingId must be the durable OSS grouping key derived from stable
+	// attributes (packageName|version|dependency-chain|ruleId).
+	assert.Equal(t, utils.CalculateFingerprintFromAdditionalData(issue1), issue1.GetFindingId(),
+		"FindingId must be the stable OSS grouping key derived from stable attributes")
+}
+
+// newUnusableIntroducingIssueForTest builds a real testapi.Issue whose introducing
+// finding (findings[0]) carries no attributes, so it holds no package name,
+// version or dependency chain. A second finding provides the issue's primary
+// vuln problem and ecosystem so processIssue reaches the point of building the
+// introducing OSS issue data. Because the introducing finding is unusable, that
+// build cannot produce a content-bearing finding: converting it anyway would
+// mint an OSS grouping key derived from empty package/version fields
+// (sha256 of "|||"+id), which collides across distinct vulns at the same
+// location and emits a contentless finding.
+func newUnusableIntroducingIssueForTest(t *testing.T) testapi.Issue {
+	t.Helper()
+
+	var eco testapi.SnykvulndbPackageEcosystem
+	require.NoError(t, eco.FromSnykvulndbBuildPackageEcosystem(testapi.SnykvulndbBuildPackageEcosystem{
+		Language:       "js",
+		PackageManager: "npm",
+	}))
+
+	var problem testapi.Problem
+	require.NoError(t, problem.FromSnykVulnProblem(testapi.SnykVulnProblem{
+		Id:          "SNYK-JS-LODASH-1",
+		PackageName: "lodash",
+		Ecosystem:   eco,
+	}))
+
+	// findings[0] has no attributes: getIntroducingFinding falls through to it
+	// because no finding exposes a matching direct-dependency path.
+	id0 := uuid.New()
+	unusableFinding := &testapi.FindingData{Id: &id0}
+
+	// findings[1] carries the SCA problem (primary problem + ecosystem) but has
+	// no dependency-path evidence, so getIntroducingFinding does not select it.
+	id1 := uuid.New()
+	problemFinding := &testapi.FindingData{
+		Id: &id1,
+		Attributes: &testapi.FindingAttributes{
+			FindingType: testapi.FindingTypeSca,
+			Key:         "aggregation-key",
+			Title:       "Prototype Pollution",
+			Problems:    []testapi.Problem{problem},
+		},
+	}
+
+	issue, err := testapi.NewIssueFromFindings([]*testapi.FindingData{unusableFinding, problemFinding})
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	return issue
+}
+
+// TestProcessIssue_OSS_SkipsUnusableIntroducingFinding proves that when the
+// introducing finding is unusable (no attributes → no package/version/chain),
+// processIssue skips it entirely rather than emitting a contentless finding with
+// a colliding grouping key. Before this change the converter continued with a
+// zero-valued OssIssueData and produced a garbage finding whose FindingId was the
+// sha256 of empty package attributes (IDE-2207 review, Should Fix).
+func TestProcessIssue_OSS_SkipsUnusableIntroducingFinding(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	workDir := types.FilePath(t.TempDir())
+	affectedFilePath := workDir + "/package.json"
+
+	ctx := ctx2.NewContextWithEngine(context.Background(), engine)
+	ctx = EnrichContextForTest(t, ctx, engine, string(workDir))
+
+	result := processIssue(ctx, newUnusableIntroducingIssueForTest(t), engine.GetLogger().With().Logger(), affectedFilePath, workDir)
+
+	assert.Nil(t, result, "an unusable introducing finding must be skipped, not converted into a garbage/colliding finding")
+}
+
+// fakeTestResult is a minimal testapi.TestResult test double whose Findings and
+// dep-graph subject can be set explicitly, so convertTestResultToIssues can be
+// exercised end-to-end without a live test API.
+type fakeTestResult struct {
+	testID   uuid.UUID
+	subject  *testapi.TestSubject
+	findings []testapi.FindingData
+}
+
+func (f *fakeTestResult) GetTestID() *uuid.UUID                            { return &f.testID }
+func (f *fakeTestResult) GetTestConfiguration() *testapi.TestConfiguration { return nil }
+func (f *fakeTestResult) GetCreatedAt() *time.Time                         { return nil }
+func (f *fakeTestResult) Get(key testapi.TestResultKeys) interface{} {
+	if key == testapi.TestResultTestSubject {
+		return f.subject
+	}
+	return nil
+}
+func (f *fakeTestResult) GetTestSubject() *testapi.TestSubject              { return f.subject }
+func (f *fakeTestResult) GetSubjectLocators() *[]testapi.TestSubjectLocator { return nil }
+func (f *fakeTestResult) GetTestResources() *[]testapi.TestResource         { return nil }
+func (f *fakeTestResult) GetExecutionState() testapi.TestExecutionStates    { return "" }
+func (f *fakeTestResult) GetErrors() *[]testapi.IoSnykApiCommonError        { return nil }
+func (f *fakeTestResult) GetWarnings() *[]testapi.IoSnykApiCommonError      { return nil }
+func (f *fakeTestResult) GetPassFail() *testapi.PassFail                    { return nil }
+func (f *fakeTestResult) GetOutcomeReason() *testapi.TestOutcomeReason      { return nil }
+func (f *fakeTestResult) GetBreachedPolicies() *testapi.PolicyRefSet        { return nil }
+func (f *fakeTestResult) GetEffectiveSummary() *testapi.FindingSummary      { return nil }
+func (f *fakeTestResult) GetRawSummary() *testapi.FindingSummary            { return nil }
+func (f *fakeTestResult) GetTestFacts() *[]testapi.TestFact                 { return nil }
+func (f *fakeTestResult) SetMetadata(_ string, _ interface{})               {}
+func (f *fakeTestResult) GetMetadataValue(_ string) interface{}             { return nil }
+func (f *fakeTestResult) GetMetadata() map[string]interface{}               { return nil }
+func (f *fakeTestResult) Findings(_ context.Context) ([]testapi.FindingData, bool, error) {
+	return f.findings, true, nil
+}
+
+// newUnusableTestResultForTest builds a real testapi.TestResult carrying a single
+// SCA finding whose vuln problem has no ecosystem. Such a finding survives
+// issue-grouping (it has attributes and a Snyk problem id) but cannot be
+// converted: processIssue skips it (returns a nil *snyk.Issue) because the
+// ecosystem cannot be resolved. It reproduces, at the caller level, any finding
+// that processIssue declines to convert — the nil-attributes introducing finding
+// is dropped earlier by grouping, so this exercises the same skip contract that
+// convertTestResultToIssues must honor without leaking a nil element.
+func newUnusableTestResultForTest(t *testing.T) testapi.TestResult {
+	t.Helper()
+
+	// Vuln problem deliberately has no Ecosystem set, so processIssue cannot
+	// resolve the ecosystem and skips the finding.
+	var problem testapi.Problem
+	require.NoError(t, problem.FromSnykVulnProblem(testapi.SnykVulnProblem{
+		Id:          "SNYK-JS-LODASH-1",
+		PackageName: "lodash",
+	}))
+
+	id := uuid.New()
+	finding := testapi.FindingData{
+		Id: &id,
+		Attributes: &testapi.FindingAttributes{
+			FindingType: testapi.FindingTypeSca,
+			Key:         "aggregation-key",
+			Title:       "Prototype Pollution",
+			Problems:    []testapi.Problem{problem},
+		},
+	}
+
+	var subject testapi.TestSubject
+	require.NoError(t, subject.FromDepGraphSubject(testapi.DepGraphSubject{
+		Locator: testapi.LocalPathLocator{Paths: []string{"package.json"}},
+	}))
+
+	return &fakeTestResult{
+		testID:   uuid.New(),
+		subject:  &subject,
+		findings: []testapi.FindingData{finding},
+	}
+}
+
+// TestConvertTestResultToIssues_SkipsUnusableFinding_NoNilElements proves that
+// when processIssue declines to convert a finding (returns a nil *snyk.Issue),
+// convertTestResultToIssues actually skips it rather than appending a typed-nil
+// pointer wrapped in a non-nil types.Issue interface. Before the append guard the
+// returned slice held one element that was a non-nil interface wrapping a nil
+// *snyk.Issue, which later panics (e.g. issue.GetRange()). The intended skip must
+// yield an empty slice for a single unusable finding.
+func TestConvertTestResultToIssues_SkipsUnusableFinding_NoNilElements(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	workDir := types.FilePath(t.TempDir())
+
+	ctx := ctx2.NewContextWithEngine(context.Background(), engine)
+	ctx = ctx2.NewContextWithWorkDirAndFilePath(ctx, workDir, workDir+"/package.json")
+	ctx = EnrichContextForTest(t, ctx, engine, string(workDir))
+
+	issues, err := convertTestResultToIssues(ctx, newUnusableTestResultForTest(t), map[string][]types.Issue{})
+	require.NoError(t, err)
+
+	for i, issue := range issues {
+		assert.NotNil(t, issue, "issues[%d] must not be a non-nil interface wrapping a nil pointer", i)
+	}
+	assert.Empty(t, issues, "a single unusable finding must be skipped entirely, leaving no elements")
+}

--- a/infrastructure/secrets/convert.go
+++ b/infrastructure/secrets/convert.go
@@ -67,6 +67,21 @@ func (c *FindingsConverter) findingToIssues(finding *testapi.FindingData, scanPa
 
 	severity := toSeverity(string(attrs.Rating.Severity))
 	cwes, ruleID, ruleName, categories := extractProblems(attrs.Problems)
+
+	// groupingKey is the durable finding-id grouping key: the rule identity, which
+	// is stable across scans. It is captured BEFORE the per-result-set ruleID
+	// fallback below so it never silently becomes attrs.Key while a rule name is
+	// available. It falls back to attrs.Key only when the finding carries no rule
+	// problem at all (a defensive case; a real secrets finding always has one).
+	groupingKey := ruleID
+	if groupingKey == "" {
+		groupingKey = ruleName
+	}
+	if groupingKey == "" {
+		c.logger.Warn().Str("key", attrs.Key).Msg("secrets finding has no rule identity (ruleID and ruleName empty); FindingId falls back to per-scan key and will not be stable across scans")
+		groupingKey = attrs.Key
+	}
+
 	if ruleID == "" {
 		ruleID = attrs.Key
 	}
@@ -125,9 +140,16 @@ func (c *FindingsConverter) findingToIssues(finding *testapi.FindingData, scanPa
 			ContentRoot:      folderPath,
 			Product:          product.ProductSecrets,
 			CWEs:             cwes,
-			FindingId:        attrs.Key,
-			Fingerprint:      attrs.Key,
-			AdditionalData:   additionalData,
+			// FindingId is the durable grouping key: the stable rule identity (rule
+			// id, falling back to rule name), never attrs.Key. attrs.Key is a
+			// per-scan UUID, so folding it in made the same finding change identity
+			// on every scan. The converter combines this grouping key with the
+			// root-relative path + range to individuate multiple occurrences.
+			FindingId: groupingKey,
+			// Fingerprint feeds delta / IsNew matching (a separate concern) and
+			// intentionally stays the per-scan key.
+			Fingerprint:    attrs.Key,
+			AdditionalData: additionalData,
 		})
 	}
 	return issues

--- a/infrastructure/secrets/convert_test.go
+++ b/infrastructure/secrets/convert_test.go
@@ -17,12 +17,14 @@
 package secrets
 
 import (
+	"bytes"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -218,6 +220,63 @@ func TestToIssues_RuleIDFallsBackToKey(t *testing.T) {
 
 	require.Len(t, issues, 1)
 	assert.Equal(t, "fallback-key", issues[0].GetID())
+}
+
+// UNIT-004: the finding-id grouping key must be the stable rule identity, not the
+// per-scan UUID (attrs.Key). attrs.Key is minted fresh every scan, so folding it
+// into FindingId made the same finding change identity each scan. The converter
+// already extracts the rule id via extractProblems; FindingId must use it.
+func TestSecrets_GroupingKey_IgnoresUUID(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	logger := engine.GetLogger()
+	converter := NewFindingsConverter(logger)
+
+	loc := newSourceLocation("src/config.yml", 10, intPtr(1), intPtr(10), intPtr(20))
+	rule := newSecretsRuleProblem("aws-access-key", "AWS Access Key", []string{"Security"})
+	finding := newFinding("per-scan-uuid-123", "Secret", "desc", testapi.SeverityHigh,
+		[]testapi.FindingLocation{loc}, []testapi.Problem{rule}, nil)
+
+	issues := converter.ToIssues([]testapi.FindingData{finding}, "", "/folder")
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "aws-access-key", issues[0].GetFindingId(),
+		"FindingId grouping key must be the stable rule id, not the per-scan UUID")
+	assert.NotEqual(t, "per-scan-uuid-123", issues[0].GetFindingId(),
+		"the per-scan UUID (attrs.Key) must not be used as the finding-id grouping key")
+	// Fingerprint is a separate concern (delta matching) and stays the per-scan UUID.
+	assert.Equal(t, "per-scan-uuid-123", issues[0].GetFingerprint())
+}
+
+// UNIT-004b: the same rule seen in two scans with DIFFERENT per-scan UUIDs must
+// produce the SAME grouping key (issue.FindingId), and two different rules must
+// produce different grouping keys.
+func TestSecrets_GroupingKey_StableAcrossScans_UniquePerRule(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	logger := engine.GetLogger()
+	converter := NewFindingsConverter(logger)
+
+	loc := newSourceLocation("src/config.yml", 10, intPtr(1), intPtr(10), intPtr(20))
+	rule := newSecretsRuleProblem("aws-access-key", "AWS Access Key", nil)
+
+	scan1 := converter.ToIssues([]testapi.FindingData{
+		newFinding("uuid-1", "Secret", "d", testapi.SeverityHigh, []testapi.FindingLocation{loc}, []testapi.Problem{rule}, nil),
+	}, "", "/folder")
+	scan2 := converter.ToIssues([]testapi.FindingData{
+		newFinding("uuid-2-different", "Secret", "d", testapi.SeverityHigh, []testapi.FindingLocation{loc}, []testapi.Problem{rule}, nil),
+	}, "", "/folder")
+	otherRule := converter.ToIssues([]testapi.FindingData{
+		newFinding("uuid-3", "Secret", "d", testapi.SeverityHigh, []testapi.FindingLocation{loc},
+			[]testapi.Problem{newSecretsRuleProblem("github-token", "GitHub Token", nil)}, nil),
+	}, "", "/folder")
+
+	require.Len(t, scan1, 1)
+	require.Len(t, scan2, 1)
+	require.Len(t, otherRule, 1)
+
+	assert.Equal(t, scan1[0].GetFindingId(), scan2[0].GetFindingId(),
+		"same rule across scans must keep the same grouping key despite the UUID changing")
+	assert.NotEqual(t, scan1[0].GetFindingId(), otherRule[0].GetFindingId(),
+		"different rules must have different grouping keys")
 }
 
 func TestToRange_FullCoordinates(t *testing.T) {
@@ -531,19 +590,28 @@ func TestToIssues_IgnoredFinding(t *testing.T) {
 	assert.Equal(t, "False positive", issues[0].GetIgnoreDetails().Reason)
 }
 
-func TestToIssues_FindingIdFromUUID(t *testing.T) {
-	engine := testutil.UnitTest(t)
-	logger := engine.GetLogger()
-	converter := NewFindingsConverter(logger)
+// TestToIssues_FindingId_FallsBackToAttrKeyWhenNoRuleIdentity pins the fallback
+// behavior when a finding carries no rule identity (ruleID and ruleName both
+// empty): FindingId falls back to the per-scan attrs.Key, which is NOT stable
+// across scans. That fallback must be diagnosable, so a warning is logged.
+func TestToIssues_FindingId_FallsBackToAttrKeyWhenNoRuleIdentity(t *testing.T) {
+	testutil.UnitTest(t)
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+	converter := NewFindingsConverter(&logger)
 
 	loc := newSourceLocation("file.yml", 1, nil, nil, nil)
+	// No secrets rule problem, so both ruleID and ruleName are empty.
 	finding := newFinding("my-key", "title", "desc", testapi.SeverityLow, []testapi.FindingLocation{loc}, nil, nil)
 
 	issues := converter.ToIssues([]testapi.FindingData{finding}, "/scan", "/folder")
 
 	require.Len(t, issues, 1)
-	assert.NotEmpty(t, issues[0].GetFindingId())
+	assert.Equal(t, "my-key", issues[0].GetFindingId(),
+		"with no rule identity the grouping key falls back to the per-scan attrs.Key")
 	assert.Equal(t, "my-key", issues[0].GetFingerprint())
+	assert.Contains(t, buf.String(), "no rule identity",
+		"the unstable per-scan fallback must be diagnosable via a warning log")
 }
 
 func TestToIssues_NilFindingId(t *testing.T) {


### PR DESCRIPTION
### **User description**
## Summary
Finalize stable per-product grouping keys so the CP-1 composite `ScanIssue.FindingId` is stable across scans for every product:
- **OSS**: source the grouping key from `CalculateFingerprintFromAdditionalData` (packageName|version|dep-chain|ruleId) instead of the per-scan testapi finding UUID.
- **Secrets**: source it from the rule identity (ruleID → ruleName) instead of the per-scan `attrs.Key` UUID; warn before the last-resort `attrs.Key` fallback so an absent rule identity is diagnosable.
- **Code**: unchanged (`SnykAssetFindingV1` already stable) + regression-lock test.
- Harden OSS converter: `buildOssIssueData` returns an error for nil-attribute findings (was a latent panic), `processIssue` skips them, and the caller guards against appending a nil issue.

`Fingerprint` (delta/IsNew) semantics unchanged; `ScanIssue.Id` unchanged; no `RootId`.

## PR Stack — Merge Order
\`\`\`mermaid
flowchart LR
    main(["main"])
    PR1366["#1366 remediation follow-ups"]
    CP1["#1373 CP-1\ndurable finding identity + canonical ContentRoot"]
    CP23["CP-2+3 ← YOU ARE HERE\nOSS + Secrets grouping keys"]
    main --> PR1366 --> CP1 --> CP23
    style CP23 fill:#ffd700,color:#000
\`\`\`

**Depends on:** #1373

## Deferred / follow-ups
- Pre-existing (not introduced here): `populateMatchingIssues` appends a zero-value on `buildOssIssueData` error; a dormant `SetFindingId` `RLock`-for-write. Worth a `deferred` child of IDE-2052.

## Test plan
- [x] `go test -race` green (infrastructure/oss, infrastructure/secrets, infrastructure/code, domain/ide/converter)
- [x] `make test` recorded; `make lint` 0 issues
- [x] Passed A+B verification gate (3 rounds)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Make OSS finding identifiers stable across scans by using package, version, and rule details.

- Make Secrets finding identifiers stable across scans by using rule identity instead of per-scan UUIDs.

- Harden finding conversion logic to skip unusable findings and log warnings for fallback scenarios.

- Add comprehensive unit tests to verify stability and robustness of finding identification.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TestAPI Finding Data"] --> B("OSS Converter");
  A --> C("Secrets Converter");
  A --> D("Code Converter");
  B --> E("Stable Attributes (Package, Version, DepChain, RuleID)");
  C --> F("Rule Identity (RuleID, RuleName)");
  D --> G("Asset Fingerprint (snyk/asset/finding/v1)");
  E --> H["FindingId (Stable)"];
  F --> H;
  G --> H;
  I["Per-scan UUID (attrs.Key)"] -.-> H;
  subgraph "Old Behavior"
    I
  end
  subgraph "New Behavior"
    H
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter_finding_identity_test.go</strong><dd><code>Add test for stable Secrets FindingId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/ide/converter/converter_finding_identity_test.go

<ul><li>Added a new test case <br><code>TestToDiagnostics_Secrets_FindingIdStable_DespiteUUIDChange</code>.<br> <li> This test verifies that the <code>FindingId</code> for secrets findings remains <br>consistent across different scans, even when the underlying per-scan <br>UUID changes.<br> <li> It asserts that the <code>FindingId</code> is derived from stable rule identities <br>rather than transient scan identifiers.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1374/changes#diff-c6807ca6fe4f9829dabc5774e306bd1867f0f3983598f05cc103039922d9f866">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convert_finding_identity_test.go</strong><dd><code>Add test for stable Code FindingId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/code/convert_finding_identity_test.go

<ul><li>Introduced <code>TestCode_FindingId_IsAssetFingerprint_StableAcrossScans</code> to <br>verify the stability of Code product's finding identifiers.<br> <li> This test confirms that the <code>FindingId</code> for Code findings correctly uses <br>the durable <code>snyk/asset/finding/v1</code> fingerprint, which is already stable <br>across scans.<br> <li> This serves as a regression lock, ensuring the existing stability is <br>maintained.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1374/changes#diff-f942106e70be44d9bb444242c55ececfcce2d880ae0afe388b0531a722242d49">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>unified_converter_finding_identity_test.go</strong><dd><code>Add OSS FindingId stability and robustness tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/unified_converter_finding_identity_test.go

<ul><li>Added <code>TestProcessIssue_OSS_FindingIdStable_DespiteChangedFindingUUID</code> <br>to confirm <code>FindingId</code> stability across scans by comparing findings <br>generated from different per-scan UUIDs.<br> <li> Added <code>TestProcessIssue_OSS_SkipsUnusableIntroducingFinding</code> to ensure <br>that findings with unusable attributes (missing package/version info) <br>are skipped, preventing contentless or colliding identifiers.<br> <li> Added <code>TestConvertTestResultToIssues_SkipsUnusableFinding_NoNilElements</code> <br>to verify that the converter correctly omits nil issues returned by <br><code>processIssue</code> without creating nil elements in the resulting slice.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1374/changes#diff-886607a248fb79575418d2ddfde9b1b3d3eb48ac0487a450d34ffe0d21eb04a1">+293/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convert_test.go</strong><dd><code>Add Secrets FindingId stability and fallback tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/secrets/convert_test.go

<ul><li>Added <code>TestSecrets_GroupingKey_IgnoresUUID</code> to assert that <code>FindingId</code> <br>uses the rule ID and not the per-scan <code>attrs.Key</code>.<br> <li> Added <code>TestSecrets_GroupingKey_StableAcrossScans_UniquePerRule</code> to <br>verify <code>FindingId</code> stability across scans for the same rule and <br>uniqueness for different rules.<br> <li> Refactored <code>TestToIssues_FindingIdFromUUID</code> to <br><code>TestToIssues_FindingId_FallsBackToAttrKeyWhenNoRuleIdentity</code> to test <br>and ensure a warning is logged when <code>FindingId</code> falls back to <code>attrs.Key</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1374/changes#diff-5554ff273e2a57af577c1024e24afdc5a6512ba15f1b3a7d2431d37c7d5a2435">+73/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_converter.go</strong><dd><code>Derive OSS FindingId from stable attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/oss/unified_converter.go

<ul><li>Modified <code>processIssue</code> to return <code>nil</code> if <code>buildOssIssueData</code> fails, <br>preventing latent panics from nil attributes.<br> <li> Updated the logic to derive <code>issue.FindingId</code> from <br><code>utils.CalculateFingerprintFromAdditionalData</code>, ensuring stability using <br>package name, version, dependency chain, and rule ID.<br> <li> Added a check for nil <code>finding.Attributes</code> in <code>buildOssIssueData</code> to <br>explicitly return an error, allowing <code>processIssue</code> to skip such <br>findings.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1374/changes#diff-75cc7b3352e4a2f1077307fb167c6b96b9d1973c24f65b5dc762d396c566eb9a">+28/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convert.go</strong><dd><code>Derive Secrets FindingId from stable rule identity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/secrets/convert.go

<ul><li>Modified <code>findingToIssues</code> to set <code>FindingId</code> to the stable rule identity <br>(<code>ruleID</code> or <code>ruleName</code>), deprecating the use of per-scan <code>attrs.Key</code>.<br> <li> Implemented a warning log for cases where the <code>FindingId</code> must fall back <br>to the unstable <code>attrs.Key</code> due to missing rule identity.<br> <li> Clarified that <code>Fingerprint</code> remains <code>attrs.Key</code> for separate delta/IsNew <br>matching logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1374/changes#diff-5b4fb4b10f5f0c93fb03b532ed36dded500766552b03587ab559a9fbcb709bc6">+25/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

