### PR TITLE
fix: return installed CLI path from download instead of re-discovering it via Find [IDE-2322]

### DIFF
--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -2538,14 +2538,13 @@ func substituteRemyFlow(t *testing.T, engine workflow.Engine) {
 	// Point SettingCliPath at the preview dir so the downloader writes there.
 	conf.Set(configresolver.UserGlobalKey(types.SettingCliPath), previewCLIPath)
 	er := error_reporting.NewTestErrorReporter(engine)
-	resolver := testutil.DefaultConfigResolver(engine)
 	cliRelease := install.NewCLIRelease(engine, func() *http.Client { return http.DefaultClient })
 	release, err := cliRelease.GetLatestReleaseByChannel("preview", false)
 	if err != nil {
 		t.Skipf("skipping: preview CLI release fetch failed (no network?): %v", err)
 	}
-	downloader := install.NewDownloader(engine, er, func() *http.Client { return http.DefaultClient }, resolver)
-	if err = downloader.Download(release, false); err != nil {
+	downloader := install.NewDownloader(engine, er, func() *http.Client { return http.DefaultClient })
+	if _, err = downloader.Download(release, previewCLIPath, false); err != nil {
 		t.Skipf("skipping: preview CLI download failed (no network?): %v", err)
 	}
 

--- a/infrastructure/cli/cli_fake.go
+++ b/infrastructure/cli/cli_fake.go
@@ -33,12 +33,16 @@ type TestExecutor struct {
 	ExecuteResponse []byte
 	wasExecuted     bool
 	ExecuteDuration time.Duration
-	startedScans    int
-	finishedScans   int
-	counterLock     sync.RWMutex
-	cmd             []string
-	logger          *zerolog.Logger
-	engine          workflow.Engine
+	// ExecuteRelease, when non-nil, replaces the ExecuteDuration timer: Execute blocks
+	// until the channel is closed (or ctx is canceled) instead of racing a wall clock.
+	// Nil by default so existing timer-based tests are unaffected.
+	ExecuteRelease chan struct{}
+	startedScans   int
+	finishedScans  int
+	counterLock    sync.RWMutex
+	cmd            []string
+	logger         *zerolog.Logger
+	engine         workflow.Engine
 }
 
 func NewTestExecutor(engine workflow.Engine) *TestExecutor {
@@ -85,19 +89,36 @@ func (t *TestExecutor) Execute(ctx context.Context, cmd []string, workingDir typ
 	t.startedScans++
 	t.counterLock.Unlock()
 
-	select {
-	case <-time.After(t.ExecuteDuration):
-		t.logger.Debug().Msg("Dummy CLI Execution time finished")
-		// Indicate that the scan has finished and return the ExecuteResponse
-		t.wasExecuted = true
-		t.counterLock.Lock()
-		t.finishedScans++
-		t.counterLock.Unlock()
-		return t.ExecuteResponse, err
-	case <-ctx.Done():
-		t.logger.Debug().Msg("Dummy CLI Execution canceled")
-		return resp, ctx.Err()
+	if t.ExecuteRelease != nil {
+		select {
+		case <-ctx.Done():
+			t.logger.Debug().Msg("Dummy CLI Execution canceled")
+			return resp, ctx.Err()
+		case <-t.ExecuteRelease:
+		}
+	} else {
+		select {
+		case <-ctx.Done():
+			t.logger.Debug().Msg("Dummy CLI Execution canceled")
+			return resp, ctx.Err()
+		case <-time.After(t.ExecuteDuration):
+		}
 	}
+
+	// A select with both cases ready picks at random, so cancellation must win by fiat,
+	// not by luck - re-check here even though ctx.Done() was already a select case above.
+	if err = ctx.Err(); err != nil {
+		t.logger.Debug().Msg("Dummy CLI Execution canceled")
+		return resp, err
+	}
+
+	t.logger.Debug().Msg("Dummy CLI Execution time finished")
+	// Indicate that the scan has finished and return the ExecuteResponse
+	t.wasExecuted = true
+	t.counterLock.Lock()
+	t.finishedScans++
+	t.counterLock.Unlock()
+	return t.ExecuteResponse, nil
 }
 
 func (t *TestExecutor) ExpandParametersFromConfig(base []string, folderConfig *types.FolderConfig) []string {

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -36,6 +36,8 @@ type Downloader struct {
 	errorReporter   error_reporting.ErrorReporter
 	httpClient      func() *http.Client
 	engine          workflow.Engine
+	removeFile      func(string) error
+	renameFile      func(string, string) error
 }
 
 func NewDownloader(engine workflow.Engine, errorReporter error_reporting.ErrorReporter, httpClientFunc func() *http.Client) *Downloader {
@@ -44,6 +46,8 @@ func NewDownloader(engine workflow.Engine, errorReporter error_reporting.ErrorRe
 		errorReporter:   errorReporter,
 		httpClient:      httpClientFunc,
 		engine:          engine,
+		removeFile:      os.Remove,
+		renameFile:      os.Rename,
 	}
 }
 
@@ -194,7 +198,7 @@ func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (string
 	}
 
 	_ = cliTmpFile.Close() // close file to allow moving it on Windows
-	destinationPath, err := d.moveToDestination(cliPath, executableFileName, cliTmpFile.Name())
+	destinationPath, err := d.moveToDestination(cliPath, executableFileName, cliTmpFile.Name(), expectedChecksum)
 
 	if isUpdate {
 		d.progressTracker.EndWithMessage("Snyk CLI has been updated.")
@@ -224,7 +228,30 @@ func (d *Downloader) destinationPath(cliPath string, destinationFileName string)
 	return filepath.Join(filepath.Dir(cliPath), destinationFileName)
 }
 
-func (d *Downloader) moveToDestination(cliPath string, destinationFileName string, sourceFilePath string) (string, error) {
+func (d *Downloader) remove(path string) error {
+	if d.removeFile != nil {
+		return d.removeFile(path)
+	}
+	return os.Remove(path)
+}
+
+func (d *Downloader) rename(sourceFilePath string, destinationFilePath string) error {
+	if d.renameFile != nil {
+		return d.renameFile(sourceFilePath, destinationFilePath)
+	}
+	return os.Rename(sourceFilePath, destinationFilePath)
+}
+
+func (d *Downloader) existingDestinationMatchesChecksum(expectedChecksum HashSum, destinationFilePath string) bool {
+	compareErr := compareChecksum(d.engine.GetLogger(), expectedChecksum, destinationFilePath)
+	if compareErr == nil {
+		return true
+	}
+	d.engine.GetLogger().Debug().Err(compareErr).Str("path", destinationFilePath).Msg("existing Snyk CLI does not match requested checksum")
+	return false
+}
+
+func (d *Downloader) moveToDestination(cliPath string, destinationFileName string, sourceFilePath string, expectedChecksum HashSum) (string, error) {
 	// Defend this file-moving boundary when it is called independently of Install.
 	if cliPath == "" {
 		return "", fmt.Errorf("CLI path is not configured")
@@ -244,25 +271,33 @@ func (d *Downloader) moveToDestination(cliPath string, destinationFileName strin
 
 	// for Windows, we have to remove original file first before move/rename
 	if fileInfo, statErr := os.Stat(destinationFilePath); statErr == nil {
-		removeErr := os.Remove(destinationFilePath)
+		removeErr := d.remove(destinationFilePath)
 		if removeErr != nil {
 			returnErr := errors.Wrap(
 				removeErr,
 				fmt.Sprintf("couldn't remove old CLI at %s. FileInfo: %v", destinationFilePath, fileInfo),
 			)
+			if d.existingDestinationMatchesChecksum(expectedChecksum, destinationFilePath) {
+				logger.Info().Str("path", destinationFilePath).Msg("another installer already wrote the requested Snyk CLI")
+				return destinationFilePath, nil
+			}
 			logger.Err(returnErr).Send()
 			return "", returnErr
 		}
 	}
 
 	logger.Debug().Str("tempFilePath", sourceFilePath).Msg("tempfile path")
-	err = os.Rename(sourceFilePath, destinationFilePath)
+	err = d.rename(sourceFilePath, destinationFilePath)
 	if err != nil {
 		returnErr :=
 			errors.Wrap(
 				err,
 				fmt.Sprintf("couldn't rename Snyk CLI from %s to %s", sourceFilePath, destinationFilePath),
 			)
+		if d.existingDestinationMatchesChecksum(expectedChecksum, destinationFilePath) {
+			logger.Info().Str("path", destinationFilePath).Msg("another installer already wrote the requested Snyk CLI")
+			return destinationFilePath, nil
+		}
 		logger.Err(returnErr).Send()
 		return "", returnErr
 	}

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -82,12 +82,15 @@ func (d *Downloader) lockFileName() (string, error) {
 	return config.CLIDownloadLockFileName(d.engine.GetConfiguration())
 }
 
-func (d *Downloader) validateDownloadPreconditions(r *Release) error {
+func (d *Downloader) validateDownloadPreconditions(r *Release, cliPath string) error {
 	if r == nil {
 		return fmt.Errorf("release cannot be nil")
 	}
 	if d.httpClient == nil {
 		return fmt.Errorf("http client function is not configured")
+	}
+	if cliPath == "" {
+		return fmt.Errorf("CLI path is not configured")
 	}
 	return nil
 }
@@ -99,8 +102,8 @@ func downloadKind(isUpdate bool) string {
 	return "download"
 }
 
-func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (string, error) {
-	if err := d.validateDownloadPreconditions(r); err != nil {
+func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (destinationPath string, err error) {
+	if err = d.validateDownloadPreconditions(r, cliPath); err != nil {
 		return "", err
 	}
 
@@ -127,6 +130,22 @@ func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (string
 		d.progressTracker.BeginWithMessage("Downloading Snyk CLI...", "We download Snyk CLI to run security scans.")
 	}
 
+	// Begin was just sent above, so from this point on every return path
+	// (early or final) must close the progress indicator exactly once. A
+	// deferred function keyed off the named return values guarantees this
+	// regardless of which return statement is hit.
+	defer func() {
+		if err != nil {
+			d.progressTracker.EndWithMessage(fmt.Sprintf("Failed to %s Snyk CLI.", kindStr))
+			return
+		}
+		if isUpdate {
+			d.progressTracker.EndWithMessage("Snyk CLI has been updated.")
+		} else {
+			d.progressTracker.EndWithMessage("Snyk CLI has been downloaded.")
+		}
+	}()
+
 	doneCh := make(chan struct{}, 1)
 
 	var resp *http.Response
@@ -145,16 +164,17 @@ func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (string
 		d.progressTracker.CancelOrDone(cancel, doneCh)
 	}(resp.Body)
 
-	if resp.StatusCode != http.StatusOK {
-		d.errorReporter.CaptureError(err)
-		return "", fmt.Errorf("failed to %s Snyk CLI from %q: %s", kindStr, downloadURL, resp.Status)
-	}
 	executableFileName := cliDiscovery.ExecutableName(isUpdate)
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 		doneCh <- struct{}{}
 		logger.Debug().Msgf("finished Snyk CLI %s", kindStr)
 	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		d.errorReporter.CaptureError(err)
+		return "", fmt.Errorf("failed to %s Snyk CLI from %q: %s", kindStr, downloadURL, resp.Status)
+	}
 
 	// pipe stream
 	cliReader := io.TeeReader(resp.Body, newWriter(resp.ContentLength, d.progressTracker, onProgress))
@@ -198,13 +218,7 @@ func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (string
 	}
 
 	_ = cliTmpFile.Close() // close file to allow moving it on Windows
-	destinationPath, err := d.moveToDestination(cliPath, executableFileName, cliTmpFile.Name(), expectedChecksum)
-
-	if isUpdate {
-		d.progressTracker.EndWithMessage("Snyk CLI has been updated.")
-	} else {
-		d.progressTracker.EndWithMessage("Snyk CLI has been downloaded.")
-	}
+	destinationPath, err = d.moveToDestination(cliPath, executableFileName, cliTmpFile.Name(), expectedChecksum)
 
 	return destinationPath, err
 }

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -38,6 +38,7 @@ type Downloader struct {
 	engine          workflow.Engine
 	removeFile      func(string) error
 	renameFile      func(string, string) error
+	mkdirTemp       func(string, string) (string, error)
 }
 
 func NewDownloader(engine workflow.Engine, errorReporter error_reporting.ErrorReporter, httpClientFunc func() *http.Client) *Downloader {
@@ -48,6 +49,7 @@ func NewDownloader(engine workflow.Engine, errorReporter error_reporting.ErrorRe
 		engine:          engine,
 		removeFile:      os.Remove,
 		renameFile:      os.Rename,
+		mkdirTemp:       os.MkdirTemp,
 	}
 }
 
@@ -185,7 +187,7 @@ func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (destin
 		logger.Err(err).Msg("couldn't create directory for Snyk CLI")
 		return "", err
 	}
-	tmpDirPath, err := os.MkdirTemp(cliDirectory, "downloads")
+	tmpDirPath, err := d.mkdirTempDir(cliDirectory, "downloads")
 	if err != nil {
 		logger.Err(err).Msg("couldn't create tmpdir")
 		return "", err
@@ -254,6 +256,13 @@ func (d *Downloader) rename(sourceFilePath string, destinationFilePath string) e
 		return d.renameFile(sourceFilePath, destinationFilePath)
 	}
 	return os.Rename(sourceFilePath, destinationFilePath)
+}
+
+func (d *Downloader) mkdirTempDir(dir string, pattern string) (string, error) {
+	if d.mkdirTemp != nil {
+		return d.mkdirTemp(dir, pattern)
+	}
+	return os.MkdirTemp(dir, pattern)
 }
 
 func (d *Downloader) existingDestinationMatchesChecksum(expectedChecksum HashSum, destinationFilePath string) bool {

--- a/infrastructure/cli/install/downloader.go
+++ b/infrastructure/cli/install/downloader.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
 	"github.com/snyk/snyk-ls/internal/progress"
-	"github.com/snyk/snyk-ls/internal/types"
 )
 
 type Downloader struct {
@@ -37,16 +36,14 @@ type Downloader struct {
 	errorReporter   error_reporting.ErrorReporter
 	httpClient      func() *http.Client
 	engine          workflow.Engine
-	configResolver  types.ConfigResolverInterface
 }
 
-func NewDownloader(engine workflow.Engine, errorReporter error_reporting.ErrorReporter, httpClientFunc func() *http.Client, configResolver types.ConfigResolverInterface) *Downloader {
+func NewDownloader(engine workflow.Engine, errorReporter error_reporting.ErrorReporter, httpClientFunc func() *http.Client) *Downloader {
 	return &Downloader{
 		progressTracker: progress.NewTracker(true, engine.GetLogger()),
 		errorReporter:   errorReporter,
 		httpClient:      httpClientFunc,
 		engine:          engine,
-		configResolver:  configResolver,
 	}
 }
 
@@ -98,10 +95,11 @@ func downloadKind(isUpdate bool) string {
 	return "download"
 }
 
-func (d *Downloader) Download(r *Release, isUpdate bool) error {
+func (d *Downloader) Download(r *Release, cliPath string, isUpdate bool) (string, error) {
 	if err := d.validateDownloadPreconditions(r); err != nil {
-		return err
+		return "", err
 	}
+
 	logger := d.engine.GetLogger().With().Str("method", "Download").Logger()
 	kindStr := downloadKind(isUpdate)
 	logger.Debug().Str("release", r.Version).Msgf("attempting %s", kindStr)
@@ -111,10 +109,10 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	// download CLI binary
 	downloadURL, err := cliDiscovery.DownloadURL(r)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if downloadURL == "" {
-		return fmt.Errorf("no builds found for current OS")
+		return "", fmt.Errorf("no builds found for current OS")
 	}
 
 	logger.Debug().Str("download_url", downloadURL).Msgf("Snyk CLI %s in progress...", kindStr)
@@ -131,7 +129,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 
 	resp, err = d.httpClient().Get(downloadURL) //nolint:bodyclose // body is closed in a longer-lived goroutine
 	if err != nil {
-		return err
+		return "", err
 	}
 	logger.Debug().Any("response-headers", resp.Header).Msg("headers")
 
@@ -145,7 +143,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 
 	if resp.StatusCode != http.StatusOK {
 		d.errorReporter.CaptureError(err)
-		return fmt.Errorf("failed to %s Snyk CLI from %q: %s", kindStr, downloadURL, resp.Status)
+		return "", fmt.Errorf("failed to %s Snyk CLI from %q: %s", kindStr, downloadURL, resp.Status)
 	}
 	executableFileName := cliDiscovery.ExecutableName(isUpdate)
 	defer func(Body io.ReadCloser) {
@@ -157,26 +155,22 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 	// pipe stream
 	cliReader := io.TeeReader(resp.Body, newWriter(resp.ContentLength, d.progressTracker, onProgress))
 
-	cliPath := d.configResolver.GetString(types.SettingCliPath, nil)
-	if cliPath != "" {
-		cliPath = filepath.Clean(cliPath)
-	}
 	cliDirectory := filepath.Dir(cliPath)
 	err = os.MkdirAll(cliDirectory, 0755)
 	if err != nil {
 		logger.Err(err).Msg("couldn't create directory for Snyk CLI")
-		return err
+		return "", err
 	}
 	tmpDirPath, err := os.MkdirTemp(cliDirectory, "downloads")
 	if err != nil {
 		logger.Err(err).Msg("couldn't create tmpdir")
-		return err
+		return "", err
 	}
 
 	cliTmpPath := filepath.Join(tmpDirPath, executableFileName)
 	cliTmpFile, err := os.Create(cliTmpPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer func() {
 		_ = cliTmpFile.Close()
@@ -185,22 +179,22 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 
 	bytesCopied, err := io.Copy(cliTmpFile, cliReader)
 	if err != nil {
-		return err
+		return "", err
 	}
 	logger.Debug().Int64("bytes_copied", bytesCopied).Msgf("copied to %s", cliTmpFile.Name())
 
 	expectedChecksum, err := expectedChecksum(r, &cliDiscovery)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = compareChecksum(d.engine.GetLogger(), expectedChecksum, cliTmpFile.Name())
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	_ = cliTmpFile.Close() // close file to allow moving it on Windows
-	err = d.moveToDestination(executableFileName, cliTmpFile.Name())
+	destinationPath, err := d.moveToDestination(cliPath, executableFileName, cliTmpFile.Name())
 
 	if isUpdate {
 		d.progressTracker.EndWithMessage("Snyk CLI has been updated.")
@@ -208,7 +202,7 @@ func (d *Downloader) Download(r *Release, isUpdate bool) error {
 		d.progressTracker.EndWithMessage("Snyk CLI has been downloaded.")
 	}
 
-	return err
+	return destinationPath, err
 }
 
 func (d *Downloader) createLockFile() error {
@@ -226,22 +220,26 @@ func (d *Downloader) createLockFile() error {
 	return nil
 }
 
-func (d *Downloader) moveToDestination(destinationFileName string, sourceFilePath string) error {
-	logger := d.engine.GetLogger().With().Str("method", "moveToDestination").Logger()
-	cliPath := d.configResolver.GetString(types.SettingCliPath, nil)
-	if cliPath != "" {
-		cliPath = filepath.Clean(cliPath)
+func (d *Downloader) destinationPath(cliPath string, destinationFileName string) string {
+	return filepath.Join(filepath.Dir(cliPath), destinationFileName)
+}
+
+func (d *Downloader) moveToDestination(cliPath string, destinationFileName string, sourceFilePath string) (string, error) {
+	// Defend this file-moving boundary when it is called independently of Install.
+	if cliPath == "" {
+		return "", fmt.Errorf("CLI path is not configured")
 	}
-	cliDirectory := filepath.Dir(cliPath)
+	logger := d.engine.GetLogger().With().Str("method", "moveToDestination").Logger()
+	destinationFilePath := d.destinationPath(cliPath, destinationFileName)
+	cliDirectory := filepath.Dir(destinationFilePath)
 	err := os.MkdirAll(cliDirectory, 0755)
 	if err != nil {
 		msg := fmt.Sprintf("couldn't create directory for Snyk CLI at %s. "+
 			"Please change permissions or configured CLI path.", cliDirectory)
 		err = errors.Wrap(err, msg)
 		logger.Err(err).Send()
-		return err
+		return "", err
 	}
-	destinationFilePath := filepath.Join(cliDirectory, destinationFileName) // snyk-win.exe.latest
 	logger.Info().Str("path", destinationFilePath).Msg("copying Snyk CLI to user directory")
 
 	// for Windows, we have to remove original file first before move/rename
@@ -253,7 +251,7 @@ func (d *Downloader) moveToDestination(destinationFileName string, sourceFilePat
 				fmt.Sprintf("couldn't remove old CLI at %s. FileInfo: %v", destinationFilePath, fileInfo),
 			)
 			logger.Err(returnErr).Send()
-			return err
+			return "", returnErr
 		}
 	}
 
@@ -266,7 +264,7 @@ func (d *Downloader) moveToDestination(destinationFileName string, sourceFilePat
 				fmt.Sprintf("couldn't rename Snyk CLI from %s to %s", sourceFilePath, destinationFilePath),
 			)
 		logger.Err(returnErr).Send()
-		return returnErr
+		return "", returnErr
 	}
 
 	logger.Info().Str("path", destinationFilePath).Msg("setting executable bit for Snyk CLI")
@@ -275,7 +273,7 @@ func (d *Downloader) moveToDestination(destinationFileName string, sourceFilePat
 		returnErr :=
 			errors.Wrap(err, fmt.Sprintf("couldn't set executable bit for Snyk CLI at %s", destinationFilePath))
 		logger.Err(returnErr).Send()
-		return returnErr
+		return "", returnErr
 	}
-	return nil
+	return destinationFilePath, nil
 }

--- a/infrastructure/cli/install/downloader_test.go
+++ b/infrastructure/cli/install/downloader_test.go
@@ -17,7 +17,12 @@
 package install
 
 import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
 	"github.com/snyk/snyk-ls/internal/progress"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -94,6 +100,337 @@ func Test_DoNotDownloadIfCancelled(t *testing.T) {
 		_, err := os.Stat(lockFileName)
 		return err != nil
 	}, time.Second*2, time.Millisecond, "lock file should not exist")
+}
+
+func TestDownloaderDownload_ReturnsErrorWhenCliPathIsEmpty(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	requested := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = true
+	}))
+	t.Cleanup(server.Close)
+
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), func() *http.Client { return server.Client() })
+	exec := (&Discovery{}).ExecutableName(false)
+
+	got, err := downloader.Download(testRelease(server.URL, "deadbeef  "+exec), "", false)
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.False(t, requested, "Download should not hit the network when cliPath is empty")
+}
+
+// closeSignalingBody wraps a response body and signals on closed when Close is called,
+// so a test can detect whether Download closed the body without blocking forever.
+type closeSignalingBody struct {
+	io.ReadCloser
+	closed chan struct{}
+}
+
+func (b *closeSignalingBody) Close() error {
+	err := b.ReadCloser.Close()
+	select {
+	case b.closed <- struct{}{}:
+	default:
+	}
+	return err
+}
+
+type closeTrackingTransport struct {
+	closed chan struct{}
+}
+
+func (rt *closeTrackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	resp.Body = &closeSignalingBody{ReadCloser: resp.Body, closed: rt.closed}
+	return resp, nil
+}
+
+func TestDownloaderDownload_ClosesResponseBodyOnNon200Status(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	closed := make(chan struct{}, 1)
+	client := &http.Client{Transport: &closeTrackingTransport{closed: closed}}
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return client },
+		engine:          engine,
+		errorReporter:   error_reporting.NewTestErrorReporter(engine),
+	}
+	exec := (&Discovery{}).ExecutableName(false)
+	cliPath := filepath.Join(t.TempDir(), exec)
+
+	_, err := d.Download(testRelease(server.URL, "deadbeef  "+exec), cliPath, false)
+
+	require.Error(t, err)
+	select {
+	case <-closed:
+		// response body was closed as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected response body to be closed after a non-200 status, but it leaked")
+	}
+	assertProgressEndedWithFailure(t, progressCh)
+}
+
+// erroringTransport fails every request at the transport level, simulating a
+// network failure (e.g. DNS failure, connection refused) from d.httpClient().Get.
+type erroringTransport struct{}
+
+func (rt *erroringTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, errors.New("simulated network failure")
+}
+
+func TestDownloaderDownload_ReportsFailureEndWhenHttpGetFails(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	exec := (&Discovery{}).ExecutableName(false)
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	client := &http.Client{Transport: &erroringTransport{}}
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return client },
+		engine:          engine,
+	}
+	cliPath := filepath.Join(t.TempDir(), exec)
+
+	_, err := d.Download(testRelease("http://127.0.0.1:0/asset", "deadbeef  "+exec), cliPath, false)
+
+	require.Error(t, err)
+	assertProgressEndedWithFailure(t, progressCh)
+}
+
+func TestDownloaderDownload_ReportsFailureEndWhenMkdirAllFails(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	binary := []byte("snyk-cli")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	exec := (&Discovery{}).ExecutableName(false)
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return server.Client() },
+		engine:          engine,
+	}
+
+	// A regular file where Download needs a directory forces os.MkdirAll to
+	// fail with ENOTDIR.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+	cliPath := filepath.Join(blocker, "sub", exec)
+
+	_, err := d.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", sha256.Sum256(binary), exec)), cliPath, false)
+
+	require.Error(t, err)
+	assertProgressEndedWithFailure(t, progressCh)
+}
+
+func TestDownloaderDownload_ReportsFailureEndWhenMkdirTempFails(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	binary := []byte("snyk-cli")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	exec := (&Discovery{}).ExecutableName(false)
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return server.Client() },
+		engine:          engine,
+	}
+
+	// Pre-create the CLI directory without write permission. os.MkdirAll sees
+	// the directory already exists and returns nil, but the subsequent
+	// os.MkdirTemp inside it needs write permission and fails.
+	cliDirectory := filepath.Join(t.TempDir(), "clidir")
+	require.NoError(t, os.Mkdir(cliDirectory, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(cliDirectory, 0o755) })
+	cliPath := filepath.Join(cliDirectory, exec)
+
+	_, err := d.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", sha256.Sum256(binary), exec)), cliPath, false)
+
+	require.Error(t, err)
+	assertProgressEndedWithFailure(t, progressCh)
+}
+
+// alwaysErrorReader always fails on Read, used to force io.Copy to fail while
+// keeping a real, successful HTTP request/response.
+type alwaysErrorReader struct{}
+
+func (alwaysErrorReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("simulated read failure")
+}
+
+type bodyReadErrorTransport struct{}
+
+func (rt *bodyReadErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(alwaysErrorReader{})
+	return resp, nil
+}
+
+func TestDownloaderDownload_ReportsFailureEndWhenIOCopyFails(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	binary := []byte("snyk-cli")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	exec := (&Discovery{}).ExecutableName(false)
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	client := &http.Client{Transport: &bodyReadErrorTransport{}}
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return client },
+		engine:          engine,
+	}
+	cliPath := filepath.Join(t.TempDir(), exec)
+
+	_, err := d.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", sha256.Sum256(binary), exec)), cliPath, false)
+
+	require.Error(t, err)
+	assertProgressEndedWithFailure(t, progressCh)
+}
+
+func TestDownloaderDownload_ReportsFailureEndWhenChecksumInfoIsMalformed(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	binary := []byte("snyk-cli")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	exec := (&Discovery{}).ExecutableName(false)
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return server.Client() },
+		engine:          engine,
+	}
+	cliPath := filepath.Join(t.TempDir(), exec)
+
+	// A checksum line with only one field fails expectedChecksum's format check.
+	_, err := d.Download(testRelease(server.URL, "onlyonefield"), cliPath, false)
+
+	require.Error(t, err)
+	assertProgressEndedWithFailure(t, progressCh)
+}
+
+func TestDownloaderDownload_ReportsFailureEndWhenChecksumMismatch(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+	binary := []byte("snyk-cli")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	exec := (&Discovery{}).ExecutableName(false)
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return server.Client() },
+		engine:          engine,
+	}
+	cliPath := filepath.Join(t.TempDir(), exec)
+
+	// Well-formed checksum line, but it does not match the downloaded bytes.
+	wrongChecksum := sha256.Sum256([]byte("not-the-downloaded-bytes"))
+	_, err := d.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", wrongChecksum, exec)), cliPath, false)
+
+	require.Error(t, err)
+	assertProgressEndedWithFailure(t, progressCh)
+}
+
+// assertProgressEndedWithFailure drains progressCh (closing it first) and
+// asserts a WorkDoneProgressEnd event was sent carrying a failure message, not
+// a success one — i.e. the client's progress indicator was not left stuck.
+func assertProgressEndedWithFailure(t *testing.T, progressCh chan types.ProgressParams) {
+	t.Helper()
+	close(progressCh)
+	sawEnd := false
+	for p := range progressCh {
+		end, ok := p.Value.(types.WorkDoneProgressEnd)
+		if !ok {
+			continue
+		}
+		sawEnd = true
+		assert.NotContains(t, end.Message, "has been downloaded")
+		assert.NotContains(t, end.Message, "has been updated")
+	}
+	assert.True(t, sawEnd, "expected a WorkDoneProgressEnd event, so the client's progress indicator is not left stuck")
+}
+
+func TestDownloaderDownload_DoesNotReportSuccessWhenMoveToDestinationFails(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Chdir(t.TempDir())
+
+	binary := []byte("snyk-cli")
+	checksum := sha256.Sum256(binary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	exec := (&Discovery{}).ExecutableName(false)
+	progressCh := make(chan types.ProgressParams, 100)
+	cancelProgressCh := make(chan bool, 1)
+	d := &Downloader{
+		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
+		httpClient:      func() *http.Client { return server.Client() },
+		engine:          engine,
+		removeFile:      os.Remove,
+		renameFile: func(string, string) error {
+			return errors.New("simulated rename failure")
+		},
+	}
+	cliPath := filepath.Join(t.TempDir(), exec)
+
+	_, err := d.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, exec)), cliPath, false)
+
+	require.Error(t, err)
+	close(progressCh)
+	sawEnd := false
+	for p := range progressCh {
+		end, ok := p.Value.(types.WorkDoneProgressEnd)
+		if !ok {
+			continue
+		}
+		sawEnd = true
+		assert.NotContains(t, end.Message, "has been downloaded")
+		assert.NotContains(t, end.Message, "has been updated")
+	}
+	assert.True(t, sawEnd, "expected a WorkDoneProgressEnd event even when moveToDestination fails, so the client's progress indicator is not left stuck")
 }
 
 func getTestAsset() *Release {

--- a/infrastructure/cli/install/downloader_test.go
+++ b/infrastructure/cli/install/downloader_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
-
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/internal/progress"
 	"github.com/snyk/snyk-ls/internal/testutil"
@@ -44,17 +42,15 @@ func TestDownloader_Download(t *testing.T) {
 		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
 		httpClient:      func() *http.Client { return http.DefaultClient },
 		engine:          engine,
-		configResolver:  testutil.DefaultConfigResolver(engine),
 	}
 	exec := (&Discovery{}).ExecutableName(false)
 	destination := filepath.Join(t.TempDir(), exec)
-	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), destination)
 	lockFileName, err := d.lockFileName()
 	require.NoError(t, err)
 	// remove any existing lockfile
 	_ = os.RemoveAll(lockFileName)
 
