### PR TITLE
fix: materialize base branch worktree directly [IDE-2473]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ brain/
 .verify-oracle-scope.txt
 .verify-oracle.pid
 .verify-lang-skill
+.verify-lang-go-marker
 .verify-chunk-diff
 .verify-triage.json
 .verify-source-map.json

--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,6 @@ brain/
 .verify-oracle-scope.txt
 .verify-oracle.pid
 .verify-lang-skill
-.verify-lang-go-marker
 .verify-chunk-diff
 .verify-triage.json
 .verify-source-map.json

--- a/application/di/init_fix_folder_test.go
+++ b/application/di/init_fix_folder_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/snyk/remediation"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -119,7 +120,7 @@ func initGitRepoForDI(t *testing.T) string {
 	dir := t.TempDir()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))

--- a/application/di/test_init.go
+++ b/application/di/test_init.go
@@ -63,12 +63,8 @@ import (
 //   - types.SetGlobalSystemDefault — stores into the per-engine configuration.
 //
 //nolint:gocyclo // high branching is inherent: one nil-check per overrideable dependency
-func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenService, overrideDeps *Dependencies, opts ...TestOption) Dependencies {
+func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenService, overrideDeps *Dependencies) Dependencies {
 	t.Helper()
-	var options testOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
 	gafConfiguration := engine.GetConfiguration()
 	types.SetGlobalSystemDefault(gafConfiguration, types.SettingCliPath, filepath.Join(t.TempDir(), "fake-cli"))
 
@@ -165,11 +161,7 @@ func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenServ
 	localSnykCodeScanner := code.New(engine, localInstrumentor, localSnykApiClient, localCodeErrorReporter, localLearnService, localFeatureFlagService, localNotifier, localCodeInstrumentor, localCodeErrorReporter, code.NewFakeCodeScannerClient, localConfigResolver, localProgressTracker)
 	localOpenSourceScanner := oss.NewCLIScanner(engine, localInstrumentor, localErrorReporter, localSnykCli, localLearnService, localNotifier, localConfigResolver, localProgressTracker)
 	localIaCScanner := iac.New(gafConfiguration, logger, localInstrumentor, localErrorReporter, localSnykCli, localConfigResolver, localProgressTracker)
-	productScanners := []types.ProductScanner{localSnykCodeScanner, localIaCScanner, localOpenSourceScanner}
-	if len(options.productScanners) > 0 {
-		productScanners = options.productScanners
-	}
-	localScanner := scanner2.NewDelegatingScanner(engine, tokenService, localScanInitializer, localInstrumentor, localScanNotifier, localSnykApiClient, localAuthenticationService, localNotifier, localScanPersister, localScanStateAggregator, localConfigResolver, productScanners...)
+	localScanner := scanner2.NewDelegatingScanner(engine, tokenService, localScanInitializer, localInstrumentor, localScanNotifier, localSnykApiClient, localAuthenticationService, localNotifier, localScanPersister, localScanStateAggregator, localConfigResolver, localSnykCodeScanner, localIaCScanner, localOpenSourceScanner)
 
 	var localHoverService hover.Service
 	if overrideDeps != nil && overrideDeps.HoverService != nil {
@@ -230,20 +222,4 @@ func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenServ
 		ScanCtx:               localScanCtx,
 		ScanCancel:            localScanCancel,
 	}
-}
-
-// TestOption customizes what TestInit builds. Variadic so existing callers are
-// unaffected.
-type TestOption func(*testOptions)
-
-type testOptions struct {
-	productScanners []types.ProductScanner
-}
-
-// WithProductScanners replaces the product scanners the delegating scanner is
-// built from. It exists so a test can substitute the Snyk API surface at
-// startup while leaving the real scanner, folder and registration assembly in
-// place, rather than hand-building a folder and reaching around registration.
-func WithProductScanners(scanners ...types.ProductScanner) TestOption {
-	return func(o *testOptions) { o.productScanners = scanners }
 }

