### PR TITLE
fix: surface logout failure instead of claiming success on settings-fallback page [IDE-2181]

### DIFF
--- a/js-tests/settings-fallback.test.mjs
+++ b/js-tests/settings-fallback.test.mjs
@@ -373,6 +373,26 @@ test("settings-fallback: after logout the status copy is concise", async () => {
   assert.strictEqual(textAfter, "Signed out.");
 });
 
+test("settings-fallback: a failed logout surfaces the error instead of claiming success", async () => {
+  const win = await buildFallbackDom();
+  let captured;
+  win.__ideExecuteCommand__ = (_cmd, _args, callback) => { captured = callback; };
+
+  const btn = win.document.getElementById("logout-button");
+  btn.dispatchEvent(new win.Event("click"));
+
+  // IDE bridge reports the command never reached the language server
+  // (e.g. it isn't initialized yet — IDE-2181).
+  captured({ error: "language server is not initialized" });
+
+  const status = win.document.getElementById("logout-status");
+  assert.strictEqual(
+    status.textContent.trim(),
+    "Failed to sign out: language server is not initialized"
+  );
+  assert.ok(!status.className.includes("hidden"), "status copy must be visible on failure too");
+});
+
 // ---------------------------------------------------------------------------
 // Payload snapshot
 // ---------------------------------------------------------------------------

--- a/shared_ide_resources/ui/html/settings-fallback.html
+++ b/shared_ide_resources/ui/html/settings-fallback.html
@@ -548,9 +548,12 @@
     function startLogout() {
       if (typeof window.__ideExecuteCommand__ !== 'function') { return; }
       var statusEl = get('logout-status');
-      function done() {
-        if (statusEl) {
-          statusEl.className = statusEl.className.replace(/\bhidden\b/, '').trim();
+      function done(result) {
+        if (!statusEl) { return; }
+        statusEl.className = statusEl.className.replace(/\bhidden\b/, '').trim();
+        if (result && result.error) {
+          statusEl.textContent = 'Failed to sign out: ' + result.error;
+        } else {
           statusEl.textContent = 'Signed out.';
         }
       }
@@ -558,6 +561,7 @@
         window.__ideExecuteCommand__('snyk.logout', [], done);
       } catch (e) {
         console.error('Error logging out:', e);
+        done({ error: String(e) });
       }
     }
 


### PR DESCRIPTION
### Description

Found while investigating [IDE-2181](https://snyksec.atlassian.net/browse/IDE-2181): `startLogout()`'s `done()` callback in `settings-fallback.html` ignored its result argument entirely, so it always set the status text to "Signed out." — even when the IDE bridge reports `snyk.logout` never reached the language server (e.g. an IntelliJ-side bug where `executeCommandWithArgs` silently no-ops when the LS hasn't finished initializing, which is close to the default state while this fallback page is showing).

This fixes the false-positive: `done(result)` now checks `result.error` and shows "Failed to sign out: ..." instead.

`settings-fallback.html` is maintained here and auto-distributed to each IDE plugin repo via `distribute-fallback-html.yaml`, so this fix lands in IntelliJ/VS Code/Eclipse/Visual Studio automatically once merged.

### Checklist

- [x] Tests added and all succeed (`js-tests/settings-fallback.test.mjs`, 26/26 pass; `make test` green)
- [x] Regenerated mocks, etc. (`make generate` — ran via `make settings-fallback-fixture`)
- [x] Linted (`make lint-fix` / `lint:es5`)
- [ ] README.md updated, if user-facing (N/A — internal UI copy only)
- [ ] License file updated, if new 3rd-party dependency is introduced (N/A)

[IDE-2181]: https://snyksec.atlassian.net/browse/IDE-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