### PR TITLE
refactor: read consistent ignores from the folder config the scan holds

### DIFF
--- a/infrastructure/code/code.go
+++ b/infrastructure/code/code.go
@@ -291,7 +291,7 @@ func internalScan(ctx context.Context, sc *Scanner, folderPath types.FilePath, l
 		return []types.Issue{}, nil
 	}
 
-	codeConsistentIgnoresEnabled := sc.featureFlagService.GetFromFolderConfig(folderPath, featureflag.SnykCodeConsistentIgnores)
+	codeConsistentIgnoresEnabled := folderConfig.GetFeatureFlag(featureflag.SnykCodeConsistentIgnores)
 	results, err = sc.UploadAndAnalyze(ctx, folderPath, folderConfig, files, filesToBeScanned, codeConsistentIgnoresEnabled, t)
 
 	return results, err

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -369,8 +369,17 @@ func Test_Scan(t *testing.T) {
 			mockEngine.EXPECT().GetLogger().Return(engine.GetLogger()).AnyTimes()
 
 			fakeFeatureFlagService := featureflag.NewFakeService()
-			fakeFeatureFlagService.Flags[featureflag.SnykCodeConsistentIgnores] = tc.cciEnabled
 			fakeFeatureFlagService.SastSettings = &sast_contract.SastResponse{SastEnabled: true}
+
+			var codeScannerClient *FakeCodeScannerClient
+			codeScannerFactory := func(sc *Scanner, folderConfig *types.FolderConfig) (codeClient.CodeScanner, error) {
+				client, err := NewFakeCodeScannerClient(sc, folderConfig)
+				if err != nil {
+					return nil, err
+				}
+				codeScannerClient, _ = client.(*FakeCodeScannerClient)
+				return client, nil
+			}
 
 			scanner := New(
 				mockEngine,
@@ -382,16 +391,23 @@ func Test_Scan(t *testing.T) {
 				notification.NewNotifier(),
 				NewCodeInstrumentor(),
 				newTestCodeErrorReporter(),
-				NewFakeCodeScannerClient,
+				codeScannerFactory,
 				defaultResolver(mockEngine),
 				testutil.NewDrainedProgressTracker(),
 			)
 			tempDir, _, _ := setupIgnoreWorkspace(t)
 
-			ctx := ctx2.NewContextWithFolderConfig(t.Context(), getTestFolderConfig(mockEngine, tempDir))
+			folderConfig := getTestFolderConfig(mockEngine, tempDir)
+			folderConfig.SetFeatureFlag(featureflag.SnykCodeConsistentIgnores, tc.cciEnabled)
+
+			ctx := ctx2.NewContextWithFolderConfig(t.Context(), folderConfig)
 			issues, err := scanner.Scan(ctx, "")
 			assert.Nil(t, err)
 			assert.NotNil(t, issues)
+
+			require.NotNil(t, codeScannerClient, "the scan must have built a code scanner")
+			assert.Equal(t, tc.createBundleCalled, codeScannerClient.LegacyUploadWasCalled,
+				"the consistent ignores flag on the folder config decides which upload path the scan takes")
 		})
 	}
 }

--- a/infrastructure/code/fake_code_client_scanner.go
+++ b/infrastructure/code/fake_code_client_scanner.go
@@ -34,6 +34,7 @@ import (
 
 type FakeCodeScannerClient struct {
 	UploadAndAnalyzeWasCalled bool
+	LegacyUploadWasCalled     bool   // Records which of the two upload paths the scan took
 	Organization              string // Captures the org the scanner was created with
 }
 
@@ -424,6 +425,7 @@ func (f *FakeCodeScannerClient) UploadAndAnalyzeLegacy(
 	statusChannel chan<- scan.LegacyScanStatus,
 ) (*codeClientSarif.SarifResponse, string, error) {
 	defer close(statusChannel)
+	f.LegacyUploadWasCalled = true
 	return f.UploadAndAnalyze(ctx, requestId, target, files, changedFiles)
 }
 


### PR DESCRIPTION
### Description

A Snyk Code scan resolved the consistent ignores feature flag by folder path while already holding that folder's config. Resolving by path builds a second folder config: a go-git enrichment of the repository and a write back to storage, for a value the config in hand already answers.

`Scan` cannot reach this point without a folder config — `ResolveFolderAndScanType` fails first with `ErrFolderConfigNotInContext`, and the folder path it returns comes from that same config — so both forms read the same key on the same configuration, and the flag value is unchanged.

`Test_Scan` listed the expected upload path per case in its table and never asserted it, so forcing the flag either way left the suite green. The fake code scanner now records which of the two upload paths ran and the cases assert it, which is what pins the flag to the folder config it is staged on. Mutation-checked: forcing the flag on fails the legacy case, forcing it off fails the consistent ignores case.

Independent of the CLI-1721 gitignore filtering stack, which makes the same move for the two file filter flags.

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced