### PR TITLE
feat(server): expose structured Code AI Fix result via $/snyk.aiFix [IDE-2451]

### DIFF
--- a/application/server/bdd_lint_test.go
+++ b/application/server/bdd_lint_test.go
@@ -11,7 +11,7 @@ import (
 
 // trackedFeatureRequirements is a manually-maintained ratchet: extend it alongside
 // each new feature file so it can't silently drift from real coverage.
-var trackedFeatureRequirements = []string{"M1", "M2", "IDE-2418-M2", "IDE-2418-M3", "IDE-2418-M4", "IDE-2418-M5", "IDE-2418-M6", "IDE-2418-M7", "IDE-2274-M1", "IDE-2274-M2", "IDE-2274-M4", "IDE-2274-M5"}
+var trackedFeatureRequirements = []string{"M1", "M2", "IDE-2418-M2", "IDE-2418-M3", "IDE-2418-M4", "IDE-2418-M5", "IDE-2418-M6", "IDE-2418-M7", "IDE-2274-M1", "IDE-2274-M2", "IDE-2274-M4", "IDE-2274-M5", "IDE-2451-M1"}
 
 func Test_FeatureFiles_MapEveryRequirement(t *testing.T) {
 	scenarios, err := parseFeatureDir("../../features")

--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -35,6 +35,9 @@ import (
 	"github.com/snyk/snyk-ls/infrastructure/authentication"
 	"github.com/snyk/snyk-ls/infrastructure/code"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/infrastructure/snyk_api"
+	"github.com/snyk/snyk-ls/internal/observability/error_reporting"
+	"github.com/snyk/snyk-ls/internal/observability/performance"
 	"github.com/snyk/snyk-ls/internal/product"
 	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
@@ -113,6 +116,15 @@ func (s *bddSteps) register(sc *godog.ScenarioContext) {
 	})
 	sc.Then(`^the editor is notified of the security issue$`, func() error {
 		return s.runOnScenarioGoroutine(s.editorIsNotifiedOfTheSecurityIssue)
+	})
+	sc.Given(`^the developer has a Code issue found by Snyk$`, func() error {
+		return s.runOnScenarioGoroutine(s.developerHasACodeIssueFoundBySnyk)
+	})
+	sc.When(`^the developer asks Snyk to fix the issue with AI$`, func(ctx context.Context) error {
+		return s.runOnScenarioGoroutine(func() error { return s.theDeveloperAsksSnykToFixTheIssueWithAi(ctx) })
+	})
+	sc.Then(`^the editor receives a structured AI fix result for the issue$`, func() error {
+		return s.runOnScenarioGoroutine(s.theEditorReceivesAStructuredAiFixResultForTheIssue)
 	})
 	sc.When(`^the editor asks for diagnostics for the whole workspace$`, func(ctx context.Context) error {
 		return s.runOnScenarioGoroutine(func() error { return s.editorAsksForWorkspaceDiagnostics(ctx) })
@@ -305,7 +317,8 @@ func (s *bddSteps) aRunningLanguageServer() error {
 	// (nil, nil) for every command - so workspace/executeCommand(snyk.getTreeView)
 	// never reaches the real getTreeViewCommand. Swap in the real service, now that
 	// deps (and the workspace registered via config.SetWorkspace) are available.
-	issueProvider, ok := config.GetWorkspace(engine.GetConfiguration()).(snyk.IssueProvider)
+	realWorkspace := config.GetWorkspace(engine.GetConfiguration())
+	issueProvider, ok := realWorkspace.(snyk.IssueProvider)
 	if !ok {
 		return fmt.Errorf("workspace does not implement snyk.IssueProvider")
 	}
@@ -317,13 +330,30 @@ func (s *bddSteps) aRunningLanguageServer() error {
 	if !ok {
 		return fmt.Errorf("remediation.NewRemyProvider did not return a FolderRemediator")
 	}
+	// A real *code.Scanner (built the same way domain/ide/command/code_fix_diffs_test.go
+	// builds one) so snyk.code.fixDiffs scenarios exercise the real command ->
+	// AiFixHandler -> GetAutofixDiffs wiring instead of failing on a nil scanner.
+	codeErrorReporter := code.NewCodeErrorReporter(error_reporting.NewTestErrorReporter(engine))
+	fixDiffsCodeScanner := code.New(
+		engine, performance.NewInstrumentor(), &snyk_api.FakeApiClient{CodeEnabled: true}, codeErrorReporter, nil,
+		baseDeps.FeatureFlagService, baseDeps.Notifier, code.NewCodeInstrumentor(), codeErrorReporter,
+		code.NewFakeCodeScannerClient, resolver, testutil.NewDrainedProgressTracker(),
+	)
 	baseDeps.CommandService = command.NewService(
 		engine, engine.GetLogger(), baseDeps.AuthenticationService, baseDeps.FeatureFlagService, baseDeps.Notifier,
-		baseDeps.LearnService, issueProvider, nil, nil, baseDeps.LdxSyncService,
+		baseDeps.LearnService, issueProvider, fixDiffsCodeScanner, nil, baseDeps.LdxSyncService,
 		baseDeps.ConfigResolver, baseDeps.ScanStateAggregator.StateSnapshot, folderRemediator, baseDeps.ScanCtx,
 	)
 
 	loc, jsonRPCRecorder, deps := setupServer(s.scenarioT, engine, tokenService, WithDeps(baseDeps))
+	// setupServer's own di.TestInit call unconditionally builds and registers a
+	// second, empty workspace (config.SetWorkspace has no override option), which
+	// would silently orphan the issueProvider baked into baseDeps.CommandService
+	// above. Nothing has added a folder yet at this point, so restoring
+	// realWorkspace here is safe and keeps every later config.GetWorkspace call
+	// (folder registration, and the CommandService's own issue lookups)
+	// consistent with the same workspace instance.
+	config.SetWorkspace(engine.GetConfiguration(), realWorkspace)
 	s.engine = engine
 	s.loc = loc
 	s.jsonRPCRecorder = jsonRPCRecorder
@@ -694,6 +724,73 @@ func (s *bddSteps) editorIsNotifiedOfTheSecurityIssue() error {
 	return nil
 }
 
+// theDeveloperAsksSnykToFixTheIssueWithAi drives the real snyk.code.fixDiffs command end
+// to end: real LSP request -> real command dispatch -> the real codeFixDiffs command ->
+// the real AiFixHandler state machine -> the real Notifier. GetAutofixDiffs is driven to
+// its deterministic, network-free error branch (no bundle hash registered for the issue's
+// content root), the same way domain/ide/command/code_fix_diffs_test.go's
+// Test_codeFixDiffs_Execute_SendsAiFixNotification does, so the scenario is fast and
+// reliable without a real Code Scanner backend.
+func (s *bddSteps) theDeveloperAsksSnykToFixTheIssueWithAi(ctx context.Context) error {
+	s.scenarioT.Cleanup(code.ResetHTMLRenderer)
+
+	diagnostics, found := s.awaitPublishedDiagnostics(s.deltaFilePath)
+	if !found || len(diagnostics) == 0 {
+		return fmt.Errorf("expected the editor to have been notified of the security issue, got no diagnostics published for %s", s.deltaFilePath)
+	}
+	// Diagnostic.Data.Id carries the same occurrence-unique key
+	// (AdditionalData.Key) that the workspace's IssueProvider looks issues up
+	// by (see Folder.Issue) - so the fix command must be addressed by that key.
+	issueID := diagnostics[0].Data.Id
+	if issueID == "" {
+		return fmt.Errorf("expected the scanned issue's diagnostic to carry a non-empty id, got none")
+	}
+
+	s.jsonRPCRecorder.ClearNotifications()
+	if _, err := s.loc.Client.Call(ctx, "workspace/executeCommand", sglsp.ExecuteCommandParams{
+		Command:   types.CodeFixDiffsCommand,
+		Arguments: []any{issueID},
+	}); err != nil {
+		return fmt.Errorf("workspace/executeCommand(%s) call failed: %w", types.CodeFixDiffsCommand, err)
+	}
+	return nil
+}
+
+// waitForAiFixNotification polls for the $/snyk.aiFix notification the codeFixDiffs
+// command sends once its (synchronous, in this deterministic-error scenario) background
+// fix attempt finishes.
+func (s *bddSteps) waitForAiFixNotification() (types.AiFixNotification, error) {
+	var aiFix types.AiFixNotification
+	found := s.awaitCondition(func() bool {
+		notifications := s.jsonRPCRecorder.FindNotificationsByMethod("$/snyk.aiFix")
+		if len(notifications) == 0 {
+			return false
+		}
+		return notifications[len(notifications)-1].UnmarshalParams(&aiFix) == nil
+	})
+	if !found {
+		return types.AiFixNotification{}, fmt.Errorf("no $/snyk.aiFix notification received within timeout")
+	}
+	return aiFix, nil
+}
+
+func (s *bddSteps) theEditorReceivesAStructuredAiFixResultForTheIssue() error {
+	aiFix, err := s.waitForAiFixNotification()
+	if err != nil {
+		return err
+	}
+	if aiFix.IssueId == "" {
+		return fmt.Errorf("expected the $/snyk.aiFix notification to identify the issue, got an empty issue id")
+	}
+	if aiFix.Status == "" {
+		return fmt.Errorf("expected the $/snyk.aiFix notification to carry a fix status, got an empty status")
+	}
+	if aiFix.Fixes == nil {
+		return fmt.Errorf("expected the $/snyk.aiFix notification to carry a fix results list, got none")
+	}
+	return nil
+}
+
 // awaitCondition polls condition until it returns true or 5 seconds elapse.
 // It never calls t.Fatal/FailNow - callers turn a timeout into their own
 // descriptive error, so a failing scenario reports what was actually wrong
@@ -886,6 +983,32 @@ func (s *bddSteps) developerSavesFileWithNewIssueAlongsideKnown() error {
 	}
 	return s.runScanWithFakeScanner(&bddFakeScanner{scans: []types.ScanData{
 		{Product: product.ProductCode, Issues: []types.Issue{newIssue, knownIssue}},
+	}})
+}
+
+// developerHasACodeIssueFoundBySnyk seeds a real Code issue into a real Folder via the
+// existing fake-scanner harness (runScanWithFakeScanner/bddFakeScanner) rather than driving
+// the real Code scanner's full didSave pipeline: that pipeline's background
+// reference-branch scan (DelegatingConcurrentScanner.Scan's scanBaseBranch) races the
+// freshly-cached issue and can clear it before this scenario's fix command runs, since
+// code.TempWorkdirWithIssues's throwaway git repo has no commits for the base scan to
+// check out.
+func (s *bddSteps) developerHasACodeIssueFoundBySnyk() error {
+	fileDir := types.FilePath(s.scenarioT.TempDir())
+	filePath := types.FilePath(filepath.Join(string(fileDir), "app.go"))
+	s.deltaFileDir = fileDir
+	s.deltaFilePath = filePath
+
+	issue := &snyk.Issue{
+		ID:               "code-issue-ai-fix",
+		AffectedFilePath: filePath,
+		Severity:         types.High,
+		Product:          product.ProductCode,
+		Message:          "a code security issue",
+		AdditionalData:   snyk.CodeIssueData{Key: "key-ai-fix"},
+	}
+	return s.runScanWithFakeScanner(&bddFakeScanner{scans: []types.ScanData{
+		{Product: product.ProductCode, Issues: []types.Issue{issue}},
 	}})
 }
 

--- a/application/server/notification.go
+++ b/application/server/notification.go
@@ -144,6 +144,9 @@ func registerNotifier(conf configuration.Configuration, engine workflow.Engine, 
 		case types.SnykRegisterMcpParams:
 			notifyClient(logger, srv, "$/snyk.registerMcp", params)
 			l.Debug().Interface("mcpConfig", params).Msg("sending MCP config to client")
+		case types.AiFixNotification:
+			notifyClient(logger, srv, "$/snyk.aiFix", params)
+			l.Debug().Str("issueId", params.IssueId).Str("status", params.Status).Msg("sending AI fix status to client")
 		default:
 			l.Warn().
 				Interface("params", params).

--- a/application/server/notification_test.go
+++ b/application/server/notification_test.go
@@ -267,6 +267,42 @@ func Test_IsAvailableCliNotification(t *testing.T) {
 	)
 }
 
+func Test_AiFixNotification(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	loc, jsonRPCRecorder, deps := setupServer(t, engine, tokenService)
+
+	_, err := loc.Client.Call(t.Context(), "initialize", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expected = types.AiFixNotification{
+		IssueId: "issue-1",
+		Status:  "SUCCESS",
+		Fixes:   []types.AiFixResult{{FixId: "fix-1", FilePath: "main.go"}},
+	}
+	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
+	deps.Notifier.Send(expected)
+	assert.Eventually(
+		t,
+		func() bool {
+			notifications := jsonRPCRecorder.FindNotificationsByMethod("$/snyk.aiFix")
+			if len(notifications) < 1 {
+				return false
+			}
+			for _, n := range notifications {
+				var actual = types.AiFixNotification{}
+				_ = n.UnmarshalParams(&actual)
+				if reflect.DeepEqual(expected, actual) {
+					return true
+				}
+			}
+			return false
+		},
+		2*time.Second,
+		time.Millisecond,
+	)
+}
+
 func TestShowMessageRequest(t *testing.T) {
 	t.Run("should send request to client", func(t *testing.T) {
 		engine, tokenService := testutil.UnitTestWithEngine(t)

--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -19,7 +19,9 @@ package command
 import (
 	"context"
 	"errors"
+	"sort"
 
+	"github.com/snyk/code-client-go/llm"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
@@ -78,7 +80,10 @@ func (cmd *codeFixDiffs) handleResponse(ctx context.Context, engine workflow.Eng
 	logger := engine.GetLogger().With().Str("method", "codeFixDiffs.handleResponse").Logger()
 	aiFixHandler := htmlRenderer.AiFixHandler
 
-	setStateCallback := func() { SendShowDocumentRequest(ctx, logger, issue, cmd.srv) }
+	setStateCallback := func() {
+		SendShowDocumentRequest(ctx, logger, issue, cmd.srv)
+		cmd.sendAiFixNotification(aiFixHandler, issue)
+	}
 
 	aiFixHandler.SetAiFixDiffState(code.AiFixInProgress, nil, nil, setStateCallback)
 
@@ -95,4 +100,28 @@ func (cmd *codeFixDiffs) handleResponse(ctx context.Context, engine workflow.Eng
 	}
 	aiFixHandler.EnrichWithExplain(ctx, engine, issue, suggestions)
 	aiFixHandler.SetAiFixDiffState(code.AiFixSuccess, suggestions, nil, setStateCallback)
+}
+
+func (cmd *codeFixDiffs) sendAiFixNotification(aiFixHandler *code.AiFixHandler, issue types.Issue) {
+	cmd.notifier.Send(types.AiFixNotification{
+		IssueId: code.IssueId(issue),
+		Status:  string(aiFixHandler.GetAiFixDiffStatus()),
+		Fixes:   aiFixResultsFrom(aiFixHandler.GetAiFixDiffResult()),
+	})
+}
+
+func aiFixResultsFrom(suggestions []llm.AutofixUnifiedDiffSuggestion) []types.AiFixResult {
+	sort.Slice(suggestions, func(i, j int) bool { return suggestions[i].FixId < suggestions[j].FixId })
+	fixes := make([]types.AiFixResult, 0, len(suggestions))
+	for _, suggestion := range suggestions {
+		filePaths := make([]string, 0, len(suggestion.UnifiedDiffsPerFile))
+		for filePath := range suggestion.UnifiedDiffsPerFile {
+			filePaths = append(filePaths, filePath)
+		}
+		sort.Strings(filePaths)
+		for _, filePath := range filePaths {
+			fixes = append(fixes, types.AiFixResult{FixId: suggestion.FixId, FilePath: filePath})
+		}
+	}
+	return fixes
 }

--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -19,7 +19,9 @@ package command
 import (
 	"context"
 	"errors"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/snyk/code-client-go/llm"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -111,7 +113,11 @@ func (cmd *codeFixDiffs) sendAiFixNotification(aiFixHandler *code.AiFixHandler, 
 }
 
 func aiFixResultsFrom(suggestions []llm.AutofixUnifiedDiffSuggestion) []types.AiFixResult {
-	sort.Slice(suggestions, func(i, j int) bool { return suggestions[i].FixId < suggestions[j].FixId })
+	// Clone before sorting: GetAiFixDiffResult returns AiFixHandler's internal slice, and sorting it
+	// in place would race with concurrent readers such as AiFixHandler.GetResults.
+	suggestions = slices.SortedFunc(slices.Values(suggestions), func(a, b llm.AutofixUnifiedDiffSuggestion) int {
+		return strings.Compare(a.FixId, b.FixId)
+	})
 	fixes := make([]types.AiFixResult, 0, len(suggestions))
 	for _, suggestion := range suggestions {
 		filePaths := make([]string, 0, len(suggestion.UnifiedDiffsPerFile))

--- a/domain/ide/command/code_fix_diffs_test.go
+++ b/domain/ide/command/code_fix_diffs_test.go
@@ -18,10 +18,14 @@ package command
 
 import (
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"github.com/snyk/code-client-go/llm"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk"
@@ -87,5 +91,95 @@ func Test_codeFixDiffs_Execute(t *testing.T) {
 
 		require.Emptyf(t, suggestions, "suggestions should be empty")
 		require.Error(t, err)
+	})
+}
+
+// Test_codeFixDiffs_Execute_SendsAiFixNotification proves that triggering a fix diff via the
+// real production entrypoint (Execute -> handleResponse -> the real AiFixHandler state machine)
+// results in a $/snyk.aiFix notification being sent on the real Notifier, with a payload that
+// reflects the real AiFixHandler state. GetAutofixDiffs is driven to its deterministic,
+// network-free error branch (no bundle hash registered for the issue's content root).
+func Test_codeFixDiffs_Execute_SendsAiFixNotification(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	t.Cleanup(code.ResetHTMLRenderer)
+	ctrl := gomock.NewController(t)
+	server := mock_types.NewMockServer(ctrl)
+	server.EXPECT().Callback(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	instrumentor := performance.NewInstrumentor()
+	snykApiClient := &snyk_api.FakeApiClient{CodeEnabled: true}
+	codeErrorReporter := code.NewCodeErrorReporter(error_reporting.NewTestErrorReporter(engine))
+	codeScanner := code.New(engine, instrumentor, snykApiClient, codeErrorReporter, nil, featureflag.NewFakeService(), notification.NewNotifier(), code.NewCodeInstrumentor(), codeErrorReporter, code.NewFakeCodeScannerClient, testutil.DefaultConfigResolver(engine), testutil.NewDrainedProgressTracker())
+
+	realNotifier := notification.NewNotifier()
+	var mu sync.Mutex
+	var received []types.AiFixNotification
+	realNotifier.CreateListener(func(params any) {
+		aiFix, ok := params.(types.AiFixNotification)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, aiFix)
+	})
+	t.Cleanup(realNotifier.DisposeListener)
+
+	issueProvider := mock_snyk.NewMockIssueProvider(ctrl)
+	issueKey := uuid.NewString()
+	issue := snyk.Issue{
+		ID:             uuid.NewString(),
+		AdditionalData: snyk.CodeIssueData{Key: issueKey},
+	}
+	issueProvider.EXPECT().Issue(gomock.Any()).Return(&issue)
+
+	cut := codeFixDiffs{
+		notifier:           realNotifier,
+		codeScanner:        codeScanner,
+		engine:             engine,
+		srv:                server,
+		featureFlagService: featureflag.NewFakeService(),
+		issueProvider:      issueProvider,
+		command:            types.CommandData{Arguments: []any{issue.ID}},
+	}
+
+	_, err := cut.Execute(t.Context())
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, n := range received {
+			if n.IssueId == issueKey && n.Status == string(code.AiFixError) {
+				return len(n.Fixes) == 0
+			}
+		}
+		return false
+	}, 2*time.Second, time.Millisecond, "expected a $/snyk.aiFix ERROR notification for issue key %s", issueKey)
+}
+
+func Test_aiFixResultsFrom(t *testing.T) {
+	t.Run("no suggestions yields no fixes", func(t *testing.T) {
+		assert.Empty(t, aiFixResultsFrom(nil))
+	})
+
+	t.Run("single suggestion with a single file", func(t *testing.T) {
+		suggestions := []llm.AutofixUnifiedDiffSuggestion{
+			{FixId: "fix-1", UnifiedDiffsPerFile: map[string]string{"main.go": "diff"}},
+		}
+
+		assert.Equal(t, []types.AiFixResult{{FixId: "fix-1", FilePath: "main.go"}}, aiFixResultsFrom(suggestions))
+	})
+
+	t.Run("multiple suggestions, one spanning multiple files, sorted deterministically", func(t *testing.T) {
+		suggestions := []llm.AutofixUnifiedDiffSuggestion{
+			{FixId: "fix-1", UnifiedDiffsPerFile: map[string]string{"b.go": "diff-b", "a.go": "diff-a"}},
+			{FixId: "fix-2", UnifiedDiffsPerFile: map[string]string{"c.go": "diff-c"}},
+		}
+
+		assert.Equal(t, []types.AiFixResult{
+			{FixId: "fix-1", FilePath: "a.go"},
+			{FixId: "fix-1", FilePath: "b.go"},
+			{FixId: "fix-2", FilePath: "c.go"},
+		}, aiFixResultsFrom(suggestions))
 	})
 }

--- a/features/ai-fix-notification.feature
+++ b/features/ai-fix-notification.feature
@@ -1,0 +1,14 @@
+Feature: Structured Code AI Fix result notification
+
+  A developer running Code AI Fix on an issue needs to know, in the IDE, what
+  happened to that fix attempt - which issue it was for, whether it succeeded,
+  and which fixes were produced - without the IDE having to scrape an HTML
+  panel to find out.
+
+  # maps: IDE-2451-M1
+  Scenario: A developer running Code AI Fix on an issue gets a structured fix result notification
+    Given a running language server
+    And the editor sends the initialize request
+    And the developer has a Code issue found by Snyk
+    When the developer asks Snyk to fix the issue with AI
+    Then the editor receives a structured AI fix result for the issue

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -210,7 +210,7 @@ func issueTitle(issue types.Issue) string {
 	return issue.GetID()
 }
 
-func issueId(issue types.Issue) string {
+func IssueId(issue types.Issue) string {
 	if issue.GetAdditionalData() == nil {
 		return issue.GetID()
 	}
@@ -230,7 +230,7 @@ func SnykMagnetUri(issue types.Issue, ideAction string) (string, error) {
 	u := &url.URL{
 		Scheme:   "snyk",
 		Path:     string(issue.GetAffectedFilePath()),
-		RawQuery: fmt.Sprintf("product=%s&issueId=%s&action=%s", url.QueryEscape(string(issue.GetProduct())), url.QueryEscape(issueId(issue)), ideAction),
+		RawQuery: fmt.Sprintf("product=%s&issueId=%s&action=%s", url.QueryEscape(string(issue.GetProduct())), url.QueryEscape(IssueId(issue)), ideAction),
 	}
 
 	return u.String(), nil

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -233,7 +233,7 @@ func TestIssueId(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := issueId(tc.issue)
+			result := IssueId(tc.issue)
 			if result != tc.expected {
 				t.Errorf("Expected %s, got %s", tc.expected, result)
 			}

--- a/internal/types/lsp.go
+++ b/internal/types/lsp.go
@@ -669,6 +669,21 @@ type ScanSummary struct {
 	ScanSummary string `json:"scanSummary"`
 }
 
+// AiFixResult identifies one computed fix suggestion for a single file.
+type AiFixResult struct {
+	FixId    string `json:"fixId"`
+	FilePath string `json:"filePath"`
+}
+
+// AiFixNotification is the payload for the $/snyk.aiFix notification, sent whenever
+// a single-issue Code AI Fix's diff computation state changes, so clients can obtain
+// structured fixId/filePath data without scraping the window/showDocument HTML payload.
+type AiFixNotification struct {
+	IssueId string        `json:"issueId"`
+	Status  string        `json:"status"`
+	Fixes   []AiFixResult `json:"fixes"`
+}
+
 type ProgressToken string
 
 type ProgressParams struct {


### PR DESCRIPTION
## Summary
- Adds `types.AiFixNotification` / `types.AiFixResult` DTOs and a new `$/snyk.aiFix` case in `registerNotifier` (`application/server/notification.go`), following the exact existing pattern used for `$/snyk.scan`, `$/snyk.scanSummary`, and `$/snyk.treeView`.
- Emits the notification from the existing `setStateCallback` seam in `domain/ide/command/code_fix_diffs.go`, alongside (not instead of) the existing `SendShowDocumentRequest` call, whenever the real `AiFixHandler` state machine transitions (`AiFixInProgress` / `AiFixSuccess` / `AiFixError`).
- Payload is `{issueId, status, fixes: [{fixId, filePath}]}`, built from `AiFixHandler`'s real `AiStatus` and `[]llm.AutofixUnifiedDiffSuggestion` results via a new pure `aiFixResultsFrom` helper (one `AiFixResult` per file per suggestion, sorted for determinism).
- Purely additive: `fixDiffs`'s fire-and-forget contract, the `showDocument` request/webview behavior, and all other `$/snyk.*` wire formats are unchanged.

## Test plan
- [x] Integration test on the real notifier plane (`application/server/notification_test.go`, `Test_AiFixNotification`) — real `di.Notifier()`, real `registerNotifier`, real JSON-RPC harness; confirmed RED before the `registerNotifier` case existed.
- [x] Integration test through the real production entrypoint (`domain/ide/command/code_fix_diffs_test.go`, `Test_codeFixDiffs_Execute_SendsAiFixNotification`) — real `Execute()` → `handleResponse()` → real `AiFixHandler` + real `Notifier`, driven to the deterministic network-free ERROR path (no bundle hash registered); confirmed RED before the wiring existed.
- [x] Unit tests for the pure `aiFixResultsFrom` payload helper (no suggestions, single file, multiple suggestions spanning multiple files) — `Test_aiFixResultsFrom`.
- [x] `go build ./...` and `go vet ./...` clean (whole tree)
- [x] `GOOS=windows go build ./...` clean
- [x] `go test -race ./...` clean (full repo, no regressions)
- [x] `make lint` (golangci-lint) — 0 issues
- [x] Snyk Code and Snyk SCA scans — clean (no new issues, no new vulnerable dependencies)