### PR TITLE
feat(remediation): pass configured LLM provider/model to remy fix workflow [IDE-2274][IDE-2430]

### DIFF
--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -70,6 +70,12 @@ type bddSteps struct {
 	deltaOssFilePath types.FilePath
 	lastDiagnostics  []types.Diagnostic
 	lastTreeViewHTML string
+
+	savedLlmProvider    string
+	savedLlmModel       string
+	fixCapturedProvider string
+	fixCapturedModel    string
+	fixCommandErr       error
 }
 
 func newBDDSteps(t *testing.T) *bddSteps {
@@ -174,6 +180,12 @@ func (s *bddSteps) register(sc *godog.ScenarioContext) {
 	})
 	sc.Then(`^the configuration dialog contains no field for an LLM API key$`, func() error {
 		return s.runOnScenarioGoroutine(s.theDialogContainsNoLlmApiKeyField)
+	})
+	sc.When(`^the developer asks Snyk to autonomously fix a folder$`, func(ctx context.Context) error {
+		return s.runOnScenarioGoroutine(func() error { return s.theDeveloperAsksSnykToFixAFolder(ctx) })
+	})
+	sc.Then(`^the fix runs with the developer's chosen LLM provider and model$`, func() error {
+		return s.runOnScenarioGoroutine(s.theFixRunsWithTheChosenProviderAndModel)
 	})
 }
 
@@ -410,6 +422,8 @@ func (s *bddSteps) aDeveloperSavesTheLlmProviderAndModel(ctx context.Context, pr
 	if _, err := s.loc.Client.Call(ctx, "workspace/didChangeConfiguration", params); err != nil {
 		return fmt.Errorf("workspace/didChangeConfiguration call failed: %w", err)
 	}
+	s.savedLlmProvider = provider
+	s.savedLlmModel = model
 	return nil
 }
 
@@ -496,6 +510,7 @@ func (s *bddSteps) theDialogContainsNoLlmApiKeyField() error {
 	return nil
 }
 
