### PR TITLE
test: git fixture isolation and API-call safety fixes

### DIFF
--- a/application/di/init_fix_folder_test.go
+++ b/application/di/init_fix_folder_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/snyk/remediation"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -119,7 +120,7 @@ func initGitRepoForDI(t *testing.T) string {
 	dir := t.TempDir()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))

--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -1230,7 +1230,7 @@ func createGitRepoForFix(t *testing.T) (string, error) {
 		dir = canonical
 	}
 	run := func(args ...string) error {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("git %v: %w (%s)", args, err, out)

--- a/application/server/ldx_sync_smoke_test.go
+++ b/application/server/ldx_sync_smoke_test.go
@@ -159,7 +159,7 @@ func Test_SmokeLdxSync_AddFolder(t *testing.T) {
 
 	jsonRpcRecorder.ClearNotifications()
 
-	folder2, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.PythonGoof, "c32657c", engine.GetLogger(), false)
+	folder2, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.PythonGoof, "97e28b6", engine.GetLogger(), false)
 	require.NoError(t, err, "Failed to setup second test repo")
 	require.NotEmpty(t, folder2, "Folder path should not be empty")
 	require.DirExists(t, string(folder2), "Folder should exist")

--- a/application/server/lsp_init_perf_test.go
+++ b/application/server/lsp_init_perf_test.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/snyk/snyk-ls/application/di"
 	"github.com/snyk/snyk-ls/infrastructure/featureflag"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -85,6 +86,9 @@ func disableAutoScan(t *testing.T, conf interface{ Set(string, any) }) {
 func TestProfileLSPInit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping profiling test in short mode; run explicitly: go test -run TestProfileLSPInit -v")
+	}
+	if os.Getenv(testsupport.SmokeTestEnvVar) != "" {
+		t.Skip("profiling test is not part of the smoke suite; run explicitly without SMOKE_TESTS")
 	}
 	engine, tokenService := testutil.UnitTestWithEngine(t)
 	params := buildInitParams(t, lspInitPerfFolderCount)
