### PR TITLE
fix: propagate distribute-fallback-html failures and use per-repo default branch [IDE-2298]

### DIFF
--- a/.github/distribute-fallback-html.sh
+++ b/.github/distribute-fallback-html.sh
@@ -53,7 +53,7 @@ FAILED=()
 
 # Single parent temp dir — one EXIT trap covers all per-repo clones.
 PARENT_WORK=$(mktemp -d)
-trap "rm -rf '$PARENT_WORK'" EXIT
+trap 'rm -rf "$PARENT_WORK"' EXIT
 
 gh auth setup-git
 
@@ -73,6 +73,10 @@ process_repo() {
   local WORK_DIR="$PARENT_WORK/$REPO_SLUG"
 
   gh repo clone "$REPO" "$WORK_DIR" -- --depth=1 --quiet
+
+  local BASE_BRANCH
+  BASE_BRANCH=$(gh repo view "$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name') \
+    || { echo "    ERROR: failed to fetch default branch for $REPO" >&2; return 1; }
 
   local DEST_FULL="$WORK_DIR/$DEST_PATH"
   mkdir -p "$(dirname "$DEST_FULL")"
@@ -98,7 +102,8 @@ process_repo() {
   # Design decision: this branch is exclusively owned by this automation.
   # Force-push is intentional — any human commits on the sync branch will be
   # overwritten. Reviewers should not push changes directly to this branch.
-  git -C "$WORK_DIR" push -f -u origin "$BRANCH"
+  git -C "$WORK_DIR" push -f -u origin "$BRANCH" \
+    || { echo "    ERROR: git push failed for $REPO" >&2; return 1; }
 
   local PR_BODY
   PR_BODY="Automatic sync of \`settings-fallback.html\` triggered by [snyk/snyk-ls@${LS_SHA}](https://github.com/snyk/snyk-ls/commit/${LS_SHA_FULL}).
@@ -121,13 +126,15 @@ Review and merge when ready. No manual testing is required beyond confirming tha
     echo "    Creating PR in $REPO"
     gh pr create \
       --repo "$REPO" \
-      --base main \
+      --base "$BASE_BRANCH" \
       --head "$BRANCH" \
       --title "$PR_TITLE" \
-      --body "$PR_BODY"
+      --body "$PR_BODY" \
+      || { echo "    ERROR: gh pr create failed for $REPO" >&2; return 1; }
   else
     echo "    Updating existing PR #$EXISTING_PR in $REPO"
-    gh pr edit "$EXISTING_PR" --repo "$REPO" --body "$PR_BODY"
+    gh pr edit "$EXISTING_PR" --repo "$REPO" --body "$PR_BODY" \
+      || { echo "    ERROR: gh pr edit failed for $REPO (PR #$EXISTING_PR)" >&2; return 1; }
   fi
 
   echo "    Done."

--- a/.github/workflows/distribute-fallback-html.yaml
+++ b/.github/workflows/distribute-fallback-html.yaml
@@ -13,6 +13,8 @@ on:
       - main
     paths:
       - 'shared_ide_resources/ui/html/settings-fallback.html'
+      - '.github/distribute-fallback-html.sh'
+      - '.github/workflows/distribute-fallback-html.yaml'
   workflow_dispatch:
 
 # Serialize runs so concurrent pushes don't race on the shared sync branch.


### PR DESCRIPTION
## Summary
- `process_repo() || FAILED+=(...)` disabled `set -e` inside the function, so a failing `git push` or `gh pr create` fell through to the trailing `echo` and returned 0 — the job reported success on all 4 targets even when every one 403'd. Push/PR failures now explicitly error to stderr and `return 1`.
- `--base main` was hardcoded; `snyk-intellij-plugin`'s default branch is `master`, so PR creation there always failed independently of the permission issue. Base branch is now fetched per-repo via `gh repo view`.
- Workflow now also triggers on changes to the script/workflow files themselves (previously only on the html source changing), so this class of bug surfaces on merge.
- Fixed `trap "rm -rf '$PARENT_WORK'" EXIT` → single-quoted (SC2064).

Underlying `TEAM_IDE_PAT` 403s (fine-grained PAT missing repo access) were fixed separately by the token owner; this PR is the script/workflow half of the incident (IDE-2298).

## Test plan
- [x] `SNYK_TOKEN="$(op item get '!Snyk Token' --field credential --reveal)" make test` passes
- [x] `shellcheck .github/distribute-fallback-html.sh` clean
- [x] Manually ran `workflow_dispatch` against the pre-fix script to confirm the failure mode (all 4 repos 403, job still exit 0); after granting PAT access, 3/4 repos got real PRs and intellij-plugin failed exactly as predicted (`No commits between main and ...`, wrong base branch) — confirms the fix addresses the actual observed failure.
- [ ] CI green on this PR