### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -110,3 +110,31 @@ alwaysApply: true
 - use `make generate-diagrams` to generate diagrams
 - document the tested scenarios for all testing stages (unit, integration, e2e) in ./docs
 </documenting>
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for agents running in the Cursor Cloud Linux VM. The
+update script already runs `go mod download`; the items below are setup context
+and gotchas, not install steps to repeat.
+
+- **Go toolchain — pin the exact patch.** `go.mod` needs Go 1.26.x; with
+  `GOTOOLCHAIN=auto` Go tries to fetch a toolchain from the **blocked** `go.dev`.
+  The environment pins `GOTOOLCHAIN=go1.26.5` (`go env -w GOTOOLCHAIN=go1.26.5`),
+  served by `proxy.golang.org`. Keep it set.
+- **golangci-lint host is blocked.** The Makefile installs it via
+  `curl … raw.githubusercontent.com/golangci/golangci-lint/…/install.sh` which
+  downloads from a blocked host. Install the pinned version from the module proxy
+  into `.bin/` instead:
+  `GOBIN=$(pwd)/.bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1`.
+- **Standard commands** (see the Makefile): `make build` → `build/snyk-ls.linux.amd64`;
+  `make lint` → `0 issues`; `make test-js` (regenerates Go HTML fixtures then runs
+  mocha; needs Node) → all pass. Verify the binary with `./build/snyk-ls.linux.amd64 -v`
+  (it speaks LSP over stdio, so there is no `--help`; a JSON-RPC `initialize`
+  handshake returns the server capabilities).
+- **Do not run the full `make test` casually** — it has a ~90m timeout and its
+  integration/smoke suites need `SNYK_TOKEN` and network. For a quick check run a
+  unit subset, e.g. `go test ./internal/... ./domain/ide/converter/...`.
+- **Node** must come from `~/.nvm/versions/node/v22.22.3/bin` (see below); nvm is
+  not auto-sourced in non-interactive shells and `/exec-daemon/node` ships no npm.
+  Prepend `PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH"` before `make test-js`.
+- **Reachable:** `proxy.golang.org`, `github.com`, `registry.npmjs.org`.
+  **Blocked:** `go.dev`, `golangci-lint.run`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `## Cursor Cloud specific instructions` section to `AGENT.md` capturing durable, non-obvious setup notes for agents running in the Cursor Cloud Linux VM.

## Notes captured

- Pin `GOTOOLCHAIN=go1.26.5` (avoids the blocked `go.dev` toolchain fetch).
- Install `golangci-lint@v2.10.1` via the Go module proxy into `.bin/` (the Makefile installer host is blocked).
- Standard commands: `make build` → `build/snyk-ls.linux.amd64`, `make lint` (`0 issues`), `make test-js` (needs Node on PATH). Verify with `./build/snyk-ls.linux.amd64 -v` / an LSP `initialize` handshake.
- Avoid the full `make test` (90m timeout, needs `SNYK_TOKEN` + network); use a unit subset instead.
- Node must come from the nvm `v22.22.3` install (prepend it to `PATH`).

## Verification

`make build` (ok), `make lint` (`0 issues`), `make test-js` (all pass), unit subset `go test ./internal/... ./domain/ide/converter/...` (pass), and an LSP initialize handshake returning server capabilities.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