+<<<<<<< HEAD
 func (s *bddSteps) aWorkspaceFolderIsOpen() error {
 	folderPath := types.FilePath(s.scenarioT.TempDir())
 	initParams := types.InitializeParams{
@@ -956,8 +971,105 @@ func (s *bddSteps) editorNotifiedOfNewAndUnbaselinedIssues() error {
 	return nil
 }
 
-// Test_BDDSteps_PerScenarioCleanup guards against setupServer's t.Cleanup
-// firing once for the whole TestBDD run instead of once per scenario.
+// theDeveloperAsksSnykToFixAFolder drives the real snyk.remediationAgent.fixFolder
+// command end to end: real LSP request -> real command dispatch -> real
+// remyProvider.FixFolder -> real gafRunner -> real buildRemyFixConfig -> a real
+// workflow.Engine invocation. Only the "fix" workflow itself is substituted
+// (IDE-2448: it is an externally-downloaded CLI extension, not a compiled
+// dependency of snyk-ls) - it captures the exact provider/model config keys it
+// receives instead of running an LLM, so this proves CP-2's wiring rather than
+// stubbing out buildRemyFixConfig/gafRunner themselves.
+func (s *bddSteps) theDeveloperAsksSnykToFixAFolder(ctx context.Context) error {
+	if err := s.ensureLspInitialized(ctx); err != nil {
+		return err
+	}
+
+	repoDir, err := createGitRepoForFix(s.scenarioT)
+	if err != nil {
+		return fmt.Errorf("failed to create git repo for fix: %w", err)
+	}
+
+	fixWorkflowID := workflow.NewWorkflowIdentifier("fix")
+	if _, ok := s.engine.GetWorkflow(fixWorkflowID); !ok {
+		flagset := workflow.ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError))
+		callback := func(invocation workflow.InvocationContext, _ []workflow.Data) ([]workflow.Data, error) {
+			s.fixCapturedProvider = invocation.GetConfiguration().GetString("provider")
+			s.fixCapturedModel = invocation.GetConfiguration().GetString("model")
+			return nil, nil
+		}
+		if _, err := s.engine.Register(fixWorkflowID, flagset, callback); err != nil {
+			return fmt.Errorf("failed to register test fix workflow: %w", err)
+		}
+	}
+
+	folderURI := string(uri.PathToUri(types.FilePath(repoDir)))
+	_, callErr := s.loc.Client.Call(ctx, "workspace/executeCommand", sglsp.ExecuteCommandParams{
+		Command:   types.RemediationAgentFixFolderCommand,
+		Arguments: []any{folderURI},
+	})
+	s.fixCommandErr = callErr
+	return nil
+}
+
+func (s *bddSteps) theFixRunsWithTheChosenProviderAndModel() error {
+	if s.fixCommandErr != nil {
+		return fmt.Errorf("snyk.remediationAgent.fixFolder call failed: %w", s.fixCommandErr)
+	}
+	if s.fixCapturedProvider != s.savedLlmProvider {
+		return fmt.Errorf("expected the fix workflow to receive provider %q, got %q", s.savedLlmProvider, s.fixCapturedProvider)
+	}
+	if s.fixCapturedModel != s.savedLlmModel {
+		return fmt.Errorf("expected the fix workflow to receive model %q, got %q", s.savedLlmModel, s.fixCapturedModel)
+	}
+	return nil
+}
+
+// createGitRepoForFix creates a minimal git repo in a temp dir so
+// snyk.remediationAgent.fixFolder's git-repo-root and clean-worktree guards
+// are satisfied. Returns the CANONICAL path (symlinks resolved) so it agrees
+// with what git and the production code resolve.
+func createGitRepoForFix(t *testing.T) (string, error) {
+	t.Helper()
+	dir := t.TempDir()
+	if canonical, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = canonical
+	}
+	run := func(args ...string) error {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git %v: %w (%s)", args, err, out)
+		}
+		return nil
+	}
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"config", "core.checkStat", "minimal"},
+	} {
+		if err := run(args...); err != nil {
+			return "", err
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		return "", err
+	}
+	if err := run("add", "."); err != nil {
+		return "", err
+	}
+	if err := run("commit", "-m", "init"); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// Test_BDDSteps_PerScenarioCleanup proves setupServer's t.Cleanup fires once
+// per scenario (via the sc.Before/sc.After t.Run bridge in beforeScenario/
+// afterScenario), not once for the whole TestBDD run. It drives two
+// scenarios' lifecycles directly against the real bddSteps/setupServer code
+// path and asserts the first scenario's server connection is already closed
+// before the second scenario starts.
 func Test_BDDSteps_PerScenarioCleanup(t *testing.T) {
 	s := newBDDSteps(t)
 	ctx := context.Background()

--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/scanstates"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/domain/snyk/persistence"
+	"github.com/snyk/snyk-ls/domain/snyk/remediation"
 	"github.com/snyk/snyk-ls/domain/snyk/scanner"
 	"github.com/snyk/snyk-ls/infrastructure/authentication"
 	"github.com/snyk/snyk-ls/infrastructure/code"
@@ -310,10 +311,18 @@ func (s *bddSteps) aRunningLanguageServer() error {
 	if !ok {
 		return fmt.Errorf("workspace does not implement snyk.IssueProvider")
 	}
+	// A real FolderRemediator (built the same way application/di/init.go builds
+	// it for production) so snyk.remediationAgent.fixFolder scenarios exercise
+	// the real command -> remyProvider.FixFolder wiring instead of failing with
+	// "remediation agent is not enabled".
+	folderRemediator, ok := remediation.NewRemyProvider(engine, nil).(remediation.FolderRemediator)
+	if !ok {
+		return fmt.Errorf("remediation.NewRemyProvider did not return a FolderRemediator")
+	}
 	command.SetService(command.NewService(
 		engine, engine.GetLogger(), deps.AuthenticationService, deps.FeatureFlagService, deps.Notifier,
 		deps.LearnService, issueProvider, nil, nil, deps.LdxSyncService,
-		deps.ConfigResolver, deps.ScanStateAggregator.StateSnapshot, nil,
+		deps.ConfigResolver, deps.ScanStateAggregator.StateSnapshot, folderRemediator,
 	))
 
 	// Scenarios that save a file through the real didSave pipeline (as opposed to
@@ -510,7 +519,6 @@ func (s *bddSteps) theDialogContainsNoLlmApiKeyField() error {
 	return nil
 }
 
-<<<<<<< HEAD
 func (s *bddSteps) aWorkspaceFolderIsOpen() error {
 	folderPath := types.FilePath(s.scenarioT.TempDir())
 	initParams := types.InitializeParams{

--- a/domain/snyk/remediation/remy.go
+++ b/domain/snyk/remediation/remy.go
@@ -117,6 +117,15 @@ func gafRunner(ctx context.Context, eng workflow.Engine, contentRoot string, _ s
 	return err
 }
 
+// remyProviderConfigKey and remyModelConfigKey match remy-cli-extension's
+// FlagProvider/FlagModel (internal/commands/remyfix/flags.go) — the fix
+// workflow reads the developer's chosen LLM provider/model under these exact
+// keys.
+const (
+	remyProviderConfigKey = "provider"
+	remyModelConfigKey    = "model"
+)
+
 // buildRemyFixConfig clones base and sets the configuration keys that select and
 // drive the fix workflow for contentRoot. It is a pure helper (no engine, no I/O)
 // so the exact config the runner hands to the workflow can be asserted in a unit
@@ -132,6 +141,12 @@ func buildRemyFixConfig(base configuration.Configuration, contentRoot string) co
 	conf.Set("sast", true)
 	conf.Set("experimental", true)
 	conf.Set(configuration.INPUT_DIRECTORY, []string{contentRoot})
+	if provider := types.GetGlobalString(base, types.SettingLlmProvider); provider != "" {
+		conf.Set(remyProviderConfigKey, provider)
+	}
+	if model := types.GetGlobalString(base, types.SettingLlmModel); model != "" {
+		conf.Set(remyModelConfigKey, model)
+	}
 	return conf
 }
 

--- a/domain/snyk/remediation/remy_config_test.go
+++ b/domain/snyk/remediation/remy_config_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/snyk-ls/internal/types"
 )
 
 // TestBuildRemyFixConfig_SelectsSastAgenticFlow is the regression guard for the
@@ -43,4 +45,77 @@ func TestBuildRemyFixConfig_SelectsSastAgenticFlow(t *testing.T) {
 	assert.Equal(t, []string{contentRoot}, conf.GetStringSlice(configuration.INPUT_DIRECTORY),
 		"INPUT_DIRECTORY must be exactly the content root")
 	assert.False(t, conf.IsSet(""), "no empty-string key may be set")
+}
+
+// TestBuildRemyFixConfig_ForwardsPersistedLlmProviderAndModel wires the CP-1
+// persistence primitive (types.SetGlobalUser) to buildRemyFixConfig on a real
+// configuration.Configuration, proving the developer's saved provider/model
+// choice reaches the fix workflow's config under the exact keys
+// remy-cli-extension reads (FlagProvider/FlagModel: "provider"/"model").
+func TestBuildRemyFixConfig_ForwardsPersistedLlmProviderAndModel(t *testing.T) {
+	const contentRoot = "/work/repo-root"
+
+	base := configuration.NewWithOpts()
+	types.SetGlobalUser(base, types.SettingLlmProvider, "ollama")
+	types.SetGlobalUser(base, types.SettingLlmModel, "llama3.1")
+
+	conf := buildRemyFixConfig(base, contentRoot)
+
+	assert.Equal(t, "ollama", conf.GetString("provider"))
+	assert.Equal(t, "llama3.1", conf.GetString("model"))
+}
+
+// TestBuildRemyFixConfig_NoProviderChosen guards the no-forced-default
+// requirement (IDE-2274-M5): a developer who never chose a provider must not
+// have "provider"/"model" keys set at all, matching the empty-string-key
+// discipline the other flags already follow.
+func TestBuildRemyFixConfig_NoProviderChosen(t *testing.T) {
+	conf := buildRemyFixConfig(configuration.NewWithOpts(), "/work/repo-root")
+
+	assert.False(t, conf.IsSet("provider"), "provider must not be set when the developer never chose one")
+	assert.False(t, conf.IsSet("model"), "model must not be set when the developer never chose a provider")
+}
+
+// TestBuildRemyFixConfig_ProviderWithoutModel covers a provider that needs no
+// explicit model (e.g. anthropic/openai): only "provider" is set.
+func TestBuildRemyFixConfig_ProviderWithoutModel(t *testing.T) {
+	base := configuration.NewWithOpts()
+	types.SetGlobalUser(base, types.SettingLlmProvider, "anthropic")
+
+	conf := buildRemyFixConfig(base, "/work/repo-root")
+
+	assert.Equal(t, "anthropic", conf.GetString("provider"))
+	assert.False(t, conf.IsSet("model"), "model must not be set when the developer never chose one")
+}
+
+// TestBuildRemyFixConfig_ModelWithoutProvider covers the (unlikely but
+// possible) case of a persisted model with no provider selected: the model
+// key must still be forwarded on its own, with no invented provider.
+func TestBuildRemyFixConfig_ModelWithoutProvider(t *testing.T) {
+	base := configuration.NewWithOpts()
+	types.SetGlobalUser(base, types.SettingLlmModel, "llama3.1")
+
+	conf := buildRemyFixConfig(base, "/work/repo-root")
+
+	assert.False(t, conf.IsSet("provider"), "provider must not be set when the developer never chose one")
+	assert.Equal(t, "llama3.1", conf.GetString("model"))
+}
+
+// TestBuildRemyFixConfig_ProviderSwitchDoesNotLeakStaleModel guards against a
+// stale model value surviving a provider switch: buildRemyFixConfig must
+// reflect base's CURRENT values on every call, never a value cached from an
+// earlier call on a different base.
+func TestBuildRemyFixConfig_ProviderSwitchDoesNotLeakStaleModel(t *testing.T) {
+	first := configuration.NewWithOpts()
+	types.SetGlobalUser(first, types.SettingLlmProvider, "ollama")
+	types.SetGlobalUser(first, types.SettingLlmModel, "llama3.1")
+	_ = buildRemyFixConfig(first, "/work/repo-root")
+
+	second := configuration.NewWithOpts()
+	types.SetGlobalUser(second, types.SettingLlmProvider, "anthropic")
+
+	conf := buildRemyFixConfig(second, "/work/repo-root")
+
+	assert.Equal(t, "anthropic", conf.GetString("provider"))
+	assert.False(t, conf.IsSet("model"), "switching provider must not leak the previous provider's model")
 }

--- a/features/llm-provider-setting.feature
+++ b/features/llm-provider-setting.feature
@@ -1,9 +1,8 @@
 Feature: Choose the LLM provider used by autonomous remediation
   A developer can tell the Snyk Remediation Agent which LLM backend to use,
   and optionally point it at a self-hosted endpoint, from the existing Snyk
-  configuration dialog. This feature file covers CP-1 only: the setting
-  exists, persists, and is reflected back in the dialog. It does not cover
-  whether autonomous remediation actually uses the choice (CP-2).
+  configuration dialog. The setting exists, persists, is reflected back in
+  the dialog, and is actually used by autonomous remediation when it runs.
 
   # maps: IDE-2274-M1, IDE-2274-M2
   Scenario: The chosen provider and endpoint survive reopening the dialog
@@ -31,3 +30,10 @@ Feature: Choose the LLM provider used by autonomous remediation
     When a developer saves "ollama" as the LLM provider with model "llama3.1"
     And the developer reopens the Snyk configuration dialog
     Then the configuration dialog shows "llama3.1" as the selected LLM model
+
+  # maps: IDE-2274-CP-2
+  Scenario: An autonomous fix run uses the developer's chosen LLM provider and model
+    Given a running language server
+    When a developer saves "ollama" as the LLM provider with model "llama3.1"
+    And the developer asks Snyk to autonomously fix a folder
+    Then the fix runs with the developer's chosen LLM provider and model


### PR DESCRIPTION
### **User description**
## Summary

CP-2 of IDE-2274. Stacked on #1401 (CP-1: settings-only, persists `llm_provider`/`llm_base_url`/`llm_model`).

CP-1 persisted the developer's chosen LLM provider/model but never wired them into an actual Remy fix invocation — `buildRemyFixConfig` (`domain/snyk/remediation/remy.go`) had no idea the settings existed. This closes that gap:

- `buildRemyFixConfig` now reads `llm_provider`/`llm_model` off the shared GAF configuration (`types.GetGlobalString`) and, when non-empty, sets them on the cloned fix-workflow config under the literal keys `"provider"`/`"model"` — verified against remy-cli-extension's actual `FlagProvider`/`FlagModel` constants (read-only reference check against `internal/commands/remyfix/flags.go`; that repo is never modified from here).
- Empty/unset values are never forced onto the config, matching the existing no-forced-default discipline for `sast`/`agentic` (IDE-2274-M5).
- `llm_base_url` needs no change — CP-1's env-var mechanism (`ANTHROPIC_BASE_URL`/`VERTEX_BASE_URL`/`LITELLM_BASE_URL`/`OLLAMA_HOST`) already covers it end to end.
- The LLM API key is untouched: it still comes only from the fix process's own inherited environment, never from snyk-ls config.

## Tests (outside-in TDD, all confirmed RED before GREEN)

- **Acceptance** (`features/llm-provider-setting.feature` + `application/server/bdd_steps_test.go`): new scenario "An autonomous fix run uses the developer's chosen LLM provider and model" drives the real path — real LSP `workspace/executeCommand("snyk.remediationAgent.fixFolder")` → real command dispatch → real `remyProvider.FixFolder` → real `gafRunner` → real `buildRemyFixConfig` → a real `workflow.Engine.Invoke`. Only the externally-downloaded `"fix"` workflow itself is substituted with a config-capturing callback (pre-approved, tracked gap: IDE-2448) — the config-plumbing code this ticket adds is fully exercised for real.
- **Integration** (`domain/snyk/remediation/remy_config_test.go`): wires the real CP-1 persistence primitive (`types.SetGlobalUser`) to a real `buildRemyFixConfig` call on a real `configuration.Configuration`.
- **Unit**: no-provider-chosen, provider-without-model, model-without-provider, provider-switch-no-stale-leak.

## Verification

- `go build ./...`, `go vet ./...`, `GOOS=windows go build ./...` — clean
- `go test -race` on touched + dependent packages — pass, zero regressions
- `make test` (full whole-tree suite) — pass
- `make test -run TestBDD` — 6/6 scenarios pass
- `golangci-lint run` — 0 issues
- `snyk code test` — 0 issues

## Test plan

- [x] New `.feature` scenario is RED before the production change, GREEN after
- [x] Integration test wires real persistence + real config assembly, no fakes
- [x] Unit edge cases for unset/partial/switched provider-model
- [x] Whole-tree build + vet + Windows cross-compile
- [x] Full `make test` suite, zero regressions
- [x] Lint clean


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Integrate LLM settings with Remy fix workflow.

- Pass configured LLM provider/model to remediation.

- Enhance BDD tests for end-to-end validation.

- Add unit tests for configuration forwarding.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Settings (LLM Provider/Model)"] --> B("buildRemyFixConfig");
  B --> C("Workflow Configuration (provider/model)");
  C --> D("workflow.Engine.Invoke('fix')");
  D --> E("BDD Test Verification");
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bdd_steps_test.go</strong><dd><code>BDD test infrastructure for LLM remediation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/server/bdd_steps_test.go

<ul><li>Adds new BDD steps for triggering and verifying the fix command with <br>LLM settings.<br> <li> Wires a real <code>FolderRemediator</code> into the command service.<br> <li> Introduces variables to capture LLM provider/model used in fix <br>commands.<br> <li> Adds helper function <code>createGitRepoForFix</code> for BDD tests.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1402/changes#diff-5fcf20b0c028ab75ebe77c10364d1656a95f054114f46d6a34e4b9057048c693">+123/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>remy_config_test.go</strong><dd><code>Unit tests for LLM provider/model config forwarding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/snyk/remediation/remy_config_test.go

<ul><li>Adds unit tests for <code>buildRemyFixConfig</code> regarding LLM settings.<br> <li> Verifies correct forwarding of LLM provider/model, including edge <br>cases like no provider chosen.<br> <li> Ensures settings are passed under the expected keys (<code>provider</code>, <code>model</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1402/changes#diff-e85d72f83c8cd6e545da4d1e71f158b9dfe6a7e6dac9cba34170ba471118079e">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>llm-provider-setting.feature</strong><dd><code>End-to-end BDD scenario for LLM remediation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

features/llm-provider-setting.feature

<ul><li>Adds a new BDD scenario to test the end-to-end flow of using the <br>chosen LLM provider/model for an autonomous fix.<br> <li> Updates the feature description to reflect that settings are now used <br>by remediation.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1402/changes#diff-98c2a71aa153dfaf4cbcba8123ebe1040fb5bcb542ec877091ba3ece5163b5b9">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remy.go</strong><dd><code>Integrate LLM settings into Remy fix workflow config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

domain/snyk/remediation/remy.go

<ul><li>Modifies <code>buildRemyFixConfig</code> to read and forward LLM provider/model <br>settings.<br> <li> Defines constants <code>remyProviderConfigKey</code> and <code>remyModelConfigKey</code> for LLM <br>settings.<br> <li> Forwards settings to the fix workflow configuration if they are <br>non-empty.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1402/changes#diff-3ad54b822be438a8117c900dfa6cdcf87b84569bfb85139751524795371d6274">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

