### PR TITLE
fix: sign commits made by distribute-fallback-html [IDE-2321]

### DIFF
--- a/.github/distribute-fallback-html.sh
+++ b/.github/distribute-fallback-html.sh
@@ -23,6 +23,9 @@
 # Required env vars:
 #   GH_TOKEN - GitHub PAT with write access to all target repos (use TEAM_IDE_PAT)
 #              Minimum required scopes: contents:write, pull_requests:write
+#   PUB_SIGNING_KEY - team-ide-user's public SSH signing key (use TEAM_IDE_USER_SSH_PUB).
+#              The matching private key must already be loaded into ssh-agent (see
+#              webfactory/ssh-agent in distribute-fallback-html.yaml) so git can sign with it.
 #
 # Usage: Run from the snyk-ls repository root.
 
@@ -54,6 +57,12 @@ FAILED=()
 # Single parent temp dir — one EXIT trap covers all per-repo clones.
 PARENT_WORK=$(mktemp -d)
 trap 'rm -rf "$PARENT_WORK"' EXIT
+
+# SSH-format commit signing key, written once and reused by every per-repo clone below.
+# The matching private key must be loaded into ssh-agent by the caller (see PUB_SIGNING_KEY
+# in the header comment) — git shells out to `ssh-keygen -Y sign`, which signs via ssh-agent.
+SIGNING_KEY_FILE="$PARENT_WORK/signingkey.pub"
+echo "$PUB_SIGNING_KEY" > "$SIGNING_KEY_FILE"
 
 gh auth setup-git
 
@@ -96,6 +105,9 @@ process_repo() {
 
   git -C "$WORK_DIR" config user.email "team-ide@snyk.io"
   git -C "$WORK_DIR" config user.name "Snyk Team IDE"
+  git -C "$WORK_DIR" config gpg.format ssh
+  git -C "$WORK_DIR" config commit.gpgsign true
+  git -C "$WORK_DIR" config user.signingkey "$SIGNING_KEY_FILE"
   git -C "$WORK_DIR" checkout -B "$BRANCH"
   git -C "$WORK_DIR" add "$DEST_PATH"
   git -C "$WORK_DIR" commit -m "$COMMIT_MSG"

--- a/.github/workflows/distribute-fallback-html.yaml
+++ b/.github/workflows/distribute-fallback-html.yaml
@@ -31,7 +31,12 @@ jobs:
       - name: Checkout snyk-ls
         uses: actions/checkout@v4
 
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TEAM_IDE_USER_SSH }}
+
       - name: Distribute settings-fallback.html to IDE repos
         env:
           GH_TOKEN: ${{ secrets.TEAM_IDE_PAT }}
+          PUB_SIGNING_KEY: ${{ secrets.TEAM_IDE_USER_SSH_PUB }}
         run: .github/distribute-fallback-html.sh


### PR DESCRIPTION
## What changed
The `distribute-fallback-html` workflow opens sync PRs in 4 IDE plugin repos, but every commit it makes is unsigned. All 4 target repos require signed commits to merge, so these PRs could never actually be merged without someone manually re-signing/re-pushing first (as happened for snyk-ls#1386's downstream PRs).

Copies the SSH-commit-signing setup already used by `create-cli-pr` (`.github/workflows/create-cli-pr.yaml` + `.github/create-cli-pr.sh`):
- Workflow: adds `webfactory/ssh-agent@v0.9.0` loading `secrets.TEAM_IDE_USER_SSH`, passes `PUB_SIGNING_KEY: ${{ secrets.TEAM_IDE_USER_SSH_PUB }}` to the script step.
- Script: sets `gpg.format ssh`, `commit.gpgsign true`, and `user.signingkey` (pointing at a file containing `$PUB_SIGNING_KEY`) before each per-repo commit.

Jira: https://snyksec.atlassian.net/browse/IDE-2321