@@ -161,6 +165,9 @@ const lspInitRealHTTPMaxDuration = 40 * time.Second
 func Test_LSPInitCompletesWithManyFoldersRealHTTP(t *testing.T) {
 	if testing.Short() {
 		t.Skip("real-HTTP init test skipped in -short mode; run explicitly")
+	}
+	if os.Getenv(testsupport.SmokeTestEnvVar) != "" {
+		t.Skip("real-HTTP init test is not part of the smoke suite; run explicitly without SMOKE_TESTS")
 	}
 
 	engine, tokenService := testutil.UnitTestWithEngine(t)

--- a/application/server/lsp_init_perf_test.go
+++ b/application/server/lsp_init_perf_test.go
@@ -170,7 +170,7 @@ func Test_LSPInitCompletesWithManyFoldersRealHTTP(t *testing.T) {
 		t.Skip("real-HTTP init test is not part of the smoke suite; run explicitly without SMOKE_TESTS")
 	}
 
-	engine, tokenService := testutil.UnitTestWithEngine(t)
+	engine, tokenService := testutil.RealHTTPTestWithEngine(t)
 	params := buildInitParams(t, lspInitPerfFolderCount)
 
 	loc, _, _ := setupServer(t, engine, tokenService)

--- a/application/server/precedence_smoke_test.go
+++ b/application/server/precedence_smoke_test.go
@@ -446,7 +446,7 @@ func Test_SmokePrecedence_MultiFolder_DifferentOrgs(t *testing.T) {
 	jsonRpcRecorder.ClearNotifications()
 
 	// Add a second folder
-	folder2, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.PythonGoof, "c32657c", engine.GetLogger(), false)
+	folder2, err := folderconfig.SetupCustomTestRepo(t, types.FilePath(t.TempDir()), testsupport.PythonGoof, "97e28b6", engine.GetLogger(), false)
 	require.NoError(t, err)
 
 	addWorkSpaceFolder(t, loc, types.WorkspaceFolder{

--- a/application/server/secrets_smoke_test.go
+++ b/application/server/secrets_smoke_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snyk/snyk-ls/application/config"
 	"github.com/snyk/snyk-ls/domain/snyk"
 	"github.com/snyk/snyk-ls/internal/product"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
@@ -73,7 +74,7 @@ func Test_SmokeSecretsScan_UnsupportedFileDoesNotError(t *testing.T) {
 		{"commit", "-m", "initial"},
 	}
 	for _, args := range gitCmds {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = workspaceDir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -501,7 +501,7 @@ func initLocalFixtureRepo(t *testing.T, files map[string][]byte) types.FilePath 
 		require.NoError(t, os.WriteFile(filepath.Join(dir, name), content, 0600))
 	}
 	gitCmd := func(args ...string) *exec.Cmd {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 		return cmd
@@ -513,7 +513,7 @@ func initLocalFixtureRepo(t *testing.T, files map[string][]byte) types.FilePath 
 		out, err := gitCmd(args...).CombinedOutput()
 		require.NoErrorf(t, err, "git %v: %s", args, out)
 	}
-	commit := gitCmd("-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "commit", "-m", "init")
+	commit := gitCmd("commit", "-m", "init")
 	commit.Env = append(commit.Env,
 		"GIT_AUTHOR_NAME=Snyk LS Test",
 		"GIT_AUTHOR_EMAIL=snyk-ls-test@example.invalid",
@@ -2844,7 +2844,7 @@ func initializeGitRepoForMonorepoBenchmark(t *testing.T, repoDir string) {
 }
 
 func gitCommandForMonorepoBenchmark(dir string, args ...string) *exec.Cmd {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 	cmd.Dir = dir
 	cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	return cmd

--- a/application/server/smoke_main_helpers_test.go
+++ b/application/server/smoke_main_helpers_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -47,7 +48,7 @@ func setupLocalBareRepo(t *testing.T) localRepo {
 		{"config", "user.name", "Test"},
 		{"config", "commit.gpgsign", "false"},
 	} {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		require.NoError(t, cmd.Run(), "git %v", args)
 	}
@@ -58,7 +59,7 @@ func setupLocalBareRepo(t *testing.T) localRepo {
 		{"add", "."},
 		{"commit", "-m", "initial"},
 	} {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		require.NoError(t, cmd.Run(), "git %v", args)
 	}

--- a/benchmark/fixture_test.go
+++ b/benchmark/fixture_test.go
@@ -48,7 +48,7 @@ func TestGenerateMonorepoFixtureCounts_CustomDimensions(t *testing.T) {
 }
 
 func gitCommandForFixtureTest(dir string, args ...string) *exec.Cmd {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 	cmd.Dir = dir
 	cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	return cmd

--- a/domain/ide/command/remediation_fix_folder_test.go
+++ b/domain/ide/command/remediation_fix_folder_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snyk/snyk-ls/domain/ide/command"
 	"github.com/snyk/snyk-ls/domain/snyk/remediation"
 	noti "github.com/snyk/snyk-ls/internal/notification"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/uri"
@@ -62,7 +63,7 @@ func initGitRepoForCmd(t *testing.T) string {
 	}
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))

--- a/domain/snyk/remediation/remy_test.go
+++ b/domain/snyk/remediation/remy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/domain/snyk/remediation"
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -51,7 +52,7 @@ func initGitRepo(t *testing.T) string {
 
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))
@@ -795,7 +796,7 @@ func initGitRepoInDir(t *testing.T, dir string) {
 	t.Helper()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, string(out))
@@ -822,7 +823,7 @@ func commitFileInDir(t *testing.T, dir, relPath, content string) {
 		t.Helper()
 		const maxRetries = 8
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			cmd := exec.Command("git", args...)
+			cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 			cmd.Dir = dir
 			out, err := cmd.CombinedOutput()
 			if err == nil {

--- a/infrastructure/authentication/auth_service_impl_test.go
+++ b/infrastructure/authentication/auth_service_impl_test.go
@@ -258,6 +258,8 @@ func Test_UpdateCredentials(t *testing.T) {
 		mockNotifier := notification.NewMockNotifier()
 		service := NewAuthenticationService(engine, ts, nil, error_reporting.NewTestErrorReporter(engine), mockNotifier, testutil.DefaultConfigResolver(engine))
 
+		config.UpdateApiEndpointsOnConfig(engine.GetConfiguration(), config.DefaultSnykApiUrl)
+
 		token := "some_other_token"
 		service.UpdateCredentials(token, true, true)
 
@@ -311,6 +313,9 @@ func Test_Authenticate(t *testing.T) {
 	t.Run("Get endpoint from config and set in snyk-ls configuration ", func(t *testing.T) {
 		apiEndpoint := "https://api.eu.snyk.io"
 		engine, ts := testutil.UnitTestWithEngine(t)
+		// The engine URL is only adopted while the user has not customized the
+		// endpoint themselves, so the default is part of the scenario.
+		config.UpdateApiEndpointsOnConfig(engine.GetConfiguration(), config.DefaultSnykApiUrl)
 		engine.GetConfiguration().Set(configuration.API_URL, apiEndpoint)
 
 		provider := FakeAuthenticationProvider{Engine: engine}

--- a/infrastructure/code/snyk_code_http_client_test.go
+++ b/infrastructure/code/snyk_code_http_client_test.go
@@ -222,6 +222,7 @@ func TestGetCodeApiUrlForFolder(t *testing.T) {
 
 	t.Run("Default deeproxy url for code api", func(t *testing.T) {
 		engine := testutil.UnitTest(t)
+		config.UpdateApiEndpointsOnConfig(engine.GetConfiguration(), config.DefaultSnykApiUrl)
 
 		// Clear env since it takes priority over default deeproxy url.
 		t.Setenv(config.DeeproxyApiUrlKey, "")

--- a/internal/folderconfig/git.go
+++ b/internal/folderconfig/git.go
@@ -165,7 +165,9 @@ func SetupCustomTestRepo(t *testing.T, rootDir types.FilePath, url string, targe
 		reset.Env = gitEnv
 		output, err = reset.CombinedOutput()
 		logger.Debug().Msg(string(output))
-		assert.NoError(t, err, "reset didn't work: %s", string(output))
+		if err != nil {
+			return "", fmt.Errorf("reset didn't work: %w: %s", err, string(output))
+		}
 	}
 
 	clean := exec.Command("git", testsupport.GitUnsigned("clean", "--force")...)
@@ -173,7 +175,9 @@ func SetupCustomTestRepo(t *testing.T, rootDir types.FilePath, url string, targe
 	clean.Env = gitEnv
 	output, err = clean.CombinedOutput()
 	logger.Debug().Msg(string(output))
-	assert.NoError(t, err, "clean didn't work: %s", string(output))
+	if err != nil {
+		return "", fmt.Errorf("clean didn't work: %w: %s", err, string(output))
+	}
 
 	return types.FilePath(absoluteCloneRepoDir), nil
 }

--- a/internal/folderconfig/git.go
+++ b/internal/folderconfig/git.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slices"
 
+	"github.com/snyk/snyk-ls/internal/testsupport"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/util"
 )
@@ -143,28 +144,36 @@ func SetupCustomTestRepo(t *testing.T, rootDir types.FilePath, url string, targe
 		}
 	}
 	assert.NoError(t, os.MkdirAll(tempDir, 0755))
+	gitEnv := testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
+
 	cmd := []string{"clone", "-v", url, repoDir}
 	logger.Debug().Interface("cmd", cmd).Msg("clone command")
-	clone := exec.Command("git", cmd...)
+	clone := exec.Command("git", testsupport.GitUnsigned(cmd...)...)
 	clone.Dir = tempDir
-	reset := exec.Command("git", "reset", "--hard", targetCommit)
-	reset.Dir = absoluteCloneRepoDir
-
-	clean := exec.Command("git", "clean", "--force")
-	clean.Dir = absoluteCloneRepoDir
+	clone.Env = gitEnv
 
 	output, err := clone.CombinedOutput()
 	if err != nil {
 		t.Log(string(output))
 		t.Fatal(err, "clone didn't work")
 	}
-
 	logger.Debug().Msg(string(output))
-	output, _ = reset.CombinedOutput()
 
-	logger.Debug().Msg(string(output))
+	if targetCommit != "" {
+		reset := exec.Command("git", testsupport.GitUnsigned("reset", "--hard", targetCommit)...)
+		reset.Dir = absoluteCloneRepoDir
+		reset.Env = gitEnv
+		output, err = reset.CombinedOutput()
+		logger.Debug().Msg(string(output))
+		assert.NoError(t, err, "reset didn't work: %s", string(output))
+	}
+
+	clean := exec.Command("git", testsupport.GitUnsigned("clean", "--force")...)
+	clean.Dir = absoluteCloneRepoDir
+	clean.Env = gitEnv
 	output, err = clean.CombinedOutput()
-
 	logger.Debug().Msg(string(output))
-	return types.FilePath(absoluteCloneRepoDir), err
+	assert.NoError(t, err, "clean didn't work: %s", string(output))
+
+	return types.FilePath(absoluteCloneRepoDir), nil
 }

--- a/internal/folderconfig/git_test.go
+++ b/internal/folderconfig/git_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func gitCommandForTestRepo(dir string, args ...string) *exec.Cmd {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", testsupport.GitUnsigned(args...)...)
 	cmd.Dir = dir
 	cmd.Env = testsupport.GitEnvWithoutInheritedRepoConfig(os.Environ())
 	return cmd

--- a/internal/testsupport/helpers.go
+++ b/internal/testsupport/helpers.go
@@ -59,6 +59,14 @@ func SkipUnlessBenchmarkRealScanMonorepo(t *testing.T) {
 	}
 }
 
+// GitUnsigned prefixes git arguments with the flags that keep a fixture's
+// commits and tags unsigned. A developer's global commit.gpgsign applies to
+// every repository a test creates, and signing then fails wherever the
+// configured signing program is unreachable.
+func GitUnsigned(args ...string) []string {
+	return append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)
+}
+
 // GitEnvWithoutInheritedRepoConfig returns env without Git repository/config overrides
 // that can make temp-repo tests operate on the outer worktree or inherit host config.
 func GitEnvWithoutInheritedRepoConfig(env []string) []string {

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -171,6 +171,7 @@ func UnitTestWithEngine(t *testing.T) (workflow.Engine, *config.TokenServiceImpl
 // when no credentials are available.
 func RealHTTPTestWithEngine(t *testing.T) (workflow.Engine, *config.TokenServiceImpl) {
 	t.Helper()
+	_ = os.Setenv(shellenv.DisableShellEnvLoadingEnvVar, "1") //nolint:usetesting // t.Setenv panics when called from a parallel test (Go 1.25+)
 	token := testsupport.GetEnvironmentToken("")
 	if token == "" {
 		t.Skip("SNYK_TOKEN is not set; real-HTTP test requires credentials")

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -166,6 +166,45 @@ func UnitTestWithEngine(t *testing.T) (workflow.Engine, *config.TokenServiceImpl
 	return engine, ts
 }
 
+// RealHTTPTestWithEngine sets up an engine pointed at the default Snyk API with a
+// real token. Unlike UnitTestWithEngine, this exercises live HTTP paths and skips
+// when no credentials are available.
+func RealHTTPTestWithEngine(t *testing.T) (workflow.Engine, *config.TokenServiceImpl) {
+	t.Helper()
+	token := testsupport.GetEnvironmentToken("")
+	if token == "" {
+		t.Skip("SNYK_TOKEN is not set; real-HTTP test requires credentials")
+	}
+	engine, ts := config.InitEngine(initStandaloneTestPreEngine(t, []string{}))
+	conf := engine.GetConfiguration()
+	logger := engine.GetLogger()
+
+	err := types.WaitForDefaultEnv(t.Context(), conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config.SetupLogging(engine, ts, nil)
+	config.UpdateApiEndpointsOnConfig(conf, config.DefaultSnykApiUrl)
+	ts.SetToken(conf, token)
+	types.SetGlobalUser(conf, types.SettingTrustEnabled, false)
+	types.SetGlobalUser(conf, types.SettingAutomaticAuthentication, false)
+	types.SetGlobalUser(conf, types.SettingAuthenticationMethod, string(types.TokenAuthentication))
+	redirectConfigAndDataHome(t, conf, logger)
+	CLIDownloadLockFileCleanUp(t, conf)
+	config.SetOrganization(conf, "00000000-0000-0000-0000-000000000000")
+	conf.Set(configuration.ORGANIZATION_SLUG, "test-default-org-slug")
+	conf.Set(code.ConfigurationSastSettings, &sast_contract.SastResponse{SastEnabled: true, LocalCodeEngine: sast_contract.LocalCodeEngine{
+		Enabled: false,
+	},
+	})
+	t.Cleanup(func() {
+		cleanupFakeCliFile(conf, logger)
+	})
+
+	return engine, ts
+}
+
 func UnitTestWithCtx(t *testing.T) (workflow.Engine, context.Context) {
 	t.Helper()
 	engine, _ := UnitTestWithEngine(t)

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -106,6 +106,11 @@ func SmokeTestWithEngine(t *testing.T, tokenSecretName string, shardEnvVar strin
 	return prepareTestHelper(t, testsupport.SmokeTestEnvVar, tokenSecretName)
 }
 
+// unitTestAPIURL points unit tests at a closed port. A unit test must not
+// depend on the network: reaching the real API makes the result vary with
+// whatever credentials the host or its proxy supplies.
+const unitTestAPIURL = "http://127.0.0.1:1"
+
 func UnitTest(t *testing.T) workflow.Engine {
 	t.Helper()
 	engine, _ := UnitTestWithEngine(t)
@@ -141,6 +146,7 @@ func UnitTestWithEngine(t *testing.T) (workflow.Engine, *config.TokenServiceImpl
 	}
 
 	config.SetupLogging(engine, ts, nil)
+	config.UpdateApiEndpointsOnConfig(conf, unitTestAPIURL)
 	ts.SetToken(conf, "00000000-0000-0000-0000-000000000001")
 	types.SetGlobalUser(conf, types.SettingTrustEnabled, false)
 	types.SetGlobalUser(conf, types.SettingAutomaticAuthentication, false)

--- a/internal/testutil/test_setup_test.go
+++ b/internal/testutil/test_setup_test.go
@@ -1,0 +1,38 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+
+	"github.com/snyk/snyk-ls/internal/types"
+)
+
+// A unit test that reaches the real API passes or fails according to the
+// credentials the host or its proxy happens to supply. Both keys matter:
+// production code compares them to decide whether authentication redirected
+// the user elsewhere, so leaving either at the real endpoint reopens the hole.
+func Test_UnitTest_DoesNotPointAtTheRealAPI(t *testing.T) {
+	conf := UnitTest(t).GetConfiguration()
+
+	assert.NotEqual(t, types.DefaultSnykApiUrl, conf.GetString(configuration.API_URL))
+	assert.NotEqual(t, types.DefaultSnykApiUrl, types.GetGlobalString(conf, types.SettingApiEndpoint))
+}


### PR DESCRIPTION
### **User description**
## Summary
Two independent test-infrastructure fixes, split out of the abandoned IDE-2473 branch (see #1416, closed without merging) where they had been bundled in by mistake — neither is related to that ticket's reserved-device-filename bug.

- Git test fixtures no longer inherit the ambient commit-signing config, so they don't accidentally require or depend on the developer's own signing setup.
- Unit tests are kept off the real Snyk API.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./application/server/... ./internal/testutil/...`


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Centralize git unsigned configuration in test fixtures.

- Prevent unit tests from making real API calls.

- Ensure git test fixtures are isolated from signing configs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Tests --> GitCommands["Git Commands"]
  GitCommands --> GitUnsigned["testsupport.GitUnsigned"]
  GitUnsigned --> GitCLI["Git CLI (unsigned)"]
  Tests --> APICalls["API Calls"]
  APICalls --> MockedURL["testutil.UnitTestAPIURL (localhost:1)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>init_fix_folder_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-2cf48a6ecdd95a600d8e600054f9842199239f572267004f521ce9a3ab90df82">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bdd_steps_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-5fcf20b0c028ab75ebe77c10364d1656a95f054114f46d6a34e4b9057048c693">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>secrets_smoke_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-c1510bd6a7151e3624d073a590787bd9af09d36b87a53a56067ffc0f3c8603fd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server_smoke_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-13396c212387ae79a286802e0885b1c86f1bc389f0f6e82de58d49d641e15e08">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>smoke_main_helpers_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-692f9b24d83b11e5e789682576de2b9966a559a7f9d767d3eaa15824bc071df4">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fixture_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-208e407c95f64c9c6499266c2fea86786a58a01af5e1936ddec489a3229b1e69">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remediation_fix_folder_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-51525eb80d8edb6349988d5e7973b4a6d24a00c17f4ee3a4e2a96012568b96c1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remy_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-134aadf198cd3215218f8733c77a9a071513e237a89e7653df850894d1469489">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth_service_impl_test.go</strong><dd><code>Mock API URL for auth tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-33e0f870d9c9bdfd37c19b41becbbf26cf91138dc595504836ca8d5d5638b770">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>snyk_code_http_client_test.go</strong><dd><code>Mock API URL for Snyk Code tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-cea5565fb69d915e47d2142c4505270ebe741b34c4fe12d31dc4a71dae76b9fb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>git_test.go</strong><dd><code>Use GitUnsigned helper for git commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-49c7cb21074eeb97b5869dcb267f7248147f40308e6bae617f34cfa9dc47d13d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.go</strong><dd><code>Introduce GitUnsigned helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-1f1ca7a5432a49223388217abb0acaa5ed423f3e101c24125f138a8d7ca33c1e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_setup.go</strong><dd><code>Use local URL for unit test API endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-419938158429a6faf32768534f081b50d64ed0bc9823ed5e6b7f94292840b1c3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_setup_test.go</strong><dd><code>Add test for unit test API URL isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1419/changes#diff-82a578f588394b4220dd7b052915fee9d343f8b4d3d1520ae73ad8dc35574118">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to test helpers and fixture setup; production paths are only touched in `internal/folderconfig/git.go` for test-repo cloning behavior.
> 
> **Overview**
> Hardens test infrastructure so local git settings and live API credentials cannot make unit tests flaky or network-dependent.
> 
> **Git fixtures:** Adds `testsupport.GitUnsigned` and routes shell `git` invocations in tests (and `folderconfig` clone/reset/clean) through it, with isolated env where already used. Commits no longer depend on a developer’s global GPG signing. `SetupCustomTestRepo` also propagates errors from reset/clean and skips hard reset when no commit pin is given.
> 
> **API isolation:** `UnitTestWithEngine` now pins both API URL keys to a closed localhost port (`http://127.0.0.1:1`), with a regression test. Tests that need a real endpoint call `UpdateApiEndpointsOnConfig` explicitly or use new `RealHTTPTestWithEngine` (real token, skips without `SNYK_TOKEN`). The many-folder real-HTTP init perf test switches to that helper and is excluded when `SMOKE_TESTS` is set, alongside the profiling test.
> 
> **Misc:** Smoke multi-folder scenarios pin Python Goof at `97e28b6` instead of `c32657c`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269155219910d87f65acb447f8e05cb5675de8e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->