-	err = d.Download(r, false)
+	_, err = d.Download(r, destination, false)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, progressCh)
@@ -77,10 +73,10 @@ func Test_DoNotDownloadIfCancelled(t *testing.T) {
 		progressTracker: progressTracker,
 		httpClient:      func() *http.Client { return http.DefaultClient },
 		engine:          engine,
-		configResolver:  testutil.DefaultConfigResolver(engine),
 	}
 
 	r := getTestAsset()
+	cliPath := filepath.Join(t.TempDir(), (&Discovery{}).ExecutableName(false))
 
 	// simulate cancellation when some progress received
 	go func() {
@@ -88,7 +84,7 @@ func Test_DoNotDownloadIfCancelled(t *testing.T) {
 		progress.Cancel(progressTracker.GetToken())
 	}()
 
-	err := d.Download(r, false)
+	_, err := d.Download(r, cliPath, false)
 	require.Error(t, err)
 
 	lockFileName, err := config.CLIDownloadLockFileName(engine.GetConfiguration())

--- a/infrastructure/cli/install/downloader_test.go
+++ b/infrastructure/cli/install/downloader_test.go
@@ -257,14 +257,12 @@ func TestDownloaderDownload_ReportsFailureEndWhenMkdirTempFails(t *testing.T) {
 		progressTracker: progress.NewTestTracker(progressCh, cancelProgressCh, engine.GetLogger()),
 		httpClient:      func() *http.Client { return server.Client() },
 		engine:          engine,
+		mkdirTemp: func(string, string) (string, error) {
+			return "", errors.New("simulated mkdir temp failure")
+		},
 	}
 
-	// Pre-create the CLI directory without write permission. os.MkdirAll sees
-	// the directory already exists and returns nil, but the subsequent
-	// os.MkdirTemp inside it needs write permission and fails.
 	cliDirectory := filepath.Join(t.TempDir(), "clidir")
-	require.NoError(t, os.Mkdir(cliDirectory, 0o555))
-	t.Cleanup(func() { _ = os.Chmod(cliDirectory, 0o755) })
 	cliPath := filepath.Join(cliDirectory, exec)
 
 	_, err := d.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", sha256.Sum256(binary), exec)), cliPath, false)

--- a/infrastructure/cli/install/installer.go
+++ b/infrastructure/cli/install/installer.go
@@ -85,19 +85,25 @@ func (i *Install) Install(ctx context.Context) (string, error) {
 }
 
 func (i *Install) installRelease(release *Release) (string, error) {
-	d := NewDownloader(i.engine, i.errorReporter, i.httpClient, i.configResolver)
+	d := NewDownloader(i.engine, i.errorReporter, i.httpClient)
 	lockFileName, err := createLockFile(i.engine, d)
 	if err != nil {
 		return "", err
 	}
 	defer func(name string) { cleanupLockFile(i.engine, name) }(lockFileName)
 
-	err = d.Download(release, false)
+	cliPath := i.configResolver.GetString(types.SettingCliPath, nil)
+	if cliPath == "" {
+		return "", fmt.Errorf("CLI path is not configured")
+	}
+	cliPath = filepath.Clean(cliPath)
+
+	installedCliPath, err := d.Download(release, cliPath, false)
 	if err != nil {
 		return "", err
 	}
 
-	return i.Find()
+	return installedCliPath, nil
 }
 
 func (i *Install) Update(ctx context.Context) (bool, error) {
@@ -111,7 +117,7 @@ func (i *Install) Update(ctx context.Context) (bool, error) {
 }
 
 func (i *Install) updateFromRelease(r *Release) (bool, error) {
-	d := NewDownloader(i.engine, i.errorReporter, i.httpClient, i.configResolver)
+	d := NewDownloader(i.engine, i.errorReporter, i.httpClient)
 	lockFileName, err := createLockFile(i.engine, d)
 	if err != nil {
 		return false, err
@@ -125,9 +131,10 @@ func (i *Install) updateFromRelease(r *Release) (bool, error) {
 	}
 
 	cliPath := i.configResolver.GetString(types.SettingCliPath, nil)
-	if cliPath != "" {
-		cliPath = filepath.Clean(cliPath)
+	if cliPath == "" {
+		return false, fmt.Errorf("CLI path is not configured")
 	}
+	cliPath = filepath.Clean(cliPath)
 	err = compareChecksum(i.engine.GetLogger(), latestChecksum, cliPath)
 	if err == nil {
 		// checksum match, no new version available
@@ -135,13 +142,13 @@ func (i *Install) updateFromRelease(r *Release) (bool, error) {
 	}
 
 	// Carry out the download of the latest release
-	err = d.Download(r, true)
+	latestCliFile, err := d.Download(r, cliPath, true)
 	if err != nil {
 		// download failed
 		return false, err
 	}
 
-	err = replaceOutdatedCli(i.engine, i.configResolver, cliDiscovery)
+	err = replaceOutdatedCli(i.engine, cliPath, latestCliFile)
 	if err != nil {
 		return false, err
 	}
@@ -149,15 +156,9 @@ func (i *Install) updateFromRelease(r *Release) (bool, error) {
 	return true, nil
 }
 
-func replaceOutdatedCli(engine workflow.Engine, configResolver types.ConfigResolverInterface, cliDiscovery Discovery) error {
+func replaceOutdatedCli(engine workflow.Engine, cliPath string, latestCliFile string) error {
 	logger := engine.GetLogger()
 	logger.Info().Str("method", "replaceOutdatedCli").Msg("replacing outdated CLI with latest")
-
-	cliPath := configResolver.GetString(types.SettingCliPath, nil)
-	if cliPath != "" {
-		cliPath = filepath.Clean(cliPath)
-	}
-	latestCliFile := filepath.Join(filepath.Dir(cliPath), cliDiscovery.ExecutableName(true))
 
 	if //goland:noinspection GoBoolExpressions
 	runtime.GOOS == "windows" {
@@ -291,7 +292,7 @@ func (t *FakeInstaller) Install(_ context.Context) (string, error) {
 	}
 
 	t.installs++
-	return "", nil
+	return path, nil
 }
 
 func (t *FakeInstaller) Update(_ context.Context) (bool, error) {

--- a/infrastructure/cli/install/installer_test.go
+++ b/infrastructure/cli/install/installer_test.go
@@ -200,7 +200,7 @@ func TestInstallerUpdate_ResolvesCliPathOnce(t *testing.T) {
 	assert.Equal(t, binary, installedBinary)
 }
 
-func TestInstallRelease_ReturnsInstalledPath_WhenCacheDirOutsideDiscovery(t *testing.T) {
+func TestInstallRelease_ReturnsConfiguredDestination_OnSuccessfulInstall(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
 	t.Setenv("PATH", t.TempDir())

--- a/infrastructure/cli/install/installer_test.go
+++ b/infrastructure/cli/install/installer_test.go
@@ -131,6 +131,32 @@ func TestInstallRelease_ReturnsErrorWhenCliPathIsEmpty(t *testing.T) {
 	assert.NoFileExists(t, filename.ExecutableName)
 }
 
+func TestUpdateFromRelease_ReturnsErrorWhenCliPathIsEmpty(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	resolver := mock_types.NewMockConfigResolverInterface(gomock.NewController(t))
+	resolver.EXPECT().GetString(types.SettingCliPath, nil).AnyTimes().Return("")
+	t.Chdir(t.TempDir())
+
+	binary := []byte("snyk-cli")
+	checksum := sha256.Sum256(binary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	installer := NewInstaller(
+		engine,
+		error_reporting.NewTestErrorReporter(engine),
+		func() *http.Client { return server.Client() },
+		resolver,
+	)
+
+	updated, err := installer.updateFromRelease(testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName)))
+
+	require.Error(t, err)
+	assert.False(t, updated)
+}
+
 func TestInstallRelease_ReturnsInstalledPath_WhenResolverCannotRediscoverIt(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)

--- a/infrastructure/cli/install/installer_test.go
+++ b/infrastructure/cli/install/installer_test.go
@@ -259,11 +259,182 @@ func TestDownloaderMoveToDestination_ReturnsErrorWhenCliPathIsEmpty(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, sourceFile.Close())
 
-	got, err := downloader.moveToDestination("", filename.ExecutableName, sourceFile.Name())
+	got, err := downloader.moveToDestination("", filename.ExecutableName, sourceFile.Name(), nil)
 
 	require.Error(t, err)
 	assert.Empty(t, got)
 	assert.NoFileExists(t, filename.ExecutableName)
+}
+
+func TestDownloaderMoveToDestination_ReturnsExistingPathWhenConcurrentInstallAlreadyWroteExpectedBinary(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	existingBinary := []byte("expected-cli")
+	require.NoError(t, os.WriteFile(cliPath, existingBinary, 0755))
+
+	sourceFile, err := os.CreateTemp(t.TempDir(), "cli-source")
+	require.NoError(t, err)
+	_, err = sourceFile.Write([]byte("new-cli"))
+	require.NoError(t, err)
+	require.NoError(t, sourceFile.Close())
+
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), nil)
+	downloader.removeFile = func(string) error { return os.ErrPermission }
+	expectedChecksum := sha256.Sum256(existingBinary)
+
+	got, err := downloader.moveToDestination(cliPath, filename.ExecutableName, sourceFile.Name(), expectedChecksum[:])
+
+	require.NoError(t, err)
+	assert.Equal(t, cliPath, got)
+	assert.FileExists(t, got)
+	assert.Equal(t, existingBinary, readFile(t, got))
+}
+
+func TestDownloaderMoveToDestination_ReturnsExistingPathWhenConcurrentInstallRenamedExpectedBinary(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	existingBinary := []byte("expected-cli")
+
+	sourceFile, err := os.CreateTemp(t.TempDir(), "cli-source")
+	require.NoError(t, err)
+	_, err = sourceFile.Write([]byte("new-cli"))
+	require.NoError(t, err)
+	require.NoError(t, sourceFile.Close())
+
+	renameErr := os.ErrPermission
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), nil)
+	downloader.renameFile = func(_, destinationFilePath string) error {
+		require.NoError(t, os.WriteFile(destinationFilePath, existingBinary, 0755))
+		return renameErr
+	}
+	expectedChecksum := sha256.Sum256(existingBinary)
+
+	got, err := downloader.moveToDestination(cliPath, filename.ExecutableName, sourceFile.Name(), expectedChecksum[:])
+
+	require.NoError(t, err)
+	assert.Equal(t, cliPath, got)
+	assert.Equal(t, existingBinary, readFile(t, got))
+}
+
+func TestDownloaderMoveToDestination_ReturnsErrorWhenConcurrentInstallRenamedWrongBinary(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+
+	sourceFile, err := os.CreateTemp(t.TempDir(), "cli-source")
+	require.NoError(t, err)
+	_, err = sourceFile.Write([]byte("new-cli"))
+	require.NoError(t, err)
+	require.NoError(t, sourceFile.Close())
+
+	renameErr := os.ErrPermission
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), nil)
+	downloader.renameFile = func(_, destinationFilePath string) error {
+		require.NoError(t, os.WriteFile(destinationFilePath, []byte("wrong-cli"), 0755))
+		return renameErr
+	}
+	expectedChecksum := sha256.Sum256([]byte("expected-cli"))
+
+	got, err := downloader.moveToDestination(cliPath, filename.ExecutableName, sourceFile.Name(), expectedChecksum[:])
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.ErrorIs(t, err, renameErr)
+}
+
+func TestDownloaderMoveToDestination_ReturnsErrorWhenExistingBinaryCannotBeRemoved(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	require.NoError(t, os.WriteFile(cliPath, []byte("outdated-cli"), 0755))
+
+	sourceFile, err := os.CreateTemp(t.TempDir(), "cli-source")
+	require.NoError(t, err)
+	_, err = sourceFile.Write([]byte("new-cli"))
+	require.NoError(t, err)
+	require.NoError(t, sourceFile.Close())
+
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), nil)
+	downloader.removeFile = func(string) error { return os.ErrPermission }
+	expectedChecksum := sha256.Sum256([]byte("new-cli"))
+
+	got, err := downloader.moveToDestination(cliPath, filename.ExecutableName, sourceFile.Name(), expectedChecksum[:])
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return contents
+}
+
+func TestDownloaderDownload_ReturnsExistingPathWhenConcurrentInstallRenamedExpectedBinary(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	existingBinary := []byte("expected-cli")
+	checksum := sha256.Sum256(existingBinary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(existingBinary)
+	}))
+	t.Cleanup(server.Close)
+
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), func() *http.Client { return server.Client() })
+	downloader.renameFile = func(_, destinationFilePath string) error {
+		require.NoError(t, os.WriteFile(destinationFilePath, existingBinary, 0755))
+		return os.ErrPermission
+	}
+
+	got, err := downloader.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName)), cliPath, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, cliPath, got)
+	assert.Equal(t, existingBinary, readFile(t, got))
+}
+
+func TestDownloaderDownload_ReturnsExistingPathWhenConcurrentInstallAlreadyWroteExpectedBinary(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	existingBinary := []byte("expected-cli")
+	require.NoError(t, os.WriteFile(cliPath, existingBinary, 0755))
+
+	checksum := sha256.Sum256(existingBinary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(existingBinary)
+	}))
+	t.Cleanup(server.Close)
+
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), func() *http.Client { return server.Client() })
+	downloader.removeFile = func(string) error { return os.ErrPermission }
+
+	got, err := downloader.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName)), cliPath, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, cliPath, got)
+	assert.Equal(t, existingBinary, readFile(t, got))
+}
+
+func TestDownloaderDownload_ReturnsErrorWhenConcurrentInstallWroteWrongBinary(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	require.NoError(t, os.WriteFile(cliPath, []byte("outdated-cli"), 0755))
+
+	newBinary := []byte("expected-cli")
+	checksum := sha256.Sum256(newBinary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(newBinary)
+	}))
+	t.Cleanup(server.Close)
+
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), func() *http.Client { return server.Client() })
+	downloader.removeFile = func(string) error { return os.ErrPermission }
+
+	got, err := downloader.Download(testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName)), cliPath, false)
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.ErrorIs(t, err, os.ErrPermission)
 }
 
 func TestFakeInstaller_Install_ReturnsPath(t *testing.T) {

--- a/infrastructure/cli/install/installer_test.go
+++ b/infrastructure/cli/install/installer_test.go
@@ -17,23 +17,29 @@
 package install
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/go-application-framework/pkg/configuration/configresolver"
 
 	"github.com/snyk/snyk-ls/application/config"
+	"github.com/snyk/snyk-ls/infrastructure/cli/filename"
 	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
 	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
+	"github.com/snyk/snyk-ls/internal/types/mock_types"
 )
 
 func TestInstaller_Find(t *testing.T) {
@@ -87,6 +93,190 @@ func Test_Find_CliPathInSettings_CliPathFound(t *testing.T) {
 
 	// Assert
 	assert.Equal(t, cliPath, foundPath)
+}
+
+func TestDefaultConfigResolver_ResolvesCliPathFromMinimalEngine(t *testing.T) {
+	engine, err := testutil.NewMinimalEngine()
+	require.NoError(t, err)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), cliPath)
+
+	assert.Equal(t, cliPath, testutil.DefaultConfigResolver(engine).GetString(types.SettingCliPath, nil))
+}
+
+func TestInstallRelease_ReturnsErrorWhenCliPathIsEmpty(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	resolver := mock_types.NewMockConfigResolverInterface(gomock.NewController(t))
+	resolver.EXPECT().GetString(types.SettingCliPath, nil).AnyTimes().Return("")
+	t.Chdir(t.TempDir())
+
+	binary := []byte("snyk-cli")
+	checksum := sha256.Sum256(binary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	installer := NewInstaller(
+		engine,
+		error_reporting.NewTestErrorReporter(engine),
+		func() *http.Client { return server.Client() },
+		resolver,
+	)
+
+	got, err := installer.installRelease(testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName)))
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.NoFileExists(t, filename.ExecutableName)
+}
+
+func TestInstallRelease_ReturnsInstalledPath_WhenResolverCannotRediscoverIt(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	resolver := mock_types.NewMockConfigResolverInterface(gomock.NewController(t))
+	reads := 0
+	resolver.EXPECT().GetString(types.SettingCliPath, nil).AnyTimes().DoAndReturn(func(string, *types.FolderConfig) string {
+		reads++
+		if reads == 1 {
+			return cliPath
+		}
+		return ""
+	})
+	t.Setenv("PATH", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	binary := []byte("snyk-cli")
+	checksum := sha256.Sum256(binary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	installer := NewInstaller(
+		engine,
+		error_reporting.NewTestErrorReporter(engine),
+		func() *http.Client { return server.Client() },
+		resolver,
+	)
+
+	release := testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName))
+	got, err := installer.installRelease(release)
+
+	require.NoError(t, err)
+	assert.Equal(t, cliPath, got)
+	assert.FileExists(t, got)
+	assert.Equal(t, 1, reads)
+}
+
+func TestInstallerUpdate_ResolvesCliPathOnce(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	require.NoError(t, os.WriteFile(cliPath, []byte("outdated-cli"), 0755))
+	resolver := mock_types.NewMockConfigResolverInterface(gomock.NewController(t))
+	resolver.EXPECT().GetString(types.SettingCliPath, nil).Times(1).Return(cliPath)
+	t.Chdir(t.TempDir())
+
+	binary := []byte("latest-cli")
+	checksum := sha256.Sum256(binary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	installer := NewInstaller(
+		engine,
+		error_reporting.NewTestErrorReporter(engine),
+		func() *http.Client { return server.Client() },
+		resolver,
+	)
+
+	updated, err := installer.updateFromRelease(testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName)))
+
+	require.NoError(t, err)
+	assert.True(t, updated)
+	installedBinary, readErr := os.ReadFile(cliPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, binary, installedBinary)
+}
+
+func TestInstallRelease_ReturnsInstalledPath_WhenCacheDirOutsideDiscovery(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	t.Setenv("PATH", t.TempDir())
+
+	binary := []byte("snyk-cli")
+	checksum := sha256.Sum256(binary)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), cliPath)
+	installer := NewInstaller(
+		engine,
+		error_reporting.NewTestErrorReporter(engine),
+		func() *http.Client { return server.Client() },
+		testutil.DefaultConfigResolver(engine),
+	)
+
+	release := testRelease(server.URL, fmt.Sprintf("%x  %s", checksum, filename.ExecutableName))
+	got, err := installer.installRelease(release)
+
+	require.NoError(t, err)
+	assert.Equal(t, cliPath, got)
+	assert.FileExists(t, got)
+}
+
+func testRelease(url, checksumInfo string) *Release {
+	asset := &ReleaseAsset{URL: url, ChecksumInfo: checksumInfo}
+	return &Release{Assets: &ReleaseAssets{
+		AlpineLinux: asset,
+		Linux:       asset,
+		LinuxARM64:  asset,
+		MacOS:       asset,
+		MacOSARM64:  asset,
+		Windows:     asset,
+	}}
+}
+
+func TestDownloaderDestinationPath_ReturnsConfiguredPath(t *testing.T) {
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	downloader := &Downloader{}
+	destinationFileName := "snyk-linux-arm64.latest"
+
+	assert.Equal(t, filepath.Join(filepath.Dir(cliPath), destinationFileName), downloader.destinationPath(cliPath, destinationFileName))
+}
+
+func TestDownloaderMoveToDestination_ReturnsErrorWhenCliPathIsEmpty(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	downloader := NewDownloader(engine, error_reporting.NewTestErrorReporter(engine), nil)
+	t.Chdir(t.TempDir())
+
+	sourceFile, err := os.CreateTemp(t.TempDir(), "cli-source")
+	require.NoError(t, err)
+	_, err = sourceFile.WriteString("snyk-cli")
+	require.NoError(t, err)
+	require.NoError(t, sourceFile.Close())
+
+	got, err := downloader.moveToDestination("", filename.ExecutableName, sourceFile.Name())
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.NoFileExists(t, filename.ExecutableName)
+}
+
+func TestFakeInstaller_Install_ReturnsPath(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	cliPath := filepath.Join(t.TempDir(), filename.ExecutableName)
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliPath), cliPath)
+	installer := NewFakeInstaller(engine, testutil.DefaultConfigResolver(engine))
+
+	got, err := installer.Install(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, cliPath, got)
+	assert.FileExists(t, got)
 }
 
 func TestInstaller_Install_DoNotDownloadIfLockfileFound(t *testing.T) {

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -603,12 +603,10 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 	workingDir, _ := os.Getwd()
 	folderPath := workingDir
 	fakeCli := cli.NewTestExecutor(engine)
-	// ponytail: 2s gives ~50-100x headroom over the <40ms it takes all 10 scans to
-	// register and cancel their predecessor (observed in CI). A superseded scan only
-	// finishes instead of being canceled if the scheduler stalls it past this window;
-	// bump further if this still flakes under heavier CI contention.
-	fakeCli.ExecuteDuration = 2 * time.Second
-	scanner := NewCLIScanner(engine, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(engine), fakeCli, getLearnMock(t), notification.NewMockNotifier(), defaultResolver(t, engine))
+	// Execute blocks on this channel instead of a wall-clock timer, so which scan is the
+	// "winner" (last registered, never canceled) is decided by scanCount, not by timing.
+	fakeCli.ExecuteRelease = make(chan struct{})
+	scanner := NewCLIScanner(engine, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(engine), fakeCli, getLearnMock(t), notification.NewMockNotifier(), defaultResolver(t, engine)).(*CLIScanner)
 	wg := sync.WaitGroup{}
 	p, _ := filepath.Abs(workingDir + testDataPackageJson)
 
@@ -616,8 +614,6 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 	for i := 0; i < concurrentScanRequests; i++ {
 		wg.Add(1)
 		go func() {
-			// Adding a short delay so the cancel listener will start before a new scan is sending the cancel signal
-			time.Sleep(20 * time.Millisecond)
 			ctx := EnrichContextForTest(t, t.Context(), engine, workingDir)
 			folderConfig := config.GetFolderConfigFromEngine(engine, testutil.DefaultConfigResolver(engine), types.FilePath(folderPath), engine.GetLogger())
 			ctx = ctx2.NewContextWithFolderConfig(ctx, folderConfig)
@@ -625,6 +621,17 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 			wg.Done()
 		}()
 	}
+
+	// scanCount starts at 1 (NewCLIScanner), so 10 registrations => 11. Every predecessor's
+	// CancelScan() runs inside the same critical section, before scanCount++, so reaching
+	// 11 means all 9 victims are already canceled - only the winner is left waiting below.
+	require.Eventually(t, func() bool {
+		scanner.mutex.RLock()
+		defer scanner.mutex.RUnlock()
+		return scanner.scanCount == concurrentScanRequests+1
+	}, 10*time.Second, time.Millisecond, "all scans should register")
+	close(fakeCli.ExecuteRelease)
+
 	wg.Wait()
 
 	// Assert

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -603,7 +603,11 @@ func Test_SeveralScansOnSameFolder_DoNotRunAtOnce(t *testing.T) {
 	workingDir, _ := os.Getwd()
 	folderPath := workingDir
 	fakeCli := cli.NewTestExecutor(engine)
-	fakeCli.ExecuteDuration = 200 * time.Millisecond
+	// ponytail: 2s gives ~50-100x headroom over the <40ms it takes all 10 scans to
+	// register and cancel their predecessor (observed in CI). A superseded scan only
+	// finishes instead of being canceled if the scheduler stalls it past this window;
+	// bump further if this still flakes under heavier CI contention.
+	fakeCli.ExecuteDuration = 2 * time.Second
 	scanner := NewCLIScanner(engine, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(engine), fakeCli, getLearnMock(t), notification.NewMockNotifier(), defaultResolver(t, engine))
 	wg := sync.WaitGroup{}
 	p, _ := filepath.Abs(workingDir + testDataPackageJson)


### PR DESCRIPTION
### **User description**
## Summary

Fixes the flaky `infrastructure/oss` CI failure where `TestMain` aborted the whole package on a CLI cache-miss run.

`installRelease` discarded the destination the downloader had just written and re-derived the CLI path through `Find()`. `Find()`'s three-tier lookup covers the configured path, the XDG data dir and `$PATH` — but not the CLI cache dir. So on a cache-miss run the binary was downloaded, checksummed, moved and made executable, and the rediscovery still failed with `unable to find snyk-linux in PATH`, aborting the package via `TestMain`'s `log.Fatalf` and silently losing its coverage.

The rediscovery was unreliable because the configured CLI path is read through the config resolver, and that read is not guaranteed to return the same value twice: a value written under a `user:global:` scoped key only round-trips when the resolver carries a scope annotation for it, and it can also be rewritten concurrently.

## What changed

- The configured CLI path is resolved **exactly once per logical operation** and threaded through, instead of re-read.
- `Downloader` no longer holds a `ConfigResolverInterface`; `Download` takes the resolved path and returns the destination it actually wrote.
- `installRelease` returns that path directly. `updateFromRelease` passes its one resolved value to both `Download` and `replaceOutdatedCli`, so the download and rename destinations cannot diverge.
- An empty configured path is a hard error rather than a silent write to a cwd-relative filename.
- `Find()` is unchanged and still locates an already-installed CLI.
- `FakeInstaller.Install` returns the path it wrote instead of an empty string.

## Correction — a regression this PR introduced, and fixed

The first commit also changed `moveToDestination`'s remove-failure branch, which had returned a nil error (silently skipping the rename). An earlier revision of this description called that "an incidental latent bug fix, not a regression". **That was wrong**, and CI proved it: `smoke (1, windows-latest)` and `smoke (2, windows-latest)` failed with

```
couldn't remove old CLI at C:\...\snyk-win.exe ...: Access is denied.
FAIL	github.com/snyk/snyk-ls/infrastructure/oss
```

That swallowed error was load-bearing. Within one `go test ./...` run packages execute in parallel, so `infrastructure/oss`'s `TestMain` and the `application/server` smoke helpers install the CLI into the same cache dir concurrently; when one holds the destination open, the other's `os.Remove` — and equally its `os.Rename` — fails. POSIX unlink-while-open hides this on Linux and macOS entirely, which is why a full local 4-shard smoke run was green and only 2 of 4 Windows shards caught it.

The second commit treats "the requested binary is already there" as success rather than failure: on a remove **or** rename failure, the file already at the destination is compared against the release's expected checksum — match means another installer wrote exactly what we wanted, so its path is returned; mismatch or unreadable returns the original wrapped error. Both call sites share one helper. A genuinely failed operation still reports failure.

## Verification

| Check | Result |
|---|---|
| `go build ./...` / `go vet ./...` | pass |
| `golangci-lint` | pass, 0 issues |
| `go test ./infrastructure/cli/install/... -race -count=20` | pass |
| `go test ./... -race` | pass |
| `make test` | pass, 0 failures |
| `make test-smoke-parallel` (4 shards) | pass, 0 failures |

The primary regression test was proven to discriminate: reverting `installRelease` to `return i.Find()` makes `TestInstallRelease_ReturnsInstalledPath_WhenResolverCannotRediscoverIt` fail with the exact CI error. A real cache-miss install was also exercised end-to-end against an empty cache dir with a genuine ~163 MB download.

**No local tier can exercise the Windows failure path** — POSIX semantics hide it. Windows CI is the only real arbiter for that part, which is precisely how the regression above slipped through review.

## Known gaps

- ~~`TestInstallRelease_ReturnsInstalledPath_WhenCacheDirOutsideDiscovery` does not discriminate against the pre-fix code.~~ **Fixed** in `35cdaa63` — renamed to `TestInstallRelease_ReturnsConfiguredDestination_OnSuccessfulInstall`, which describes what it actually asserts. The genuine regression guard remains `..._WhenResolverCannotRediscoverIt`.
- Reviewer suggestions accepted but not acted on: the checksum-match fallback does not re-assert the executable bit (moot on Windows; a low-probability compound race on POSIX), and the debug log does not distinguish a checksum mismatch from an unreadable file.
- Snyk SCA via MCP did not complete (its trust step timed out); it was run via the CLI instead — 9 pre-existing dependency vulnerabilities, none introduced here, no manifests changed. Snyk Code reports 8 pre-existing findings in the unchanged `benchmark/testdata` fixture.

## Test plan

- [ ] CI green, **including all Windows smoke shards**
- [ ] Confirm a cache-miss smoke run no longer aborts `infrastructure/oss`

---

This fix was produced by an automated flake-fix loop.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes flaky CI by improving CLI path resolution.

- CLI path resolved once and passed explicitly.

- Enhances handling of concurrent CLI installations.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Installer] -->|Get CLI Path| B(Config Resolver)
  A -->|Download CLI| C{Downloader}
  C -->|Uses CLI Path| D[File Operations]
  D -->|Handles Conflicts| E[File System]
  A -->|Returns Installed Path| F[Caller]
  subgraph Refactor
    C -- "Explicit Path" --> D
    D -- "Concurrency Handling" --> E
  end
  B -- "Resolved Once" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_smoke_test.go</strong><dd><code>Smoke Test Adjusts Preview CLI Path Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/server_smoke_test.go

<ul><li>Updates the test to pass the specific <code>previewCLIPath</code> to the <br><code>Downloader.Download</code> method.<br> <li> Aligns the test with the refactored downloader API that expects an <br>explicit path.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-13396c212387ae79a286802e0885b1c86f1bc389f0f6e82de58d49d641e15e08">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>downloader_test.go</strong><dd><code>Update Downloader Tests for New API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/cli/install/downloader_test.go

<ul><li>Updates existing tests to accommodate the refactored <br><code>Downloader.Download</code> method signature.<br> <li> Ensures tests correctly pass the destination path and verify the <br>returned installed path.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-bc987779bba3bce6c86614e040335b0da96085c7dc9e7ce403ad6e5a6c4fa13c">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>installer_test.go</strong><dd><code>Add Extensive Tests for CLI Install and Download</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/cli/install/installer_test.go

<ul><li>Adds new unit tests to cover various scenarios for CLI installation <br>and download, including:<br>   - Empty CLI path configuration.<br>   - <br>Concurrent installation conflicts and resolutions.<br>   - Correct path <br>resolution and return values.<br>   - <code>FakeInstaller</code>'s behavior.<br> <li> Introduces mocks for <code>ConfigResolverInterface</code> to isolate test cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-1708a6a27d97bc0f7269e4994bf6e7c8f82df1cbbd91d93cce862aa579f9ecdb">+361/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>downloader.go</strong><dd><code>Refactor Downloader, Improve Concurrency Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/cli/install/downloader.go

<ul><li>Refactors the <code>Downloader</code> to no longer depend on <br><code>ConfigResolverInterface</code>.<br> <li> The <code>Download</code> method now accepts the target <code>cliPath</code> and returns the <br>installed path.<br> <li> Introduces more robust handling for concurrent CLI installations by <br>checking existing files against checksums.<br> <li> Adds dependency injection for <code>os.Remove</code> and <code>os.Rename</code> for improved <br>testability.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-7ba28fb2e4a170e8d1517e55166f1731bf866b6b0ce21759b8cca002b0b7fc06">+69/-36</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>installer.go</strong><dd><code>Integrate Refactored Downloader in Installer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/cli/install/installer.go

<ul><li>Integrates the refactored <code>Downloader</code> in <code>installRelease</code> and <br><code>updateFromRelease</code>, passing the resolved CLI path.<br> <li> Ensures the <code>installRelease</code> method now returns the actual installed CLI <br>path.<br> <li> Fixes <code>FakeInstaller.Install</code> to return the path it writes to, aligning <br>with the new contract.<br> <li> Removes redundant CLI path lookups within <code>updateFromRelease</code> and <br><code>replaceOutdatedCli</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-8421d797f924e31a4db10413bf4cdac016fad3dae3f424d1035ac9377c56fbd5">+17/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