--- a/application/di/test_init.go
+++ b/application/di/test_init.go
@@ -63,8 +63,12 @@ import (
 //   - types.SetGlobalSystemDefault — stores into the per-engine configuration.
 //
 //nolint:gocyclo // high branching is inherent: one nil-check per overrideable dependency
-func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenService, overrideDeps *Dependencies) Dependencies {
+func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenService, overrideDeps *Dependencies, opts ...TestOption) Dependencies {
 	t.Helper()
+	var options testOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	gafConfiguration := engine.GetConfiguration()
 	types.SetGlobalSystemDefault(gafConfiguration, types.SettingCliPath, filepath.Join(t.TempDir(), "fake-cli"))
 
@@ -161,7 +165,11 @@ func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenServ
 	localSnykCodeScanner := code.New(engine, localInstrumentor, localSnykApiClient, localCodeErrorReporter, localLearnService, localFeatureFlagService, localNotifier, localCodeInstrumentor, localCodeErrorReporter, code.NewFakeCodeScannerClient, localConfigResolver, localProgressTracker)
 	localOpenSourceScanner := oss.NewCLIScanner(engine, localInstrumentor, localErrorReporter, localSnykCli, localLearnService, localNotifier, localConfigResolver, localProgressTracker)
 	localIaCScanner := iac.New(gafConfiguration, logger, localInstrumentor, localErrorReporter, localSnykCli, localConfigResolver, localProgressTracker)
-	localScanner := scanner2.NewDelegatingScanner(engine, tokenService, localScanInitializer, localInstrumentor, localScanNotifier, localSnykApiClient, localAuthenticationService, localNotifier, localScanPersister, localScanStateAggregator, localConfigResolver, localSnykCodeScanner, localIaCScanner, localOpenSourceScanner)
+	productScanners := []types.ProductScanner{localSnykCodeScanner, localIaCScanner, localOpenSourceScanner}
+	if len(options.productScanners) > 0 {
+		productScanners = options.productScanners
+	}
+	localScanner := scanner2.NewDelegatingScanner(engine, tokenService, localScanInitializer, localInstrumentor, localScanNotifier, localSnykApiClient, localAuthenticationService, localNotifier, localScanPersister, localScanStateAggregator, localConfigResolver, productScanners...)
 
 	var localHoverService hover.Service
 	if overrideDeps != nil && overrideDeps.HoverService != nil {
@@ -222,4 +230,20 @@ func TestInit(t *testing.T, engine workflow.Engine, tokenService types.TokenServ
 		ScanCtx:               localScanCtx,
 		ScanCancel:            localScanCancel,
 	}
+}
+
+// TestOption customizes what TestInit builds. Variadic so existing callers are
+// unaffected.
+type TestOption func(*testOptions)
+
+type testOptions struct {
+	productScanners []types.ProductScanner
+}
+
+// WithProductScanners replaces the product scanners the delegating scanner is
+// built from. It exists so a test can substitute the Snyk API surface at
+// startup while leaving the real scanner, folder and registration assembly in
+// place, rather than hand-building a folder and reaching around registration.
+func WithProductScanners(scanners ...types.ProductScanner) TestOption {
+	return func(o *testOptions) { o.productScanners = scanners }
 }

--- a/application/server/bdd_lint_test.go
+++ b/application/server/bdd_lint_test.go
@@ -11,7 +11,7 @@ import (
 
 // trackedFeatureRequirements is a manually-maintained ratchet: extend it alongside
 // each new feature file so it can't silently drift from real coverage.
-var trackedFeatureRequirements = []string{"M1", "M2", "IDE-2418-M2", "IDE-2418-M3", "IDE-2418-M4", "IDE-2418-M5", "IDE-2418-M6", "IDE-2418-M7", "IDE-2274-M1", "IDE-2274-M2", "IDE-2274-M4", "IDE-2274-M5", "IDE-2451-M1"}
+var trackedFeatureRequirements = []string{"M1", "M2", "IDE-2418-M2", "IDE-2418-M3", "IDE-2418-M4", "IDE-2418-M5", "IDE-2418-M6", "IDE-2418-M7", "IDE-2274-M1", "IDE-2274-M2", "IDE-2274-M4", "IDE-2274-M5", "IDE-2451-M1", "IDE-2473-M1"}
 
 func Test_FeatureFiles_MapEveryRequirement(t *testing.T) {
 	scenarios, err := parseFeatureDir("../../features")

--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -1447,7 +1447,7 @@ func createGitRepoForFix(t *testing.T) (string, error) {
 		dir = canonical
 	}
 	run := func(args ...string) error {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("git %v: %w (%s)", args, err, out)

--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -4,17 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/creachadair/jrpc2/server"
 	"github.com/cucumber/godog"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
@@ -59,6 +64,7 @@ type bddSteps struct {
 	stepResult   chan error
 
 	engine              workflow.Engine
+	tokenService        types.TokenService
 	loc                 server.Local
 	jsonRPCRecorder     *testsupport.JsonRPCRecorder
 	deps                di.Dependencies
@@ -75,6 +81,9 @@ type bddSteps struct {
 	deltaOssFilePath types.FilePath
 	lastDiagnostics  []types.Diagnostic
 	lastTreeViewHTML string
+	// expectedNewIssueCode is the diagnostic code editorNotifiedOfOnlyNewIssue
+	// requires; scenarios set it to the finding they deliberately introduced.
+	expectedNewIssueCode string
 
 	savedLlmProvider    string
 	savedLlmModel       string
@@ -92,7 +101,12 @@ func (s *bddSteps) register(sc *godog.ScenarioContext) {
 	sc.Before(s.beforeScenario)
 	sc.After(s.afterScenario)
 	sc.Given(`^a running language server$`, func() error {
-		return s.runOnScenarioGoroutine(s.aRunningLanguageServer)
+		return s.runOnScenarioGoroutine(func() error { return s.startLanguageServer() })
+	})
+	sc.Given(`^a running language server that finds one issue in every source file$`, func() error {
+		return s.runOnScenarioGoroutine(func() error {
+			return s.startLanguageServer(WithProductScanners(bddPerFileScanner{}))
+		})
 	})
 	// Step, not When: this step is reused as "And" (inheriting Given) in the
 	// delta-fail-open scenarios, and Given/When/Then in godog match only their
@@ -158,6 +172,12 @@ func (s *bddSteps) register(sc *godog.ScenarioContext) {
 	})
 	sc.Then(`^the editor is notified of both the newly introduced "([^"]*)" issue and the "([^"]*)" issue$`, func(product1, product2 string) error {
 		return s.runOnScenarioGoroutine(func() error { return s.editorNotifiedOfBothProductIssues(product1, product2) })
+	})
+	sc.Given(`^the developer opens a repository whose base branch carries a file named after a Windows device$`, func() error {
+		return s.runOnScenarioGoroutine(s.developerOpensRepositoryWithDeviceFileNameOnBaseBranch)
+	})
+	sc.When(`^the developer scans the whole repository$`, func(ctx context.Context) error {
+		return s.runOnScenarioGoroutine(func() error { return s.developerScansTheWholeRepository(ctx) })
 	})
 	sc.Given(`^a workspace folder is open$`, func() error {
 		return s.runOnScenarioGoroutine(s.aWorkspaceFolderIsOpen)
@@ -290,7 +310,7 @@ func (s *bddSteps) runOnScenarioGoroutine(fn func() error) error {
 	}
 }
 
-func (s *bddSteps) aRunningLanguageServer() error {
+func (s *bddSteps) startLanguageServer(serverOpts ...ServerTestOption) error {
 	engine, tokenService := testutil.UnitTestWithEngine(s.scenarioT)
 	// A real GitPersistenceProvider (rather than the NopScanPersister default) so
 	// baseline-availability scenarios can exercise ErrBaselineDoesntExist and Add()
@@ -345,7 +365,7 @@ func (s *bddSteps) aRunningLanguageServer() error {
 		baseDeps.ConfigResolver, baseDeps.ScanStateAggregator.StateSnapshot, folderRemediator, baseDeps.ScanCtx,
 	)
 
-	loc, jsonRPCRecorder, deps := setupServer(s.scenarioT, engine, tokenService, WithDeps(baseDeps))
+	loc, jsonRPCRecorder, deps := setupServer(s.scenarioT, engine, tokenService, append([]ServerTestOption{WithDeps(baseDeps)}, serverOpts...)...)
 	// setupServer's own di.TestInit call unconditionally builds and registers a
 	// second, empty workspace (config.SetWorkspace has no override option), which
 	// would silently orphan the issueProvider baked into baseDeps.CommandService
@@ -355,6 +375,7 @@ func (s *bddSteps) aRunningLanguageServer() error {
 	// consistent with the same workspace instance.
 	config.SetWorkspace(engine.GetConfiguration(), realWorkspace)
 	s.engine = engine
+	s.tokenService = tokenService
 	s.loc = loc
 	s.jsonRPCRecorder = jsonRPCRecorder
 	s.deps = deps
@@ -550,6 +571,157 @@ func (s *bddSteps) theDialogShowsNoLlmProviderSelected() error {
 func (s *bddSteps) theDialogContainsNoLlmApiKeyField() error {
 	if strings.Contains(strings.ToLower(s.dialogHTML), "llm_api_key") {
 		return fmt.Errorf("configuration dialog must never contain an LLM API key field")
+	}
+	return nil
+}
+
+// developerOpensRepositoryWithDeviceFileNameOnBaseBranch builds the customer's
+// repository: master carries the reserved device name plus a file with an
+// already-known finding, and the checked-out feature branch drops the reserved
+// name and adds a file with a new finding. Nothing writes a reserved device
+// name to disk, so this runs on every platform.
+func (s *bddSteps) developerOpensRepositoryWithDeviceFileNameOnBaseBranch() error {
+	repoPath := s.newScenarioRepoPath()
+	repo := testutil.InitGitRepo(s.scenarioT, repoPath)
+	storer := repo.Storer
+
+	knownBlob := testutil.WriteGitBlob(s.scenarioT, storer, bddDummySource)
+	buildTree := testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
+		{Name: "prn.sh", Mode: filemode.Regular, Hash: testutil.WriteGitBlob(s.scenarioT, storer, bddBuildScriptSource)},
+	})
+	scriptsTree := testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
+		{Name: "build", Mode: filemode.Dir, Hash: buildTree},
+	})
+	masterCommit := testutil.CommitGitTree(s.scenarioT, repo, testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
+		{Name: bddKnownFindingFile, Mode: filemode.Regular, Hash: knownBlob},
+		{Name: "scripts", Mode: filemode.Dir, Hash: scriptsTree},
+	}))
+
+	featureTree := testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
+		{Name: bddKnownFindingFile, Mode: filemode.Regular, Hash: knownBlob},
+		{Name: bddNewFindingFile, Mode: filemode.Regular, Hash: testutil.WriteGitBlob(s.scenarioT, storer, bddDummySource)},
+	})
+	testutil.CommitGitTreeOnBranch(s.scenarioT, repo, plumbing.NewBranchReferenceName("feature"), featureTree, masterCommit)
+
+	// Checking out the feature branch is just writing its two files.
+	for _, name := range []string{bddKnownFindingFile, bddNewFindingFile} {
+		if err := writeScenarioFile(repoPath, name, bddDummySource); err != nil {
+			return err
+		}
+	}
+
+	s.deltaFileDir = repoPath
+	s.deltaFilePath = types.FilePath(filepath.Join(string(repoPath), bddNewFindingFile))
+	s.expectedNewIssueCode = bddNewFindingFile
+	return s.openScenarioRepo(repoPath)
+}
+
+const (
+	bddDummySource       = "public class Dummy {}\n"
+	bddBuildScriptSource = "#!/bin/sh\necho build\n"
+	// One finding per source file, named after it, so the delta between the base
+	// branch and the working tree is exactly the file the feature branch added.
+	bddKnownFindingFile = "Known.java"
+	bddNewFindingFile   = "New.java"
+)
+
+// bddPerFileScanner reports one finding per .java file it finds under the path
+// it is handed. Only the product scanner is substituted: the real
+// DelegatingConcurrentScanner still clones the base branch and diffs against it,
+// which is the code this scenario exists to exercise.
+type bddPerFileScanner struct{}
+
+func (bddPerFileScanner) Product() product.Product { return product.ProductCode }
+
+func (bddPerFileScanner) IsEnabledForFolder(*types.FolderConfig) bool { return true }
+
+func (bddPerFileScanner) Scan(_ context.Context, pathToScan types.FilePath) ([]types.Issue, error) {
+	var issues []types.Issue
+	err := filepath.WalkDir(string(pathToScan), func(p string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || filepath.Ext(p) != code.FakeFileExtension {
+			return nil //nolint:nilerr // an unreadable entry is simply not a finding
+		}
+		issues = append(issues, &snyk.Issue{
+			ID:               filepath.Base(p),
+			AffectedFilePath: types.FilePath(p),
+			ContentRoot:      pathToScan,
+			Severity:         types.High,
+			Product:          product.ProductCode,
+			Message:          "finding in " + filepath.Base(p),
+			AdditionalData:   snyk.CodeIssueData{Key: "key-" + filepath.Base(p)},
+		})
+		return nil
+	})
+	return issues, err
+}
+
+func (s *bddSteps) newScenarioRepoPath() types.FilePath {
+	repoPath := types.FilePath(s.scenarioT.TempDir())
+	if canonical, err := filepath.EvalSymlinks(string(repoPath)); err == nil {
+		repoPath = types.FilePath(canonical)
+	}
+	return repoPath
+}
+
+func writeScenarioFile(repoPath types.FilePath, name, content string) error {
+	onDisk := filepath.Join(string(repoPath), filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(onDisk), 0o755); err != nil {
+		return fmt.Errorf("creating %s failed: %w", filepath.Dir(onDisk), err)
+	}
+	if err := os.WriteFile(onDisk, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("writing %s failed: %w", onDisk, err)
+	}
+	return nil
+}
+
+// openScenarioRepo opens repoPath the way an editor does: initialize carrying
+// the workspace folder, initialized, then the base branch over the settings
+// channel. The server builds the folder and its scanner itself, so registration
+// (including the persister's cache directory) runs for real.
+func (s *bddSteps) openScenarioRepo(repoPath types.FilePath) error {
+	ctx := s.scenarioT.Context()
+	initParams := types.InitializeParams{
+		WorkspaceFolders: []types.WorkspaceFolder{
+			{Uri: uri.PathToUri(repoPath), Name: "bdd-device-name-repo"},
+		},
+	}
+	if _, err := s.loc.Client.Call(ctx, "initialize", initParams); err != nil {
+		return fmt.Errorf("initialize call failed: %w", err)
+	}
+	// Simulates an org policy locking auto-scan off, so the scan this scenario
+	// triggers explicitly is the only one running.
+	disableAutoScan(s.scenarioT, s.engine.GetConfiguration())
+	if _, err := s.loc.Client.Call(ctx, "initialized", types.InitializedParams{}); err != nil {
+		return fmt.Errorf("initialized call failed: %w", err)
+	}
+	types.WaitForLspInitialized(s.engine.GetConfiguration())
+
+	settings := types.DidChangeConfigurationParams{
+		Settings: types.LspConfigurationParam{
+			FolderConfigs: []types.LspFolderConfig{
+				{
+					FolderPath: repoPath,
+					Settings: map[string]*types.ConfigSetting{
+						types.SettingBaseBranch:      {Value: "master", Changed: true},
+						types.SettingReferenceBranch: {Value: "master", Changed: true},
+					},
+				},
+			},
+		},
+	}
+	if _, err := s.loc.Client.Call(ctx, "workspace/didChangeConfiguration", settings); err != nil {
+		return fmt.Errorf("workspace/didChangeConfiguration call failed: %w", err)
+	}
+
+	s.folderPath = repoPath
+	return nil
+}
+
+func (s *bddSteps) developerScansTheWholeRepository(ctx context.Context) error {
+	if _, err := s.loc.Client.Call(ctx, "workspace/executeCommand", sglsp.ExecuteCommandParams{
+		Command: types.WorkspaceScanCommand,
+	}); err != nil {
+		return fmt.Errorf("workspace/executeCommand(%s) call failed: %w", types.WorkspaceScanCommand, err)
 	}
 	return nil
 }
@@ -973,6 +1145,7 @@ func (s *bddSteps) developerSavesFileWithNewIssueAlongsideKnown() error {
 		Message:          "newly introduced code issue",
 		AdditionalData:   snyk.CodeIssueData{Key: "key-new"},
 	}
+	s.expectedNewIssueCode = "new-issue"
 	knownIssue := &snyk.Issue{
 		ID:               "known-issue",
 		AffectedFilePath: s.deltaFilePath,
@@ -1012,18 +1185,62 @@ func (s *bddSteps) developerHasACodeIssueFoundBySnyk() error {
 	}})
 }
 
+// editorNotifiedOfOnlyNewIssue asserts across every file the editor was told
+// about, not just deltaFilePath: with the pre-existing and the new finding in
+// different files, a per-file check would pass even when no baseline exists at
+// all and delta fails open, because the new file has one finding either way.
 func (s *bddSteps) editorNotifiedOfOnlyNewIssue() error {
-	diagnostics, found := s.awaitPublishedDiagnostics(s.deltaFilePath)
-	if !found {
+	if _, found := s.awaitPublishedDiagnostics(s.deltaFilePath); !found {
 		return fmt.Errorf("expected a textDocument/publishDiagnostics notification for %s, got none", s.deltaFilePath)
 	}
-	if len(diagnostics) != 1 {
-		return fmt.Errorf("expected exactly one diagnostic (only the newly introduced issue), got %d: %+v", len(diagnostics), diagnostics)
+
+	// A base branch scan runs after the working scan has already published, so
+	// the delta-filtered republish arrives later; poll for the settled state.
+	var withFindings []string
+	var total int
+	settled := s.awaitCondition(func() bool {
+		withFindings, total = s.filesWithFindings()
+		return total == 1
+	})
+	if !settled {
+		return fmt.Errorf("expected exactly one diagnostic in the whole workspace (only the newly introduced issue), got %d across %v", total, withFindings)
 	}
-	if diagnostics[0].Code != "new-issue" {
-		return fmt.Errorf("expected the newly introduced issue %q, got %q", "new-issue", diagnostics[0].Code)
+
+	diagnostics := s.latestDiagnosticsByFile()[string(uri.PathToUri(s.deltaFilePath))]
+	if len(diagnostics) != 1 {
+		return fmt.Errorf("expected the one remaining diagnostic to be on %s, it was on %v", s.deltaFilePath, withFindings)
+	}
+	if diagnostics[0].Code != s.expectedNewIssueCode {
+		return fmt.Errorf("expected the newly introduced issue %q, got %q", s.expectedNewIssueCode, diagnostics[0].Code)
 	}
 	return nil
+}
+
+// filesWithFindings returns the files the editor currently shows findings for,
+// and how many diagnostics that is in total.
+func (s *bddSteps) filesWithFindings() (files []string, total int) {
+	for path, diagnostics := range s.latestDiagnosticsByFile() {
+		if len(diagnostics) > 0 {
+			files = append(files, path)
+			total += len(diagnostics)
+		}
+	}
+	sort.Strings(files)
+	return files, total
+}
+
+// latestDiagnosticsByFile returns the most recent publishDiagnostics payload per
+// URI. A folder republishes per product, so only the last one per file counts.
+func (s *bddSteps) latestDiagnosticsByFile() map[string][]types.Diagnostic {
+	latest := map[string][]types.Diagnostic{}
+	for _, n := range s.jsonRPCRecorder.FindNotificationsByMethod("textDocument/publishDiagnostics") {
+		var params types.PublishDiagnosticsParams
+		if err := n.UnmarshalParams(&params); err != nil {
+			continue
+		}
+		latest[string(params.URI)] = params.Diagnostics
+	}
+	return latest
 }
 
 // theDeveloperAsksSnykToFixAFolder drives the real snyk.remediationAgent.fixFolder
@@ -1271,7 +1488,7 @@ func Test_BDDSteps_PerScenarioCleanup(t *testing.T) {
 
 	ctx, err := s.beforeScenario(ctx, &godog.Scenario{Name: "scenario one"})
 	require.NoError(t, err)
-	require.NoError(t, s.aRunningLanguageServer())
+	require.NoError(t, s.startLanguageServer())
 	firstClient := s.loc.Client
 
 	_, err = s.afterScenario(ctx, &godog.Scenario{Name: "scenario one"}, nil)
@@ -1281,7 +1498,7 @@ func Test_BDDSteps_PerScenarioCleanup(t *testing.T) {
 
 	ctx, err = s.beforeScenario(ctx, &godog.Scenario{Name: "scenario two"})
 	require.NoError(t, err)
-	require.NoError(t, s.aRunningLanguageServer())
+	require.NoError(t, s.startLanguageServer())
 	secondClient := s.loc.Client
 
 	assert.False(t, secondClient.IsStopped(), "expected scenario two's own server to still be running, independently of scenario one's teardown")

--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/creachadair/jrpc2/server"
 	"github.com/cucumber/godog"
+	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -85,6 +85,11 @@ type bddSteps struct {
 	// requires; scenarios set it to the finding they deliberately introduced.
 	expectedNewIssueCode string
 
+	reservedDeviceRepoPath   types.FilePath
+	reservedDeviceRepo       *git.Repository
+	reservedDeviceBaseCommit plumbing.Hash
+	reservedDeviceKnownBlob  plumbing.Hash
+
 	savedLlmProvider    string
 	savedLlmModel       string
 	fixCapturedProvider string
@@ -102,11 +107,6 @@ func (s *bddSteps) register(sc *godog.ScenarioContext) {
 	sc.After(s.afterScenario)
 	sc.Given(`^a running language server$`, func() error {
 		return s.runOnScenarioGoroutine(func() error { return s.startLanguageServer() })
-	})
-	sc.Given(`^a running language server that finds one issue in every source file$`, func() error {
-		return s.runOnScenarioGoroutine(func() error {
-			return s.startLanguageServer(WithProductScanners(bddPerFileScanner{}))
-		})
 	})
 	// Step, not When: this step is reused as "And" (inheriting Given) in the
 	// delta-fail-open scenarios, and Given/When/Then in godog match only their
@@ -173,8 +173,18 @@ func (s *bddSteps) register(sc *godog.ScenarioContext) {
 	sc.Then(`^the editor is notified of both the newly introduced "([^"]*)" issue and the "([^"]*)" issue$`, func(product1, product2 string) error {
 		return s.runOnScenarioGoroutine(func() error { return s.editorNotifiedOfBothProductIssues(product1, product2) })
 	})
-	sc.Given(`^the developer opens a repository whose base branch carries a file named after a Windows device$`, func() error {
-		return s.runOnScenarioGoroutine(s.developerOpensRepositoryWithDeviceFileNameOnBaseBranch)
+	sc.Given(`^the developer opens a repository whose base branch carries a file named "([^"]*)"$`, func(deviceName string) error {
+		return s.runOnScenarioGoroutine(func() error {
+			return s.developerOpensRepositoryOnBaseBranchWithDeviceFile(deviceName)
+		})
+	})
+	sc.Given(`^the developer has a file named "([^"]*)" checked out in their working tree$`, func(deviceName string) error {
+		return s.runOnScenarioGoroutine(func() error {
+			return s.developerHasDeviceFileCheckedOutInWorkingTree(deviceName)
+		})
+	})
+	sc.Given(`^their feature branch adds a finding the base branch does not have$`, func() error {
+		return s.runOnScenarioGoroutine(s.featureBranchAddsNewFinding)
 	})
 	sc.When(`^the developer scans the whole repository$`, func(ctx context.Context) error {
 		return s.runOnScenarioGoroutine(func() error { return s.developerScansTheWholeRepository(ctx) })
@@ -283,7 +293,8 @@ func (s *bddSteps) runStep(fn func() error) {
 	}()
 	err := fn()
 	reported = true
-	if err != nil && s.scenarioT != nil {
+	// ErrSkip is godog's signal to skip the rest of the scenario, not a failure.
+	if err != nil && !errors.Is(err, godog.ErrSkip) && s.scenarioT != nil {
 		s.scenarioT.Fail()
 	}
 	s.stepResult <- err
@@ -575,45 +586,76 @@ func (s *bddSteps) theDialogContainsNoLlmApiKeyField() error {
 	return nil
 }
 
-// developerOpensRepositoryWithDeviceFileNameOnBaseBranch builds the customer's
-// repository: master carries the reserved device name plus a file with an
-// already-known finding, and the checked-out feature branch drops the reserved
-// name and adds a file with a new finding. Nothing writes a reserved device
+// developerOpensRepositoryOnBaseBranchWithDeviceFile builds the base branch:
+// a file with an already-known finding plus the reserved device name tucked
+// inside scripts/build. featureBranchAddsNewFinding commits and checks out
+// the feature branch on top of it. Nothing here writes the reserved device
 // name to disk, so this runs on every platform.
-func (s *bddSteps) developerOpensRepositoryWithDeviceFileNameOnBaseBranch() error {
+func (s *bddSteps) developerOpensRepositoryOnBaseBranchWithDeviceFile(deviceName string) error {
 	repoPath := s.newScenarioRepoPath()
 	repo := testutil.InitGitRepo(s.scenarioT, repoPath)
 	storer := repo.Storer
 
 	knownBlob := testutil.WriteGitBlob(s.scenarioT, storer, bddDummySource)
 	buildTree := testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
-		{Name: "prn.sh", Mode: filemode.Regular, Hash: testutil.WriteGitBlob(s.scenarioT, storer, bddBuildScriptSource)},
+		{Name: deviceName, Mode: filemode.Regular, Hash: testutil.WriteGitBlob(s.scenarioT, storer, bddBuildScriptSource)},
 	})
 	scriptsTree := testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
 		{Name: "build", Mode: filemode.Dir, Hash: buildTree},
 	})
-	masterCommit := testutil.CommitGitTree(s.scenarioT, repo, testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
+	baseCommit := testutil.CommitGitTreeOnBranch(s.scenarioT, repo, plumbing.NewBranchReferenceName(bddBaseBranch), testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
 		{Name: bddKnownFindingFile, Mode: filemode.Regular, Hash: knownBlob},
 		{Name: "scripts", Mode: filemode.Dir, Hash: scriptsTree},
 	}))
 
+	s.reservedDeviceRepoPath = repoPath
+	s.reservedDeviceRepo = repo
+	s.reservedDeviceBaseCommit = baseCommit
+	s.reservedDeviceKnownBlob = knownBlob
+	return nil
+}
+
+// developerHasDeviceFileCheckedOutInWorkingTree matches the customer's actual
+// configuration: the device name is a real file on disk, not only a git tree
+// entry. Git itself refuses to check such a file out on Windows, so that
+// state cannot exist there; the step reports ErrSkip instead of attempting
+// the write and failing on the OS's own rejection.
+func (s *bddSteps) developerHasDeviceFileCheckedOutInWorkingTree(deviceName string) error {
+	if runtime.GOOS == "windows" {
+		return godog.ErrSkip
+	}
+	if err := s.developerOpensRepositoryOnBaseBranchWithDeviceFile(deviceName); err != nil {
+		return err
+	}
+	return writeScenarioFile(s.reservedDeviceRepoPath, deviceName, bddBuildScriptSource)
+}
+
+// featureBranchAddsNewFinding commits the feature branch on top of the base
+// branch built by developerOpensRepositoryOnBaseBranchWithDeviceFile, checks
+// it out by writing its files to disk, and opens the repository - the point
+// at which both scenarios trigger the base-branch clone.
+func (s *bddSteps) featureBranchAddsNewFinding() error {
+	repo := s.reservedDeviceRepo
+	storer := repo.Storer
+	newFile := bddNewFindingFile
+
 	featureTree := testutil.WriteGitTree(s.scenarioT, storer, []object.TreeEntry{
-		{Name: bddKnownFindingFile, Mode: filemode.Regular, Hash: knownBlob},
-		{Name: bddNewFindingFile, Mode: filemode.Regular, Hash: testutil.WriteGitBlob(s.scenarioT, storer, bddDummySource)},
+		{Name: bddKnownFindingFile, Mode: filemode.Regular, Hash: s.reservedDeviceKnownBlob},
+		{Name: newFile, Mode: filemode.Regular, Hash: testutil.WriteGitBlob(s.scenarioT, storer, bddDummySource)},
 	})
-	testutil.CommitGitTreeOnBranch(s.scenarioT, repo, plumbing.NewBranchReferenceName("feature"), featureTree, masterCommit)
+	testutil.CommitGitTreeOnBranch(s.scenarioT, repo, plumbing.NewBranchReferenceName(bddFeatureBranch), featureTree, s.reservedDeviceBaseCommit)
 
 	// Checking out the feature branch is just writing its two files.
-	for _, name := range []string{bddKnownFindingFile, bddNewFindingFile} {
-		if err := writeScenarioFile(repoPath, name, bddDummySource); err != nil {
+	for _, name := range []string{bddKnownFindingFile, newFile} {
+		if err := writeScenarioFile(s.reservedDeviceRepoPath, name, bddDummySource); err != nil {
 			return err
 		}
 	}
 
-	s.deltaFileDir = repoPath
-	s.deltaFilePath = types.FilePath(filepath.Join(string(repoPath), bddNewFindingFile))
-	s.expectedNewIssueCode = bddNewFindingFile
-	return s.openScenarioRepo(repoPath)
+	s.deltaFileDir = s.reservedDeviceRepoPath
+	s.deltaFilePath = types.FilePath(filepath.Join(string(s.reservedDeviceRepoPath), newFile))
+	s.expectedNewIssueCode = newFile
+	return s.openScenarioRepo(s.reservedDeviceRepoPath, bddBaseBranch)
 }
 
 const (
@@ -623,37 +665,9 @@ const (
 	// branch and the working tree is exactly the file the feature branch added.
 	bddKnownFindingFile = "Known.java"
 	bddNewFindingFile   = "New.java"
+	bddBaseBranch       = "master"
+	bddFeatureBranch    = "feature"
 )
-
-// bddPerFileScanner reports one finding per .java file it finds under the path
-// it is handed. Only the product scanner is substituted: the real
-// DelegatingConcurrentScanner still clones the base branch and diffs against it,
-// which is the code this scenario exists to exercise.
-type bddPerFileScanner struct{}
-
-func (bddPerFileScanner) Product() product.Product { return product.ProductCode }
-
-func (bddPerFileScanner) IsEnabledForFolder(*types.FolderConfig) bool { return true }
-
-func (bddPerFileScanner) Scan(_ context.Context, pathToScan types.FilePath) ([]types.Issue, error) {
-	var issues []types.Issue
-	err := filepath.WalkDir(string(pathToScan), func(p string, entry fs.DirEntry, err error) error {
-		if err != nil || entry.IsDir() || filepath.Ext(p) != code.FakeFileExtension {
-			return nil //nolint:nilerr // an unreadable entry is simply not a finding
-		}
-		issues = append(issues, &snyk.Issue{
-			ID:               filepath.Base(p),
-			AffectedFilePath: types.FilePath(p),
-			ContentRoot:      pathToScan,
-			Severity:         types.High,
-			Product:          product.ProductCode,
-			Message:          "finding in " + filepath.Base(p),
-			AdditionalData:   snyk.CodeIssueData{Key: "key-" + filepath.Base(p)},
-		})
-		return nil
-	})
-	return issues, err
-}
 
 func (s *bddSteps) newScenarioRepoPath() types.FilePath {
 	repoPath := types.FilePath(s.scenarioT.TempDir())
@@ -678,7 +692,7 @@ func writeScenarioFile(repoPath types.FilePath, name, content string) error {
 // the workspace folder, initialized, then the base branch over the settings
 // channel. The server builds the folder and its scanner itself, so registration
 // (including the persister's cache directory) runs for real.
-func (s *bddSteps) openScenarioRepo(repoPath types.FilePath) error {
+func (s *bddSteps) openScenarioRepo(repoPath types.FilePath, baseBranch string) error {
 	ctx := s.scenarioT.Context()
 	initParams := types.InitializeParams{
 		WorkspaceFolders: []types.WorkspaceFolder{
@@ -702,8 +716,8 @@ func (s *bddSteps) openScenarioRepo(repoPath types.FilePath) error {
 				{
 					FolderPath: repoPath,
 					Settings: map[string]*types.ConfigSetting{
-						types.SettingBaseBranch:      {Value: "master", Changed: true},
-						types.SettingReferenceBranch: {Value: "master", Changed: true},
+						types.SettingBaseBranch:      {Value: baseBranch, Changed: true},
+						types.SettingReferenceBranch: {Value: baseBranch, Changed: true},
 					},
 				},
 			},
@@ -1217,12 +1231,21 @@ func (s *bddSteps) editorNotifiedOfOnlyNewIssue() error {
 }
 
 // filesWithFindings returns the files the editor currently shows findings for,
-// and how many diagnostics that is in total.
+// and how many diagnostics that is in total. This feature drives OSS and IaC
+// alongside Code, so a scan failure in either can publish a folder-level "Snyk
+// Error" diagnostic that has nothing to do with the new-issue assertion here.
 func (s *bddSteps) filesWithFindings() (files []string, total int) {
 	for path, diagnostics := range s.latestDiagnosticsByFile() {
-		if len(diagnostics) > 0 {
+		count := 0
+		for _, diagnostic := range diagnostics {
+			if diagnostic.Code == "Snyk Error" {
+				continue
+			}
+			count++
+		}
+		if count > 0 {
 			files = append(files, path)
-			total += len(diagnostics)
+			total += count
 		}
 	}
 	sort.Strings(files)

--- a/application/server/secrets_smoke_test.go
+++ b/application/server/secrets_smoke_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
@@ -72,7 +73,7 @@ func Test_SmokeSecretsScan_UnsupportedFileDoesNotError(t *testing.T) {
 		{"commit", "-m", "initial"},
 	}
 	for _, args := range gitCmds {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = workspaceDir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -500,7 +500,7 @@ func initLocalFixtureRepo(t *testing.T, files map[string][]byte) types.FilePath 
 		require.NoError(t, os.WriteFile(filepath.Join(dir, name), content, 0600))
 	}
 	gitCmd := func(args ...string) *exec.Cmd {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 		return cmd
@@ -512,7 +512,7 @@ func initLocalFixtureRepo(t *testing.T, files map[string][]byte) types.FilePath 
 		out, err := gitCmd(args...).CombinedOutput()
 		require.NoErrorf(t, err, "git %v: %s", args, out)
 	}
-	commit := gitCmd("-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "commit", "-m", "init")
+	commit := gitCmd("commit", "-m", "init")
 	commit.Env = append(commit.Env,
 		"GIT_AUTHOR_NAME=Snyk LS Test",
 		"GIT_AUTHOR_EMAIL=snyk-ls-test@example.invalid",
@@ -2754,7 +2754,7 @@ func initializeGitRepoForMonorepoBenchmark(t *testing.T, repoDir string) {
 }
 
 func gitCommandForMonorepoBenchmark(dir string, args ...string) *exec.Cmd {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 	cmd.Dir = dir
 	cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	return cmd

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -101,6 +101,7 @@ type serverTestConfig struct {
 	apiEndpoint     string
 	concurrency     int
 	scannerOverride scanner.Scanner
+	diTestOptions   []di.TestOption
 }
 
 func WithRealDI() ServerTestOption {
@@ -141,6 +142,15 @@ func WithAPIEndpoint(endpoint string) ServerTestOption {
 func WithScanner(s scanner.Scanner) ServerTestOption {
 	return func(cfg *serverTestConfig) {
 		cfg.scannerOverride = s
+	}
+}
+
+// WithProductScanners replaces the product scanners the server's real delegating
+// scanner is built from, so a test can substitute the Snyk API surface at startup
+// and still let initialize drive the real folder registration.
+func WithProductScanners(scanners ...types.ProductScanner) ServerTestOption {
+	return func(cfg *serverTestConfig) {
+		cfg.diTestOptions = append(cfg.diTestOptions, di.WithProductScanners(scanners...))
 	}
 }
 
@@ -194,7 +204,7 @@ func setupServer(
 		t.Cleanup(deps.TreeEmitter.Dispose)
 		t.Cleanup(deps.ScanCancel)
 	} else {
-		deps = di.TestInit(t, engine, tokenService, cfg.overrideDeps)
+		deps = di.TestInit(t, engine, tokenService, cfg.overrideDeps, cfg.diTestOptions...)
 
 		// Merge WithDeps overrides into deps struct for fields that are not handled by TestInit,
 		// i.e. InlineValueProvider.

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -101,7 +101,6 @@ type serverTestConfig struct {
 	apiEndpoint     string
 	concurrency     int
 	scannerOverride scanner.Scanner
-	diTestOptions   []di.TestOption
 }
 
 func WithRealDI() ServerTestOption {
@@ -142,15 +141,6 @@ func WithAPIEndpoint(endpoint string) ServerTestOption {
 func WithScanner(s scanner.Scanner) ServerTestOption {
 	return func(cfg *serverTestConfig) {
 		cfg.scannerOverride = s
-	}
-}
-
-// WithProductScanners replaces the product scanners the server's real delegating
-// scanner is built from, so a test can substitute the Snyk API surface at startup
-// and still let initialize drive the real folder registration.
-func WithProductScanners(scanners ...types.ProductScanner) ServerTestOption {
-	return func(cfg *serverTestConfig) {
-		cfg.diTestOptions = append(cfg.diTestOptions, di.WithProductScanners(scanners...))
 	}
 }
 
@@ -204,7 +194,7 @@ func setupServer(
 		t.Cleanup(deps.TreeEmitter.Dispose)
 		t.Cleanup(deps.ScanCancel)
 	} else {
-		deps = di.TestInit(t, engine, tokenService, cfg.overrideDeps, cfg.diTestOptions...)
+		deps = di.TestInit(t, engine, tokenService, cfg.overrideDeps)
 
 		// Merge WithDeps overrides into deps struct for fields that are not handled by TestInit,
 		// i.e. InlineValueProvider.

--- a/application/server/smoke_main_helpers_test.go
+++ b/application/server/smoke_main_helpers_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -46,7 +47,7 @@ func setupLocalBareRepo(t *testing.T) localRepo {
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "Test"},
 	} {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		require.NoError(t, cmd.Run(), "git %v", args)
 	}
@@ -57,7 +58,7 @@ func setupLocalBareRepo(t *testing.T) localRepo {
 		{"add", "."},
 		{"commit", "-m", "initial"},
 	} {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		require.NoError(t, cmd.Run(), "git %v", args)
 	}

--- a/benchmark/fixture_test.go
+++ b/benchmark/fixture_test.go
@@ -48,7 +48,7 @@ func TestGenerateMonorepoFixtureCounts_CustomDimensions(t *testing.T) {
 }
 
 func gitCommandForFixtureTest(dir string, args ...string) *exec.Cmd {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 	cmd.Dir = dir
 	cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	return cmd

--- a/domain/ide/command/remediation_fix_folder_test.go
+++ b/domain/ide/command/remediation_fix_folder_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/snyk/remediation"
 	noti "github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -62,7 +63,7 @@ func initGitRepoForCmd(t *testing.T) string {
 	}
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))

--- a/domain/snyk/remediation/remy_test.go
+++ b/domain/snyk/remediation/remy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk/remediation"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -51,7 +52,7 @@ func initGitRepo(t *testing.T) string {
 
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))
@@ -794,7 +795,7 @@ func initGitRepoInDir(t *testing.T, dir string) {
 	t.Helper()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))
@@ -820,7 +821,7 @@ func commitFileInDir(t *testing.T, dir, relPath, content string) {
 		t.Helper()
 		const maxRetries = 8
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			cmd := exec.Command("git", args...)
+			cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 			cmd.Dir = dir
 			out, err := cmd.CombinedOutput()
 			if err == nil {

--- a/domain/snyk/scanner/base_scan_test.go
+++ b/domain/snyk/scanner/base_scan_test.go
@@ -18,6 +18,8 @@ package scanner
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -33,6 +35,7 @@ import (
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/types/mock_types"
+	"github.com/snyk/snyk-ls/internal/vcs"
 )
 
 func TestScanBaseBranch_AllProducts_ReceiveCorrectPathAndFolderPath(t *testing.T) {
@@ -239,6 +242,50 @@ func TestScanBaseBranch_AllProducts_UseCorrectOrgFromFolderConfig(t *testing.T) 
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestScanBaseBranch_ClonesRepositoryHoldingAWindowsDeviceFileName(t *testing.T) {
+	engine, tokenService := testutil.UnitTestWithEngine(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repoPath := types.FilePath(t.TempDir())
+	testutil.InitGitRepoWithFiles(t, repoPath, map[string]string{
+		"app.go":               "package main\n",
+		"scripts/build/prn.sh": "#!/bin/sh\necho build\n",
+	})
+
+	folderConfig := &types.FolderConfig{FolderPath: repoPath}
+	syncFolderToConfig(t, engine, folderConfig, &syncFolderOpts{BaseBranch: "master"})
+
+	var scannedPath types.FilePath
+	mockScanner := mock_types.NewMockProductScanner(ctrl)
+	mockScanner.EXPECT().Product().Return(product.ProductCode).AnyTimes()
+	mockScanner.EXPECT().IsEnabledForFolder(gomock.Any()).Return(true).AnyTimes()
+	mockScanner.EXPECT().Scan(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, path types.FilePath) ([]types.Issue, error) {
+			scannedPath = path
+			return []types.Issue{}, nil
+		}).Times(1)
+
+	dcs := setupScannerWithMock(t, engine, tokenService, mockScanner)
+	checkoutHandler := vcs.NewCheckoutHandler(engine.GetConfiguration())
+	t.Cleanup(func() {
+		if cleanup := checkoutHandler.CleanupFunc(); cleanup != nil {
+			cleanup()
+		}
+	})
+
+	err := dcs.scanBaseBranch(t.Context(), mockScanner, folderConfig, checkoutHandler)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, scannedPath)
+	// Read through vcs.OSPath: on Windows a plain open of a reserved device name
+	// resolves to the device, so a bare FileExists could pass having proved nothing.
+	reserved, err := os.ReadFile(vcs.OSPath(filepath.Join(string(scannedPath), "scripts", "build", "prn.sh")))
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/sh\necho build\n", string(reserved))
+	assert.FileExists(t, filepath.Join(string(scannedPath), "app.go"))
 }
 
 // setupScannerWithMock creates a scanner with a mock ProductScanner for testing

--- a/features/reserved-device-filenames.feature
+++ b/features/reserved-device-filenames.feature
@@ -1,20 +1,35 @@
-Feature: New Issues scanning in repositories containing Windows device file names
+Feature: New Issues in repositories containing Windows device filenames
 
-  CON, PRN, AUX, NUL, COM1-9 and LPT1-9 are ordinary file names on macOS and
-  Linux. Snyk clones the base branch to work out which findings are new, so a
-  repository carrying such a name anywhere on its base branch stops producing
-  new-issue results at all: findings keep showing under Total and nothing ever
-  appears under New.
-
-  The customer hit this with the file checked out in their own working tree.
-  The scenario below puts it only on the base branch, which reaches the bug
-  through the same code and is additionally a state a Windows developer can be
-  in, since git will not check such a file out on Windows.
+  CON, PRN, AUX, NUL, COM1-9 and LPT1-9 are ordinary filenames on macOS and
+  Linux, and a repository is free to contain them. Snyk clones the base branch
+  to decide which findings are new. One such file anywhere on the base branch
+  stopped that clone completing, so no baseline was ever recorded: findings kept
+  appearing under Total while New stayed permanently empty.
 
   # maps: IDE-2473-M1
-  Scenario: A developer sees only the finding they introduced, not the one already on the base branch
-    Given a running language server that finds one issue in every source file
+  Scenario Outline: A developer sees only the finding they introduced, not the one already on the base branch
+    Given a running language server
     And delta findings are switched to "New new issues" globally
-    And the developer opens a repository whose base branch carries a file named after a Windows device
+    And the developer opens a repository whose base branch carries a file named "<filename>"
+    And their feature branch adds a finding the base branch does not have
+    When the developer scans the whole repository
+    Then the editor is notified of only the newly introduced issue
+
+    Examples:
+      | filename |
+      | prn.sh   |
+      | con.cmd  |
+      | aux.bat  |
+      | nul.sh   |
+      | com1.exe |
+      | lpt1.sh  |
+      | prn      |
+
+  # maps: IDE-2473-M2
+  Scenario: A developer working on a branch with a device-named file in their checkout still sees new findings
+    Given a running language server
+    And delta findings are switched to "New new issues" globally
+    And the developer has a file named "prn.sh" checked out in their working tree
+    And their feature branch adds a finding the base branch does not have
     When the developer scans the whole repository
     Then the editor is notified of only the newly introduced issue

--- a/features/reserved-device-filenames.feature
+++ b/features/reserved-device-filenames.feature
@@ -1,0 +1,20 @@
+Feature: New Issues scanning in repositories containing Windows device file names
+
+  CON, PRN, AUX, NUL, COM1-9 and LPT1-9 are ordinary file names on macOS and
+  Linux. Snyk clones the base branch to work out which findings are new, so a
+  repository carrying such a name anywhere on its base branch stops producing
+  new-issue results at all: findings keep showing under Total and nothing ever
+  appears under New.
+
+  The customer hit this with the file checked out in their own working tree.
+  The scenario below puts it only on the base branch, which reaches the bug
+  through the same code and is additionally a state a Windows developer can be
+  in, since git will not check such a file out on Windows.
+
+  # maps: IDE-2473-M1
+  Scenario: A developer sees only the finding they introduced, not the one already on the base branch
+    Given a running language server that finds one issue in every source file
+    And delta findings are switched to "New new issues" globally
+    And the developer opens a repository whose base branch carries a file named after a Windows device
+    When the developer scans the whole repository
+    Then the editor is notified of only the newly introduced issue

--- a/infrastructure/authentication/auth_service_impl_test.go
+++ b/infrastructure/authentication/auth_service_impl_test.go
@@ -258,6 +258,8 @@ func Test_UpdateCredentials(t *testing.T) {
 		mockNotifier := notification.NewMockNotifier()
 		service := NewAuthenticationService(engine, ts, nil, error_reporting.NewTestErrorReporter(engine), mockNotifier, testutil.DefaultConfigResolver(engine))
 
+		config.UpdateApiEndpointsOnConfig(engine.GetConfiguration(), config.DefaultSnykApiUrl)
+
 		token := "some_other_token"
 		service.UpdateCredentials(token, true, true)
 
@@ -311,6 +313,9 @@ func Test_Authenticate(t *testing.T) {
 	t.Run("Get endpoint from config and set in snyk-ls configuration ", func(t *testing.T) {
 		apiEndpoint := "https://api.eu.snyk.io"
 		engine, ts := testutil.UnitTestWithEngine(t)
+		// The engine URL is only adopted while the user has not customized the
+		// endpoint themselves, so the default is part of the scenario.
+		config.UpdateApiEndpointsOnConfig(engine.GetConfiguration(), config.DefaultSnykApiUrl)
 		engine.GetConfiguration().Set(configuration.API_URL, apiEndpoint)
 
 		provider := FakeAuthenticationProvider{Engine: engine}

--- a/infrastructure/code/fake_code_client_scanner.go
+++ b/infrastructure/code/fake_code_client_scanner.go
@@ -397,18 +397,127 @@ func getSarifResponseJson2(filePath string) string {
 `, DontUsePrintStackTrace, CatchingInterruptedExceptionWithoutInterrupt, filePath)
 }
 
+// buildMultiFileSarifResponse returns one security-categorized finding per file, with the
+// ruleId set to the file's base name. The delta fuzzy matcher requires equal ruleIds before it
+// will compare two findings at all, so per-file ruleIds keep findings in different files from
+// ever being mistaken for each other while still letting the same file match across scans.
+func buildMultiFileSarifResponse(relativePaths []string) codeClientSarif.SarifResponse {
+	var rules []codeClientSarif.Rule
+	var results []codeClientSarif.Result
+
+	for _, relativePath := range relativePaths {
+		ruleID := filepath.Base(relativePath)
+		escapedPath := strings.ReplaceAll(relativePath, `\`, `\\`)
+
+		rules = append(rules, codeClientSarif.Rule{
+			ID:               ruleID,
+			Name:             ruleID,
+			ShortDescription: codeClientSarif.ShortDescription{Text: ruleID},
+			DefaultConfiguration: codeClientSarif.DefaultConfiguration{
+				Level: "warning",
+			},
+			Properties: codeClientSarif.RuleProperties{
+				Categories: []string{"Security"},
+				Precision:  "very-high",
+			},
+		})
+
+		results = append(results, codeClientSarif.Result{
+			RuleID: ruleID,
+			Level:  "warning",
+			Message: codeClientSarif.ResultMessage{
+				Text: fmt.Sprintf("Test finding for %s", ruleID),
+			},
+			Locations: []codeClientSarif.Location{
+				{
+					PhysicalLocation: codeClientSarif.PhysicalLocation{
+						ArtifactLocation: codeClientSarif.ArtifactLocation{
+							URI:       escapedPath,
+							URIBaseID: "dummy",
+						},
+						Region: codeClientSarif.Region{
+							StartLine:   6,
+							EndLine:     6,
+							StartColumn: 7,
+							EndColumn:   7,
+						},
+					},
+				},
+			},
+			Fingerprints: codeClientSarif.Fingerprints{
+				Num1: relativePath,
+			},
+		})
+	}
+
+	return codeClientSarif.SarifResponse{
+		Type:     "sarif",
+		Progress: 1,
+		Status:   "COMPLETE",
+		Sarif: codeClientSarif.SarifDocument{
+			Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+			Version: "2.1.0",
+			Runs: []codeClientSarif.Run{
+				{
+					Tool: codeClientSarif.Tool{
+						Driver: codeClientSarif.Driver{
+							Name:            "SnykCode",
+							SemanticVersion: "1.0.0",
+							Version:         "1.0.0",
+							Rules:           rules,
+						},
+					},
+					Results: results,
+				},
+			},
+		},
+	}
+}
+
 func (f *FakeCodeScannerClient) UploadAndAnalyze(
 	_ context.Context,
 	_ string,
-	_ scan.Target,
+	target scan.Target,
 	files <-chan string,
 	_ map[string]bool,
 ) (*codeClientSarif.SarifResponse, string, error) {
+	var filePaths []string
+	for filePath := range files {
+		filePaths = append(filePaths, filePath)
+	}
+
 	var analysisResponse codeClientSarif.SarifResponse
-	responseJson := getSarifResponseJson2(filepath.Base(<-files))
-	err := json.Unmarshal([]byte(responseJson), &analysisResponse)
+
+	// At most one file can never collide with another file, so keep returning the original
+	// fixed two-finding fixture callers already depend on (exact ruleIds, ignore/suppression
+	// data) - including when the channel yields nothing, which existing callers rely on to
+	// still produce the fixture. Cross-file collisions are only possible with more than one file.
+	if len(filePaths) <= 1 {
+		var firstFile string
+		if len(filePaths) == 1 {
+			firstFile = filePaths[0]
+		}
+		responseJson := getSarifResponseJson2(filepath.Base(firstFile))
+		err := json.Unmarshal([]byte(responseJson), &analysisResponse)
+		f.UploadAndAnalyzeWasCalled = true
+		return &analysisResponse, "", err
+	}
+
+	// The caller always scans from the same folder root it built target from, so that root -
+	// not a heuristic over the file list - is what artifact URIs must be relative to.
+	scanRoot := target.GetPath()
+	relativePaths := make([]string, 0, len(filePaths))
+	for _, fp := range filePaths {
+		relPath, err := filepath.Rel(scanRoot, fp)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to make %s relative to scan root %s: %w", fp, scanRoot, err)
+		}
+		relativePaths = append(relativePaths, relPath)
+	}
+
+	analysisResponse = buildMultiFileSarifResponse(relativePaths)
 	f.UploadAndAnalyzeWasCalled = true
-	return &analysisResponse, "", err
+	return &analysisResponse, "", nil
 }
 
 func (f *FakeCodeScannerClient) Upload(context.Context, string, scan.Target, <-chan string, map[string]bool) (bundle.Bundle, error) {

--- a/infrastructure/code/fake_code_client_scanner_test.go
+++ b/infrastructure/code/fake_code_client_scanner_test.go
@@ -1,0 +1,67 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package code
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/snyk/code-client-go/scan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/internal/testutil"
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// TestFakeCodeScannerClient_UploadAndAnalyze_ArtifactURIsRelativeToScanRoot mirrors the
+// path shape the reserved-device-filenames BDD scenario scans: a file directly under the
+// scan root plus a file nested under scripts/build/. The scan root must come from the
+// scan.Target the real caller passes, not from a heuristic over the file list, or an
+// artifact URI can end up empty and get published as a diagnostic on the folder itself.
+func TestFakeCodeScannerClient_UploadAndAnalyze_ArtifactURIsRelativeToScanRoot(t *testing.T) {
+	scanRoot := t.TempDir()
+	testutil.InitGitRepoWithFiles(t, types.FilePath(scanRoot), map[string]string{"README.md": "test repo\n"})
+	rootFile := filepath.Join(scanRoot, "Known.java")
+	nestedFile := filepath.Join(scanRoot, "scripts", "build", "prn.sh")
+
+	target, err := scan.NewRepositoryTarget(scanRoot)
+	require.NoError(t, err)
+
+	files := make(chan string, 2)
+	files <- rootFile
+	files <- nestedFile
+	close(files)
+
+	fake := &FakeCodeScannerClient{}
+	response, _, err := fake.UploadAndAnalyze(context.Background(), "request-id", target, files, nil)
+	require.NoError(t, err)
+	require.Len(t, response.Sarif.Runs, 1)
+
+	var uris []string
+	for _, result := range response.Sarif.Runs[0].Results {
+		for _, loc := range result.Locations {
+			uris = append(uris, loc.PhysicalLocation.ArtifactLocation.URI)
+		}
+	}
+
+	assert.Contains(t, uris, "Known.java")
+	assert.Contains(t, uris, "scripts/build/prn.sh")
+	assert.NotContains(t, uris, "")
+	assert.NotContains(t, uris, ".")
+}

--- a/infrastructure/code/snyk_code_http_client_test.go
+++ b/infrastructure/code/snyk_code_http_client_test.go
@@ -222,6 +222,7 @@ func TestGetCodeApiUrlForFolder(t *testing.T) {
 
 	t.Run("Default deeproxy url for code api", func(t *testing.T) {
 		engine := testutil.UnitTest(t)
+		config.UpdateApiEndpointsOnConfig(engine.GetConfiguration(), config.DefaultSnykApiUrl)
 
 		// Clear env since it takes priority over default deeproxy url.
 		t.Setenv(config.DeeproxyApiUrlKey, "")

--- a/internal/folderconfig/git_test.go
+++ b/internal/folderconfig/git_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func gitCommandForTestRepo(dir string, args ...string) *exec.Cmd {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 	cmd.Dir = dir
 	cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	return cmd

--- a/internal/testsupport/helpers.go
+++ b/internal/testsupport/helpers.go
@@ -59,6 +59,14 @@ func SkipUnlessBenchmarkRealScanMonorepo(t *testing.T) {
 	}
 }
 
+// GitUnsigned prefixes git arguments with the flags that keep a fixture's
+// commits and tags unsigned. A developer's global commit.gpgsign applies to
+// every repository a test creates, and signing then fails wherever the
+// configured signing program is unreachable.
+func GitUnsigned(args ...string) []string {
+	return append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)
+}
+
 // GitEnvWithoutInheritedRepoConfig returns env without Git repository/config overrides
 // that can make temp-repo tests operate on the outer worktree or inherit host config.
 func GitEnvWithoutInheritedRepoConfig(env []string) []string {

--- a/internal/testutil/gitrepo.go
+++ b/internal/testutil/gitrepo.go
@@ -1,0 +1,210 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testutil
+
+import (
+	"io"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// GitFixtureFile is one committed file: Content is the blob payload, or the
+// link target when Mode is filemode.Symlink.
+type GitFixtureFile struct {
+	Content string
+	Mode    filemode.FileMode
+}
+
+// InitGitRepo creates an empty repository at repoPath carrying an origin remote.
+func InitGitRepo(t *testing.T, repoPath types.FilePath) *git.Repository {
+	t.Helper()
+	repo, err := git.PlainInit(string(repoPath), false)
+	require.NoError(t, err)
+
+	repoConfig, err := repo.Config()
+	require.NoError(t, err)
+	repoConfig.Remotes["origin"] = &config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:snyk/snyk-goof.git"},
+	}
+	require.NoError(t, repo.Storer.SetConfig(repoConfig))
+	return repo
+}
+
+// InitGitRepoWithFiles creates a repository at repoPath whose master branch
+// holds files, keyed by slash-separated relative path.
+func InitGitRepoWithFiles(t *testing.T, repoPath types.FilePath, files map[string]string) *git.Repository {
+	t.Helper()
+	entries := make(map[string]GitFixtureFile, len(files))
+	for name, content := range files {
+		entries[name] = GitFixtureFile{Content: content, Mode: filemode.Regular}
+	}
+	return InitGitRepoWithEntries(t, repoPath, entries)
+}
+
+// InitGitRepoWithEntries is InitGitRepoWithFiles with per-file modes. It writes
+// objects only and leaves the worktree empty, so a fixture can commit names the
+// host filesystem would refuse to create. Tests that need the files on disk as
+// well must write them themselves.
+func InitGitRepoWithEntries(t *testing.T, repoPath types.FilePath, files map[string]GitFixtureFile) *git.Repository {
+	t.Helper()
+	repo := InitGitRepo(t, repoPath)
+
+	root := &gitTreeNode{}
+	for name, file := range files {
+		root.add(t, repo.Storer, strings.Split(name, "/"), file)
+	}
+	CommitGitTree(t, repo, root.write(t, repo.Storer))
+	return repo
+}
+
+// WriteGitBlob stores content as a blob object and returns its hash.
+func WriteGitBlob(t *testing.T, storer storage.Storer, content string) plumbing.Hash {
+	t.Helper()
+	blob := storer.NewEncodedObject()
+	blob.SetType(plumbing.BlobObject)
+	writer, err := blob.Writer()
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return storeGitObject(t, storer, blob)
+}
+
+// WriteGitTree stores entries as a tree object and returns its hash. Entries are
+// sorted into git's canonical order, so callers may pass them in any order.
+func WriteGitTree(t *testing.T, storer storage.Storer, entries []object.TreeEntry) plumbing.Hash {
+	t.Helper()
+	sorted := slices.Clone(entries)
+	sort.Sort(object.TreeEntrySorter(sorted))
+
+	treeObject := storer.NewEncodedObject()
+	require.NoError(t, (&object.Tree{Entries: sorted}).Encode(treeObject))
+	return storeGitObject(t, storer, treeObject)
+}
+
+// CommitGitTree commits treeHash as master's tip and points HEAD at master.
+func CommitGitTree(t *testing.T, repo *git.Repository, treeHash plumbing.Hash) plumbing.Hash {
+	t.Helper()
+	return CommitGitTreeOnBranch(t, repo, plumbing.Master, treeHash)
+}
+
+// CommitGitTreeOnBranch commits treeHash as branchName's tip with the given
+// parents and points HEAD at branchName.
+func CommitGitTreeOnBranch(
+	t *testing.T,
+	repo *git.Repository,
+	branchName plumbing.ReferenceName,
+	treeHash plumbing.Hash,
+	parents ...plumbing.Hash,
+) plumbing.Hash {
+	t.Helper()
+	signature := object.Signature{Name: t.Name(), Email: "test@example.com", When: time.Unix(0, 0).UTC()}
+	commitObject := repo.Storer.NewEncodedObject()
+	require.NoError(t, (&object.Commit{
+		Author:       signature,
+		Committer:    signature,
+		Message:      "init",
+		TreeHash:     treeHash,
+		ParentHashes: parents,
+	}).Encode(commitObject))
+	commitHash := storeGitObject(t, repo.Storer, commitObject)
+
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(branchName, commitHash)))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, branchName)))
+	return commitHash
+}
+
+// DetachGitRepoHeadBehindMaster advances master by one commit and leaves HEAD
+// on the previous one. A shallow clone of master cannot be served from that
+// state, which is what makes vcs.Clone fall back to copying the .git directory.
+func DetachGitRepoHeadBehindMaster(t *testing.T, repo *git.Repository) {
+	t.Helper()
+	master, err := repo.Reference(plumbing.Master, true)
+	require.NoError(t, err)
+	parent, err := repo.CommitObject(master.Hash())
+	require.NoError(t, err)
+
+	signature := object.Signature{Name: t.Name(), Email: "test@example.com", When: time.Unix(1, 0).UTC()}
+	commitObject := repo.Storer.NewEncodedObject()
+	require.NoError(t, (&object.Commit{
+		Author:       signature,
+		Committer:    signature,
+		Message:      "advance master",
+		TreeHash:     parent.TreeHash,
+		ParentHashes: []plumbing.Hash{parent.Hash},
+	}).Encode(commitObject))
+	commitHash := storeGitObject(t, repo.Storer, commitObject)
+
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.Master, commitHash)))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.HEAD, parent.Hash)))
+}
+
+func storeGitObject(t *testing.T, storer storage.Storer, encoded plumbing.EncodedObject) plumbing.Hash {
+	t.Helper()
+	hash, err := storer.SetEncodedObject(encoded)
+	require.NoError(t, err)
+	return hash
+}
+
+type gitTreeNode struct {
+	files   []object.TreeEntry
+	subdirs map[string]*gitTreeNode
+}
+
+func (n *gitTreeNode) add(t *testing.T, storer storage.Storer, parts []string, file GitFixtureFile) {
+	t.Helper()
+	if len(parts) == 1 {
+		n.files = append(n.files, object.TreeEntry{
+			Name: parts[0],
+			Mode: file.Mode,
+			Hash: WriteGitBlob(t, storer, file.Content),
+		})
+		return
+	}
+	if n.subdirs == nil {
+		n.subdirs = map[string]*gitTreeNode{}
+	}
+	child, ok := n.subdirs[parts[0]]
+	if !ok {
+		child = &gitTreeNode{}
+		n.subdirs[parts[0]] = child
+	}
+	child.add(t, storer, parts[1:], file)
+}
+
+func (n *gitTreeNode) write(t *testing.T, storer storage.Storer) plumbing.Hash {
+	t.Helper()
+	entries := slices.Clone(n.files)
+	for name, subdir := range n.subdirs {
+		entries = append(entries, object.TreeEntry{Name: name, Mode: filemode.Dir, Hash: subdir.write(t, storer)})
+	}
+	return WriteGitTree(t, storer, entries)
+}

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -105,6 +105,11 @@ func SmokeTestWithEngine(t *testing.T, tokenSecretName string, shardEnvVar strin
 	return prepareTestHelper(t, testsupport.SmokeTestEnvVar, tokenSecretName)
 }
 
+// unitTestAPIURL points unit tests at a closed port. A unit test must not
+// depend on the network: reaching the real API makes the result vary with
+// whatever credentials the host or its proxy supplies.
+const unitTestAPIURL = "http://127.0.0.1:1"
+
 func UnitTest(t *testing.T) workflow.Engine {
 	t.Helper()
 	engine, _ := UnitTestWithEngine(t)
@@ -140,6 +145,7 @@ func UnitTestWithEngine(t *testing.T) (workflow.Engine, *config.TokenServiceImpl
 	}
 
 	config.SetupLogging(engine, ts, nil)
+	config.UpdateApiEndpointsOnConfig(conf, unitTestAPIURL)
 	ts.SetToken(conf, "00000000-0000-0000-0000-000000000001")
 	types.SetGlobalUser(conf, types.SettingTrustEnabled, false)
 	types.SetGlobalUser(conf, types.SettingAutomaticAuthentication, false)

--- a/internal/testutil/test_setup_test.go
+++ b/internal/testutil/test_setup_test.go
@@ -1,0 +1,38 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// A unit test that reaches the real API passes or fails according to the
+// credentials the host or its proxy happens to supply. Both keys matter:
+// production code compares them to decide whether authentication redirected
+// the user elsewhere, so leaving either at the real endpoint reopens the hole.
+func Test_UnitTest_DoesNotPointAtTheRealAPI(t *testing.T) {
+	conf := UnitTest(t).GetConfiguration()
+
+	assert.NotEqual(t, types.DefaultSnykApiUrl, conf.GetString(configuration.API_URL))
+	assert.NotEqual(t, types.DefaultSnykApiUrl, types.GetGlobalString(conf, types.SettingApiEndpoint))
+}

--- a/internal/vcs/checkout_handler.go
+++ b/internal/vcs/checkout_handler.go
@@ -35,6 +35,8 @@ type CheckoutHandler struct {
 	baseFolderPath types.FilePath
 	repository     *git.Repository
 	cleanupFunc    func()
+	attempted      bool
+	attemptErr     error
 	mutex          sync.Mutex
 	conf           configuration.Configuration
 }
@@ -49,6 +51,11 @@ func (ch *CheckoutHandler) BaseFolderPath() types.FilePath {
 	return ch.baseFolderPath
 }
 
+// Repo returns the base branch clone. Its worktree is written directly rather
+// than checked out, so no index describes it: every file reads as both
+// deleted-from-index and untracked, and `git ls-files` is empty. On the
+// detached-HEAD fallback the index is worse than empty - it is the source
+// repository's, copied along with .git and never reset.
 func (ch *CheckoutHandler) Repo() *git.Repository {
 	return ch.repository
 }
@@ -60,11 +67,20 @@ func (ch *CheckoutHandler) CleanupFunc() func() {
 func (ch *CheckoutHandler) CheckoutBaseBranch(logger *zerolog.Logger, folderConfig *types.FolderConfig) error {
 	ch.mutex.Lock()
 	defer ch.mutex.Unlock()
-	folderPath := folderConfig.FolderPath
 
-	if ch.baseFolderPath != "" && ch.repository != nil && ch.cleanupFunc != nil {
-		return nil
+	// Memoize the attempt, not just success. This handler is per scan and every
+	// product scanner calls it, so a failure would otherwise be repeated N times,
+	// each retry now also paying for its own cleanup inside this lock.
+	if ch.attempted {
+		return ch.attemptErr
 	}
+	ch.attempted = true
+	ch.attemptErr = ch.checkoutBaseBranch(logger, folderConfig)
+	return ch.attemptErr
+}
+
+func (ch *CheckoutHandler) checkoutBaseBranch(logger *zerolog.Logger, folderConfig *types.FolderConfig) error {
+	folderPath := folderConfig.FolderPath
 
 	baseBranchName := GetBaseBranchName(ch.conf, folderPath, logger)
 
@@ -82,23 +98,26 @@ func (ch *CheckoutHandler) CheckoutBaseBranch(logger *zerolog.Logger, folderConf
 		return err
 	}
 
-	repo, err := Clone(logger, folderPath, types.FilePath(baseBranchFolderPath), baseBranchName)
-
-	if err != nil {
-		logger.Error().Err(err).Msg("Failed to clone base branch")
-		return err
-	}
-
 	cleanupFunc := func() {
 		if baseBranchFolderPath == "" {
 			return
 		}
-		err = os.RemoveAll(baseBranchFolderPath)
 		logger.Info().Msg("removing base branch tmp dir " + baseBranchFolderPath)
-
-		if err != nil {
-			logger.Error().Err(err).Msg("couldn't remove tmp dir " + baseBranchFolderPath)
+		// Through OSPath because that is how the clone's files were created; a
+		// reserved device name is not reachable by any other spelling.
+		if removeErr := os.RemoveAll(OSPath(baseBranchFolderPath)); removeErr != nil {
+			logger.Error().Err(removeErr).Msg("couldn't remove tmp dir " + baseBranchFolderPath)
 		}
+	}
+
+	repo, err := Clone(logger, folderPath, types.FilePath(baseBranchFolderPath), baseBranchName)
+
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to clone base branch")
+		// A failed clone can still have written a partial worktree, and every
+		// product scanner retries this, so each attempt would leak its own copy.
+		cleanupFunc()
+		return err
 	}
 
 	ch.baseFolderPath = types.FilePath(baseBranchFolderPath)

--- a/internal/vcs/checkout_handler_test.go
+++ b/internal/vcs/checkout_handler_test.go
@@ -17,9 +17,13 @@
 package vcs
 
 import (
+	"os"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -28,7 +32,7 @@ import (
 func TestCheckoutHandler_ShouldCheckout(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	_, _ = initGitRepo(t, repoPath, false)
+	_, _ = initWorktreeRepo(t, repoPath, false)
 	ch := NewCheckoutHandler(engine.GetConfiguration())
 
 	err := ch.CheckoutBaseBranch(engine.GetLogger(), getFolderConfig(repoPath))
@@ -55,7 +59,7 @@ func TestCheckoutHandler_InvalidGitRepo(t *testing.T) {
 func TestCheckoutHandler_AlreadyCreated(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	_, _ = initGitRepo(t, repoPath, false)
+	_, _ = initWorktreeRepo(t, repoPath, false)
 
 	ch := NewCheckoutHandler(engine.GetConfiguration())
 
@@ -77,6 +81,34 @@ func TestCheckoutHandler_AlreadyCreated(t *testing.T) {
 	assert.Equal(t, firstRunRepo, ch.Repo())
 	assert.Equal(t, firstRunPath, ch.BaseFolderPath())
 	ch.CleanupFunc()()
+}
+
+// TestCheckoutHandler_RemovesTempDirWhenCloneFails covers a clone that fails
+// after PlainClone succeeded, so the orphan holds a partial worktree, and every
+// product scanner retries the checkout and would leak one directory each.
+func TestCheckoutHandler_RemovesTempDirWhenCloneFails(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	repo := testutil.InitGitRepo(t, repoPath)
+	testutil.CommitGitTree(t, repo, testutil.WriteGitTree(t, repo.Storer, []object.TreeEntry{
+		{Name: "git~1", Mode: filemode.Regular, Hash: testutil.WriteGitBlob(t, repo.Storer, "payload")},
+	}))
+
+	// A private temp root, so the assertion cannot see directories other tests
+	// create concurrently: t.TempDir names are ordinals like "002", so the
+	// handler's "<folder>_<branch>" prefix is not unique across packages.
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv("TMP", tempRoot)
+	t.Setenv("TEMP", tempRoot)
+
+	ch := NewCheckoutHandler(engine.GetConfiguration())
+	err := ch.CheckoutBaseBranch(engine.GetLogger(), getFolderConfig(repoPath))
+
+	require.Error(t, err)
+	entries, readErr := os.ReadDir(tempRoot)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "a failed clone must not leave its temp directory behind")
 }
 
 func getFolderConfig(path types.FilePath) *types.FolderConfig {

--- a/internal/vcs/git_cloner.go
+++ b/internal/vcs/git_cloner.go
@@ -17,6 +17,7 @@
 package vcs
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -30,6 +31,12 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
+// Clone copies targetBranchName of srcRepoPath into destinationPath, which must
+// be an empty absolute directory. The worktree is written directly rather than
+// checked out, so the clone carries no index describing it: git plumbing there
+// sees every file as both deleted-from-index and untracked, and `git ls-files`
+// is empty. Only read the clone as a directory of files - note that the
+// pre-scan command runs an arbitrary user command inside it.
 func Clone(logger *zerolog.Logger, srcRepoPath types.FilePath, destinationPath types.FilePath, targetBranchName string) (*git.Repository, error) {
 	// Resolve the git root in case srcRepoPath is a subfolder of the actual repository
 	resolvedRoot, err := GitRepoRoot(srcRepoPath)
@@ -50,6 +57,7 @@ func Clone(logger *zerolog.Logger, srcRepoPath types.FilePath, destinationPath t
 		ReferenceName: targetBranchReferenceName,
 		SingleBranch:  true,
 		Depth:         1,
+		NoCheckout:    true,
 	})
 
 	if err != nil {
@@ -60,11 +68,24 @@ func Clone(logger *zerolog.Logger, srcRepoPath types.FilePath, destinationPath t
 		}
 		// Repository might be in a detached head state.
 		logger.Debug().Msg("Clone operation failed. Maybe repo is in detached HEAD state?")
-		targetRepo := cloneRepoWithFsCopy(logger, resolvedRoot, destinationPath, targetBranchReferenceName)
-		if targetRepo == nil {
-			return nil, err
+		targetRepo, fsCopyErr := cloneRepoWithFsCopy(logger, resolvedRoot, destinationPath, targetBranchReferenceName)
+		if fsCopyErr != nil {
+			logger.Error().Err(fsCopyErr).Msgf("Could not clone base branch %s into %s via FS copy", targetBranchReferenceName, destinationPath)
+			return nil, fsCopyErr
 		}
 		return targetRepo, nil
+	}
+
+	clonedHead, err := clonedRepo.Head()
+	if err != nil {
+		logger.Error().Err(err).Msgf("Could not resolve HEAD in cloned repo: %s", destinationPath)
+		return nil, err
+	}
+
+	err = materializeWorktree(logger, clonedRepo, string(destinationPath), clonedHead.Hash())
+	if err != nil {
+		logger.Error().Err(err).Msgf("Could not write base branch files into cloned repo: %s", destinationPath)
+		return nil, err
 	}
 
 	// Patch Origin Remote for the cloned repo. This is only necessary if we use checkout since the remote origin URL will be the srcRepoPath
@@ -127,36 +148,33 @@ func patchClonedRepoRemoteOrigin(logger *zerolog.Logger, srcRepoPath types.FileP
 	return nil
 }
 
-func cloneRepoWithFsCopy(logger *zerolog.Logger, srcRepoPath types.FilePath, destinationRepoPath types.FilePath, targetBranchReferenceName plumbing.ReferenceName) *git.Repository {
+func cloneRepoWithFsCopy(logger *zerolog.Logger, srcRepoPath types.FilePath, destinationRepoPath types.FilePath, targetBranchReferenceName plumbing.ReferenceName) (*git.Repository, error) {
 	repo, err := git.PlainOpenWithOptions(string(srcRepoPath), &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	branchExists := targetBranchExists(targetBranchReferenceName, repo)
 	if !branchExists {
-		logger.Debug().Msgf("Branch %s does not exist in repo %s. Exiting", targetBranchReferenceName.Short(), srcRepoPath)
-		return nil
+		return nil, fmt.Errorf("branch %s does not exist in repo %s", targetBranchReferenceName.Short(), srcRepoPath)
 	}
 	var gitSrcRepoPath = filepath.Join(string(srcRepoPath), ".git")
 	gitDestRepoPath := filepath.Join(string(destinationRepoPath), ".git")
 	logger.Debug().Msgf("Attemping to copy repo .git folder from: %s to: %s ", gitSrcRepoPath, gitDestRepoPath)
 	err = copy.Copy(gitSrcRepoPath, gitDestRepoPath)
 	if err != nil {
-		logger.Debug().Err(err).Msgf("Copy operation failed. Exiting")
-		return nil
+		return nil, fmt.Errorf("copying %s to %s failed: %w", gitSrcRepoPath, gitDestRepoPath, err)
 	}
 	logger.Debug().Msg("Copy operation succeeded")
-	targetRepo, checkOutErr := resetAndCheckoutRepo(string(destinationRepoPath), targetBranchReferenceName)
+	targetRepo, checkOutErr := materializeBranchWorktree(logger, string(destinationRepoPath), targetBranchReferenceName)
 	if checkOutErr != nil {
-		logger.Debug().Err(checkOutErr).Msgf("Could not checkout target branch %s. Exiting", targetBranchReferenceName.Short())
-		return nil
+		return nil, fmt.Errorf("checking out %s in %s failed: %w", targetBranchReferenceName.Short(), destinationRepoPath, checkOutErr)
 	}
 
 	logger.Debug().
 		Str("branch", targetBranchReferenceName.Short()).
 		Msg("successfully cloned base branch via FS copy")
 
-	return targetRepo
+	return targetRepo, nil
 }
 
 func LocalRepoHasChanges(conf configuration.Configuration, logger *zerolog.Logger, repoPath types.FilePath) (bool, error) {

--- a/internal/vcs/git_cloner_test.go
+++ b/internal/vcs/git_cloner_test.go
@@ -25,10 +25,12 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
@@ -36,7 +38,7 @@ import (
 func TestClone_ShouldClone(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepo(t, repoPath, false)
+	initWorktreeRepo(t, repoPath, false)
 
 	tmpFolderPath := types.FilePath(t.TempDir())
 	cloneTargetBranchName := "master"
@@ -49,7 +51,7 @@ func TestClone_ShouldClone(t *testing.T) {
 func TestClone_ShouldClone_SameOriginRemoteUrl(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	srcRepo, _ := initGitRepo(t, repoPath, false)
+	srcRepo, _ := initWorktreeRepo(t, repoPath, false)
 
 	tmpFolderPath := types.FilePath(t.TempDir())
 	cloneTargetBranchName := "master"
@@ -74,7 +76,7 @@ func TestClone_ShouldClone_SameOriginRemoteUrl(t *testing.T) {
 func TestClone_InvalidBranchName(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepo(t, repoPath, false)
+	initWorktreeRepo(t, repoPath, false)
 
 	tmpFolderPath := types.FilePath(t.TempDir())
 	cloneTargetBranchName := "foobar"
@@ -87,8 +89,8 @@ func TestClone_InvalidBranchName(t *testing.T) {
 func TestClone_DetachedHead_TargetBranchExists(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	destinationPath := types.FilePath(t.TempDir())
-	repo, currentHead := initGitRepo(t, repoPath, true)
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	repo, currentHead := initWorktreeRepo(t, repoPath, true)
 	worktree, err := repo.Worktree()
 	assert.NoError(t, err)
 	_, err = worktree.Commit("testCommit", &git.CommitOptions{
@@ -109,8 +111,8 @@ func TestClone_DetachedHead_TargetBranchExists(t *testing.T) {
 func TestClone_DetachedHead_TargetBranchExists_SameOriginRemoteUrl(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	destinationPath := types.FilePath(t.TempDir())
-	srcRepo, currentHead := initGitRepo(t, repoPath, true)
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	srcRepo, currentHead := initWorktreeRepo(t, repoPath, true)
 	worktree, err := srcRepo.Worktree()
 	assert.NoError(t, err)
 	_, err = worktree.Commit("testCommit", &git.CommitOptions{
@@ -143,8 +145,8 @@ func TestClone_DetachedHead_TargetBranchExists_SameOriginRemoteUrl(t *testing.T)
 func TestClone_DetachedHead_TargetBranchDoesNotExists(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	destinationPath := types.FilePath(t.TempDir())
-	repo, currentHead := initGitRepo(t, repoPath, true)
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	repo, currentHead := initWorktreeRepo(t, repoPath, true)
 	worktree, err := repo.Worktree()
 	assert.NoError(t, err)
 	_, err = worktree.Commit("testCommit", &git.CommitOptions{
@@ -165,8 +167,8 @@ func TestClone_DetachedHead_TargetBranchDoesNotExists(t *testing.T) {
 func TestClone_DetachedHead_TargetBranchExists_OpenChanges(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	destinationPath := types.FilePath(t.TempDir())
-	repo, currentHead := initGitRepo(t, repoPath, true)
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	repo, currentHead := initWorktreeRepo(t, repoPath, true)
 	worktree, err := repo.Worktree()
 	assert.NoError(t, err)
 	_, err = worktree.Commit("testCommit", &git.CommitOptions{
@@ -205,7 +207,7 @@ func TestClone_InvalidGitRepo(t *testing.T) {
 func TestClone_ShouldShallowClone(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepoWithHistory(t, repoPath, 10)
+	initWorktreeRepoWithHistory(t, repoPath, 10)
 
 	tmpFolderPath := types.FilePath(t.TempDir())
 	repo, err := Clone(engine.GetLogger(), repoPath, tmpFolderPath, "master")
@@ -229,7 +231,7 @@ func TestClone_ShouldShallowClone(t *testing.T) {
 func TestClone_FromSubfolder_ShouldClone(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepo(t, repoPath, false)
+	initWorktreeRepo(t, repoPath, false)
 
 	// Create a subfolder inside the git repo
 	subfolder := filepath.Join(string(repoPath), "subproject")
@@ -245,10 +247,336 @@ func TestClone_FromSubfolder_ShouldClone(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestClone_MaterializesNestedWindowsDeviceFileName(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	testutil.InitGitRepoWithFiles(t, repoPath, map[string]string{
+		"testFile.txt":         "testData",
+		"scripts/build/prn.sh": "#!/bin/sh\necho build\n",
+	})
+
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	repo, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	requireFileContent(t, filepath.Join(string(destinationPath), "testFile.txt"), "testData")
+	requireFileContent(t, filepath.Join(string(destinationPath), "scripts", "build", "prn.sh"), "#!/bin/sh\necho build\n")
+}
+
+func TestClone_MaterializesWindowsReservedDeviceNames(t *testing.T) {
+	testCases := []struct {
+		name     string
+		filePath string
+	}{
+		{name: "CON", filePath: "con.go"},
+		{name: "NUL", filePath: "NUL.md"},
+		{name: "AUX as directory", filePath: "aux/x.txt"},
+		{name: "COM1", filePath: "com1.txt"},
+		{name: "LPT9", filePath: "lpt9.js"},
+		{name: "CONIN$", filePath: "conin$.sh"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := testutil.UnitTest(t)
+			repoPath := types.FilePath(t.TempDir())
+			testutil.InitGitRepoWithFiles(t, repoPath, map[string]string{tc.filePath: "content"})
+
+			destinationPath := types.FilePath(newWorktreeDir(t))
+			repo, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+			require.NoError(t, err)
+			require.NotNil(t, repo)
+			requireFileContent(t, filepath.Join(string(destinationPath), filepath.FromSlash(tc.filePath)), "content")
+		})
+	}
+}
+
+// TestClone_MaterializesBackslashInFileName guards a name that is ordinary on
+// POSIX filesystems and that real git does commit, against the separator check
+// materializeTree applies to entry names.
+func TestClone_MaterializesBackslashInFileName(t *testing.T) {
+	testsupport.NotOnWindows(t, `a backslash is a path separator on Windows, so no such file can exist there`)
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	testutil.InitGitRepoWithFiles(t, repoPath, map[string]string{`weird\name.txt`: "content"})
+
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	repo, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	requireFileContent(t, filepath.Join(string(destinationPath), `weird\name.txt`), "content")
+}
+
+func TestClone_DetachedHead_MaterializesWindowsDeviceFileName(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	srcRepo := testutil.InitGitRepoWithFiles(t, repoPath, map[string]string{
+		"testFile.txt":         "testData",
+		"scripts/build/prn.sh": "#!/bin/sh\necho build\n",
+	})
+	testutil.DetachGitRepoHeadBehindMaster(t, srcRepo)
+
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	repo, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	requireFileContent(t, filepath.Join(string(destinationPath), "testFile.txt"), "testData")
+	requireFileContent(t, filepath.Join(string(destinationPath), "scripts", "build", "prn.sh"), "#!/bin/sh\necho build\n")
+}
+
+func TestClone_MaterializesExecutablesAndSymlinks(t *testing.T) {
+	testsupport.NotOnWindows(t, "symlink creation needs elevated privileges on Windows")
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	testutil.InitGitRepoWithEntries(t, repoPath, map[string]testutil.GitFixtureFile{
+		"plain.txt":  {Content: "plain", Mode: filemode.Regular},
+		"run.sh":     {Content: "#!/bin/sh\n", Mode: filemode.Executable},
+		"link-to-me": {Content: "plain.txt", Mode: filemode.Symlink},
+	})
+
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	repo, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	executable, err := os.Stat(OSPath(filepath.Join(string(destinationPath), "run.sh")))
+	require.NoError(t, err)
+	assert.NotZero(t, executable.Mode()&0100, "executable bit should survive materialization")
+
+	linkPath := OSPath(filepath.Join(string(destinationPath), "link-to-me"))
+	link, err := os.Lstat(linkPath)
+	require.NoError(t, err)
+	assert.NotZero(t, link.Mode()&os.ModeSymlink, "symlink should be written as a symlink")
+	linkTarget, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, "plain.txt", linkTarget)
+}
+
+// TestMaterializeWorktree_ReportsUnreadableSubtree pins that a subtree go-git
+// cannot load is an error rather than a short worktree reported as complete: a
+// partial baseline gets persisted against the real commit hash, and the
+// snapshot-exists check then suppresses every later scan.
+//
+// It drives materializeWorktree rather than Clone because a commit referencing
+// a missing object cannot be served by upload-pack at all, so a Clone-level
+// test would fail during the fetch and prove nothing about the walk.
+func TestMaterializeWorktree_ReportsUnreadableSubtree(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	repo := testutil.InitGitRepo(t, repoPath)
+
+	// A root tree naming a subtree whose object was never written, alongside a
+	// file sorting after it that a truncating walk would silently drop.
+	missingSubtree := plumbing.NewHash("1111111111111111111111111111111111111111")
+	commitHash := testutil.CommitGitTree(t, repo, testutil.WriteGitTree(t, repo.Storer, []object.TreeEntry{
+		{Name: "gone", Mode: filemode.Dir, Hash: missingSubtree},
+		{Name: "zz-last.txt", Mode: filemode.Regular, Hash: testutil.WriteGitBlob(t, repo.Storer, "kept")},
+	}))
+
+	destinationPath := t.TempDir()
+	err := materializeWorktree(engine.GetLogger(), repo, destinationPath, commitHash)
+
+	require.Error(t, err, "an unreadable subtree must fail, not truncate the worktree")
+	assert.NoFileExists(t, OSPath(filepath.Join(destinationPath, "zz-last.txt")))
+}
+
+func TestClone_DoesNotWriteThroughSymlinkedTreeEntries(t *testing.T) {
+	testsupport.NotOnWindows(t, "symlink creation needs elevated privileges on Windows")
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	outsidePath := t.TempDir()
+	repo := testutil.InitGitRepo(t, repoPath)
+
+	// "EVIL" twice: a symlink out of the worktree, then the directory holding
+	// "payload". Git orders "EVIL" before "EVIL/", so a materializer that creates
+	// symlinks as it walks has the link in place before it writes the file.
+	innerTree := testutil.WriteGitTree(t, repo.Storer, []object.TreeEntry{
+		{Name: "payload", Mode: filemode.Regular, Hash: testutil.WriteGitBlob(t, repo.Storer, "owned")},
+	})
+	testutil.CommitGitTree(t, repo, testutil.WriteGitTree(t, repo.Storer, []object.TreeEntry{
+		{Name: "EVIL", Mode: filemode.Symlink, Hash: testutil.WriteGitBlob(t, repo.Storer, outsidePath)},
+		{Name: "EVIL", Mode: filemode.Dir, Hash: innerTree},
+	}))
+
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	_, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(outsidePath)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "materialization must not write through a symlink named by the tree")
+	assert.FileExists(t, filepath.Join(string(destinationPath), "EVIL", "payload"))
+}
+
+func TestClone_DoesNotWriteThroughSymlinkNamedByAnotherSymlink(t *testing.T) {
+	testsupport.NotOnWindows(t, "symlink creation needs elevated privileges on Windows")
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	outsidePath := t.TempDir()
+	repo := testutil.InitGitRepo(t, repoPath)
+
+	// "a" points out of the worktree and "a/b" carries a slash in its name, which
+	// go-git's decoder accepts. Both defer to the symlink pass, "a" sorts first,
+	// so creating "a/b" resolves its parent through the link.
+	testutil.CommitGitTree(t, repo, testutil.WriteGitTree(t, repo.Storer, []object.TreeEntry{
+		{Name: "a", Mode: filemode.Symlink, Hash: testutil.WriteGitBlob(t, repo.Storer, outsidePath)},
+		{Name: "a/b", Mode: filemode.Symlink, Hash: testutil.WriteGitBlob(t, repo.Storer, "payload")},
+	}))
+
+	destinationPath := types.FilePath(newWorktreeDir(t))
+	_, cloneErr := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+	entries, err := os.ReadDir(outsidePath)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "materialization must not write through a symlink it created itself")
+
+	require.ErrorIs(t, cloneErr, ErrInvalidTreeEntryName,
+		"a tree entry name git could not have produced must abort the clone")
+}
+
+func TestClone_RejectsDotGitDisguisedTreeEntries(t *testing.T) {
+	testCases := []struct {
+		name     string
+		filePath string
+	}{
+		{name: "NTFS short name", filePath: "git~1"},
+		{name: "trailing space", filePath: ".git "},
+		{name: "nested trailing dot", filePath: "nested/.git./config"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := testutil.UnitTest(t)
+			repoPath := types.FilePath(t.TempDir())
+			testutil.InitGitRepoWithFiles(t, repoPath, map[string]string{tc.filePath: "payload"})
+
+			destinationPath := types.FilePath(newWorktreeDir(t))
+			repo, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+			require.Error(t, err)
+			assert.Nil(t, repo)
+			// Must be go-git's ValidTreePath, the guard the materializer rests on
+			// for .git safety, and not our own separator check.
+			require.ErrorIs(t, err, ErrRejectedTreeEntryPath)
+			require.NotErrorIs(t, err, ErrInvalidTreeEntryName)
+			assert.NoFileExists(t, OSPath(filepath.Join(string(destinationPath), filepath.FromSlash(tc.filePath))))
+		})
+	}
+}
+
+// requireFileContent reads through OSPath, because a plain Lstat of a reserved
+// device name on Windows resolves to the device instead of what we wrote.
+func requireFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	content, err := os.ReadFile(OSPath(path)) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, want, string(content))
+}
+
+// TestClone_MaterializesCollidingEntries covers two legal tree entries that land
+// on one path. One of them has to lose, but losing the whole baseline is this
+// ticket's own bug, so the clone must still succeed and later entries must still
+// be written.
+//
+// Only the duplicate-name case collides on a case-sensitive filesystem, so it is
+// the one that actually exercises the tolerance here; the case-differing pair is
+// the shape real repositories have, and collides on APFS and NTFS.
+func TestClone_MaterializesCollidingEntries(t *testing.T) {
+	testCases := []struct {
+		name  string
+		first string
+		last  string
+	}{
+		{name: "duplicate names", first: "dup.txt", last: "dup.txt"},
+		{name: "names differing only in case", first: "A.txt", last: "a.txt"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := testutil.UnitTest(t)
+			repoPath := types.FilePath(t.TempDir())
+			repo := testutil.InitGitRepo(t, repoPath)
+			blob := testutil.WriteGitBlob(t, repo.Storer, "content")
+			testutil.CommitGitTree(t, repo, testutil.WriteGitTree(t, repo.Storer, []object.TreeEntry{
+				{Name: tc.first, Mode: filemode.Regular, Hash: blob},
+				{Name: tc.last, Mode: filemode.Regular, Hash: blob},
+				{Name: "zz-sibling.txt", Mode: filemode.Regular, Hash: testutil.WriteGitBlob(t, repo.Storer, "after")},
+			}))
+
+			destinationPath := types.FilePath(newWorktreeDir(t))
+			cloned, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+			require.NoError(t, err, "a colliding entry must not cost the whole baseline")
+			require.NotNil(t, cloned)
+			assert.FileExists(t, filepath.Join(string(destinationPath), tc.first))
+			// The entry sorting after the collision still has to be written; an
+			// abort would silently truncate the baseline right here.
+			requireFileContent(t, filepath.Join(string(destinationPath), "zz-sibling.txt"), "after")
+		})
+	}
+}
+
+// TestClone_RejectsGitmodulesSymlinks pins go-git's validSymlinkName, upstream
+// git's CVE-2018-11235 mitigation, which ValidTreePath does not cover.
+func TestClone_RejectsGitmodulesSymlinks(t *testing.T) {
+	testCases := []struct {
+		name  string
+		entry string
+	}{
+		{name: "at the root", entry: ".gitmodules"},
+		{name: "in a subdirectory", entry: "sub/.gitmodules"},
+		{name: "case insensitively", entry: ".GitModules"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := testutil.UnitTest(t)
+			repoPath := types.FilePath(t.TempDir())
+			testutil.InitGitRepoWithEntries(t, repoPath, map[string]testutil.GitFixtureFile{
+				tc.entry: {Content: "../outside/evil", Mode: filemode.Symlink},
+			})
+
+			destinationPath := types.FilePath(newWorktreeDir(t))
+			_, err := Clone(engine.GetLogger(), repoPath, destinationPath, "master")
+
+			require.ErrorIs(t, err, ErrGitModulesSymlink)
+			assert.NoFileExists(t, filepath.Join(string(destinationPath), filepath.FromSlash(tc.entry)))
+		})
+	}
+}
+
+func TestMaterializeWorktree_RejectsRelativeRoot(t *testing.T) {
+	engine := testutil.UnitTest(t)
+	repoPath := types.FilePath(t.TempDir())
+	repo := testutil.InitGitRepoWithFiles(t, repoPath, map[string]string{"a.txt": "content"})
+	master, err := repo.Reference(plumbing.Master, true)
+	require.NoError(t, err)
+
+	err = materializeWorktree(engine.GetLogger(), repo, "relative/destination", master.Hash())
+
+	require.ErrorIs(t, err, ErrRelativeWorktreeRoot)
+}
+
+// newWorktreeDir returns an empty directory whose cleanup goes through OSPath.
+// t.TempDir's own cleanup uses an unprefixed RemoveAll and calls t.Errorf when
+// it fails, which on Windows is every directory holding a reserved device name.
+func newWorktreeDir(t *testing.T) string {
+	t.Helper()
+	//nolint:usetesting // t.TempDir cleans up with an unprefixed RemoveAll, which cannot delete a reserved device name on Windows
+	dir, err := os.MkdirTemp("", "snyk-ls-worktree")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(OSPath(dir)) })
+	return dir
+}
+
 func TestLocalRepoHasChanges_SameBranchNames_NoModification_SkipClone(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepo(t, repoPath, false)
+	initWorktreeRepo(t, repoPath, false)
 	shouldclone, err := LocalRepoHasChanges(engine.GetConfiguration(), engine.GetLogger(), repoPath)
 
 	assert.NoError(t, err)
@@ -258,7 +586,7 @@ func TestLocalRepoHasChanges_SameBranchNames_NoModification_SkipClone(t *testing
 func TestLocalRepoHasChanges_SameBranchNames_WithModification_Clone(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepo(t, repoPath, true)
+	initWorktreeRepo(t, repoPath, true)
 	shouldclone, err := LocalRepoHasChanges(engine.GetConfiguration(), engine.GetLogger(), repoPath)
 
 	assert.NoError(t, err)
@@ -268,7 +596,7 @@ func TestLocalRepoHasChanges_SameBranchNames_WithModification_Clone(t *testing.T
 func TestLocalRepoHasChanges_DifferentBranchNames_Clone(t *testing.T) {
 	engine := testutil.UnitTest(t)
 	repoPath := types.FilePath(t.TempDir())
-	repo, _ := initGitRepo(t, repoPath, true)
+	repo, _ := initWorktreeRepo(t, repoPath, true)
 	wt, err := repo.Worktree()
 	assert.NoError(t, err)
 	err = wt.Checkout(&git.CheckoutOptions{
@@ -284,7 +612,7 @@ func TestLocalRepoHasChanges_DifferentBranchNames_Clone(t *testing.T) {
 }
 
 func TestLocalRepoHasChanges_HasUncommittedChanges(t *testing.T) {
-	repo, _ := initGitRepo(t, types.FilePath(t.TempDir()), true)
+	repo, _ := initWorktreeRepo(t, types.FilePath(t.TempDir()), true)
 
 	hasChanges := hasUncommitedChanges(repo)
 
@@ -292,14 +620,14 @@ func TestLocalRepoHasChanges_HasUncommittedChanges(t *testing.T) {
 }
 
 func TestLocalRepoHasChanges_HasCommittedChanges(t *testing.T) {
-	repo, _ := initGitRepo(t, types.FilePath(t.TempDir()), false)
+	repo, _ := initWorktreeRepo(t, types.FilePath(t.TempDir()), false)
 
 	hasChanges := hasUncommitedChanges(repo)
 
 	assert.False(t, hasChanges)
 }
 
-func initGitRepoWithHistory(t *testing.T, repoPath types.FilePath, commits int) *git.Repository {
+func initWorktreeRepoWithHistory(t *testing.T, repoPath types.FilePath, commits int) *git.Repository {
 	t.Helper()
 	repo, err := git.PlainInit(string(repoPath), false)
 	require.NoError(t, err)
@@ -328,7 +656,7 @@ func initGitRepoWithHistory(t *testing.T, repoPath types.FilePath, commits int) 
 	return repo
 }
 
-func initGitRepo(t *testing.T, repoPath types.FilePath, isModified bool) (*git.Repository, *plumbing.Reference) {
+func initWorktreeRepo(t *testing.T, repoPath types.FilePath, isModified bool) (*git.Repository, *plumbing.Reference) {
 	t.Helper()
 	repoPathAsString := string(repoPath)
 	repo, err := git.PlainInit(repoPathAsString, false)

--- a/internal/vcs/git_utils.go
+++ b/internal/vcs/git_utils.go
@@ -143,22 +143,23 @@ func targetBranchExists(branchName plumbing.ReferenceName, repo *git.Repository)
 	return branchExists
 }
 
-func resetAndCheckoutRepo(repoPath string, branchName plumbing.ReferenceName) (*git.Repository, error) {
+func materializeBranchWorktree(logger *zerolog.Logger, repoPath string, branchName plumbing.ReferenceName) (*git.Repository, error) {
 	repo, err := git.PlainOpenWithOptions(repoPath, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		return nil, err
 	}
-	workTree, err := repo.Worktree()
+
+	branchRef, err := repo.Reference(branchName, true)
 	if err != nil {
 		return nil, err
 	}
 
-	err = workTree.Reset(&git.ResetOptions{Mode: git.HardReset})
+	err = repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, branchName))
 	if err != nil {
 		return nil, err
 	}
 
-	err = workTree.Checkout(&git.CheckoutOptions{Force: true, Branch: branchName})
+	err = materializeWorktree(logger, repo, repoPath, branchRef.Hash())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git_utils_test.go
+++ b/internal/vcs/git_utils_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestGitRepoRoot_AtRepoRoot(t *testing.T) {
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepo(t, repoPath, false)
+	initWorktreeRepo(t, repoPath, false)
 
 	root, err := GitRepoRoot(repoPath)
 
@@ -39,7 +39,7 @@ func TestGitRepoRoot_AtRepoRoot(t *testing.T) {
 
 func TestGitRepoRoot_FromSubfolder(t *testing.T) {
 	repoPath := types.FilePath(t.TempDir())
-	initGitRepo(t, repoPath, false)
+	initWorktreeRepo(t, repoPath, false)
 
 	subfolder := filepath.Join(string(repoPath), "some", "nested", "subfolder")
 	require.NoError(t, os.MkdirAll(subfolder, 0o755))

--- a/internal/vcs/os_path_other.go
+++ b/internal/vcs/os_path_other.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vcs
+
+// OSPath is only meaningful on Windows, where reserved device names need the
+// extended-length prefix to reach the filesystem.
+func OSPath(p string) string {
+	return p
+}
+
+// isSymlinkPrivilegeError is Windows-only; symlink creation is unprivileged here.
+func isSymlinkPrivilegeError(error) bool {
+	return false
+}

--- a/internal/vcs/os_path_windows.go
+++ b/internal/vcs/os_path_windows.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vcs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const extendedLengthPrefix = `\\?\`
+
+// OSPath returns p in extended-length form, which skips Win32 path parsing and
+// with it the interception of reserved device names such as prn.sh. Extended
+// paths get no normalization, so p must already be absolute and cleaned;
+// anything else is returned unchanged rather than silently mangled. Exported
+// because callers outside this package need it to stat or read what we wrote.
+func OSPath(p string) string {
+	if strings.HasPrefix(p, extendedLengthPrefix) || !filepath.IsAbs(p) {
+		return p
+	}
+	if strings.HasPrefix(p, `\\`) {
+		return extendedLengthPrefix + `UNC` + strings.TrimPrefix(p, `\`)
+	}
+	return extendedLengthPrefix + p
+}
+
+// isSymlinkPrivilegeError reports the one failure git itself tolerates: an
+// unprivileged Windows process cannot create symlinks at all.
+func isSymlinkPrivilegeError(err error) bool {
+	const errorPrivilegeNotHeld syscall.Errno = 1314
+
+	var linkErr *os.LinkError
+	if !errors.As(err, &linkErr) {
+		return false
+	}
+	var errno syscall.Errno
+	return errors.As(linkErr.Err, &errno) && errno == errorPrivilegeNotHeld
+}

--- a/internal/vcs/os_path_windows_test.go
+++ b/internal/vcs/os_path_windows_test.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vcs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOSPath(t *testing.T) {
+	testCases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "drive absolute gets the extended-length prefix",
+			path: `C:\Users\dev\repo\prn.sh`,
+			want: `\\?\C:\Users\dev\repo\prn.sh`,
+		},
+		{
+			name: "UNC absolute gets the UNC extended form",
+			path: `\\server\share\repo\nul.md`,
+			want: `\\?\UNC\server\share\repo\nul.md`,
+		},
+		{
+			name: "already prefixed is left alone",
+			path: `\\?\C:\Users\dev\repo\con.go`,
+			want: `\\?\C:\Users\dev\repo\con.go`,
+		},
+		{
+			name: "already prefixed UNC is left alone",
+			path: `\\?\UNC\server\share\repo\aux`,
+			want: `\\?\UNC\server\share\repo\aux`,
+		},
+		{
+			name: "relative is left alone, an extended path must be absolute",
+			path: `repo\lpt9.js`,
+			want: `repo\lpt9.js`,
+		},
+		{
+			name: "drive relative is left alone, it is not absolute",
+			path: `C:repo\com1.txt`,
+			want: `C:repo\com1.txt`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, OSPath(tc.path))
+		})
+	}
+}
+
+// TestOSPath_ReachesAReservedDeviceName is the claim the whole Windows path
+// rests on: the returned form addresses a real file rather than the device.
+func TestOSPath_ReachesAReservedDeviceName(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "prn.sh")
+
+	require.NoError(t, os.WriteFile(OSPath(target), []byte("content"), 0600))
+
+	content, err := os.ReadFile(OSPath(target))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}

--- a/internal/vcs/worktree_materializer.go
+++ b/internal/vcs/worktree_materializer.go
@@ -1,0 +1,305 @@
+/*
+ * © 2026 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file writes base branch worktrees itself instead of using go-git's
+// checkout, which refuses Windows reserved device names such as prn.sh on every
+// OS. Setting core.protectNTFS=false would fix macOS and Linux but not Windows,
+// where the OS intercepts the name and only an extended-length path gets past
+// it, and it would drop go-git's .git-disguise mitigations wholesale. The
+// validators go-git applies at that layer are reproduced below.
+
+package vcs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/rs/zerolog"
+)
+
+const (
+	gitmodulesFile = ".gitmodules"
+	// maxTreeDepth matches go-git's own limit on self-referencing trees.
+	maxTreeDepth = 1024
+)
+
+var (
+	// ErrInvalidTreeEntryName is returned for a tree entry name that git itself
+	// could not have produced.
+	ErrInvalidTreeEntryName = errors.New("invalid tree entry name")
+	// ErrRejectedTreeEntryPath is returned when go-git's own tree path validation
+	// rejects an entry, which is what guards ".." and the .git disguises.
+	ErrRejectedTreeEntryPath = errors.New("tree entry path rejected")
+	// ErrUnsupportedTreeEntryMode is returned for a tree entry whose mode is not
+	// one this package knows how to materialize.
+	ErrUnsupportedTreeEntryMode = errors.New("unsupported tree entry mode")
+	// ErrGitModulesSymlink mirrors go-git's refusal to check out a symlinked
+	// .gitmodules, which is upstream git's CVE-2018-11235 mitigation.
+	ErrGitModulesSymlink = errors.New(gitmodulesFile + " is a symlink")
+	// ErrMaxTreeDepth is returned for a tree nested past maxTreeDepth.
+	ErrMaxTreeDepth = errors.New("maximum tree depth exceeded")
+	// ErrRelativeWorktreeRoot is returned when the destination is not absolute,
+	// which on Windows would silently disable extended-length path handling.
+	ErrRelativeWorktreeRoot = errors.New("worktree root must be an absolute path")
+)
+
+// pendingSymlink is a symlink held back until every directory and regular file
+// has been written.
+type pendingSymlink struct {
+	path string
+	hash plumbing.Hash
+}
+
+// worktreeWriter materializes one commit's tree into rootPath.
+type worktreeWriter struct {
+	logger          *zerolog.Logger
+	repo            *git.Repository
+	rootPath        string
+	pendingSymlinks []pendingSymlink
+}
+
+// materializeWorktree writes commitHash's tree to rootPath, which must be an
+// empty absolute directory: the writes below rely on nothing already being
+// there. Entries this platform cannot represent (submodules, and names holding
+// a separator) are logged and skipped; anything else is written or fails.
+func materializeWorktree(logger *zerolog.Logger, repo *git.Repository, rootPath string, commitHash plumbing.Hash) error {
+	if !filepath.IsAbs(rootPath) {
+		return fmt.Errorf("%w: %q", ErrRelativeWorktreeRoot, rootPath)
+	}
+
+	commit, err := repo.CommitObject(commitHash)
+	if err != nil {
+		return err
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return err
+	}
+
+	writer := &worktreeWriter{logger: logger, repo: repo, rootPath: rootPath}
+	if err = writer.writeTree(tree, "", 0); err != nil {
+		return err
+	}
+
+	// Symlinks are written last so one can never be a leading component of a
+	// path still to be written, which the directory and file writes would follow.
+	for _, symlink := range writer.pendingSymlinks {
+		if err = writer.writeSymlink(symlink); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeTree walks tree itself rather than using object.NewTreeWalker, whose
+// documented behavior is to skip objects it cannot load - it turns a failed
+// subtree read into io.EOF, which would end the walk and report a partial
+// worktree as a complete one.
+func (w *worktreeWriter) writeTree(tree *object.Tree, prefix string, depth int) error {
+	if depth > maxTreeDepth {
+		return fmt.Errorf("%w at %q", ErrMaxTreeDepth, prefix)
+	}
+
+	for _, entry := range tree.Entries {
+		if err := checkTreeEntryName(tree, entry); err != nil {
+			return err
+		}
+		name := path.Join(prefix, entry.Name)
+
+		// A backslash is an ordinary character in a POSIX file name and real
+		// repositories hold such files, but on Windows it is a path separator.
+		if runtime.GOOS == "windows" && strings.ContainsRune(entry.Name, '\\') {
+			w.logger.Warn().Str("path", name).Msg("base branch worktree omits an entry whose name this platform cannot represent")
+			continue
+		}
+
+		if err := w.writeEntry(entry, name, depth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *worktreeWriter) writeEntry(entry object.TreeEntry, name string, depth int) error {
+	target := filepath.Join(w.rootPath, filepath.FromSlash(name))
+
+	switch entry.Mode {
+	case filemode.Dir:
+		subtree, err := object.GetTree(w.repo.Storer, entry.Hash)
+		if err != nil {
+			return err
+		}
+		if err = os.MkdirAll(OSPath(target), 0700); err != nil {
+			return err
+		}
+		return w.writeTree(subtree, name, depth+1)
+	case filemode.Symlink:
+		if err := rejectGitmodulesSymlink(name); err != nil {
+			return err
+		}
+		w.pendingSymlinks = append(w.pendingSymlinks, pendingSymlink{path: target, hash: entry.Hash})
+		return nil
+	case filemode.Regular, filemode.Deprecated, filemode.Executable:
+		return w.writeFile(target, name, entry)
+	case filemode.Submodule:
+		// Nothing to check out, and we never run submodule update on this clone.
+		w.logger.Warn().Str("path", name).Msg("base branch worktree omits a submodule")
+		return nil
+	default:
+		return fmt.Errorf("%w: %q is %v", ErrUnsupportedTreeEntryMode, name, entry.Mode)
+	}
+}
+
+func (w *worktreeWriter) writeFile(target, name string, entry object.TreeEntry) error {
+	err := writeWorktreeFile(w.repo, target, entry.Hash, entry.Mode)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, fs.ErrExist) {
+		return err
+	}
+	// Two entries differing only in case or Unicode form, on a filesystem that
+	// folds them together: the first written wins, as under go-git's checkout.
+	w.logger.Warn().Str("path", name).Msg("base branch worktree omits an entry whose path another entry already took")
+	return nil
+}
+
+// checkTreeEntryName applies the two name guards: git stores exactly one path
+// component per entry, so a slash cannot come from an object git produced and is
+// the only way a deferred symlink could parent a later write; and go-git's
+// ValidTreePath rejects "..", ".git" and its HFS+ and NTFS disguises at every
+// position, independently of any config.
+func checkTreeEntryName(tree *object.Tree, entry object.TreeEntry) error {
+	if strings.ContainsRune(entry.Name, '/') {
+		return fmt.Errorf("%w: %q", ErrInvalidTreeEntryName, entry.Name)
+	}
+	if _, err := tree.FindEntry(entry.Name); err != nil {
+		return fmt.Errorf("%w: %q: %w", ErrRejectedTreeEntryPath, entry.Name, err)
+	}
+	return nil
+}
+
+// rejectGitmodulesSymlink reproduces go-git's validSymlinkName, which refuses a
+// symlink whose path names .gitmodules so a checkout cannot plant submodule
+// config. The NTFS and HFS+ disguises it also covers need go-git internals we
+// cannot import, so only the plain name is matched here.
+func rejectGitmodulesSymlink(name string) error {
+	for _, part := range strings.Split(name, "/") {
+		if strings.EqualFold(part, gitmodulesFile) {
+			return fmt.Errorf("%w: %q", ErrGitModulesSymlink, name)
+		}
+	}
+	return nil
+}
+
+func writeWorktreeFile(repo *git.Repository, target string, hash plumbing.Hash, mode filemode.FileMode) error {
+	blob, err := repo.BlobObject(hash)
+	if err != nil {
+		return err
+	}
+	reader, err := blob.Reader()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+
+	perm := os.FileMode(0600)
+	if mode == filemode.Executable {
+		perm = 0700
+	}
+	file, err := createWorktreeFile(target, perm)
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(file, reader); err != nil {
+		_ = file.Close()
+		return err
+	}
+	// Not deferred: a Close error means the bytes never landed, and a truncated
+	// blob would otherwise be persisted as part of the baseline.
+	return file.Close()
+}
+
+// createWorktreeFile opens target for writing. O_EXCL because the root starts
+// empty, so an existing path means two tree entries collided and the caller
+// gets to decide rather than one silently overwriting the other.
+func createWorktreeFile(target string, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(OSPath(target), os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+}
+
+func (w *worktreeWriter) writeSymlink(symlink pendingSymlink) error {
+	return writeWorktreeSymlink(w.logger, w.repo, symlink.path, symlink.hash)
+}
+
+func writeWorktreeSymlink(logger *zerolog.Logger, repo *git.Repository, target string, hash plumbing.Hash) error {
+	blob, err := repo.BlobObject(hash)
+	if err != nil {
+		return err
+	}
+	reader, err := blob.Reader()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+
+	linkTarget, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+
+	// Parent directories already exist from the first pass.
+	switch err = os.Symlink(string(linkTarget), OSPath(target)); {
+	case err == nil:
+		return nil
+	case errors.Is(err, fs.ErrExist):
+		logger.Warn().Err(err).Str("path", target).Msg("base branch worktree omits a symlink whose path another entry already took")
+		return nil
+	case isSymlinkPrivilegeError(err):
+		// What git does under core.symlinks=false: store the link text as a file,
+		// so the scan sees the entry instead of a hole in the baseline.
+		return writeWorktreeSymlinkFallback(logger, target, linkTarget)
+	default:
+		return err
+	}
+}
+
+func writeWorktreeSymlinkFallback(logger *zerolog.Logger, target string, linkTarget []byte) error {
+	file, err := createWorktreeFile(target, 0600)
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			logger.Warn().Err(err).Str("path", target).Msg("base branch worktree omits a symlink whose path another entry already took")
+			return nil
+		}
+		return err
+	}
+	if _, err = file.Write(linkTarget); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}


### PR DESCRIPTION
### Description

Delta scanning reported no new issues for any repository containing a file whose base name is a Windows reserved device (`CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9`). go-git v5.19.x rejects those names in `worktreeFilesystem.validPath` on **every** operating system, where real git gates the equivalent `is_valid_win32_path` to Windows-native builds. So the base branch clone failed on macOS and Linux with `lstat: invalid path`, no baseline was recorded, and "New Issues" silently showed nothing.

Bumping go-git does not fix it. The reserved-name check on the checkout path is unchanged through v5.19.2, upstream is unfixed on the v5 line, and a fix there would land on `main` (v6) and need a separate backport plus a release. This is deliberately a local fix.

**Approach.** Clone with `NoCheckout` and write the commit tree ourselves, so go-git's worktree filesystem is never involved. On Windows the writes go through a `\\?\` extended-length prefix, which skips Win32 path parsing and lets NTFS hold the file. That covers the case a Windows developer can actually reach, where the reserved name is on the base branch and not in their working tree, since git refuses to check such a file out on Windows at all.

Setting `core.protectNTFS=false` on the clone would be ~5 lines and would fix macOS, but not Windows, and it disables a CVE mitigation wholesale.

### Owning the guards we left behind

Bypassing that layer means taking over the path safety it was applying. Every validator in go-git's `worktree_fs.go` was enumerated and accounted for:

| go-git guard | Here |
|---|---|
| control chars, empty path, `.`/`..`, volume names, `.git` + HFS+/NTFS disguises | still go-git's, via `ValidTreePath` |
| reserved device names | dropped deliberately, this is the bug |
| `validNoLeadingSymlink` | replaced: deferred symlink pass + separator rejection |
| `validSymlinkName` (`.gitmodules`) | reimplemented, plain name only |
| `maxTreeDepth` | reimplemented, 1024 |
| `Chroot`, `TempFile`, `readGitmodulesFile` | unreachable, we never chroot or run submodule ops |

Four of those were missing at some point during development and each has a regression test written red first: symlink traversal via a symlink shadowing a directory, the same via an entry name holding a path separator, `.gitmodules` symlinks, and the depth limit. Colliding entries are tolerated rather than fatal, because two tree entries can differ only in case or Unicode form and fold together on APFS and NTFS.

**Please review `internal/vcs/worktree_materializer.go` with that table in mind.** Worth a ProdSec look given the input is a tree object from a repository we do not control.

### Tests

Outside-in, each layer red before the next. The acceptance scenario drives the real server over LSP only (`initialize` with `WorkspaceFolders`, `initialized`, `didChangeConfiguration`, `executeCommand`) and asserts on `publishDiagnostics`, so it checks the customer-visible outcome: the developer sees the finding they introduced and not the one already on the base branch. It fails on a partial baseline, which an "a baseline exists" assertion structurally cannot.

The Snyk API is substituted at startup via a new test-only `di.WithProductScanners`, leaving the real scanner, folder and registration assembly in place.

### Known gaps

- Three symlink tests are `NotOnWindows`, since symlink creation needs elevated privileges there. So the deferred symlink pass, the privilege-error handling and both escape regressions do not run on Windows.
- `TestClone_MaterializesBackslashInFileName` is also `NotOnWindows`, which means the Windows-only warn-and-skip branch for separator-bearing names has no coverage on any platform. Small and worth a follow-up.
- Four pre-existing IDE-2418 BDD steps reach around the server rather than driving it over LSP. Not touched here; the `WithProductScanners` seam this PR adds would let them be rewired.

### Checklist

- [x] Tests added and all succeed
- [ ] Regenerated mocks, etc. (`make generate`) — not needed, no interfaces changed
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing — not needed
- [ ] License file updated, if new 3rd-party dependency is introduced — none added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
