### PR TITLE
feat: add workspace/diagnostic and textDocument/diagnostic handlers [IDE-2253]

### DIFF
--- a/application/server/server.go
+++ b/application/server/server.go
@@ -286,6 +286,8 @@ func initHandlers(srv *jrpc2.Server, handlers handler.Map, conf configuration.Co
 	handlers["window/workDoneProgress/cancel"] = enrich(windowWorkDoneProgressCancelHandler(conf))
 	handlers["workspace/executeCommand"] = enrich(executeCommandHandler(srv))
 	handlers["$/cancelRequest"] = cancelRequestHandler(srv)
+	handlers["textDocument/diagnostic"] = enrich(textDocumentDiagnosticHandler(conf))
+	handlers["workspace/diagnostic"] = enrich(workspaceDiagnosticHandler(conf))
 }
 
 func authenticationServiceFromContext(ctx context.Context) (authentication.AuthenticationService, bool) {
@@ -704,6 +706,10 @@ func initializeHandler(conf configuration.Configuration, engine workflow.Engine,
 				InlineValueProvider: true,
 				ExecuteCommandProvider: &sglsp.ExecuteCommandOptions{
 					Commands: commands(conf),
+				},
+				DiagnosticProvider: &types.DiagnosticOptions{
+					InterFileDependencies: false,
+					WorkspaceDiagnostics:  true,
 				},
 			},
 		}
@@ -1279,6 +1285,50 @@ func noOpHandler() jrpc2.Handler {
 	return handler.New(func(ctx context.Context, params sglsp.DidCloseTextDocumentParams) (any, error) {
 		ctx2.LoggerFromContext(ctx).Debug().Str("method", "NoOpHandler").Interface("params", params).Msg("RECEIVING")
 		return nil, nil
+	})
+}
+
+func workspaceDiagnosticHandler(conf configuration.Configuration) jrpc2.Handler {
+	// Always returns full results; previousResultIds is not used.
+	return handler.New(func(_ context.Context, _ types.WorkspaceDiagnosticParams) (any, error) {
+		reports := []types.WorkspaceDocumentDiagnosticReport{}
+		for _, folder := range config.GetWorkspace(conf).Folders() {
+			if !folder.IsTrusted() {
+				continue
+			}
+			fip, ok := folder.(snyk.FilteringIssueProvider)
+			if !ok {
+				continue
+			}
+			filtered := fip.FilterIssues(fip.Issues(), folder.DisplayableIssueTypes())
+			for filePath, issues := range filtered {
+				reports = append(reports, types.WorkspaceDocumentDiagnosticReport{
+					Kind:    "full",
+					URI:     uri.PathToUri(filePath),
+					Version: nil,
+					Items:   converter.ToDiagnostics(issues),
+				})
+			}
+		}
+		return types.WorkspaceDiagnosticReport{Items: reports}, nil
+	})
+}
+
+func textDocumentDiagnosticHandler(conf configuration.Configuration) jrpc2.Handler {
+	return handler.New(func(_ context.Context, params types.DocumentDiagnosticParams) (any, error) {
+		report := types.RelatedFullDocumentDiagnosticReport{Kind: "full", Items: []types.Diagnostic{}}
+		filePath := uri.PathFromUri(params.TextDocument.URI)
+		folder := config.GetWorkspace(conf).GetFolderContaining(filePath)
+		if folder == nil || !folder.IsTrusted() {
+			return report, nil
+		}
+		fip, ok := folder.(snyk.FilteringIssueProvider)
+		if !ok {
+			return report, nil
+		}
+		filtered := fip.FilterIssues(fip.Issues(), folder.DisplayableIssueTypes())
+		report.Items = converter.ToDiagnostics(filtered[filePath])
+		return report, nil
 	})
 }
 

