### PR TITLE
refactor: log delta pre-filter before/after counts in FilterIssues [IDE-2477]

### DIFF
--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -792,7 +792,7 @@ func (f *Folder) filterIssuesWithConfig(
 
 	if len(filterReasonCounts) > 0 {
 		logger.Debug().
-			Interface("filterReasons", filterReasonCounts).
+			Any("filterReasons", filterReasonCounts).
 			Bool("deltaEnabled", deltaEnabled).
 			Msgf("%d issue(s) filtered", lo.Sum(lo.Values(filterReasonCounts)))
 	} else {

--- a/domain/ide/workspace/folder.go
+++ b/domain/ide/workspace/folder.go
@@ -620,7 +620,8 @@ func (f *Folder) FilterAndPublishDiagnostics(p product.Product) {
 // Issues are enriched with IsNew at scan time via enrichCachedIssuesWithDelta
 func (f *Folder) GetDelta(p product.Product) snyk.IssuesByFile {
 	issueByFile := f.IssuesByProduct()[p]
-	return filterByIsNew(issueByFile)
+	filtered, _ := filterByIsNew(issueByFile)
+	return filtered
 }
 
 // enrichCachedIssuesWithDelta runs the delta computation once and stamps IsNew on cached issue pointers in-place.
@@ -683,16 +684,23 @@ func getFlatIssueList(issueByFile snyk.IssuesByFile) []types.Issue {
 	return currentFlatIssueList
 }
 
-func filterByIsNew(issues snyk.IssuesByFile) snyk.IssuesByFile {
+// filterByIsNew returns only new issues, plus how many were dropped
+func filterByIsNew(issues snyk.IssuesByFile) (snyk.IssuesByFile, int) {
 	filtered := snyk.IssuesByFile{}
+	dropped := 0
 	for path, issueSlice := range issues {
 		for _, issue := range issueSlice {
-			if issue != nil && issue.GetIsNew() {
+			if issue == nil {
+				continue
+			}
+			if issue.GetIsNew() {
 				filtered[path] = append(filtered[path], issue)
+			} else {
+				dropped++
 			}
 		}
 	}
-	return filtered
+	return filtered, dropped
 }
 
 func (f *Folder) filterDiagnostics(issues snyk.IssuesByFile) snyk.IssuesByFile {
@@ -707,6 +715,7 @@ type FilterReason string
 
 const (
 	FilterReasonNotFiltered      FilterReason = ""
+	FilterReasonNotNetNew        FilterReason = "not net new (delta filtering)"
 	FilterReasonUnsupportedType  FilterReason = "unsupported issue type"
 	FilterReasonSeverity         FilterReason = "severity filter"
 	FilterReasonRiskScore        FilterReason = "risk score threshold"
@@ -755,8 +764,13 @@ func (f *Folder) filterIssuesWithConfig(
 	filteredIssues := snyk.IssuesByFile{}
 	filterReasonCounts := make(map[FilterReason]int)
 
-	if f.isDeltaFindingsEnabledForFolder(folderConfig) {
-		issues = filterByIsNew(issues)
+	deltaEnabled := f.isDeltaFindingsEnabledForFolder(folderConfig)
+	if deltaEnabled {
+		var droppedNotNetNew int
+		issues, droppedNotNetNew = filterByIsNew(issues)
+		if droppedNotNetNew > 0 {
+			filterReasonCounts[FilterReasonNotNetNew] = droppedNotNetNew
+		}
 	}
 
 	fCtx := f.buildFilterContext(folderConfig)
@@ -777,9 +791,14 @@ func (f *Folder) filterIssuesWithConfig(
 	}
 
 	if len(filterReasonCounts) > 0 {
-		logger.Debug().Interface("filterReasons", filterReasonCounts).Msgf("%d issue(s) filtered", lo.Sum(lo.Values(filterReasonCounts)))
+		logger.Debug().
+			Interface("filterReasons", filterReasonCounts).
+			Bool("deltaEnabled", deltaEnabled).
+			Msgf("%d issue(s) filtered", lo.Sum(lo.Values(filterReasonCounts)))
 	} else {
-		logger.Debug().Msg("No issues were filtered out")
+		logger.Debug().
+			Bool("deltaEnabled", deltaEnabled).
+			Msg("No issues were filtered out")
 	}
 
 	return filteredIssues

--- a/domain/ide/workspace/folder_test.go
+++ b/domain/ide/workspace/folder_test.go
@@ -765,6 +765,62 @@ func Test_FilterIssues_CombinedFiltering(t *testing.T) {
 	assert.NotContains(t, filteredIssues[filePath], ignoredIssue, "Ignored issue should be filtered (issue view options)")
 }
 
+// Test_FilterIssues_DeltaDisabled_KeepsNonNewIssue verifies a non-new issue still reaches
+// diagnostics when delta filtering is disabled.
+func Test_FilterIssues_DeltaDisabled_KeepsNonNewIssue(t *testing.T) {
+	engine := testutil.UnitTest(t)
+
+	folderPath := types.FilePath(t.TempDir())
+	resolver := defaultResolver(engine)
+	folderConfig := &types.FolderConfig{
+		FolderPath:     folderPath,
+		ConfigResolver: resolver,
+	}
+
+	sc := scanner.NewTestScanner()
+	folder := NewFolder(engine.GetConfiguration(), engine.GetLogger(), folderPath, "test-folder", sc, hover.NewFakeHoverService(), scanner.NewMockScanNotifier(), notification.NewMockNotifier(), persistence.NewNopScanPersister(), scanstates.NewNoopStateAggregator(), featureflag.NewFakeService(), resolver, engine)
+
+	filePath := types.FilePath(filepath.Join(string(folderPath), "test.go"))
+	notNewIssue := &snyk.Issue{
+		ID:               "not-new",
+		AffectedFilePath: filePath,
+		Severity:         types.High,
+		Product:          product.ProductOpenSource,
+		IsNew:            false,
+	}
+	issuesByFile := snyk.IssuesByFile{filePath: {notNewIssue}}
+	supportedIssueTypes := map[product.FilterableIssueType]bool{
+		product.FilterableIssueTypeOpenSource: true,
+	}
+
+	engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingScanNetNew), false)
+
+	filtered := folder.filterIssuesWithConfig(issuesByFile, supportedIssueTypes, folderConfig)
+
+	assert.Contains(t, filtered[filePath], notNewIssue, "the issue must pass through when delta filtering is disabled")
+}
+
+func Test_filterByIsNew(t *testing.T) {
+	filePath := types.FilePath("/test/test.go")
+
+	newIssue := &snyk.Issue{ID: "new", IsNew: true}
+	oldIssue := &snyk.Issue{ID: "old", IsNew: false}
+
+	t.Run("returns only new issues and counts the rest as dropped", func(t *testing.T) {
+		filtered, dropped := filterByIsNew(snyk.IssuesByFile{filePath: {newIssue, oldIssue}})
+
+		assert.Equal(t, []types.Issue{newIssue}, filtered[filePath])
+		assert.Equal(t, 1, dropped)
+	})
+
+	t.Run("nil issues are skipped without being counted as dropped", func(t *testing.T) {
+		filtered, dropped := filterByIsNew(snyk.IssuesByFile{filePath: {newIssue, nil, oldIssue}})
+
+		assert.Equal(t, []types.Issue{newIssue}, filtered[filePath])
+		assert.Equal(t, 1, dropped, "a nil entry must not be counted as a not-net-new drop")
+	})
+}
+
 func Test_ClearDiagnosticsByIssueType(t *testing.T) {
 	// Arrange
 	engine := testutil.UnitTest(t)


### PR DESCRIPTION
### Description

`filterIssuesWithConfig` applies a delta pre-filter (`filterByIsNew`) ahead of its reason-counted filter loop, so an issue set emptied there produced no distinguishing log line — a debug log could show "No issues were filtered out" while diagnostics came out empty, with no way to tell why.

Folds the drop count into the existing `filterReasonCounts` mechanism via a new `FilterReasonNotNetNew` reason, computed only when delta filtering is enabled. `filterByIsNew` now classifies and counts dropped issues in the same pass it filters them (returning `(snyk.IssuesByFile, int)`) rather than diffing two separate before/after counts; nil entries are skipped without being counted as a drop. `GetDelta`, `filterByIsNew`'s other caller, discards the count. Both `filterReasonCounts` log lines now also carry a `deltaEnabled` field.

Also adds direct coverage for `filterByIsNew`'s filtered/dropped return values (including the nil-skip case), and for the previously-untested direction of `FilterIssues` where a non-new issue passes through when delta filtering is disabled.

### Checklist

- [x] Tests added and all succeed
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing (not user-facing)
- [ ] License file updated, if new 3rd-party dependency is introduced (no new dependencies)