### PR TITLE
feat: add file/issue search to the tree view [IDE-2362]

### DIFF
--- a/docs/tree-view.md
+++ b/docs/tree-view.md
@@ -209,6 +209,42 @@ window.__ideExecuteCommand__ = function(command, args, callback) {
 | Filter toggle | `snyk.toggleTreeFilter` | combined token in `args[0]` — `["severity_high", enabled]`, `["issueView_openIssues", enabled]`, `["riskScore", threshold]`, `["reset"]` |
 | Expand/collapse | `snyk.setNodeExpanded` | `[nodeID, expanded]` |
 
+### File / Issue Search (client-side)
+
+A magnifier toggle (`#treeSearchToggle`) sits in the filter toolbar next to the
+severity icons whenever there are issues to search (`TotalIssues > 0`). Clicking it
+reveals a search box above the tree; clicking it again (or pressing `Escape` in the
+field) hides the box and resets the filter. It reproduces the native JetBrains
+`TreeSpeedSearch` that the old Swing tree got for free, but as a web-native control
+it benefits every IDE.
+
+The filter is entirely **client-side and transient** — it runs in `tree.js`, never
+calls the LS, and persists no state:
+
+- As the user types, each node is matched against its own label (the full,
+  pre-truncation value) and, for file nodes, the full file path.
+- A node stays visible when it matches or when any descendant matches; ancestors
+  of a match are auto-expanded so the match is reachable. Non-matching nodes get
+  the `tree-search-hidden` class (`display: none`).
+- The pre-search expand state is snapshotted on the first keystroke and restored
+  verbatim when the query is cleared, so searching never disturbs the user's
+  layout. The auto-expand during search is **not** persisted via
+  `snyk.setNodeExpanded`.
+- When nothing matches, a "No files or issues match your search" message
+  (`#treeSearchEmpty`) is shown.
+- Closing the box (toggle again or `Escape`) clears the query and resets the
+  filter. Input is debounced to one pass per animation frame.
+
+Because a `$/snyk.treeView` push replaces the entire HTML (scan complete, severity
+toggle, …), the search text is reset on re-render — matching the transient nature
+of the original speed search.
+
+| File | Role |
+|------|------|
+| `domain/ide/treeview/template/tree.html` | Renders `#treeSearchToggle` in the toolbar + hidden `#treeSearch` input + `#treeSearchEmpty` (gated on `TotalIssues > 0`) |
+| `domain/ide/treeview/template/tree.js` | Toolbar toggle (open/close + reset), client-side recursive filter, auto-expand tracking, no-results toggle |
+| `domain/ide/treeview/template/styles.css` | `.tree-search-toggle`, `.tree-search`, `.tree-search-input`, `.tree-node.tree-search-hidden`, `.tree-search-empty` |
+
 ### Filter Architecture
 
 ```mermaid
@@ -280,7 +316,7 @@ All JS is ES5 (no arrow functions, no `const`/`let`, no template literals). CSS 
 
 **Unit tests (`make test`):**
 - Tree builder: empty, single, multi-folder, filtered, sorted, TotalIssues computation, deterministic IDs, expand state defaults + overrides, product display names, product order, disabled products, fixable info nodes, scanning description
-- HTML renderer: valid output, node rendering, filter toolbar, badge ordering, disabled product class, isEnabled template function
+- HTML renderer: valid output, node rendering, filter toolbar, badge ordering, disabled product class, isEnabled template function, search box rendered/omitted based on TotalIssues
 - Emitter: notification sent, TotalIssues propagated, per-product scan status in HTML, concurrent Emit() calls (race detector)
 - ExpandState: set/get, defaults by node type, overrides, concurrent access
 - ScanStateAggregator: ProductScanStates populated from per-product scan states
@@ -331,6 +367,15 @@ Located in `domain/ide/treeview/template/js-tests/tree-runtime.test.mjs`. These 
 | issue click applies .selected | clicking issue node highlights it, removes from previous |
 | __selectTreeNode__ programmatic select | IDE→JS bridge selects node by ID |
 | __selectTreeNode__ unknown ID | no crash when nodeId not found |
+| file/issue search hides non-matches | typing filters file nodes, matches label + path, case-insensitive |
+| search reveals matched issues | matching an issue title keeps its ancestor file visible, hides siblings |
+| search auto-expands ancestors | ancestors of a match expand without persisting expand state to the LS |
+| clearing search restores state | visibility and pre-search expand state restored, no LS calls |
+| search no-results message | empty message shown when nothing matches, hidden otherwise |
+| search absent input no-op | tree.js tolerates a missing search input |
+| toolbar toggle opens the box | box hidden until the toggle is clicked, then shown + focused |
+| toolbar toggle closes + resets | second click hides the box, clears the query, resets the filter |
+| Escape closes + resets search | Escape in the field hides the box and resets the filter |
 
 Run JS tests standalone: `make test-js`
 

--- a/domain/ide/treeview/template/styles.css
+++ b/domain/ide/treeview/template/styles.css
@@ -387,6 +387,93 @@ body {
   cursor: pointer;
 }
 
+/* File/issue search box (IDE-2362).
+   Sits between the filter toolbar and the tree. tree.js filters the rendered
+   nodes client-side as the user types, mirroring the native TreeSpeedSearch the
+   old Swing tree provided. Reuses the same input tokens as the delta ref picker
+   so it tracks the IDE theme. */
+.tree-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--panel-border);
+  position: relative;
+}
+
+/* Hidden until the toolbar toggle opens it. Needed because .tree-search sets an
+   explicit display, which would otherwise defeat the `hidden` attribute. */
+.tree-search[hidden] {
+  display: none;
+}
+
+/* Toolbar toggle that shows/hides the search box. Matches the neutral funnel
+   trigger treatment (not the dim severity-icon treatment) so the magnifier
+   reads clearly at rest, and highlights while the box is open. */
+.tree-search-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 4px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background-color: transparent;
+  color: var(--description-foreground);
+  font: inherit;
+  line-height: 0;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.tree-search-toggle svg {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+}
+
+.tree-search-toggle:hover,
+.tree-search-toggle[aria-expanded="true"] {
+  background-color: var(--list-hover-background);
+  color: var(--text-color);
+}
+
+.tree-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 3px 6px;
+  font-family: var(--default-font);
+  font-size: var(--font-size);
+  /* Match the tree/sidebar background so the field blends into the panel
+     instead of showing as a bright white box (IDE-2362). */
+  background-color: var(--sidebar-background);
+  color: var(--text-color);
+  border: 1px solid var(--input-border);
+  border-radius: 2px;
+  outline: none;
+}
+
+.tree-search-input:focus {
+  border-color: var(--focus-border);
+}
+
+/* Nodes filtered out by the client-side search. !important so it overrides the
+   .tree-node.expanded > .tree-node-children display rules for hidden subtrees. */
+.tree-node.tree-search-hidden {
+  display: none !important;
+}
+
+/* "No results" message shown by tree.js when a query matches nothing. */
+.tree-search-empty {
+  padding: 8px 12px;
+  color: var(--description-foreground);
+  font-style: italic;
+}
+
+.tree-search-empty[hidden] {
+  display: none;
+}
+
 /* Filter toolbar */
 .tree-filters {
   padding: 6px 8px;
@@ -404,6 +491,14 @@ body {
 .filter-group {
   display: inline-block;
   vertical-align: middle;
+}
+
+/* Right-hand toolbar cluster: search toggle + "more filters" funnel. Kept on the
+   right by the toolbar's space-between, with the two controls sitting together. */
+.filter-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .filter-separator {

--- a/domain/ide/treeview/template/tree.html
+++ b/domain/ide/treeview/template/tree.html
@@ -39,6 +39,13 @@
         Per-scanner chevrons (see .tree-chevron in styles.css) handle
         expand/collapse. tree.js keeps the expandAll/collapseAll handlers,
         which no-op when the buttons are absent. */}}
+    {{/* Right-side actions: search toggle + the "more filters" funnel. */}}
+    <span class="filter-actions">
+    {{if gt .TotalIssues 0}}
+      {{/* Search toggle (IDE-2362). Toggles the search box below the toolbar;
+          clicking again hides it and resets the filter (handled in tree.js). */}}
+      <button type="button" id="treeSearchToggle" class="tree-search-toggle" title="Search files and issues" aria-label="Search files and issues" aria-expanded="false" aria-controls="treeSearch"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.3"/><path d="M11 11l3 3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg></button>
+    {{end}}
     {{if .FilterState.ShowFilterPopover}}
     <span class="filter-popover-wrap">
       <button type="button" id="filtersPopoverBtn" class="filters-popover-trigger{{if or .FilterState.RiskScoreMixed .FilterState.MixedIssueViewOptions.OpenIssues .FilterState.MixedIssueViewOptions.IgnoredIssues}} filters-popover-trigger-mixed{{end}}" title="More filters" aria-haspopup="dialog" aria-expanded="false" aria-controls="filtersPopover"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M2 3h12l-4.5 6v4l-3 1.5V9L2 3z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" fill="none"/></svg></button>
@@ -66,13 +73,27 @@
       </div>
     </span>
     {{end}}
+    </span>
   </div>
+
+  {{if gt .TotalIssues 0}}
+  {{/* Client-side file/issue search (IDE-2362). Purely transient: tree.js filters
+      the rendered nodes in the webview, so there is no LS round-trip and no
+      persisted state. Hidden by default; toggled by #treeSearchToggle. */}}
+  <div class="tree-search" id="treeSearch" hidden>
+    <input type="search" id="treeSearchInput" class="tree-search-input" placeholder="Search files and issues" aria-label="Search files and issues" autocomplete="off" autocapitalize="off" spellcheck="false">
+  </div>
+  {{end}}
 
   <div class="tree-container" id="treeContainer" data-total-issues="{{.TotalIssues}}">
     {{range .Nodes}}
       {{template "treeNode" .}}
     {{end}}
   </div>
+
+  {{if gt .TotalIssues 0}}
+  <div class="tree-search-empty" id="treeSearchEmpty" hidden>No files or issues match your search.</div>
+  {{end}}
 
   {{if not .FeedbackBannerDismissed}}
   <div class="feedback-banner" id="feedbackBanner"{{if not .FeedbackBannerInteracted}} hidden{{end}}>

--- a/domain/ide/treeview/template/tree.js
+++ b/domain/ide/treeview/template/tree.js
@@ -1020,4 +1020,164 @@
     document.addEventListener('click', arm);
     document.addEventListener('keydown', arm);
   })();
+
+  // File/issue search (IDE-2362).
+  // A transient, client-side filter. As the user types it hides non-matching
+  // nodes, keeps the ancestors of a match visible (auto-expanding them so the
+  // match is reachable), and shows a "no results" message when a query matches
+  // nothing. Nothing here touches the LS: the change is purely visual, and only
+  // the nodes this filter auto-expanded are collapsed again when the query
+  // changes or clears, so the user's own expand/collapse state is preserved.
+  (function() {
+    var searchInput = document.getElementById('treeSearchInput');
+    if (!searchInput) return;
+    var emptyMessage = document.getElementById('treeSearchEmpty');
+    var searchRow = document.getElementById('treeSearch');
+    var toggle = document.getElementById('treeSearchToggle');
+
+    // Nodes that WE expanded to reveal a match. Only these are collapsed again
+    // when the filter is recomputed or cleared, so the search never disturbs the
+    // user's own (LS-persisted) expand/collapse state — even if they toggle a
+    // node mid-search — and each keystroke recomputes auto-expansion from a clean
+    // baseline regardless of typing history.
+    var autoExpanded = [];
+
+    function collapseAutoExpanded() {
+      for (var i = 0; i < autoExpanded.length; i++) {
+        autoExpanded[i].classList.remove('expanded');
+      }
+      autoExpanded = [];
+    }
+
+    function ownRow(node) {
+      var kids = node.childNodes;
+      for (var i = 0; i < kids.length; i++) {
+        if (hasClass(kids[i], 'tree-node-row')) return kids[i];
+      }
+      return null;
+    }
+
+    // The lower-cased text a node matches against: its own label (the full,
+    // pre-truncation value when the truncation pass has stashed one) plus, for
+    // file nodes, the full file path so a match works even when the visible
+    // label is middle-truncated.
+    function ownText(node) {
+      var row = ownRow(node);
+      if (!row) return '';
+      var text = '';
+      var label = row.querySelector('.tree-label');
+      if (label) {
+        var full = label.getAttribute('data-full-label');
+        text = (full !== null ? full : label.textContent) || '';
+      }
+      if (hasClass(node, 'tree-node-file')) {
+        var fp = node.getAttribute('data-file-path');
+        if (fp) text += ' ' + fp;
+      }
+      return text.toLowerCase();
+    }
+
+    // Recursively show/hide a node. Returns true when the node or any descendant
+    // matches. An empty query matches everything — used both to clear the filter
+    // and to reveal the whole subtree beneath a self-matched ancestor. Nodes
+    // hidden via the HTML `hidden` attribute (e.g. the filter-empty info node)
+    // are never matchable, so they can't keep the "no results" message hidden.
+    function filterNode(node, query) {
+      if (node.hidden) return false;
+      var selfMatch = query === '' || ownText(node).indexOf(query) !== -1;
+      var childContainer = findChildrenContainer(node);
+      var anyChildVisible = false;
+      if (childContainer) {
+        var children = childContainer.childNodes;
+        for (var i = 0; i < children.length; i++) {
+          var child = children[i];
+          if (!hasClass(child, 'tree-node')) continue;
+          if (filterNode(child, selfMatch ? '' : query)) {
+            anyChildVisible = true;
+          }
+        }
+      }
+      var visible = selfMatch || anyChildVisible;
+      if (visible) {
+        node.classList.remove('tree-search-hidden');
+        // Expand only to reveal a descendant match, and only when the node isn't
+        // already open, tracking it so we can collapse it back afterwards. A
+        // self-matched container is left as-is so the user opens it themselves.
+        if (anyChildVisible && !selfMatch && childContainer && !node.classList.contains('expanded')) {
+          node.classList.add('expanded');
+          autoExpanded.push(node);
+        }
+      } else {
+        node.classList.add('tree-search-hidden');
+      }
+      return visible;
+    }
+
+    function applySearch() {
+      var query = searchInput.value.trim().toLowerCase();
+      // Recompute from a clean baseline: undo our previous auto-expansions so
+      // this pass reflects only the current query.
+      collapseAutoExpanded();
+
+      var anyVisible = false;
+      var tops = container.childNodes;
+      for (var i = 0; i < tops.length; i++) {
+        var top = tops[i];
+        if (!hasClass(top, 'tree-node')) continue;
+        if (filterNode(top, query)) anyVisible = true;
+      }
+
+      if (emptyMessage) {
+        emptyMessage.hidden = (query === '' || anyVisible);
+      }
+    }
+
+    // Debounce to one filter pass per frame so fast typing doesn't thrash the DOM.
+    var searchPending = false;
+    function scheduleSearch() {
+      if (searchPending) return;
+      searchPending = true;
+      var run = function() { searchPending = false; applySearch(); };
+      if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(run);
+      } else {
+        setTimeout(run, 16);
+      }
+    }
+
+    // Open/close the search box from the toolbar toggle. Closing always resets
+    // the filter so a dismissed search never leaves the tree filtered.
+    function openSearch() {
+      if (searchRow) searchRow.hidden = false;
+      if (toggle) toggle.setAttribute('aria-expanded', 'true');
+      searchInput.focus();
+    }
+
+    function closeSearch() {
+      if (searchRow) searchRow.hidden = true;
+      if (toggle) toggle.setAttribute('aria-expanded', 'false');
+      if (searchInput.value !== '') {
+        searchInput.value = '';
+        applySearch();
+      }
+    }
+
+    searchInput.addEventListener('input', scheduleSearch);
+    searchInput.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27) {
+        closeSearch();
+      }
+    });
+
+    if (toggle) {
+      toggle.addEventListener('click', function(e) {
+        e.stopPropagation();
+        if (!searchRow || searchRow.hidden) {
+          openSearch();
+        } else {
+          closeSearch();
+        }
+      });
+    }
+  })();
 })();

--- a/domain/ide/treeview/tree_html_test.go
+++ b/domain/ide/treeview/tree_html_test.go
@@ -469,6 +469,32 @@ func TestTreeHtmlRenderer_FilterToolbar_ExpandCollapseButtons_NotRendered(t *tes
 	assert.NotContains(t, html, `id="collapseAllBtn"`)
 }
 
+func TestTreeHtmlRenderer_SearchBox_RenderedWhenIssuesPresent(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	renderer, err := NewTreeHtmlRenderer(engine.GetLogger())
+	require.NoError(t, err)
+
+	html := renderer.RenderTreeView(TreeViewData{TotalIssues: 3})
+
+	assert.Contains(t, html, `id="treeSearchToggle"`, "toolbar search toggle should render when there are issues to search")
+	assert.Contains(t, html, `id="treeSearchInput"`, "search input should render when there are issues to search")
+	assert.Contains(t, html, `id="treeSearchEmpty"`, "no-results element should render alongside the search input")
+	// The box is hidden until the toggle opens it.
+	assert.Contains(t, html, `id="treeSearch" hidden>`, "search box should start hidden")
+}
+
+func TestTreeHtmlRenderer_SearchBox_OmittedWhenNoIssues(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	renderer, err := NewTreeHtmlRenderer(engine.GetLogger())
+	require.NoError(t, err)
+
+	html := renderer.RenderTreeView(TreeViewData{TotalIssues: 0})
+
+	assert.NotContains(t, html, `id="treeSearchToggle"`, "search toggle must not render when there are no issues")
+	assert.NotContains(t, html, `id="treeSearchInput"`, "search input must not render when there are no issues")
+	assert.NotContains(t, html, `id="treeSearchEmpty"`, "no-results element must not render when there are no issues")
+}
+
 func TestTreeHtmlRenderer_MultiRoot_FolderNodes_Rendered(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	renderer, err := NewTreeHtmlRenderer(engine.GetLogger())

--- a/js-tests/tree-runtime.test.mjs
+++ b/js-tests/tree-runtime.test.mjs
@@ -13,12 +13,13 @@ async function loadRuntimeScript() {
   return readFile(scriptPath, "utf8");
 }
 
-function buildHtml({ totalIssues, nodesHtml, runtimeScript, filterToolbar = "" }) {
+function buildHtml({ totalIssues, nodesHtml, runtimeScript, filterToolbar = "", searchBar = "" }) {
   return `<!doctype html>
 <html>
   <head><meta charset="utf-8"></head>
   <body>
     ${filterToolbar}
+    ${searchBar}
     <div class="tree-container" id="treeContainer" data-total-issues="${String(totalIssues)}">
       ${nodesHtml}
     </div>
@@ -27,21 +28,34 @@ function buildHtml({ totalIssues, nodesHtml, runtimeScript, filterToolbar = "" }
 </html>`;
 }
 
+// Mirrors the search toggle + (hidden) search box + no-results element emitted
+// by tree.html when TotalIssues > 0. tree.js finds the elements by id, so their
+// exact position does not matter for tests. The box starts hidden, opened by the
+// toggle — matching the real toolbar affordance.
+function treeSearchHtml() {
+  return `<button type="button" id="treeSearchToggle" class="tree-search-toggle" aria-expanded="false" aria-controls="treeSearch"><svg width="14" height="14" viewBox="0 0 16 16"><circle cx="7" cy="7" r="4.5"/></svg></button>
+  <div class="tree-search" id="treeSearch" hidden>
+    <input type="search" id="treeSearchInput" class="tree-search-input" placeholder="Search files and issues" aria-label="Search files and issues" autocomplete="off" spellcheck="false">
+  </div>
+  <div class="tree-search-empty" id="treeSearchEmpty" hidden>No files or issues match your search.</div>`;
+}
+
 function fileNodeHtml(nodeId = "file-1", opts = {}) {
   const expandedClass = opts.expanded ? " expanded" : "";
+  const label = opts.label || "main.go";
   return `<div class="tree-node tree-node-file${expandedClass}"
       data-node-id="${nodeId}"
       data-file-path="${opts.filePath || "/workspace/main.go"}"
       data-product="${opts.product || "oss"}">
     <div class="tree-node-row">
       <span class="tree-chevron"></span>
-      <span class="tree-label">main.go</span>
+      <span class="tree-label">${label}</span>
     </div>
     <div class="tree-node-children">${opts.childrenHtml || ""}</div>
   </div>`;
 }
 
-function issueNodeHtml(issueId = "vuln-1") {
+function issueNodeHtml(issueId = "vuln-1", label = "Test Vulnerability") {
   return `<div class="tree-node tree-node-issue" data-node-id="issue-${issueId}">
     <div class="tree-node-row"
          data-file-path="/workspace/main.go"
@@ -51,7 +65,7 @@ function issueNodeHtml(issueId = "vuln-1") {
          data-end-char="20"
          data-issue-id="${issueId}">
       <span class="severity-icon severity-high">H</span>
-      <span class="tree-label">Test Vulnerability</span>
+      <span class="tree-label">${label}</span>
     </div>
   </div>`;
 }
@@ -823,6 +837,417 @@ test("error overlay is dismissed on click outside", async () => {
     null,
     "overlay should be removed after clicking outside"
   );
+});
+
+function typeSearch(dom, value) {
+  const input = dom.window.document.getElementById("treeSearchInput");
+  input.value = value;
+  input.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+}
+
+function twoFileTree() {
+  return productNodeHtml(
+    fileNodeHtml("file-a", {
+      label: "alpha.go",
+      filePath: "/workspace/alpha.go",
+      childrenHtml: issueNodeHtml("v1", "SQL Injection"),
+    }) +
+    fileNodeHtml("file-b", {
+      label: "beta.go",
+      filePath: "/workspace/beta.go",
+      childrenHtml: issueNodeHtml("v2", "Cross-site Scripting"),
+    })
+  );
+}
+
+test("typing a file name hides non-matching file nodes", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  typeSearch(dom, "alpha");
+  await sleep(20);
+
+  const { document } = dom.window;
+  const fileA = document.querySelector('[data-node-id="file-a"]');
+  const fileB = document.querySelector('[data-node-id="file-b"]');
+  assert.ok(!fileA.className.includes("tree-search-hidden"), "matching file should stay visible");
+  assert.ok(fileB.className.includes("tree-search-hidden"), "non-matching file should be hidden");
+});
+
+test("search matches against the full file path, not only the label", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  // "/workspace/beta.go" contains "workspace/beta" but the label "beta.go" does not.
+  typeSearch(dom, "workspace/beta");
+  await sleep(20);
+
+  const { document } = dom.window;
+  assert.ok(document.querySelector('[data-node-id="file-b"]').className.includes("tree-search-hidden") === false, "file matched by path stays visible");
+  assert.ok(document.querySelector('[data-node-id="file-a"]').className.includes("tree-search-hidden"), "other file hidden");
+});
+
+test("search is case-insensitive", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  typeSearch(dom, "ALPHA");
+  await sleep(20);
+
+  const { document } = dom.window;
+  assert.ok(!document.querySelector('[data-node-id="file-a"]').className.includes("tree-search-hidden"), "uppercase query should still match");
+  assert.ok(document.querySelector('[data-node-id="file-b"]').className.includes("tree-search-hidden"), "non-matching file hidden");
+});
+
+test("matching an issue title keeps its ancestor file visible and hides sibling files", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  typeSearch(dom, "cross-site");
+  await sleep(20);
+
+  const { document } = dom.window;
+  const fileA = document.querySelector('[data-node-id="file-a"]');
+  const fileB = document.querySelector('[data-node-id="file-b"]');
+  const issue = document.querySelector('[data-node-id="issue-v2"]');
+  assert.ok(fileB.className.includes("tree-search-hidden") === false, "file containing matching issue stays visible");
+  assert.ok(!issue.className.includes("tree-search-hidden"), "matching issue stays visible");
+  assert.ok(fileA.className.includes("tree-search-hidden"), "file with no matching issue is hidden");
+});
+
+test("search auto-expands ancestors of matches without persisting expand state", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const calls = [];
+  // Product node starts collapsed, file node collapsed too.
+  const collapsedProduct = `<div class="tree-node" data-node-id="product-1">
+    <div class="tree-node-row"><span class="tree-chevron"></span><span class="tree-label">Snyk Open Source</span></div>
+    <div class="tree-node-children">${fileNodeHtml("file-b", { label: "beta.go", filePath: "/workspace/beta.go", childrenHtml: issueNodeHtml("v2", "Cross-site Scripting") })}</div>
+  </div>`;
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 1, nodesHtml: collapsedProduct, runtimeScript, searchBar: treeSearchHtml() }),
+    {
+      runScripts: "dangerously",
+      pretendToBeVisual: true,
+      beforeParse(window) {
+        window.__ideExecuteCommand__ = ideBridge(calls);
+      },
+    }
+  );
+
+  typeSearch(dom, "cross-site");
+  await sleep(20);
+
+  const { document } = dom.window;
+  const product = document.querySelector('[data-node-id="product-1"]');
+  const file = document.querySelector('[data-node-id="file-b"]');
+  assert.ok(product.className.includes("expanded"), "ancestor product should be auto-expanded to reveal the match");
+  assert.ok(file.className.includes("expanded"), "ancestor file should be auto-expanded to reveal the match");
+  const expandCalls = calls.filter((c) => c.cmd === "snyk.setNodeExpanded");
+  assert.equal(expandCalls.length, 0, "search auto-expand must not persist expand state to the LS");
+});
+
+test("clearing the search restores visibility and prior expand state", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const calls = [];
+  const collapsedProduct = `<div class="tree-node" data-node-id="product-1">
+    <div class="tree-node-row"><span class="tree-chevron"></span><span class="tree-label">Snyk Open Source</span></div>
+    <div class="tree-node-children">${fileNodeHtml("file-b", { label: "beta.go", filePath: "/workspace/beta.go", childrenHtml: issueNodeHtml("v2", "Cross-site Scripting") })}</div>
+  </div>`;
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 1, nodesHtml: collapsedProduct, runtimeScript, searchBar: treeSearchHtml() }),
+    {
+      runScripts: "dangerously",
+      pretendToBeVisual: true,
+      beforeParse(window) {
+        window.__ideExecuteCommand__ = ideBridge(calls);
+      },
+    }
+  );
+
+  const { document } = dom.window;
+  const product = document.querySelector('[data-node-id="product-1"]');
+  assert.ok(!product.className.includes("expanded"), "product starts collapsed");
+
+  typeSearch(dom, "cross-site");
+  await sleep(20);
+  assert.ok(product.className.includes("expanded"), "product expanded during search");
+
+  typeSearch(dom, "");
+  await sleep(20);
+
+  assert.ok(!product.className.includes("expanded"), "product returns to its original collapsed state after clearing");
+  const hidden = document.querySelectorAll(".tree-search-hidden");
+  assert.equal(hidden.length, 0, "no nodes remain hidden after clearing the search");
+  const expandCalls = calls.filter((c) => c.cmd === "snyk.setNodeExpanded");
+  assert.equal(expandCalls.length, 0, "restoring expand state must not persist to the LS");
+});
+
+test("switching queries recomputes auto-expansion without leaving stale expands", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const collapsedProduct = `<div class="tree-node" data-node-id="product-1">
+    <div class="tree-node-row"><span class="tree-chevron"></span><span class="tree-label">Snyk Open Source</span></div>
+    <div class="tree-node-children">${
+      fileNodeHtml("file-a", { label: "alpha.go", filePath: "/workspace/alpha.go", childrenHtml: issueNodeHtml("v1", "SQL Injection") }) +
+      fileNodeHtml("file-b", { label: "beta.go", filePath: "/workspace/beta.go", childrenHtml: issueNodeHtml("v2", "Cross-site Scripting") })
+    }</div>
+  </div>`;
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: collapsedProduct, runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+  const { document } = dom.window;
+  const fileA = document.querySelector('[data-node-id="file-a"]');
+  const fileB = document.querySelector('[data-node-id="file-b"]');
+
+  typeSearch(dom, "cross-site");
+  await sleep(20);
+  assert.ok(fileB.className.includes("expanded"), "beta auto-expanded for its matching issue");
+
+  typeSearch(dom, "sql");
+  await sleep(20);
+  assert.ok(fileA.className.includes("expanded"), "alpha auto-expanded for the new query");
+  assert.ok(!fileB.className.includes("expanded"), "beta's stale auto-expand is reverted when the query changes");
+  assert.ok(fileB.className.includes("tree-search-hidden"), "beta hidden for the new query");
+});
+
+test("a manual expand during search is preserved after clearing", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const calls = [];
+  const collapsedProduct = `<div class="tree-node" data-node-id="product-1">
+    <div class="tree-node-row"><span class="tree-chevron"></span><span class="tree-label">Snyk Open Source</span></div>
+    <div class="tree-node-children">${fileNodeHtml("file-b", { label: "beta.go", filePath: "/workspace/beta.go", childrenHtml: issueNodeHtml("v2", "Cross-site Scripting") })}</div>
+  </div>`;
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 1, nodesHtml: collapsedProduct, runtimeScript, searchBar: treeSearchHtml() }),
+    {
+      runScripts: "dangerously",
+      pretendToBeVisual: true,
+      beforeParse(window) {
+        window.__ideExecuteCommand__ = ideBridge(calls);
+      },
+    }
+  );
+  const { document } = dom.window;
+  const product = document.querySelector('[data-node-id="product-1"]');
+  const file = document.querySelector('[data-node-id="file-b"]');
+
+  typeSearch(dom, "beta");
+  await sleep(20);
+  assert.ok(product.className.includes("expanded"), "product auto-expanded to reveal matched file");
+  assert.ok(!file.className.includes("expanded"), "self-matched file is left for the user to open");
+
+  // User manually expands the matched file mid-search.
+  file.querySelector(":scope > .tree-node-row").dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+  assert.ok(file.className.includes("expanded"), "file expanded by manual click");
+
+  typeSearch(dom, "");
+  await sleep(20);
+  assert.ok(!product.className.includes("expanded"), "auto-expanded product collapses back on clear");
+  assert.ok(file.className.includes("expanded"), "manual expand is preserved after clearing the search");
+});
+
+test("a query with no matches shows the no-results message", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  typeSearch(dom, "zzz-nothing-matches");
+  await sleep(20);
+
+  const { document } = dom.window;
+  const empty = document.getElementById("treeSearchEmpty");
+  assert.ok(!empty.hidden, "no-results message should be visible when nothing matches");
+  const visibleTops = Array.from(document.querySelectorAll('#treeContainer > .tree-node'))
+    .filter((n) => !n.className.includes("tree-search-hidden"));
+  assert.equal(visibleTops.length, 0, "all top-level nodes hidden when nothing matches");
+
+  typeSearch(dom, "");
+  await sleep(20);
+  assert.ok(empty.hidden, "no-results message hidden again when the query is cleared");
+});
+
+test("the no-results message stays hidden while there are matches", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  typeSearch(dom, "alpha");
+  await sleep(20);
+
+  const empty = dom.window.document.getElementById("treeSearchEmpty");
+  assert.ok(empty.hidden, "no-results message should be hidden while a match exists");
+});
+
+test("a partial substring matches file paths and issue titles alike", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  // Andrew's example: "ite" should match "cross-site scripting" issues as well as
+  // files whose path contains "website"/"sites".
+  const tree = productNodeHtml(
+    fileNodeHtml("file-login", { label: "login.js", filePath: "/src/website/login/login.js", childrenHtml: issueNodeHtml("i1", "SQL Injection") }) +
+    fileNodeHtml("file-office", { label: "our-office-sites.html", filePath: "/src/website/about/our-office-sites.html", childrenHtml: issueNodeHtml("i2", "Improper Input Validation") }) +
+    fileNodeHtml("file-users", { label: "users.js", filePath: "/src/api/users.js", childrenHtml: issueNodeHtml("i3", "Cross-site Scripting") }) +
+    fileNodeHtml("file-config", { label: "config.go", filePath: "/src/api/config.go", childrenHtml: issueNodeHtml("i4", "Hardcoded Secret") })
+  );
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 4, nodesHtml: tree, runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  typeSearch(dom, "ite");
+  await sleep(20);
+
+  const { document } = dom.window;
+  const hidden = (id) => document.querySelector('[data-node-id="' + id + '"]').className.includes("tree-search-hidden");
+  assert.ok(!hidden("file-login"), "path .../website/... matches 'ite'");
+  assert.ok(!hidden("file-office"), "path .../website/...-sites.html matches 'ite'");
+  assert.ok(!hidden("file-users"), "file kept visible because its issue title 'Cross-site Scripting' matches 'ite'");
+  assert.ok(!document.querySelector('[data-node-id="issue-i3"]').className.includes("tree-search-hidden"), "the matching cross-site issue stays visible");
+  assert.ok(hidden("file-config"), "file with no 'ite' in path/label/issues is hidden");
+});
+
+test("nodes hidden via the hidden attribute never count as matches", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  // A hidden info node whose text would match must not suppress the no-results
+  // message nor become visible.
+  const hiddenInfo = `<div class="tree-node tree-node-info" data-node-id="info-empty" hidden>
+    <div class="tree-node-row tree-node-row-info"><span class="tree-label">no filter matches placeholder</span></div>
+  </div>`;
+  const tree = productNodeHtml(fileNodeHtml("file-a", { label: "alpha.go", filePath: "/w/alpha.go", childrenHtml: issueNodeHtml("v1", "SQL Injection") })) + hiddenInfo;
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 1, nodesHtml: tree, runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  // "placeholder" only appears in the hidden info node.
+  typeSearch(dom, "placeholder");
+  await sleep(20);
+
+  const { document } = dom.window;
+  const info = document.querySelector('[data-node-id="info-empty"]');
+  assert.ok(info.hidden, "hidden node stays hidden");
+  assert.ok(!info.className.includes("tree-search-hidden"), "hidden node is untouched, not force-shown");
+  assert.ok(!document.getElementById("treeSearchEmpty").hidden, "no-results shown: the hidden node did not count as a match");
+});
+
+test("search matches the full pre-truncation label via data-full-label", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  // Simulate the truncation pass having replaced the visible label text while
+  // stashing the full path in data-full-label. The query matches only the full
+  // label (not the visible text nor data-file-path), exercising that fallback.
+  const truncatedFile = `<div class="tree-node tree-node-file expanded" data-node-id="file-trunc" data-file-path="/x/y.js" data-product="code">
+    <div class="tree-node-row">
+      <span class="tree-chevron"></span>
+      <span class="tree-label" data-full-label="/alpha/beta/deep.js">…/deep.js</span>
+    </div>
+    <div class="tree-node-children">${issueNodeHtml("t1", "Some Issue")}</div>
+  </div>`;
+  const tree = productNodeHtml(truncatedFile);
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 1, nodesHtml: tree, runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  typeSearch(dom, "beta");
+  await sleep(20);
+
+  const file = dom.window.document.querySelector('[data-node-id="file-trunc"]');
+  assert.ok(!file.className.includes("tree-search-hidden"), "file matched via its full (pre-truncation) label");
+});
+
+test("search runtime is a no-op when the search input is absent", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  assert.doesNotThrow(() => {
+    // No searchBar passed — tree.js must tolerate a missing input.
+    new JSDOM(
+      buildHtml({ totalIssues: 0, nodesHtml: fileNodeHtml(), runtimeScript }),
+      { runScripts: "dangerously", pretendToBeVisual: true }
+    );
+  }, "tree.js must not throw when there is no search input");
+});
+
+test("the search box is hidden until the toolbar toggle is clicked", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+  const { document } = dom.window;
+  const toggle = document.getElementById("treeSearchToggle");
+  const row = document.getElementById("treeSearch");
+  const input = document.getElementById("treeSearchInput");
+
+  assert.ok(row.hidden, "search box starts hidden");
+  assert.equal(toggle.getAttribute("aria-expanded"), "false", "toggle starts collapsed");
+
+  toggle.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+
+  assert.ok(!row.hidden, "search box is shown after clicking the toggle");
+  assert.equal(toggle.getAttribute("aria-expanded"), "true", "toggle reflects expanded state");
+  assert.equal(document.activeElement, input, "the input is focused when opened");
+});
+
+test("clicking the toggle again hides the box and resets the filter", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+  const { document } = dom.window;
+  const toggle = document.getElementById("treeSearchToggle");
+  const row = document.getElementById("treeSearch");
+  const input = document.getElementById("treeSearchInput");
+  const fileB = document.querySelector('[data-node-id="file-b"]');
+
+  toggle.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+  typeSearch(dom, "alpha");
+  await sleep(20);
+  assert.ok(fileB.className.includes("tree-search-hidden"), "filter is active while searching");
+
+  // Second click: hide + reset.
+  toggle.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+
+  assert.ok(row.hidden, "search box hidden after second toggle click");
+  assert.equal(toggle.getAttribute("aria-expanded"), "false", "toggle collapsed again");
+  assert.equal(input.value, "", "query is cleared on close");
+  assert.equal(document.querySelectorAll(".tree-search-hidden").length, 0, "filter is reset on close");
+});
+
+test("Escape in the search box closes it and resets the filter", async () => {
+  const runtimeScript = await loadRuntimeScript();
+  const dom = new JSDOM(
+    buildHtml({ totalIssues: 2, nodesHtml: twoFileTree(), runtimeScript, searchBar: treeSearchHtml() }),
+    { runScripts: "dangerously", pretendToBeVisual: true }
+  );
+  const { document } = dom.window;
+  const toggle = document.getElementById("treeSearchToggle");
+  const row = document.getElementById("treeSearch");
+  const input = document.getElementById("treeSearchInput");
+
+  toggle.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+  typeSearch(dom, "alpha");
+  await sleep(20);
+
+  input.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+  assert.ok(row.hidden, "Escape hides the search box");
+  assert.equal(input.value, "", "Escape clears the query");
+  assert.equal(document.querySelectorAll(".tree-search-hidden").length, 0, "Escape resets the filter");
 });
 
 test("expand all sends batch setNodeExpanded with all node IDs", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a search capability to the issue tree view, restoring the "search the list of issues" feature users had in the old JetBrains tree.

**Why:** The old JetBrains tree view was built from Swing components, so JetBrains rendered a native `TreeSpeedSearch` box for free. The new tree view is a server-driven HTML panel rendered by snyk-ls, which had no equivalent — a gap raised in developer feedback. Because the new tree is web-native, adding the filter in the shared HTML/JS benefits **every** IDE (VS Code, JetBrains, Visual Studio, Eclipse), not just JetBrains.

**What:** A magnifier **toggle** on the right of the filter toolbar reveals a search box above the tree. The filter is client-side and transient, in `tree.js`, mirroring `TreeSpeedSearch`:

- Matches file nodes on their label **and** full file path, and issue nodes on their title — case-insensitive substring match (e.g. `ser` matches `src/api/users.js`).
- A node stays visible when it matches or any descendant matches; ancestors of a match are auto-expanded so the match is reachable.
- Only the nodes *we* auto-expanded are collapsed again when the query changes or is cleared, so the user's own (LS-persisted) expand/collapse state is never disturbed — even if they toggle a node mid-search.
- Clicking the toggle again (or `Escape` in the field) hides the box and **resets** the filter. Shows a "no results" message when nothing matches. Input is debounced to one pass per animation frame.
- The search field uses the tree/sidebar background so it blends into the panel.

Runs entirely in the webview — **no LS round-trip, no persisted state, no new LSP command, no changes to server-side issue filtering**. The toggle + box only render when there is something to search (`TotalIssues > 0`).

> Note: an earlier revision also added product-filter checkboxes to the funnel popover; that was reverted per team decision (reusing the scanner-enable settings made it an enablement toggle rather than a pure view filter, which was confusing). This PR is now search-only.

Files:
- `domain/ide/treeview/template/tree.html` — `#treeSearchToggle` in the toolbar + hidden `#treeSearch` box + `#treeSearchEmpty`
- `domain/ide/treeview/template/tree.js` — toggle (open/close + reset), recursive filter, auto-expand tracking, no-results toggle (ES5)
- `domain/ide/treeview/template/styles.css` — toggle + search + hidden-node styles
- `domain/ide/treeview/tree_html_test.go`, `js-tests/tree-runtime.test.mjs` — tests
- `docs/tree-view.md` — documentation

### Checklist

- [x] Tests added and all succeed (`make test-js` 155/155 + Go render tests; ES5 lint clean)
- [x] Regenerated mocks, etc. (`make generate` — no diff)
- [x] Linted (`make lint` — 0 issues)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://snyk.slack.com/archives/C0BCMAGSB2B/p1784240426765989?thread_ts=1784240426.765989&cid=C0BCMAGSB2B)

<div><a href="https://cursor.com/agents/bc-5f26d341-276a-56b3-8813-d6a4723e42d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f26d341-276a-56b3-8813-d6a4723e42d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

