### PR TITLE
chore: fallback settings clear credentials button styling and label

### DIFF
--- a/js-tests/settings-fallback.test.mjs
+++ b/js-tests/settings-fallback.test.mjs
@@ -350,7 +350,7 @@ test("settings-fallback: activating the control is a no-op-safe when the bridge 
   }, "clicking the log out control without a bridge must not throw");
 });
 
-test("settings-fallback: after logout the status copy confirms credentials were cleared", async () => {
+test("settings-fallback: after logout the status copy is concise", async () => {
   const win = await buildFallbackDom();
   let captured;
   win.__ideExecuteCommand__ = (_cmd, _args, callback) => { captured = callback; };
@@ -368,12 +368,9 @@ test("settings-fallback: after logout the status copy confirms credentials were 
   // Fire the done callback (LS confirmed credentials cleared).
   captured();
 
-  // After done the status copy must confirm the cleared state.
+  // After done the status copy must confirm sign-out.
   const textAfter = status.textContent.trim();
-  assert.ok(
-    /signed out|credentials.*cleared/i.test(textAfter),
-    `status copy must confirm credentials cleared after done; got "${textAfter}"`
-  );
+  assert.strictEqual(textAfter, "Signed out.");
 });
 
 // ---------------------------------------------------------------------------

--- a/js-tests/settings-fallback.test.mjs
+++ b/js-tests/settings-fallback.test.mjs
@@ -301,6 +301,11 @@ test("settings-fallback: the authentication section offers a log out control and
   const win = await buildFallbackDom();
   const logoutBtn = win.document.getElementById("logout-button");
   assert.ok(logoutBtn, "a log out control (#logout-button) must exist");
+  assert.strictEqual(
+    logoutBtn.textContent.trim(),
+    "Clear credentials",
+    'log out control label must be "Clear credentials"'
+  );
 
   // No login/"Connect" control must be present.
   assert.ok(
@@ -358,7 +363,7 @@ test("settings-fallback: after logout the status copy confirms credentials were 
   // Before done fires the status copy is the default prompt.
   const status = win.document.getElementById("logout-status");
   const textBefore = status.textContent.trim();
-  assert.ok(textBefore.length > 0, "status copy must be present before logout");
+  assert.strictEqual(textBefore.length, 0, "status copy must be empty before logout");
 
   // Fire the done callback (LS confirmed credentials cleared).
   captured();

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -551,7 +551,7 @@
       function done() {
         if (statusEl) {
           statusEl.className = statusEl.className.replace(/\bhidden\b/, '').trim();
-          statusEl.textContent = 'Signed out. Your stored credentials were cleared — reopen Settings to sign in again.';
+          statusEl.textContent = 'Signed out.';
         }
       }
       try {

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -62,6 +62,10 @@
       /* Buttons */
       --button-background: var(--vscode-button-background, #0e639c);
       --button-foreground: var(--vscode-button-foreground, #ffffff);
+      --button-hover-background: var(--vscode-button-hoverBackground, #1177bb);
+      --button-secondary-background: var(--vscode-button-secondaryBackground, #3a3d41);
+      --button-secondary-foreground: var(--vscode-button-secondaryForeground, #ffffff);
+      --button-secondary-hover-background: var(--vscode-button-secondaryHoverBackground, #45494e);
 
       /* Other */
       --border-radius: 4px;
@@ -226,13 +230,18 @@
     .logout-button {
       align-self: flex-start;
       padding: var(--input-padding) 16px;
-      background-color: var(--button-background);
-      color: var(--button-foreground);
-      border: 1px solid var(--button-background);
+      background-color: var(--button-secondary-background);
+      color: var(--button-secondary-foreground);
+      border: none;
       border-radius: var(--border-radius-small);
       font-family: inherit;
       font-size: inherit;
+      font-weight: 600;
       cursor: pointer;
+    }
+
+    .logout-button:hover {
+      background-color: var(--button-secondary-hover-background);
     }
 
     .logout-button:focus {
@@ -338,8 +347,8 @@
     <h2>Authentication</h2>
 
     <div class="form-group">
-      <p id="logout-status" class="logout-status">If Snyk is stuck, clear your stored credentials to recover, then reopen Settings to sign in again.</p>
-      <button type="button" id="logout-button" class="logout-button">Log out</button>
+      <p id="logout-status" class="logout-status hidden" aria-live="polite"></p>
+      <button type="button" id="logout-button" class="logout-button">Clear credentials</button>
     </div>
 
     <div class="form-group half-width">
@@ -541,6 +550,7 @@
       var statusEl = get('logout-status');
       function done() {
         if (statusEl) {
+          statusEl.className = statusEl.className.replace(/\bhidden\b/, '').trim();
           statusEl.textContent = 'Signed out. Your stored credentials were cleared — reopen Settings to sign in again.';
         }
       }

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -346,8 +346,8 @@
   <div class="section">
     <h2>Authentication</h2>
 
-    <div class="form-group">
-      <p id="logout-status" class="logout-status hidden" aria-live="polite"></p>
+    <div class="form-group" aria-live="polite">
+      <p id="logout-status" class="logout-status hidden"></p>
       <button type="button" id="logout-button" class="logout-button">Clear credentials</button>
     </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Align the fallback settings authentication action with the full settings page secondary button style and requested copy.

- Renamed fallback authentication button from `Log out` to `Clear credentials`
- Removed the initial helper text shown above the button
- Updated fallback button styling to use the same secondary (grey) color token and hover token as the full settings page Log out button
- Simplified post-action status feedback to exactly: `Signed out.`
- Updated JS tests for the new label and concise post-action status behavior

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

### Screenshot

<img width="604" height="422" alt="Screenshot 2026-07-23 at 17 07 16" src="https://github.com/user-attachments/assets/5c68fcdb-05ff-459e-a3a5-69c01f72a826" />

Live view [link](https://raw.githack.com/snyk/snyk-ls/refs/heads/cursor/fallback-clear-credentials-836f/shared_ide_resources/ui/html/settings-fallback.html)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1486636c-52fd-435d-87b5-2e199686836f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1486636c-52fd-435d-87b5-2e199686836f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

