### PR TITLE
fix(remediation): bound FixFolder timeout, cap root-mutex growth, dedup actions [IDE-2052]

### DIFF
--- a/domain/snyk/remediation/remy.go
+++ b/domain/snyk/remediation/remy.go
@@ -145,6 +145,23 @@ func (p *remyProvider) FixFolder(ctx context.Context, root types.FilePath) (*typ
 	if prefix := strings.TrimSpace(string(out)); prefix != "" {
 		return nil, fmt.Errorf("remy: FixFolder: %q is a subdirectory of a git repository (prefix %q); the caller must pass the git repository root", r, prefix)
 	}
+	// Guard: the passed worktree must be clean of tracked-file changes.
+	// --untracked-files=no excludes "??" lines for untracked files (e.g. build
+	// artifacts) so they do not falsely trip the guard. Only uncommitted
+	// modifications to tracked files matter: they would be silently included in
+	// the returned edit, making the fix unpredictable and violating the isolation
+	// guarantee that the caller must pass a fresh detached-HEAD worktree.
+	statusOut, err := exec.CommandContext(ctx, "git", "-C", r, "status", "--porcelain", "--untracked-files=no").Output()
+	if err != nil {
+		return nil, fmt.Errorf("remy: FixFolder: failed to check worktree status of %q: %w", r, err)
+	}
+	if status := strings.TrimSpace(string(statusOut)); status != "" {
+		return nil, fmt.Errorf("remy: FixFolder: %q has uncommitted changes to tracked files; the caller must pass a clean detached-HEAD worktree:\n%s", r, status)
+	}
+	// Bound the folder-wide run with the configured timeout so a hung fix
+	// cannot stall the caller indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, p.opts.Timeout)
+	defer cancel()
 	// findingID is "" because FixFolder targets the whole folder, not a single finding.
 	// fileHashes is ignored: FixFolder returns a one-shot WorkspaceEdit and does not cache.
 	changes, _, err := p.collectFixEdits(ctx, r, r, "")

--- a/domain/snyk/remediation/remy_review_fixes_test.go
+++ b/domain/snyk/remediation/remy_review_fixes_test.go
@@ -1,0 +1,77 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package remediation_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/domain/snyk/remediation"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// TestFixFolder_DirtyWorktree_ReturnsError verifies that FixFolder rejects a
+// worktree that has uncommitted modifications to tracked files.  The guard
+// runs git status --porcelain --untracked-files=no; any non-empty output
+// causes an error containing "has uncommitted changes".  Inverting the guard
+// condition (status != "" → status == "") would make a dirty worktree pass
+// and this test would fail because the error would no longer be returned.
+func TestFixFolder_DirtyWorktree_ReturnsError(t *testing.T) {
+	repo := initGitRepo(t)
+	commitFile(t, repo, "main.go", "package main\nvar x = 1\n")
+
+	// Modify the tracked file without staging/committing it.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\nvar x = 2\n"), 0o644))
+
+	var runnerCalled bool
+	trackingRunner := func(_ context.Context, _ workflow.Engine, _, _ string) error {
+		runnerCalled = true
+		return nil
+	}
+
+	p := remediation.NewRemyProvider(nil, trackingRunner)
+	edit, err := p.FixFolder(context.Background(), types.FilePath(repo))
+	require.ErrorContains(t, err, "has uncommitted changes")
+	assert.Nil(t, edit)
+	assert.False(t, runnerCalled, "runner must NOT be called when the dirty-worktree guard fires")
+}
+
+// TestFixFolder_AppliesInternalTimeout verifies that FixFolder wraps the runner
+// with a context deadline (p.opts.Timeout). The caller passes context.Background()
+// (no deadline); the runner must observe a deadline on its context.
+func TestFixFolder_AppliesInternalTimeout(t *testing.T) {
+	repo := initGitRepo(t)
+	commitFile(t, repo, "main.go", "package main\nvar x = 1\n")
+
+	var hadDeadline bool
+	runner := func(ctx context.Context, _ workflow.Engine, root, _ string) error {
+		_, hadDeadline = ctx.Deadline()
+		return os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\nvar x = 2\n"), 0644)
+	}
+
+	p := remediation.NewRemyProvider(nil, runner)
+	_, err := p.FixFolder(context.Background(), types.FilePath(repo))
+	require.NoError(t, err)
+	assert.True(t, hadDeadline,
+		"FixFolder must bound the runner with an internal timeout so a hung run cannot stall the caller")
+}


### PR DESCRIPTION
### **User description**
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [ ] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces the `snyk.remediationAgent.fixFolder` command.

- Integrates the Snyk Remediation Agent (`remediation.FolderRemediator`).

- The feature is enabled via the `remediation_agent_enabled` configuration flag.

- The command executes remediation workflows on a provided folder and sends edits to the client.

- Includes comprehensive unit and integration tests for the new feature.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Client] -- Command: snyk.remediationAgent.fixFolder --> B(LS Server);
  B -- DI Wiring --> C{Command Service};
  C -- Creates --> D[remediationFixFolderCommand];
  D -- Uses --> E(remediation.FolderRemediator);
  E -- Conditional based on --> F[remediation_agent_enabled flag];
  E -- Calls --> G[remyProvider.FixFolder];
  G -- Executes --> H{Fix Folder Workflow};
  H -- Applies Edits --> I[Client WorkspaceApplyEdit];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>init.go</strong><dd><code>Conditionally wire remediation provider in DI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-3dfa2a6c1d0ed218f91d033ea2c5e5575f64d80c2575b71fe0605ec4fa41d4f6">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Register remediation command and update handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-1b5a200b7dc3f37ed67632d0c2682eeb53762813f96edb15cb7660e076fa6031">+13/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>command_factory.go</strong><dd><code>Add remediation provider to command factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-b7c8bb6d3fa17d1b86a8de859670a7d849bdcedceb8d9a27f4e7f1a74b5d340d">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>command_service.go</strong><dd><code>Add remediation provider to command service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-f91e9940ae7491a26a9708f682296ad692d4044fb82fad0d67811bc13f50fa0f">+29/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>remediation_fix_folder.go</strong><dd><code>Implement remediation agent fix folder command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-a46bf7764ee3ef42e8255d31130e0c267ff5748c3571840987bd63dc70648827">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>provider.go</strong><dd><code>Define FolderRemediator interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-0e46427f6767027246b58ab35e85a14ff7e45d9f664ac023859c0eee0ae2116a">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remy.go</strong><dd><code>Implement RemyProvider for remediation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-3ad54b822be438a8117c900dfa6cdcf87b84569bfb85139751524795371d6274">+489/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>command.go</strong><dd><code>Add RemediationAgentFixFolderCommand constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-c47396508e52286b319ab3223027408ab420efb9b2bba05f907148fdc860b9e8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>init_fix_folder_test.go</strong><dd><code>Add tests for remediation provider wiring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-2cf48a6ecdd95a600d8e600054f9842199239f572267004f521ce9a3ab90df82">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>execute_command_test.go</strong><dd><code>Adjust command service setup for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-62dafdad0c9b4059a5d99a1eb3f1fcf677e7720b1cac9f4f87ea711faeec86ab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server_test.go</strong><dd><code>Add tests for remediation agent integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-165bad981a0cc202462a2fea7f236eab9ca3a72bd47fe8bae6b3adad801351fb">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>command_factory_test.go</strong><dd><code>Test command factory wiring for remediation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-eb4303c3dfca4138ca834732978cf2a2c8644ea45cba6a54eedca36a180d0920">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>command_service_test.go</strong><dd><code>Adjust command service setup for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-4e5012d752e62ca48321ab14a65a40b32718552b72d0510af51c9eccfb981154">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export_for_test.go</strong><dd><code>Export remediation command constructors for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-6b6ec1d2ed47bdfc2f4a334aaba263e6bdb24ecc61e9f19df095aa639a0019ac">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remediation_fix_folder_test.go</strong><dd><code>Add extensive tests for remediation fix folder command</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-51525eb80d8edb6349988d5e7973b4a6d24a00c17f4ee3a4e2a96012568b96c1">+447/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>export_for_test.go</strong><dd><code>Export workspaceEditFromContent for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-bf7adcab8ff48fed48cdebf9501e0b3b26455f224598049dbc1df29d7bf8f4a4">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remy_fix_folder_test.go</strong><dd><code>Add tests for remyProvider FixFolder validations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-4f679ddab2595fd552c720f4817ff706bdf9ba53b7c43ba58efdaf38d1cfef82">+285/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>remy_provider_test.go</strong><dd><code>Test RemyProvider constructor and utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-df0127432dc24635f48abecfdd8df08c67ffb9da514021b61ec09cbc7cd83370">+123/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>remy_test.go</strong><dd><code>Add tests for diff parsing and git helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-134aadf198cd3215218f8733c77a9a071513e237a89e7653df850894d1469489">+188/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>command_remediation_test.go</strong><dd><code>Test remediation command constant value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-ec48e30eeef4126f949df53dc27a119435d7b32d8fed662d3ba1a67624e32a5a">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>converter.go</strong><dd><code>Minor refactor in ToCodeAction Kind assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-906b744a0a633abffa7bc1bfd39886eb37836f675579617c61d13e96c32a4fe9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>authentication_flows_e2e_test.go</strong></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-9deadd440a71de07926bf9936df138c9c5512696795d6b6544d4f40c01d06752">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remy_review_fixes_test.go</strong></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1376/changes#diff-b90d9ba6b80c2a2410d755cda6ebfa60f3545ea9a239f39520a8399bebe67a58">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