--- a/application/server/server_diagnostic_test.go
+++ b/application/server/server_diagnostic_test.go
@@ -1,0 +1,234 @@
+/*
+ * © 2022-2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	sglsp "github.com/sourcegraph/go-lsp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
+
+	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/application/di"
+	"github.com/snyk/snyk-ls/domain/ide/workspace"
+	"github.com/snyk/snyk-ls/infrastructure/authentication"
+	"github.com/snyk/snyk-ls/infrastructure/code"
+	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+	"github.com/snyk/snyk-ls/internal/uri"
+)
+
+// ACC-004: the initialize result must advertise diagnosticProvider with
+// workspaceDiagnostics:true so out-of-process LSP clients discover pull support.
+func Test_initialize_advertisesDiagnosticProvider(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, _, _ := setupServer(t, engine, tokenService)
+
+	rsp, err := loc.Client.Call(t.Context(), "initialize", nil)
+	require.NoError(t, err)
+
+	var result types.InitializeResult
+	require.NoError(t, rsp.UnmarshalResult(&result))
+
+	require.NotNil(t, result.Capabilities.DiagnosticProvider,
+		"server must advertise diagnosticProvider capability")
+	assert.True(t, result.Capabilities.DiagnosticProvider.WorkspaceDiagnostics,
+		"diagnosticProvider.workspaceDiagnostics must be true")
+}
+
+// INT-001: workspace/diagnostic is a registered method (no MethodNotFound).
+func Test_workspaceDiagnostic_isRegistered(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, _, _ := setupServer(t, engine, tokenService)
+
+	rsp, err := loc.Client.Call(t.Context(), "workspace/diagnostic", types.WorkspaceDiagnosticParams{})
+	require.NoError(t, err)
+
+	var result types.WorkspaceDiagnosticReport
+	require.NoError(t, rsp.UnmarshalResult(&result))
+	assert.NotNil(t, result.Items)
+}
+
+// INT-002: textDocument/diagnostic is a registered method (no MethodNotFound).
+func Test_textDocumentDiagnostic_isRegistered(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, _, _ := setupServer(t, engine, tokenService)
+
+	rsp, err := loc.Client.Call(t.Context(), "textDocument/diagnostic", types.DocumentDiagnosticParams{
+		TextDocument: sglsp.TextDocumentIdentifier{URI: "file:///nonexistent.go"},
+	})
+	require.NoError(t, err)
+
+	var result types.RelatedFullDocumentDiagnosticReport
+	require.NoError(t, rsp.UnmarshalResult(&result))
+	assert.Equal(t, "full", result.Kind)
+}
+
+// ACC-006: workspace/diagnostic returns empty items when no folders are in the workspace.
+func Test_workspaceDiagnostic_emptyWorkspace(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, _, _ := setupServer(t, engine, tokenService)
+
+	rsp, err := loc.Client.Call(t.Context(), "workspace/diagnostic", types.WorkspaceDiagnosticParams{})
+	require.NoError(t, err)
+
+	var result types.WorkspaceDiagnosticReport
+	require.NoError(t, rsp.UnmarshalResult(&result))
+	assert.Empty(t, result.Items)
+}
+
+// ACC-007: workspace/diagnostic skips folders that are not trusted.
+func Test_workspaceDiagnostic_skipsUntrustedFolder(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, _, _ := setupServer(t, engine, tokenService)
+
+	// Enable trust feature — any folder not in SettingTrustedFolders is now untrusted.
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingTrustEnabled), true)
+
+	folderPath := types.FilePath(t.TempDir())
+	config.GetWorkspace(engine.GetConfiguration()).AddFolder(workspace.NewFolder(
+		engine.GetConfiguration(), engine.GetLogger(), folderPath,
+		"untrusted",
+		di.Scanner(),
+		di.HoverService(),
+		di.ScanNotifier(),
+		di.Notifier(),
+		di.ScanPersister(),
+		di.ScanStateAggregator(),
+		featureflag.NewFakeService(),
+		di.ConfigResolver(),
+		engine,
+	))
+
+	rsp, err := loc.Client.Call(t.Context(), "workspace/diagnostic", types.WorkspaceDiagnosticParams{})
+	require.NoError(t, err)
+
+	var result types.WorkspaceDiagnosticReport
+	require.NoError(t, rsp.UnmarshalResult(&result))
+	assert.Empty(t, result.Items, "untrusted folder must be skipped by workspace/diagnostic")
+}
+
+// ACC-009: textDocument/diagnostic returns a full empty report for a document
+// that does not belong to any known workspace folder.
+func Test_textDocumentDiagnostic_unknownDocumentReturnsEmpty(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, _, _ := setupServer(t, engine, tokenService)
+
+	rsp, err := loc.Client.Call(t.Context(), "textDocument/diagnostic", types.DocumentDiagnosticParams{
+		TextDocument: sglsp.TextDocumentIdentifier{URI: "file:///no/such/file.go"},
+	})
+	require.NoError(t, err)
+
+	var result types.RelatedFullDocumentDiagnosticReport
+	require.NoError(t, rsp.UnmarshalResult(&result))
+	assert.Equal(t, "full", result.Kind)
+	assert.Empty(t, result.Items)
+}
+
+// ACC-001+002: workspace/diagnostic returns the same finding set as textDocument/publishDiagnostics
+// for the same scan state.
+func Test_workspaceDiagnostic_returnsSameFindingSetAsPush(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, jsonRPCRecorder, _ := setupServer(t, engine, tokenService)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+	di.AuthenticationService().Provider().(*authentication.FakeAuthenticationProvider).IsAuthenticated = true
+
+	_, err := loc.Client.Call(t.Context(), "initialize", nil)
+	require.NoError(t, err)
+	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
+
+	filePath, fileDir := code.TempWorkdirWithIssues(t)
+	fileUri := sendFileSavedMessage(t, engine, filePath, fileDir, loc)
+
+	require.Eventually(t,
+		checkForPublishedDiagnostics(t, engine, uri.PathFromUri(fileUri), -1, jsonRPCRecorder),
+		5*time.Second, time.Millisecond)
+
+	// Collect push diagnostics for the scanned file URI.
+	var pushItems []types.Diagnostic
+	for _, n := range jsonRPCRecorder.FindNotificationsByMethod("textDocument/publishDiagnostics") {
+		var params types.PublishDiagnosticsParams
+		_ = n.UnmarshalParams(&params)
+		if params.URI == fileUri {
+			pushItems = params.Diagnostics
+		}
+	}
+
+	rsp, err := loc.Client.Call(t.Context(), "workspace/diagnostic", types.WorkspaceDiagnosticParams{})
+	require.NoError(t, err)
+
+	var wsResult types.WorkspaceDiagnosticReport
+	require.NoError(t, rsp.UnmarshalResult(&wsResult))
+
+	var pullItems []types.Diagnostic
+	for _, item := range wsResult.Items {
+		if item.URI == fileUri {
+			pullItems = item.Items
+		}
+	}
+
+	require.NotEmpty(t, pullItems, "workspace/diagnostic must return findings for the scanned file")
+	assert.Equal(t, pushItems, pullItems,
+		"pull and push must report byte-identical findings")
+}
+
+// ACC-003: textDocument/diagnostic returns the same file findings as the push path.
+func Test_textDocumentDiagnostic_returnsFileFindings(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, jsonRPCRecorder, _ := setupServer(t, engine, tokenService)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingSnykCodeEnabled), true)
+	di.AuthenticationService().Provider().(*authentication.FakeAuthenticationProvider).IsAuthenticated = true
+
+	_, err := loc.Client.Call(t.Context(), "initialize", nil)
+	require.NoError(t, err)
+	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
+
+	filePath, fileDir := code.TempWorkdirWithIssues(t)
+	fileUri := sendFileSavedMessage(t, engine, filePath, fileDir, loc)
+
+	require.Eventually(t,
+		checkForPublishedDiagnostics(t, engine, uri.PathFromUri(fileUri), -1, jsonRPCRecorder),
+		5*time.Second, time.Millisecond)
+
+	// Collect push diagnostics for the scanned file URI.
+	var pushItems []types.Diagnostic
+	for _, n := range jsonRPCRecorder.FindNotificationsByMethod("textDocument/publishDiagnostics") {
+		var params types.PublishDiagnosticsParams
+		_ = n.UnmarshalParams(&params)
+		if params.URI == fileUri {
+			pushItems = params.Diagnostics
+		}
+	}
+
+	rsp, err := loc.Client.Call(t.Context(), "textDocument/diagnostic", types.DocumentDiagnosticParams{
+		TextDocument: sglsp.TextDocumentIdentifier{URI: fileUri},
+	})
+	require.NoError(t, err)
+
+	var result types.RelatedFullDocumentDiagnosticReport
+	require.NoError(t, rsp.UnmarshalResult(&result))
+
+	assert.Equal(t, "full", result.Kind)
+	require.NotEmpty(t, result.Items, "textDocument/diagnostic must return findings for the scanned file")
+	assert.Equal(t, pushItems, result.Items,
+		"pull and push must report byte-identical findings")
+}

--- a/internal/types/lsp.go
+++ b/internal/types/lsp.go
@@ -206,6 +206,7 @@ type ServerCapabilities struct {
 	SemanticHighlighting             *sglsp.SemanticHighlightingOptions     `json:"semanticHighlighting,omitempty"`
 	Workspace                        *WorkspaceCapabilities                 `json:"workspace,omitempty"`
 	InlineValueProvider              bool                                   `json:"inlineValueProvider,omitempty"`
+	DiagnosticProvider               *DiagnosticOptions                     `json:"diagnosticProvider,omitempty"`
 }
 
 type ClientCapabilities struct {
@@ -1292,4 +1293,57 @@ type SecretIssueData struct {
 	Rows           Point    `json:"rows"`
 	Fingerprint    string   `json:"fingerprint"`
 	LocationsCount int      `json:"locationsCount"`
+}
+
+// LSP 3.17 pull-diagnostic types (sourcegraph/go-lsp predates 3.17, so defined here).
+
+// DiagnosticOptions is advertised in ServerCapabilities.DiagnosticProvider.
+type DiagnosticOptions struct {
+	Identifier            string `json:"identifier,omitempty"`
+	InterFileDependencies bool   `json:"interFileDependencies"`
+	WorkspaceDiagnostics  bool   `json:"workspaceDiagnostics"`
+}
+
+// DocumentDiagnosticParams is the request body for textDocument/diagnostic.
+type DocumentDiagnosticParams struct {
+	TextDocument     sglsp.TextDocumentIdentifier `json:"textDocument"`
+	Identifier       string                       `json:"identifier,omitempty"`
+	PreviousResultID string                       `json:"previousResultId,omitempty"`
+}
+
+// RelatedFullDocumentDiagnosticReport is the response for textDocument/diagnostic.
+// Kind is always "full" in v1.
+type RelatedFullDocumentDiagnosticReport struct {
+	Kind     string       `json:"kind"`
+	ResultID string       `json:"resultId,omitempty"`
+	Items    []Diagnostic `json:"items"`
+}
+
+// PreviousResultID is one entry in WorkspaceDiagnosticParams.PreviousResultIDs.
+// The field tag is "value" (not "resultId") per the LSP 3.17 spec.
+type PreviousResultID struct {
+	URI   sglsp.DocumentURI `json:"uri"`
+	Value string            `json:"value"`
+}
+
+// WorkspaceDiagnosticParams is the request body for workspace/diagnostic.
+type WorkspaceDiagnosticParams struct {
+	Identifier        string             `json:"identifier,omitempty"`
+	PreviousResultIDs []PreviousResultID `json:"previousResultIds"`
+}
+
+// WorkspaceDiagnosticReport is the response for workspace/diagnostic.
+// Items is a list of per-document reports (one per file with findings).
+type WorkspaceDiagnosticReport struct {
+	Items []WorkspaceDocumentDiagnosticReport `json:"items"`
+}
+
+// WorkspaceDocumentDiagnosticReport is one entry in WorkspaceDiagnosticReport.Items.
+// Version uses *int with no omitempty so nil serializes as JSON null per the spec.
+type WorkspaceDocumentDiagnosticReport struct {
+	Kind     string            `json:"kind"`
+	URI      sglsp.DocumentURI `json:"uri"`
+	Version  *int              `json:"version"`
+	ResultID string            `json:"resultId,omitempty"`
+	Items    []Diagnostic      `json:"items"`
 }

--- a/internal/types/lsp_diagnostic_test.go
+++ b/internal/types/lsp_diagnostic_test.go
@@ -1,0 +1,117 @@
+/*
+ * © 2022-2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	sglsp "github.com/sourcegraph/go-lsp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// UNIT-001: WorkspaceDiagnosticReport serializes with "kind":"full", "version":null,
+// and the double-nested items shape the AC-verified wire contract requires.
+func Test_WorkspaceDiagnosticReport_wireShape(t *testing.T) {
+	report := WorkspaceDiagnosticReport{
+		Items: []WorkspaceDocumentDiagnosticReport{
+			{
+				Kind:    "full",
+				URI:     sglsp.DocumentURI("file:///foo.go"),
+				Version: nil,
+				Items:   []Diagnostic{},
+			},
+		},
+	}
+
+	b, err := json.Marshal(report)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	outerItems, ok := raw["items"].([]any)
+	require.True(t, ok, "outer items must be an array")
+	require.Len(t, outerItems, 1)
+
+	item, ok := outerItems[0].(map[string]any)
+	require.True(t, ok, "outer items[0] must be an object")
+	assert.Equal(t, "full", item["kind"], `kind must be "full"`)
+	// version must be present and null — *int with no omitempty guarantees this.
+	versionRaw, hasVersion := item["version"]
+	assert.True(t, hasVersion, "version key must be present in JSON (not omitted)")
+	assert.Nil(t, versionRaw, "version must serialize as null when *int is nil")
+	// Inner items must be present (double-nesting).
+	_, hasInnerItems := item["items"]
+	assert.True(t, hasInnerItems, "inner items key must be present (double-nested shape)")
+}
+
+// UNIT-002: WorkspaceDiagnosticParams deserialises previousResultIds using the
+// field tag "value" (not "resultId") matching the AC wire contract.
+func Test_WorkspaceDiagnosticParams_previousResultIdValueTag(t *testing.T) {
+	raw := `{"previousResultIds":[{"uri":"file:///x","value":"r1"}]}`
+	var params WorkspaceDiagnosticParams
+	require.NoError(t, json.Unmarshal([]byte(raw), &params))
+	require.Len(t, params.PreviousResultIDs, 1)
+	assert.Equal(t, sglsp.DocumentURI("file:///x"), params.PreviousResultIDs[0].URI)
+	assert.Equal(t, "r1", params.PreviousResultIDs[0].Value, `field tag must be "value"`)
+}
+
+// UNIT-003: Diagnostic.Data carries the identity fields the push path emits.
+// These are existing types; this test pins their JSON tags so pull and push
+// always emit byte-identical Data objects.
+func Test_Diagnostic_dataCarriesIdentityTags(t *testing.T) {
+	d := Diagnostic{
+		Message: "something vulnerable",
+		Data: ScanIssue{
+			FindingId:   "abc-123",
+			ContentRoot: "/workspace",
+			IsNew:       true,
+		},
+	}
+
+	b, err := json.Marshal(d)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	data, ok := raw["data"].(map[string]any)
+	require.True(t, ok, "data field must be a JSON object")
+	assert.Equal(t, "abc-123", data["findingId"], `findingId tag must be "findingId"`)
+	assert.Equal(t, "/workspace", data["contentRoot"], `contentRoot tag must be "contentRoot"`)
+	assert.Equal(t, true, data["isNew"], `isNew tag must be "isNew"`)
+}
+
+// UNIT-004: DiagnosticOptions serializes workspaceDiagnostics:true and
+// interFileDependencies:false (both without omitempty so false is explicit).
+func Test_DiagnosticOptions_wireShape(t *testing.T) {
+	opts := DiagnosticOptions{
+		WorkspaceDiagnostics:  true,
+		InterFileDependencies: false,
+	}
+
+	b, err := json.Marshal(opts)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	assert.Equal(t, true, raw["workspaceDiagnostics"])
+	assert.Equal(t, false, raw["interFileDependencies"])
+}


### PR DESCRIPTION
### **User description**
## Summary

- CP1: Add `DiagnosticProvider` capability + LSP 3.17 types (`DiagnosticOptions`, `DocumentDiagnosticParams`, `RelatedFullDocumentDiagnosticReport`, `WorkspaceDiagnosticParams`, `WorkspaceDiagnosticReport`, `WorkspaceDocumentDiagnosticReport`)
- CP2: `workspace/diagnostic` handler — iterates trusted folders, filters via `FilteringIssueProvider`, reuses `converter.ToDiagnostics`
- CP3: `textDocument/diagnostic` handler — resolves folder by URI, trust-gates, reuses `converter.ToDiagnostics` for byte-identical `Diagnostic.Data`

Both handlers always return full results (`kind: "full"`, `Version: null`). `previousResultIds` deferred to a later ticket.

## PR Stack — Merge Order
```mermaid
flowchart LR
    main(["main"])
    PR1327["#1327 IDE-2052 remediation\nworktree isolation + remy"]
    PR_THIS["#NEW IDE-2253 ← YOU ARE HERE\nLSP pull-diagnostics handlers"]
    main --> PR1327 --> PR_THIS
    style PR_THIS fill:#ffd700,color:#000
```

**Depends on:** #1327

## Test plan
- [ ] INT-001: `workspace/diagnostic` method registered in jrpc2 handler map
- [ ] INT-002: `textDocument/diagnostic` method registered in jrpc2 handler map
- [ ] ACC-004: `initialize` response includes `diagnosticProvider.workspaceDiagnostics: true`
- [ ] ACC-006: `workspace/diagnostic` returns empty items for empty workspace
- [ ] ACC-007: `workspace/diagnostic` skips untrusted folders
- [ ] ACC-009: `textDocument/diagnostic` returns empty for unknown document
- [ ] ACC-001+002: `workspace/diagnostic` returns same findings (content equality) as `textDocument/publishDiagnostics`
- [ ] ACC-003: `textDocument/diagnostic` returns same file findings (content equality) as push path


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implement LSP 3.17 diagnostic pulling.

- Add `workspace/diagnostic` and `textDocument/diagnostic` handlers.

- Define new LSP types and server capabilities.

- Add comprehensive tests for handlers.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Client --> Server
  Server --> "workspace/diagnostic Handler"
  Server --> "textDocument/diagnostic Handler"
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Register new diagnostic handlers and update initialize.</code>&nbsp; &nbsp; </dd></summary>
<hr>

application/server/server.go

<ul><li>Registers <code>textDocument/diagnostic</code> and <code>workspace/diagnostic</code> handlers in <br>the server.<br> <li> Updates <code>initializeHandler</code> to advertise <code>DiagnosticProvider</code> capability <br>with <code>WorkspaceDiagnostics: true</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1378/changes#diff-1b5a200b7dc3f37ed67632d0c2682eeb53762813f96edb15cb7660e076fa6031">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lsp.go</strong><dd><code>Define LSP 3.17 diagnostic types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/types/lsp.go

<ul><li>Defines new LSP 3.17 types for diagnostic pulling.<br> <li> Adds <code>DiagnosticProvider</code> field to <code>ServerCapabilities</code> struct.<br> <li> Introduces <code>DiagnosticOptions</code>, <code>DocumentDiagnosticParams</code>, <br><code>WorkspaceDiagnosticParams</code>, and related report types.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1378/changes#diff-c16b9b2fc8b4479b07708b28ebdaa473e8f3a73eb62d9402538790b2aed3f978">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_diagnostic_test.go</strong><dd><code>Comprehensive tests for diagnostic handlers.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/server_diagnostic_test.go

<ul><li>Adds tests to verify <code>initialize</code> advertises <code>DiagnosticProvider</code>.<br> <li> Adds tests for <code>workspace/diagnostic</code> and <code>textDocument/diagnostic</code> <br>handler registration and functionality.<br> <li> Includes tests for edge cases like empty workspaces and untrusted <br>folders.<br> <li> Verifies that pull diagnostics match push diagnostics.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1378/changes#diff-d5f9d17f180557f5efc8e518031af62417504cb5e91a6156a578c21d0b85c62a">+234/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lsp_diagnostic_test.go</strong><dd><code>Unit tests for LSP diagnostic types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/types/lsp_diagnostic_test.go

<ul><li>Adds unit tests for new LSP diagnostic types.<br> <li> Focuses on verifying JSON serialization/deserialization, especially <br>for <code>version:null</code> and <code>previousResultIds</code> tag.<br> <li> Tests ensure the correct wire shape for diagnostic reports.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1378/changes#diff-0aa2dbf4b1a8d6efab5b499cdc8ea68a30a29d58b43cf0cca6bdfdd1008f8010">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

