### PR TITLE
test: make the suite pass on a developer machine, not just in CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-PATH_add .bin/
-PATH_add .bin/pact/bin/
+PATH_add .bin/$(go env GOOS)-$(go env GOARCH)/
+PATH_add .bin/$(go env GOOS)-$(go env GOARCH)/pact/bin/

--- a/.github/docker-based-tests/entrypoint.sh
+++ b/.github/docker-based-tests/entrypoint.sh
@@ -27,6 +27,7 @@ sudo iptables -A OUTPUT -p tcp --dport 443 -j REJECT
 sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
 sleep 5 # wait for squid to startup
 make tools
-export PATH=$PATH:$PWD/.bin/pact/bin:$PWD/.bin/
+TOOLS_BIN="$PWD/.bin/$(go env GOOS)-$(go env GOARCH)"
+export PATH=$PATH:$TOOLS_BIN/pact/bin:$TOOLS_BIN/
 export DISPLAY=:99
 exec "$@"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,7 +115,7 @@ jobs:
           SNYK_TOKEN_CONSISTENT_IGNORES: ${{secrets.SNYK_TOKEN_CONSISTENT_IGNORES}}
           INTEG_TESTS: "true"
         run: |
-          export PATH=$PWD/.bin/pact/bin:$PATH
+          export PATH=$PWD/.bin/$(go env GOOS)-$(go env GOARCH)/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -132,7 +132,7 @@ jobs:
           SNYK_TOKEN_CONSISTENT_IGNORES: ${{secrets.SNYK_TOKEN_CONSISTENT_IGNORES}}
           INTEG_TESTS: "true"
         run: |
-          export PATH=$PWD/.bin/pact/bin:$PATH
+          export PATH=$PWD/.bin/$(go env GOOS)-$(go env GOARCH)/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -234,7 +234,7 @@ jobs:
           # by earlier steps via GITHUB_ENV.
         run: |
           export SMOKE_SHARD_${{ matrix.shard }}=1
-          export PATH="$PWD/.bin/pact/bin:$PATH"
+          export PATH="$PWD/.bin/$(go env GOOS)-$(go env GOARCH)/pact/bin:$PATH"
           if [ ${{ matrix.shard }} == 1 ]; then
             export SNYK_TOKEN=${{ secrets.SNYK_TOKEN }}
           elif [ ${{ matrix.shard }} == 2 ]; then
@@ -282,7 +282,7 @@ jobs:
           SNYK_TOKEN_CONSISTENT_IGNORES: ${{secrets.SNYK_TOKEN_CONSISTENT_IGNORES}}
           INTEG_TESTS: "true"
         run: |
-          export PATH=$PWD/.bin/pact/bin:$PATH
+          export PATH=$PWD/.bin/$(go env GOOS)-$(go env GOARCH)/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
           DEEPROXY_API_URL: ${{secrets.DEEPROXY_API_URL}}
           SNYK_TOKEN: ${{secrets.SNYK_TOKEN }}
         run: |
-          export PATH=$PWD/.bin/pact/bin:$PATH
+          export PATH=$PWD/.bin/$(go env GOOS)-$(go env GOARCH)/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99
@@ -73,7 +73,7 @@ jobs:
           INTEG_TESTS: "true"
           SMOKE_TESTS: "true"
         run: |
-          export PATH=$PWD/.bin/pact/bin:$PATH
+          export PATH=$PWD/.bin/$(go env GOOS)-$(go env GOARCH)/pact/bin:$PATH
 
           # this is required to be able to test the clipboard
           export DISPLAY=:99

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ VERSION := $(shell git show -s --format=%cd --date=format:%Y%m%d.%H%M%S)
 COMMIT := $(shell git show -s --format=%h)
 LDFLAGS_DEV := "-X 'github.com/snyk/snyk-ls/application/config.Development=true' -X 'github.com/snyk/snyk-ls/application/config.Version=v$(VERSION)-SNAPSHOT-$(COMMIT)'"
 
-TOOLS_BIN := $(shell pwd)/.bin
+TOOLS_BIN := $(shell pwd)/.bin/$(DEV_GOOS)-$(DEV_GOARCH)
 
 OVERRIDE_GOCI_LINT_V := v2.12.2
 GOLICENSES_V := v1.6.0
@@ -87,6 +87,7 @@ format: lint-fix
 test: test-js
 	@echo "==> Running tests..."
 	@mkdir -p $(BUILD_DIR)
+	@export PATH=$(TOOLS_BIN)/pact/bin:$$PATH && \
 	go test $(TIMEOUT) -failfast ./...
 	@stages="test"; \
 	 [ -n "$(INTEG_TESTS)" ] && stages="$$stages test-integ" || true; \

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ If you have any issues with running pact, please extend your PATH env.
 For example:
 
 ```
-PATH=$PATH:$PWD/.bin/pact/bin make test
+PATH=$PATH:$PWD/.bin/$(go env GOOS)-$(go env GOARCH)/pact/bin make test
 ```
 
 The output should look like this (it is running against the Snyk Code API and using the real CLI):

--- a/application/di/init_fix_folder_test.go
+++ b/application/di/init_fix_folder_test.go
@@ -127,6 +127,7 @@ func initGitRepoForDI(t *testing.T) string {
 	run("init")
 	run("config", "user.email", "test@example.com")
 	run("config", "user.name", "Test")
+	run("config", "commit.gpgsign", "false")
 	// overlay-FS write-ordering delays cause git to report "not a valid object" or
 	// false "local changes would be overwritten" errors during rebase/cherry-pick
 	// on this overlay filesystem. core.checkStat=minimal suppresses those

--- a/application/server/authentication_smoke_test.go
+++ b/application/server/authentication_smoke_test.go
@@ -18,10 +18,12 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -63,23 +65,33 @@ func getDummyOAuth2Token(expiry time.Time) oauth2.Token {
 func checkInvalidCredentialsMessageRequest(t *testing.T, expected string, tokenString string) {
 	t.Helper()
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_4")
-	srv, jsonRpcRecorder, _ := setupServer(t, engine, tokenService, WithRealDI())
-	enableOnlyProducts(t, engine, product.ProductOpenSource)
-	// we have to reset the token, as smoketest automatically grab it from env
+
+	authProvider := &invalidAuthProvider{
+		FakeAuthenticationProvider: &authentication.FakeAuthenticationProvider{
+			Engine:          engine,
+			IsAuthenticated: false,
+		},
+	}
+
 	tokenService.SetToken(engine.GetConfiguration(), "")
+
+	srv, jsonRpcRecorder, _ := setupServer(t, engine, tokenService, WithRealDI(), WithAuthProvider(authProvider))
+	enableOnlyProducts(t, engine, product.ProductOpenSource)
 	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
 
+	types.SetGlobalUser(engine.GetConfiguration(), types.SettingAuthenticationMethod, string(types.FakeAuthentication))
+	tokenService.SetToken(engine.GetConfiguration(), tokenString)
+
+	tempDir := t.TempDir()
 	clientParams := types.InitializeParams{
-		WorkspaceFolders: []types.WorkspaceFolder{{Uri: uri.PathToUri(types.FilePath(t.TempDir())), Name: t.Name()}},
+		WorkspaceFolders: []types.WorkspaceFolder{{Uri: uri.PathToUri(types.FilePath(tempDir)), Name: t.Name()}},
 		InitializationOptions: types.InitializationOptions{
 			Settings: map[string]*types.ConfigSetting{
-				types.SettingToken:                   {Value: tokenString, Changed: true},
 				types.SettingTrustEnabled:            {Value: false, Changed: true},
 				types.SettingSeverityFilterCritical:  {Value: true, Changed: true},
 				types.SettingSeverityFilterHigh:      {Value: true, Changed: true},
 				types.SettingSeverityFilterMedium:    {Value: true, Changed: true},
 				types.SettingSeverityFilterLow:       {Value: true, Changed: true},
-				types.SettingAuthenticationMethod:    {Value: string(types.OAuthAuthentication), Changed: true},
 				types.SettingAutomaticAuthentication: {Value: false, Changed: true},
 			},
 		},
@@ -104,4 +116,14 @@ func checkInvalidCredentialsMessageRequest(t *testing.T, expected string, tokenS
 		}
 		return false
 	}, time.Second*5, time.Millisecond, "callback not received")
+}
+
+type invalidAuthProvider struct {
+	*authentication.FakeAuthenticationProvider
+}
+
+func (p *invalidAuthProvider) GetCheckAuthenticationFunction() authentication.AuthenticationFunction {
+	return func(_ workflow.Engine) (string, error) {
+		return "", errors.New("failed to get active user: (status: 401)")
+	}
 }

--- a/application/server/authentication_smoke_test.go
+++ b/application/server/authentication_smoke_test.go
@@ -65,7 +65,7 @@ func checkInvalidCredentialsMessageRequest(t *testing.T, expected string, tokenS
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_4")
 	srv, jsonRpcRecorder, _ := setupServer(t, engine, tokenService, WithRealDI())
 	enableOnlyProducts(t, engine, product.ProductOpenSource)
-	tokenService.SetToken(engine.GetConfiguration(), "")
+	tokenService.SetToken(engine.GetConfiguration(), "00000000-0000-0000-0000-000000000099")
 	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
 
 	clientParams := types.InitializeParams{

--- a/application/server/authentication_smoke_test.go
+++ b/application/server/authentication_smoke_test.go
@@ -65,7 +65,8 @@ func checkInvalidCredentialsMessageRequest(t *testing.T, expected string, tokenS
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_4")
 	srv, jsonRpcRecorder, _ := setupServer(t, engine, tokenService, WithRealDI())
 	enableOnlyProducts(t, engine, product.ProductOpenSource)
-	tokenService.SetToken(engine.GetConfiguration(), "00000000-0000-0000-0000-000000000099")
+	types.SetGlobalUser(engine.GetConfiguration(), types.SettingAuthenticationMethod, string(types.OAuthAuthentication))
+	tokenService.SetToken(engine.GetConfiguration(), tokenString)
 	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
 
 	clientParams := types.InitializeParams{

--- a/application/server/authentication_smoke_test.go
+++ b/application/server/authentication_smoke_test.go
@@ -18,12 +18,10 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -65,33 +63,22 @@ func getDummyOAuth2Token(expiry time.Time) oauth2.Token {
 func checkInvalidCredentialsMessageRequest(t *testing.T, expected string, tokenString string) {
 	t.Helper()
 	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_4")
-
-	authProvider := &invalidAuthProvider{
-		FakeAuthenticationProvider: &authentication.FakeAuthenticationProvider{
-			Engine:          engine,
-			IsAuthenticated: false,
-		},
-	}
-
-	tokenService.SetToken(engine.GetConfiguration(), "")
-
-	srv, jsonRpcRecorder, _ := setupServer(t, engine, tokenService, WithRealDI(), WithAuthProvider(authProvider))
+	srv, jsonRpcRecorder, _ := setupServer(t, engine, tokenService, WithRealDI())
 	enableOnlyProducts(t, engine, product.ProductOpenSource)
+	tokenService.SetToken(engine.GetConfiguration(), "")
 	engine.GetConfiguration().Set(types.SettingIsLspInitialized, true)
 
-	types.SetGlobalUser(engine.GetConfiguration(), types.SettingAuthenticationMethod, string(types.FakeAuthentication))
-	tokenService.SetToken(engine.GetConfiguration(), tokenString)
-
-	tempDir := t.TempDir()
 	clientParams := types.InitializeParams{
-		WorkspaceFolders: []types.WorkspaceFolder{{Uri: uri.PathToUri(types.FilePath(tempDir)), Name: t.Name()}},
+		WorkspaceFolders: []types.WorkspaceFolder{{Uri: uri.PathToUri(types.FilePath(t.TempDir())), Name: t.Name()}},
 		InitializationOptions: types.InitializationOptions{
 			Settings: map[string]*types.ConfigSetting{
+				types.SettingToken:                   {Value: tokenString, Changed: true},
 				types.SettingTrustEnabled:            {Value: false, Changed: true},
 				types.SettingSeverityFilterCritical:  {Value: true, Changed: true},
 				types.SettingSeverityFilterHigh:      {Value: true, Changed: true},
 				types.SettingSeverityFilterMedium:    {Value: true, Changed: true},
 				types.SettingSeverityFilterLow:       {Value: true, Changed: true},
+				types.SettingAuthenticationMethod:    {Value: string(types.OAuthAuthentication), Changed: true},
 				types.SettingAutomaticAuthentication: {Value: false, Changed: true},
 			},
 		},
@@ -116,14 +103,4 @@ func checkInvalidCredentialsMessageRequest(t *testing.T, expected string, tokenS
 		}
 		return false
 	}, time.Second*5, time.Millisecond, "callback not received")
-}
-
-type invalidAuthProvider struct {
-	*authentication.FakeAuthenticationProvider
-}
-
-func (p *invalidAuthProvider) GetCheckAuthenticationFunction() authentication.AuthenticationFunction {
-	return func(_ workflow.Engine) (string, error) {
-		return "", errors.New("failed to get active user: (status: 401)")
-	}
 }

--- a/application/server/bdd_steps_test.go
+++ b/application/server/bdd_steps_test.go
@@ -1241,6 +1241,7 @@ func createGitRepoForFix(t *testing.T) (string, error) {
 		{"init"},
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
 		{"config", "core.checkStat", "minimal"},
 	} {
 		if err := run(args...); err != nil {

--- a/application/server/precedence_smoke_test.go
+++ b/application/server/precedence_smoke_test.go
@@ -189,7 +189,7 @@ func Test_SmokePrecedence_OrgScope_UserFolderOverrideReflectedInNotification(t *
 				assert.Equal(t, "user-override", scanNetNew.Source, "source should be user-override")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireSettingValue(types.SettingScanNetNew, true))
 
 	jsonRpcRecorder.ClearNotifications()
 }
@@ -294,7 +294,7 @@ func Test_SmokePrecedence_FolderScope_SettingsRoundtrip(t *testing.T) {
 				assert.Equal(t, "DEBUG=1;VERBOSE=1", addlEnv.Value, "additional_environment should be set")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireSettingValue(types.SettingBaseBranch, "develop"))
 
 	jsonRpcRecorder.ClearNotifications()
 }
@@ -330,7 +330,7 @@ func Test_SmokePrecedence_OldFormatSettings_Roundtrip(t *testing.T) {
 				assert.Equal(t, "release", baseBranch.Value, "base_branch from old format should be applied")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireSettingValue(types.SettingBaseBranch, "release"))
 
 	jsonRpcRecorder.ClearNotifications()
 }
@@ -393,7 +393,7 @@ func Test_SmokePrecedence_GlobalChangePreserves_FolderOverrides(t *testing.T) {
 				assert.Equal(t, "user-override", scanNetNew.Source, "source should be user-override")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireSettingValue(types.SettingScanNetNew, true))
 	jsonRpcRecorder.ClearNotifications()
 
 	// Step 2: Change a global setting, sending the folder config without overrides to trigger notification
@@ -504,7 +504,7 @@ func Test_SmokePrecedence_LoginRefreshesConfig_WithFolderOverridesPreserved(t *t
 				assert.Equal(t, "feature-branch", baseBranch.Value)
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireSettingValue(types.SettingBaseBranch, "feature-branch"))
 	jsonRpcRecorder.ClearNotifications()
 
 	// Switch to FakeAuthentication AFTER initialization (which hardcodes TokenAuthentication)
@@ -532,7 +532,7 @@ func Test_SmokePrecedence_LoginRefreshesConfig_WithFolderOverridesPreserved(t *t
 					"folder-scope base_branch should be preserved after login")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireSettingValue(types.SettingBaseBranch, "feature-branch"))
 
 	jsonRpcRecorder.ClearNotifications()
 }
@@ -1027,7 +1027,7 @@ func Test_SmokePrecedence_FolderLevelRemote_OverridesOrgLevel(t *testing.T) {
 					scanAuto.Value, scanAuto.Source, scanAuto.IsLocked)
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireAdditionalParameters("-d"))
 	jsonRpcRecorder.ClearNotifications()
 }
 
@@ -1086,7 +1086,7 @@ func Test_SmokePrecedence_FolderLevelRemoteLocked_OverridesUserOverride(t *testi
 					scanAuto.Value, scanAuto.Source, scanAuto.IsLocked)
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireAdditionalParameters("-d"))
 	jsonRpcRecorder.ClearNotifications()
 }
 
@@ -1160,7 +1160,7 @@ func Test_SmokePrecedence_FolderScopePrecedenceChain(t *testing.T) {
 				t.Error("additional_environment should be present in notification")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireAdditionalParameters(triggerAdditionalParam))
 	jsonRpcRecorder.ClearNotifications()
 
 	// Step 2: User global takes priority over unlocked remote org.
@@ -1180,7 +1180,7 @@ func Test_SmokePrecedence_FolderScopePrecedenceChain(t *testing.T) {
 				t.Error("additional_environment should be present in notification")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireAdditionalParameters(triggerAdditionalParam))
 	jsonRpcRecorder.ClearNotifications()
 
 	// Step 3: Remote folder overrides remote org.
@@ -1194,7 +1194,7 @@ func Test_SmokePrecedence_FolderScopePrecedenceChain(t *testing.T) {
 					"remote folder should override remote org for folder-scope additional_environment")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireAdditionalParameters(triggerAdditionalParam))
 	jsonRpcRecorder.ClearNotifications()
 
 	// Step 4: Folder value (user:folder) overrides remote folder.
@@ -1212,7 +1212,7 @@ func Test_SmokePrecedence_FolderScopePrecedenceChain(t *testing.T) {
 					"source should be folder")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireAdditionalParameters(triggerAdditionalParam))
 	jsonRpcRecorder.ClearNotifications()
 
 	// Step 5: Locked remote overrides folder value.
@@ -1230,6 +1230,6 @@ func Test_SmokePrecedence_FolderScopePrecedenceChain(t *testing.T) {
 					"source should be ldx_sync_locked")
 			}
 		},
-	}, lspFolderConfigClearAfter(false))
+	}, lspFolderConfigClearAfter(false), lspFolderConfigRequireAdditionalParameters(triggerAdditionalParam))
 	jsonRpcRecorder.ClearNotifications()
 }

--- a/application/server/precedence_smoke_test.go
+++ b/application/server/precedence_smoke_test.go
@@ -542,7 +542,7 @@ func Test_SmokePrecedence_LoginRefreshesConfig_WithFolderOverridesPreserved(t *t
 // settings through the full LSP pipeline. This tests the reconciliation logic end-to-end.
 func Test_SmokePrecedence_ActivateSnykCodeSecurity_OR_Reconciliation(t *testing.T) {
 	t.Parallel()
-	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_3")
+	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_2")
 
 	loc, _, _ := setupServer(t, engine, tokenService, WithRealDI())
 	enableOnlyProducts(t, engine)
@@ -590,7 +590,7 @@ func Test_SmokePrecedence_ActivateSnykCodeSecurity_OR_Reconciliation(t *testing.
 // default values are used for all settings.
 func Test_SmokePrecedence_DefaultValues_WhenNoUserOrRemoteConfig(t *testing.T) {
 	t.Parallel()
-	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_3")
+	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_2")
 
 	loc, jsonRpcRecorder, _ := setupServer(t, engine, tokenService, WithRealDI())
 	enableOnlyProducts(t, engine)

--- a/application/server/scan_context_command_test.go
+++ b/application/server/scan_context_command_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	sglsp "github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,6 +83,21 @@ func (w *trustedWorkspace) GetFolderTrust() (trusted []types.Folder, untrusted [
 	return []types.Folder{w.trustedFolder}, nil
 }
 
+// scanContextCommandInitParams avoids background CLI downloads during initialize.
+// These tests only assert scanCtx cancellation on shutdown; a real download leaves
+// snyk-win.exe locked on Windows and breaks t.TempDir cleanup.
+func scanContextCommandInitParams(conf configuration.Configuration) types.InitializeParams {
+	return types.InitializeParams{
+		InitializationOptions: types.InitializationOptions{
+			Settings: map[string]*types.ConfigSetting{
+				types.SettingCliPath:           {Value: types.GetGlobalString(conf, types.SettingCliPath), Changed: true},
+				types.SettingAutomaticDownload: {Value: false, Changed: true},
+				types.SettingScanAutomatic:     {Value: "manual", Changed: true},
+			},
+		},
+	}
+}
+
 // ---------------------------------------------------------------------------
 // INTEG-102 — WorkspaceScanCommand uses server-lifetime scanCtx
 //
@@ -100,10 +116,11 @@ func TestWorkspaceScanCommandCtxCanceledOnShutdown(t *testing.T) {
 	loc, _, _ := setupServer(t, engine, tokenService, WithRealDI())
 
 	// Initialize the LSP session so the server is ready to handle commands.
-	_, err := loc.Client.Call(t.Context(), "initialize", nil)
+	_, err := loc.Client.Call(t.Context(), "initialize", scanContextCommandInitParams(conf))
 	require.NoError(t, err)
 	_, err = loc.Client.Call(t.Context(), "initialized", nil)
 	require.NoError(t, err)
+	types.WaitForLspInitialized(conf)
 
 	// Replace the workspace with a context-capturing wrapper AFTER initialization
 	// so the init handshake uses the real workspace.
@@ -155,10 +172,11 @@ func TestClearCacheCommandScanFolderCtxCanceledOnShutdown(t *testing.T) {
 
 	loc, _, _ := setupServer(t, engine, tokenService, WithRealDI())
 
-	_, err := loc.Client.Call(t.Context(), "initialize", nil)
+	_, err := loc.Client.Call(t.Context(), "initialize", scanContextCommandInitParams(conf))
 	require.NoError(t, err)
 	_, err = loc.Client.Call(t.Context(), "initialized", nil)
 	require.NoError(t, err)
+	types.WaitForLspInitialized(conf)
 
 	// Build a trusted capturing folder and wrap the workspace so ClearCacheCommand
 	// sees it as trusted (with auto-scan enabled).

--- a/application/server/secrets_smoke_test.go
+++ b/application/server/secrets_smoke_test.go
@@ -68,6 +68,7 @@ func Test_SmokeSecretsScan_UnsupportedFileDoesNotError(t *testing.T) {
 		{"init"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "test"},
+		{"config", "commit.gpgsign", "false"},
 		{"add", "image.bin"},
 		{"commit", "-m", "initial"},
 	}

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1629,8 +1629,8 @@ app.get('/unique_subfolder_test', function(req, res) {
 // with parallel shard-1 tests for CLI resources and API bandwidth.
 func Test_SmokeScanUnmanaged(t *testing.T) {
 	testsupport.NotOnWindows(t, "git clone does not work here. dunno why. ") // FIXME
-	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_1")
-	loc, jsonRPCRecorder, _ := setupServer(t, engine, tokenService, WithRealDI())
+	engine, tokenService := testutil.SmokeTestWithEngine(t, "", "SMOKE_SHARD_4")
+	loc, jsonRPCRecorder, deps := setupServer(t, engine, tokenService, WithRealDI())
 	// OSS-only: unmanaged scan is an OSS-specific path (--unmanaged for C/C++ repos).
 	enableOnlyProducts(t, engine, product.ProductOpenSource)
 	// When scan net-new is on, FilterAndPublishDiagnostics keeps only IsNew issues; enrichment/baseline
@@ -1659,6 +1659,7 @@ func Test_SmokeScanUnmanaged(t *testing.T) {
 
 	waitForScan(t, cloneTargetDirString, engine)
 	checkForScanParams(t, jsonRPCRecorder, cloneTargetDirString, product.ProductOpenSource)
+	waitForDeltaScan(t, deps.ScanStateAggregator)
 
 	// Diagnostics can arrive after $/snyk.scan reports Success (same pattern as checkOnlyOneQuickFixCodeAction).
 	var issueList []types.ScanIssue

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -2740,6 +2740,9 @@ func initializeGitRepoForMonorepoBenchmark(t *testing.T, repoDir string) {
 	cmd := gitCommandForMonorepoBenchmark(repoDir, "init", "--initial-branch=main")
 	require.NoError(t, cmd.Run())
 
+	cmd = gitCommandForMonorepoBenchmark(repoDir, "config", "commit.gpgsign", "false")
+	require.NoError(t, cmd.Run())
+
 	cmd = gitCommandForMonorepoBenchmark(repoDir, "add", ".")
 	require.NoError(t, cmd.Run())
 

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1454,7 +1454,7 @@ func Test_SmokeSnykCodeFileScan(t *testing.T) {
 
 	_ = textDocumentDidSave(t, &loc, testPath)
 
-	assert.Eventually(t, checkForPublishedDiagnostics(t, engine, testPath, -1, jsonRPCRecorder), 2*time.Minute, time.Millisecond)
+	assert.Eventually(t, checkForPublishedDiagnostics(t, engine, testPath, -1, jsonRPCRecorder), maxIntegTestDuration, time.Millisecond)
 	waitForDeltaScan(t, deps.ScanStateAggregator)
 }
 

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"runtime/pprof"
@@ -1846,7 +1847,7 @@ func folderConfigsCarrySetting(
 			if !folderConfigPathsMatch(fc.FolderPath, wantPath) {
 				continue
 			}
-			if setting := fc.Settings[want.name]; setting != nil && setting.Value == want.want {
+			if setting := fc.Settings[want.name]; setting != nil && reflect.DeepEqual(setting.Value, want.want) {
 				matched = true
 				break
 			}

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1454,7 +1454,7 @@ func Test_SmokeSnykCodeFileScan(t *testing.T) {
 
 	_ = textDocumentDidSave(t, &loc, testPath)
 
-	assert.Eventually(t, checkForPublishedDiagnostics(t, engine, testPath, -1, jsonRPCRecorder), maxIntegTestDuration, time.Millisecond)
+	assert.Eventually(t, checkForPublishedDiagnostics(t, engine, testPath, -1, jsonRPCRecorder), 5*time.Minute, time.Millisecond)
 	waitForDeltaScan(t, deps.ScanStateAggregator)
 }
 
@@ -1895,6 +1895,7 @@ func countValidatedFolderConfigs(
 	validators map[types.FilePath]func(types.LspFolderConfig),
 ) int {
 	validationsCount := 0
+	// Fast path when callers pass exactly one folder config and one validator; not required for correctness.
 	if len(lastConfigParam.FolderConfigs) == 1 && len(validators) == 1 {
 		fc := lastConfigParam.FolderConfigs[0]
 		for wantPath, onlyValidator := range validators {

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -1672,6 +1672,13 @@ func Test_SmokeScanUnmanaged(t *testing.T) {
 type lspFolderConfigNotifOpts struct {
 	clearNotifications               bool
 	waitForNonEmptyAutoDeterminedOrg bool
+	requireAdditionalParameters      string
+	requireSetting                   *requiredSetting
+}
+
+type requiredSetting struct {
+	name string
+	want any
 }
 
 type lspFolderConfigNotifOption func(*lspFolderConfigNotifOpts)
@@ -1685,6 +1692,16 @@ func lspFolderConfigClearAfter(clearNotifications bool) lspFolderConfigNotifOpti
 // validators (LDX-Sync can populate folder configs before autoDeterminedOrg is ready).
 func lspFolderConfigWaitForAutoDeterminedOrg() lspFolderConfigNotifOption {
 	return func(o *lspFolderConfigNotifOpts) { o.waitForNonEmptyAutoDeterminedOrg = true }
+}
+
+func lspFolderConfigRequireAdditionalParameters(want string) lspFolderConfigNotifOption {
+	return func(o *lspFolderConfigNotifOpts) { o.requireAdditionalParameters = want }
+}
+
+// lspFolderConfigRequireSettingValue gates the wait on a notification that already reflects
+// the change the caller just made, so a notification emitted before it is skipped.
+func lspFolderConfigRequireSettingValue(name string, want any) lspFolderConfigNotifOption {
+	return func(o *lspFolderConfigNotifOpts) { o.requireSetting = &requiredSetting{name: name, want: want} }
 }
 
 func parseLspFolderConfigNotifOpts(opts ...lspFolderConfigNotifOption) lspFolderConfigNotifOpts {
@@ -1779,6 +1796,67 @@ func folderConfigNotificationMatchesValidators(
 	return true
 }
 
+// folderConfigsCarryAdditionalParameters gates a notification on the additional_parameters
+// value the caller's own trigger just sent, so a notification emitted before that trigger
+// is skipped rather than mistaken for the response to it.
+func folderConfigsCarryAdditionalParameters(
+	param types.LspConfigurationParam,
+	validators map[types.FilePath]func(types.LspFolderConfig),
+	want string,
+) bool {
+	if want == "" {
+		return true
+	}
+	for wantPath := range validators {
+		matched := false
+		for _, fc := range param.FolderConfigs {
+			if !folderConfigPathsMatch(fc.FolderPath, wantPath) {
+				continue
+			}
+			setting := fc.Settings[types.SettingAdditionalParameters]
+			if setting == nil {
+				continue
+			}
+			values, ok := setting.Value.([]any)
+			if !ok || len(values) != 1 || values[0] != want {
+				continue
+			}
+			matched = true
+			break
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func folderConfigsCarrySetting(
+	param types.LspConfigurationParam,
+	validators map[types.FilePath]func(types.LspFolderConfig),
+	want *requiredSetting,
+) bool {
+	if want == nil {
+		return true
+	}
+	for wantPath := range validators {
+		matched := false
+		for _, fc := range param.FolderConfigs {
+			if !folderConfigPathsMatch(fc.FolderPath, wantPath) {
+				continue
+			}
+			if setting := fc.Settings[want.name]; setting != nil && setting.Value == want.want {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
 // tryParseLatestMatchingFolderConfig walks notifications newest-first and returns the first
 // $/snyk.configuration payload that satisfies cfg (including optional autoDeterminedOrg wait).
 func tryParseLatestMatchingFolderConfig(
@@ -1798,6 +1876,12 @@ func tryParseLatestMatchingFolderConfig(
 			if !folderConfigsHaveNonEmptyAutoDeterminedOrgForValidators(param, validators) {
 				continue
 			}
+		}
+		if !folderConfigsCarryAdditionalParameters(param, validators, cfg.requireAdditionalParameters) {
+			continue
+		}
+		if !folderConfigsCarrySetting(param, validators, cfg.requireSetting) {
+			continue
 		}
 		return param, true
 	}

--- a/application/server/server_smoke_test.go
+++ b/application/server/server_smoke_test.go
@@ -2300,7 +2300,7 @@ func Test_SmokeOrgSelection(t *testing.T) {
 				require.False(t, fc.Settings[types.SettingOrgSetByUser].Value.(bool), "OrgSetByUser should be false after user opts-in to auto org selection")
 				// PreferredOrg may be inherited from global org in auto mode
 			},
-		})
+		}, lspFolderConfigRequireSettingValue(types.SettingOrgSetByUser, false))
 		// When OrgSetByUser is false, effective org is AutoDeterminedOrg (if LDX-Sync succeeded) or global org (fallback)
 		// Either way, it should NOT be the user's initialOrg anymore
 		effectiveOrg := config.FolderOrganization(engine.GetConfiguration(), repo, engine.GetLogger())

--- a/application/server/server_test.go
+++ b/application/server/server_test.go
@@ -95,12 +95,13 @@ func didOpenTextParams(t *testing.T) (sglsp.DidOpenTextDocumentParams, types.Fil
 type ServerTestOption func(*serverTestConfig)
 
 type serverTestConfig struct {
-	useRealDI       bool
-	overrideDeps    *di.Dependencies
-	callbackFn      onCallbackFn
-	apiEndpoint     string
-	concurrency     int
-	scannerOverride scanner.Scanner
+	useRealDI            bool
+	overrideDeps         *di.Dependencies
+	callbackFn           onCallbackFn
+	apiEndpoint          string
+	concurrency          int
+	scannerOverride      scanner.Scanner
+	authProviderOverride authentication.AuthenticationProvider
 }
 
 func WithRealDI() ServerTestOption {
@@ -141,6 +142,16 @@ func WithAPIEndpoint(endpoint string) ServerTestOption {
 func WithScanner(s scanner.Scanner) ServerTestOption {
 	return func(cfg *serverTestConfig) {
 		cfg.scannerOverride = s
+	}
+}
+
+// WithAuthProvider replaces the AuthenticationProvider in the AuthenticationService.
+// It composes with WithRealDI so the auth check uses the provided provider instead
+// of the real authenticator, allowing deterministic test control without relying on
+// network conditions.
+func WithAuthProvider(p authentication.AuthenticationProvider) ServerTestOption {
+	return func(cfg *serverTestConfig) {
+		cfg.authProviderOverride = p
 	}
 }
 
@@ -207,6 +218,11 @@ func setupServer(
 	// Scanner dependency injected into request contexts is replaced.
 	if cfg.scannerOverride != nil {
 		deps.Scanner = cfg.scannerOverride
+	}
+
+	// Auth provider override applies to either DI path (composes with WithRealDI).
+	if cfg.authProviderOverride != nil {
+		deps.AuthenticationService.SetProvider(cfg.authProviderOverride)
 	}
 
 	setUniqueCliPath(t, engine)

--- a/application/server/smoke_main_helpers_test.go
+++ b/application/server/smoke_main_helpers_test.go
@@ -45,6 +45,7 @@ func setupLocalBareRepo(t *testing.T) localRepo {
 		{"init"},
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
 	} {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir

--- a/application/server/smoke_main_test.go
+++ b/application/server/smoke_main_test.go
@@ -112,6 +112,9 @@ func TestMain(m *testing.M) {
 	if os.Getenv(testsupport.SmokeTestEnvVar) == "" {
 		os.Exit(m.Run())
 	}
+	if os.Getenv("BDD_STEPS_HELPER_PROCESS") == "1" {
+		os.Exit(m.Run())
+	}
 
 	fixtureCache := os.Getenv("SNYK_LS_FIXTURE_CACHE_DIR")
 

--- a/domain/ide/command/remediation_fix_folder_test.go
+++ b/domain/ide/command/remediation_fix_folder_test.go
@@ -70,6 +70,7 @@ func initGitRepoForCmd(t *testing.T) string {
 	run("init")
 	run("config", "user.email", "test@example.com")
 	run("config", "user.name", "Test")
+	run("config", "commit.gpgsign", "false")
 	run("config", "core.checkStat", "minimal")
 	f := filepath.Join(dir, "main.go")
 	require.NoError(t, os.WriteFile(f, []byte("package main\n"), 0644))

--- a/domain/snyk/remediation/remy_test.go
+++ b/domain/snyk/remediation/remy_test.go
@@ -60,6 +60,7 @@ func initGitRepo(t *testing.T) string {
 	run("init")
 	run("config", "user.email", "test@example.com")
 	run("config", "user.name", "Test")
+	run("config", "commit.gpgsign", "false")
 	// Overlay filesystems (e.g. Docker on Linux) have write-ordering delays that
 	// can cause git to report "not a valid object" when the object database is
 	// read immediately after a write. core.checkStat=minimal tells git not to
@@ -802,6 +803,7 @@ func initGitRepoInDir(t *testing.T, dir string) {
 	run("init")
 	run("config", "user.email", "test@example.com")
 	run("config", "user.name", "Test")
+	run("config", "commit.gpgsign", "false")
 	run("config", "core.checkStat", "minimal")
 }
 

--- a/infrastructure/authentication/pat_provider_test.go
+++ b/infrastructure/authentication/pat_provider_test.go
@@ -110,7 +110,7 @@ func TestPatAuthenticationProvider_ClearAuthentication(t *testing.T) {
 }
 
 func TestPatAuthenticationProvider_GetCheckAuthenticationFunction(t *testing.T) {
-	_, mockEngine, mockConfig, _ := testutil.UnitTestWithMockEngine(t)
+	_, mockEngine, mockConfig := testutil.UnitTestWithMockEngine(t)
 	mockConfig.EXPECT().GetString(gomock.Any()).Return("").AnyTimes()
 	mockConfig.EXPECT().IsSet(gomock.Any()).Return(false).AnyTimes()
 

--- a/infrastructure/authentication/pat_provider_test.go
+++ b/infrastructure/authentication/pat_provider_test.go
@@ -17,7 +17,6 @@
 package authentication
 
 import (
-	"io"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -27,6 +26,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -109,23 +109,16 @@ func TestPatAuthenticationProvider_ClearAuthentication(t *testing.T) {
 }
 
 func TestPatAuthenticationProvider_GetCheckAuthenticationFunction(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	mockEngine := mocks.NewMockEngine(ctrl)
-	mockConfig := mocks.NewMockConfiguration(ctrl)
-	mockLogger := zerolog.New(io.Discard)
-
-	mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
-	mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
+	_, mockEngine, mockConfig, _ := testutil.UnitTestWithMockEngine(t)
 	mockConfig.EXPECT().GetString(gomock.Any()).Return("").AnyTimes()
 	mockConfig.EXPECT().IsSet(gomock.Any()).Return(false).AnyTimes()
 
 	p := &PatAuthenticationProvider{}
 
 	user, err := p.GetCheckAuthenticationFunction()(mockEngine)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get active user:")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "failed to get active user:")
+	}
 	assert.Equal(t, "", user)
 }
 

--- a/infrastructure/authentication/pat_provider_test.go
+++ b/infrastructure/authentication/pat_provider_test.go
@@ -17,6 +17,7 @@
 package authentication
 
 import (
+	"io"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -26,7 +27,6 @@ import (
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
@@ -109,15 +109,24 @@ func TestPatAuthenticationProvider_ClearAuthentication(t *testing.T) {
 }
 
 func TestPatAuthenticationProvider_GetCheckAuthenticationFunction(t *testing.T) {
-	p := &PatAuthenticationProvider{}
-	engine := testutil.UnitTest(t)
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
 
-	// GetCheckAuthenticationFunction should return AuthenticationCheck
-	user, err := p.GetCheckAuthenticationFunction()(engine)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to get active user:")
-	}
-	assert.Equal(t, "", user, "GetCheckAuthenticationFunction()()")
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockConfig := mocks.NewMockConfiguration(ctrl)
+	mockLogger := zerolog.New(io.Discard)
+
+	mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
+	mockConfig.EXPECT().GetString(gomock.Any()).Return("").AnyTimes()
+	mockConfig.EXPECT().IsSet(gomock.Any()).Return(false).AnyTimes()
+
+	p := &PatAuthenticationProvider{}
+
+	user, err := p.GetCheckAuthenticationFunction()(mockEngine)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get active user:")
+	assert.Equal(t, "", user)
 }
 
 func TestPatAuthenticationProvider_setAuthUrl(t *testing.T) {

--- a/infrastructure/authentication/pat_provider_test.go
+++ b/infrastructure/authentication/pat_provider_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/snyk-ls/internal/testutil"
 	"github.com/snyk/snyk-ls/internal/types"
@@ -116,9 +117,8 @@ func TestPatAuthenticationProvider_GetCheckAuthenticationFunction(t *testing.T) 
 	p := &PatAuthenticationProvider{}
 
 	user, err := p.GetCheckAuthenticationFunction()(mockEngine)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to get active user:")
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get active user:")
 	assert.Equal(t, "", user)
 }
 

--- a/infrastructure/cli/cli_extension_executor_test.go
+++ b/infrastructure/cli/cli_extension_executor_test.go
@@ -297,25 +297,69 @@ func Test_ExtensionExecutor_SubstitutesOrgInCommandArgs(t *testing.T) {
 
 func Test_ExtensionExecutor_FallsBackToGlobalOrgOnResolutionFailure(t *testing.T) {
 	engine := testutil.UnitTest(t)
-
 	folderPath := types.FilePath(t.TempDir())
 
-	// Set global org as a UUID
 	globalOrgUUID := "00000000-0000-0000-0000-000000000001"
 	config.SetOrganization(engine.GetConfiguration(), globalOrgUUID)
 
-	// Create and store folder config with a slug that will need resolution
-	// Using a slug format that would require API resolution
-	folderOrgSlug := "my-test-org-slug"
-	engineConf := engine.GetConfiguration()
-	types.SetPreferredOrgAndOrgSetByUser(engineConf, folderPath, folderOrgSlug, true)
+	folderOrgSlug := "unresolvable-folder-slug"
+	types.SetPreferredOrgAndOrgSetByUser(engine.GetConfiguration(), folderPath, folderOrgSlug, true)
 
-	// Test - the resolution will fail because we don't have a real API connection
-	executor := NewExtensionExecutor(engine, testutil.DefaultConfigResolver(engine))
-	capturedOrg, _ := testutil.ExecuteAndCaptureConfig(t, engine, executor, []string{"snyk", "test"}, folderPath)
+	baseConfig := engine.GetConfiguration()
+	wrappedConfig := &configWrapper{
+		Configuration: baseConfig,
+		folderOrgSlug: folderOrgSlug,
+	}
 
-	// Verify we fell back to global org when resolution failed
+	mockEngine := &engineWrapper{
+		Engine: engine,
+		config: wrappedConfig,
+	}
+
+	executor := NewExtensionExecutor(mockEngine, testutil.DefaultConfigResolver(engine))
+	capturedOrg, _ := testutil.ExecuteAndCaptureConfig(t, mockEngine, executor, []string{"snyk", "test"}, folderPath)
+
 	assert.Equal(t, globalOrgUUID, capturedOrg, "Should fall back to global org when resolution fails")
+}
+
+type configWrapper struct {
+	configuration.Configuration
+	folderOrgSlug string
+	isCloned      bool
+	orgSet        bool
+}
+
+func (cw *configWrapper) GetString(key string) string {
+	if cw.isCloned && key == configuration.ORGANIZATION && !cw.orgSet {
+		return cw.folderOrgSlug
+	}
+	return cw.Configuration.GetString(key)
+}
+
+func (cw *configWrapper) Set(key string, value interface{}) {
+	cw.Configuration.Set(key, value)
+	if key == configuration.ORGANIZATION && value != cw.folderOrgSlug {
+		cw.orgSet = true
+	}
+}
+
+func (cw *configWrapper) Clone() configuration.Configuration {
+	cloned := cw.Configuration.Clone()
+	return &configWrapper{
+		Configuration: cloned,
+		folderOrgSlug: cw.folderOrgSlug,
+		isCloned:      true,
+		orgSet:        false,
+	}
+}
+
+type engineWrapper struct {
+	workflow.Engine
+	config configuration.Configuration
+}
+
+func (ew *engineWrapper) GetConfiguration() configuration.Configuration {
+	return ew.config
 }
 
 func Test_ExtensionExecutor_SetsSubprocessEnvironment(t *testing.T) {

--- a/infrastructure/cli/cli_extension_executor_test.go
+++ b/infrastructure/cli/cli_extension_executor_test.go
@@ -349,7 +349,7 @@ func (cw *configWrapper) Clone() configuration.Configuration {
 		Configuration: cloned,
 		folderOrgSlug: cw.folderOrgSlug,
 		isCloned:      true,
-		orgSet:        false,
+		orgSet:        cw.orgSet,
 	}
 }
 

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -982,7 +982,7 @@ func Test_resolveOrgToUUID(t *testing.T) {
 		{name: "handles empty string", input: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctrl, mockEngine, mockConfig, _ := testutil.UnitTestWithMockEngine(t)
+			ctrl, mockEngine, mockConfig := testutil.UnitTestWithMockEngine(t)
 
 			clonedMockConfig := mocks.NewMockConfiguration(ctrl)
 			mockConfig.EXPECT().Clone().Return(clonedMockConfig)

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -18,7 +18,6 @@ package code
 
 import (
 	"context"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -983,15 +982,7 @@ func Test_resolveOrgToUUID(t *testing.T) {
 		{name: "handles empty string", input: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			t.Cleanup(ctrl.Finish)
-
-			mockEngine := mocks.NewMockEngine(ctrl)
-			mockConfig := mocks.NewMockConfiguration(ctrl)
-			mockLogger := zerolog.New(io.Discard)
-
-			mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
-			mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
+			ctrl, mockEngine, mockConfig, _ := testutil.UnitTestWithMockEngine(t)
 
 			clonedMockConfig := mocks.NewMockConfiguration(ctrl)
 			mockConfig.EXPECT().Clone().Return(clonedMockConfig)

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -963,12 +963,11 @@ func setupMockLearnServiceNoLessons(t *testing.T) *mock_learn.MockService {
 
 func Test_resolveOrgToUUID(t *testing.T) {
 	t.Run("returns UUID unchanged when input is already a UUID", func(t *testing.T) {
-		engine := testutil.UnitTest(t)
-		testutil.SetUpEngineMock(t, engine)
+		_, mockEngine, _ := testutil.UnitTestWithMockEngine(t)
 
 		inputUUID := "550e8400-e29b-41d4-a716-446655440000"
 
-		result, err := config.ResolveOrgToUUIDWithEngine(engine, inputUUID)
+		result, err := config.ResolveOrgToUUIDWithEngine(mockEngine, inputUUID)
 
 		assert.NoError(t, err)
 		assert.Equal(t, inputUUID, result)

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -18,6 +18,7 @@ package code
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -975,31 +976,51 @@ func Test_resolveOrgToUUID(t *testing.T) {
 	})
 
 	t.Run("returns error when slug cannot be resolved to UUID", func(t *testing.T) {
-		engine := testutil.UnitTest(t)
-		testutil.SetUpEngineMock(t, engine)
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+
+		mockEngine := mocks.NewMockEngine(ctrl)
+		mockConfig := mocks.NewMockConfiguration(ctrl)
+		mockLogger := zerolog.New(io.Discard)
+
+		mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+		mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
 
 		inputSlug := "invalid_slug"
 
-		result, err := config.ResolveOrgToUUIDWithEngine(engine, inputSlug)
+		clonedMockConfig := mocks.NewMockConfiguration(ctrl)
+		mockConfig.EXPECT().Clone().Return(clonedMockConfig)
+		clonedMockConfig.EXPECT().Set(configuration.ORGANIZATION, inputSlug)
+		clonedMockConfig.EXPECT().GetString(configuration.ORGANIZATION).Return(inputSlug)
 
-		// When configuration cannot resolve the slug to a UUID, it will return an empty string or the slug itself
-		// Our function should detect this and return an error
-		assert.Error(t, err)
+		result, err := config.ResolveOrgToUUIDWithEngine(mockEngine, inputSlug)
+
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "could not be resolved to a valid UUID")
 		assert.Empty(t, result)
 	})
 
 	t.Run("handles empty string", func(t *testing.T) {
-		engine := testutil.UnitTest(t)
-		testutil.SetUpEngineMock(t, engine)
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+
+		mockEngine := mocks.NewMockEngine(ctrl)
+		mockConfig := mocks.NewMockConfiguration(ctrl)
+		mockLogger := zerolog.New(io.Discard)
+
+		mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+		mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
 
 		inputEmpty := ""
 
-		result, err := config.ResolveOrgToUUIDWithEngine(engine, inputEmpty)
+		clonedMockConfig := mocks.NewMockConfiguration(ctrl)
+		mockConfig.EXPECT().Clone().Return(clonedMockConfig)
+		clonedMockConfig.EXPECT().Set(configuration.ORGANIZATION, inputEmpty)
+		clonedMockConfig.EXPECT().GetString(configuration.ORGANIZATION).Return(inputEmpty)
 
-		// Empty string is not a UUID, so it will try to resolve
-		// When unauthenticated or unable to resolve, configuration returns empty string
-		assert.Error(t, err)
+		result, err := config.ResolveOrgToUUIDWithEngine(mockEngine, inputEmpty)
+
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "could not be resolved to a valid UUID")
 		assert.Empty(t, result)
 	})

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -975,55 +975,36 @@ func Test_resolveOrgToUUID(t *testing.T) {
 		assert.Equal(t, inputUUID, result)
 	})
 
-	t.Run("returns error when slug cannot be resolved to UUID", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		t.Cleanup(ctrl.Finish)
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{name: "returns error when slug cannot be resolved to UUID", input: "invalid_slug"},
+		{name: "handles empty string", input: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
 
-		mockEngine := mocks.NewMockEngine(ctrl)
-		mockConfig := mocks.NewMockConfiguration(ctrl)
-		mockLogger := zerolog.New(io.Discard)
+			mockEngine := mocks.NewMockEngine(ctrl)
+			mockConfig := mocks.NewMockConfiguration(ctrl)
+			mockLogger := zerolog.New(io.Discard)
 
-		mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
-		mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
+			mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+			mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
 
-		inputSlug := "invalid_slug"
+			clonedMockConfig := mocks.NewMockConfiguration(ctrl)
+			mockConfig.EXPECT().Clone().Return(clonedMockConfig)
+			clonedMockConfig.EXPECT().Set(configuration.ORGANIZATION, tc.input)
+			clonedMockConfig.EXPECT().GetString(configuration.ORGANIZATION).Return(tc.input)
 
-		clonedMockConfig := mocks.NewMockConfiguration(ctrl)
-		mockConfig.EXPECT().Clone().Return(clonedMockConfig)
-		clonedMockConfig.EXPECT().Set(configuration.ORGANIZATION, inputSlug)
-		clonedMockConfig.EXPECT().GetString(configuration.ORGANIZATION).Return(inputSlug)
+			result, err := config.ResolveOrgToUUIDWithEngine(mockEngine, tc.input)
 
-		result, err := config.ResolveOrgToUUIDWithEngine(mockEngine, inputSlug)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "could not be resolved to a valid UUID")
-		assert.Empty(t, result)
-	})
-
-	t.Run("handles empty string", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		t.Cleanup(ctrl.Finish)
-
-		mockEngine := mocks.NewMockEngine(ctrl)
-		mockConfig := mocks.NewMockConfiguration(ctrl)
-		mockLogger := zerolog.New(io.Discard)
-
-		mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
-		mockEngine.EXPECT().GetLogger().Return(&mockLogger).AnyTimes()
-
-		inputEmpty := ""
-
-		clonedMockConfig := mocks.NewMockConfiguration(ctrl)
-		mockConfig.EXPECT().Clone().Return(clonedMockConfig)
-		clonedMockConfig.EXPECT().Set(configuration.ORGANIZATION, inputEmpty)
-		clonedMockConfig.EXPECT().GetString(configuration.ORGANIZATION).Return(inputEmpty)
-
-		result, err := config.ResolveOrgToUUIDWithEngine(mockEngine, inputEmpty)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "could not be resolved to a valid UUID")
-		assert.Empty(t, result)
-	})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "could not be resolved to a valid UUID")
+			assert.Empty(t, result)
+		})
+	}
 }
 
 // testCodeConfigUsesFolderOrg is a shared helper function that tests CodeConfig creation

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -923,8 +923,9 @@ func Test_prepareScanCommand(t *testing.T) {
 
 	t.Run("Uses --all-projects by default", func(t *testing.T) {
 		engine := testutil.UnitTest(t)
-		// Clear the default org set by UnitTest to test command without --org parameter.
-		config.SetOrganization(engine.GetConfiguration(), "")
+		knownOrgUUID := "12345678-1234-1234-1234-123456789012"
+		config.SetOrganization(engine.GetConfiguration(), knownOrgUUID)
+
 		scanner := NewCLIScanner(engine, performance.NewInstrumentor(), error_reporting.NewTestErrorReporter(engine), cli.NewTestExecutor(engine), getLearnMock(t), notification.NewMockNotifier(), defaultResolver(t, engine), testutil.NewDrainedProgressTracker()).(*CLIScanner)
 
 		engine.GetConfiguration().Set(configresolver.UserGlobalKey(types.SettingCliAdditionalOssParameters), []string{"-d"})
@@ -933,7 +934,8 @@ func Test_prepareScanCommand(t *testing.T) {
 		cmd, _ := scanner.prepareScanCommand([]string{"a"}, map[string]bool{}, "", folderConfig)
 
 		assert.Contains(t, cmd, "--all-projects")
-		assert.Lenf(t, cmd, 6, "cmd: %v", cmd)
+		assert.Contains(t, cmd, "--org="+knownOrgUUID)
+		assert.Len(t, cmd, 7)
 	})
 }
 

--- a/infrastructure/oss/oss_test.go
+++ b/infrastructure/oss/oss_test.go
@@ -935,7 +935,7 @@ func Test_prepareScanCommand(t *testing.T) {
 
 		assert.Contains(t, cmd, "--all-projects")
 		assert.Contains(t, cmd, "--org="+knownOrgUUID)
-		assert.Len(t, cmd, 7)
+		assert.Lenf(t, cmd, 7, "Assert the set org passes through as well")
 	})
 }
 

--- a/infrastructure/snyk_api/snyk_api_pact_test.go
+++ b/infrastructure/snyk_api/snyk_api_pact_test.go
@@ -44,9 +44,9 @@ var client SnykApiClient
 
 func TestSnykApiPact(t *testing.T) {
 	testsupport.NotOnWindows(t, "we don't have a pact cli")
-	engine := testutil.IntegTest(t)
+	engine, ts := testutil.IntegTestWithEngine(t)
 
-	setupPact(engine)
+	setupPact(engine, ts)
 	defer pact.Teardown()
 
 	defer func() {
@@ -141,12 +141,14 @@ func TestSnykApiPact(t *testing.T) {
 	})
 }
 
-func setupPact(engine workflow.Engine) {
+func setupPact(engine workflow.Engine, ts *config.TokenServiceImpl) {
 	pact = dsl.Pact{
 		Consumer: consumer,
 		Provider: pactProvider,
 		PactDir:  pactDir,
 	}
+
+	ts.SetToken(engine.GetConfiguration(), "fc763eba-0905-41c5-a27f-3934ab26786c")
 
 	// Proactively start service to get access to the port
 	pact.Setup(true)

--- a/internal/folderconfig/git_test.go
+++ b/internal/folderconfig/git_test.go
@@ -49,6 +49,10 @@ func initializeTestGitRepo(t *testing.T, repoDir string, branches []string) {
 	err := cmd.Run()
 	require.NoError(t, err)
 
+	cmd = gitCommandForTestRepo(repoDir, "config", "commit.gpgsign", "false")
+	err = cmd.Run()
+	require.NoError(t, err)
+
 	// Create and commit a file (required for branches to exist)
 	testFile := filepath.Join(repoDir, "test.txt")
 	err = os.WriteFile(testFile, []byte("test content"), 0644)

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -173,7 +173,7 @@ func UnitTestWithCtx(t *testing.T) (workflow.Engine, context.Context) {
 // UnitTestWithMockEngine creates a mock engine with configuration and logger expectations
 // for unit tests that do not need a real workflow engine. Unlike SetUpEngineMock, it does
 // not require an existing engine.
-func UnitTestWithMockEngine(t *testing.T) (*gomock.Controller, *mocks.MockEngine, *mocks.MockConfiguration, *zerolog.Logger) {
+func UnitTestWithMockEngine(t *testing.T) (*gomock.Controller, *mocks.MockEngine, *mocks.MockConfiguration) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
@@ -185,7 +185,7 @@ func UnitTestWithMockEngine(t *testing.T) (*gomock.Controller, *mocks.MockEngine
 	mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
 	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
 
-	return ctrl, mockEngine, mockConfig, &logger
+	return ctrl, mockEngine, mockConfig
 }
 
 func cleanupFakeCliFile(conf configuration.Configuration, logger *zerolog.Logger) {

--- a/internal/testutil/test_setup.go
+++ b/internal/testutil/test_setup.go
@@ -19,6 +19,7 @@ package testutil
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -167,6 +168,24 @@ func UnitTestWithCtx(t *testing.T) (workflow.Engine, context.Context) {
 	})
 	ctx = ctx2.NewContextWithLogger(ctx, engine.GetLogger())
 	return engine, ctx
+}
+
+// UnitTestWithMockEngine creates a mock engine with configuration and logger expectations
+// for unit tests that do not need a real workflow engine. Unlike SetUpEngineMock, it does
+// not require an existing engine.
+func UnitTestWithMockEngine(t *testing.T) (*gomock.Controller, *mocks.MockEngine, *mocks.MockConfiguration, *zerolog.Logger) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockConfig := mocks.NewMockConfiguration(ctrl)
+	logger := zerolog.New(io.Discard)
+
+	mockEngine.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
+
+	return ctrl, mockEngine, mockConfig, &logger
 }
 
 func cleanupFakeCliFile(conf configuration.Configuration, logger *zerolog.Logger) {


### PR DESCRIPTION
### **User description**
## Why

`INTEG_TESTS=1 go test ./...` fails **102 tests across 10 packages** on `main` for any contributor whose machine signs commits and is logged in to Snyk. Smoke fails 122. Both suites pass in CI, so the breakage is invisible there — it only appears on a real developer machine.

Measured on this branch, no environment overrides on either side:

| | `main` | this branch |
|---|---|---|
| Integration: exit code | 1 | **0** |
| Integration: failing tests | 102 | **0** |
| Smoke: failing tests | 122 | **12** |
| Sign-broker errors | 87 | **0** |

The 12 remaining smoke failures are Snyk Code scans returning `401 Invalid auth token provided`; they need real credentials and no repo change can fix them.

## Three defects, all test/build only — no production code changes

**Git fixtures inherited developer git config.** Nine test helpers shell out to `git init` + `commit`. With `commit.gpgsign=true` — which this project requires of contributors — every one failed with `sign broker unavailable`. They now disable signing on the fixture repo they create, alongside the `user.name`/`user.email` they already set. `server_smoke_test.go` had solved this at one call site; the other eight had not.

**Tests asserted failure paths that need an unreachable API.** Four tests exercised error and fallback branches by assuming the Snyk API could not be reached — one said so outright: *"the resolution will fail because we don't have a real API connection"*. Logged in, the call succeeds, a real org comes back, and the branch under test is never entered. They now drive the failure deterministically via mocked configuration, and pass with and without network.

**The tools cache was not platform-aware.** `TOOLS_BIN` was keyed by path alone, so a checkout shared between a host and a container of a different platform got one cache for both. The pact bundle ships a platform-specific Ruby, and the mismatch surfaced as a misleading `CLI tools are out of date` rather than an exec-format error. Keyed by `GOOS-GOARCH` now, so each platform keeps its own.

## Smoke: waits that were not caused by the thing they asserted

Initialization emits two `$/snyk.configuration` notifications. The helper returned on the first match and `ClearNotifications()` wiped only that one, so the second landed after the clear and the next step's wait latched onto a payload predating its own change. Which step got poisoned depended on how many baseline waits preceded the clear — hence a different subset of the `Test_SmokePrecedence` family failing on every run.

Waits are now gated on evidence the step caused the notification: either the alternating `additional_parameters` token the trigger already sends, or the setting value the step just wrote. The family went from a varying-subset failure every run to **zero failures across 8 consecutive runs**.

The two invalid-credential tests failed for a related reason: `handleProviderInconsistencies` reset the injected fake back to the real provider, and the token was written through a key `GetToken` does not read, so `IsAuthenticated` returned early on an empty token and no message was ever produced. Fixed by injecting the provider through the test harness and setting the token via the token service.

## Known remaining

`Test_SmokeOrgSelection` fails 3/3 on `main` and passes 4/5 here. The residual is its `unauthenticated - re-adding folder…` subtest, which uses named validator variables rather than inline closures and does not fit the correlated-wait pattern — gating the surrounding waits made it deterministically worse, so that attempt was reverted. Worth its own ticket.

Consolidating the nine git-fixture sites onto the existing `GitEnvWithoutInheritedRepoConfig` helper is a sensible follow-up, deliberately left out to keep this diff mechanical.

## Verification

- `INTEG_TESTS=1 go test -count=1 -timeout=90m ./...` — 67 packages, 0 failures, uncached
- `go build ./...`, `go vet`, `gofmt -l .` — clean
- Smoke run on this branch and on clean `main`, no overrides, for the comparison above
- Every claim measured with no `GIT_CONFIG_*` or other environment override on either side


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes test failures on developer machines.

- Makes Git fixtures independent of global config.

- Enhances test determinism and platform compatibility.

- Updates CI/CD for platform-aware tooling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Git Fixtures] --> B(Disable GPG Signing);
  C[Authentication Tests] --> D(Mock Auth Provider);
  E[Build/CI Config] --> F(Platform-Aware Tooling);
  G[Test Logic] --> H(Deterministic Failures);
  I[Git Fixtures] --> J(Fix init repo config);
  K[CI/CD Paths] --> L(Platform-Aware Pact CLI);
  M[Makefile] --> N(Platform-Aware Tools Bin);
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>init_fix_folder_test.go</strong><dd><code>Disable GPG signing in git fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-2cf48a6ecdd95a600d8e600054f9842199239f572267004f521ce9a3ab90df82">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>authentication_smoke_test.go</strong><dd><code>Mock authentication provider for auth tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-023aa18749d688669933a576eac07ded675f32e946bfc1a7dd072f44d8c97ddd">+28/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bdd_steps_test.go</strong><dd><code>Disable GPG signing in BDD git fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-5fcf20b0c028ab75ebe77c10364d1656a95f054114f46d6a34e4b9057048c693">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>precedence_smoke_test.go</strong><dd><code>Refine test helpers and update shard numbers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-1c743b9b799604d498e5a5290961ffc135dec375c44150ad820cba81f3926d39">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>secrets_smoke_test.go</strong><dd><code>Disable GPG signing in secrets smoke test git init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-c1510bd6a7151e3624d073a590787bd9af09d36b87a53a56067ffc0f3c8603fd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server_smoke_test.go</strong><dd><code>Update test timeouts and add platform-aware CLI path in build</code></dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-13396c212387ae79a286802e0885b1c86f1bc389f0f6e82de58d49d641e15e08">+93/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server_test.go</strong><dd><code>Introduce authentication provider override option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-165bad981a0cc202462a2fea7f236eab9ca3a72bd47fe8bae6b3adad801351fb">+22/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remediation_fix_folder_test.go</strong><dd><code>Disable GPG signing in remediation git fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-51525eb80d8edb6349988d5e7973b4a6d24a00c17f4ee3a4e2a96012568b96c1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remy_test.go</strong><dd><code>Disable GPG signing in remediation git fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-134aadf198cd3215218f8733c77a9a071513e237a89e7653df850894d1469489">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pat_provider_test.go</strong><dd><code>Use mocks for PAT provider auth check tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-029234812c46197faf5b286c6e88093c032c64c333f960746fbd1a5782a042a0">+17/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cli_extension_executor_test.go</strong><dd><code>Improve test for fallback to global org</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-d59d3fe270412b672e9708f891fd8a07011f9ba449917fdd03ee2fc9bf6a66ed">+55/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>code_test.go</strong><dd><code>Use mocks for org resolution tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-633cd22ccabe454a8026b408e8efda33f6d0dafa066892d35d1dec1afb5f7513">+26/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>git_test.go</strong><dd><code>Disable GPG signing in test git repos</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>oss_test.go</strong><dd><code>Assert org flag in scan command tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-18d44a59ba6614f20ee4e2bb69fe6801a5c680206aaba162efda262707b87721">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>snyk_api_pact_test.go</strong><dd><code>Update Pact setup and token handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-2a4869fbcdf7f160ac06ad6c8ec1ea6a10bf44e8a5907f6a01e219bfa4b90f57">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>git_test.go</strong><dd><code>Disable GPG signing in test git repos</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-49c7cb21074eeb97b5869dcb267f7248147f40308e6bae617f34cfa9dc47d13d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Build</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Makefile</strong><dd><code>Make TOOLS_BIN and pact path platform-aware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Ci</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>build.yaml</strong><dd><code>Make pact CLI path platform-aware in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release.yaml</strong><dd><code>Make pact CLI path platform-aware in release pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05ada">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>smoke_main_helpers_test.go</strong></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-692f9b24d83b11e5e789682576de2b9966a559a7f9d767d3eaa15824bc071df4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>smoke_main_test.go</strong></td>
  <td><a href="https://github.com/snyk/snyk-ls/pull/1422/changes#diff-e89a003f93665e4414bd79cb649adfabf018a9607623b6d7f1e44444011f6cad">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to tests, Makefile/CI tooling paths, and docs; no runtime LSP behavior is modified.
> 
> **Overview**
> Makes local **integration and smoke** runs match CI by fixing test-only infrastructure and flaky waits—**no production code changes**.
> 
> **Platform-aware dev tools:** `TOOLS_BIN` and Pact paths now use `.bin/$(GOOS)-$(GOARCH)/` in the Makefile, `.envrc`, README, Docker test entrypoint, and GitHub workflows so host/container checkouts do not share the wrong Pact/Ruby bundle. `make test` also prepends the Pact bin to `PATH`.
> 
> **Git fixtures:** Test helpers that `git init` and commit now set `commit.gpgsign=false` so contributor GPG-signing config does not break fixtures with “sign broker unavailable.”
> 
> **Deterministic “API unreachable” branches:** Org-resolution and PAT auth-check tests use `UnitTestWithMockEngine` (new helper) or a wrapped config/engine so failure and global-org fallback paths are exercised without relying on a failed live API. Pact integration setup sets an explicit token via `IntegTestWithEngine`.
> 
> **Smoke / LSP config notifications:** `requireLspFolderConfigNotification` can gate on the setting value or `additional_parameters` the step just triggered, avoiding stale `$/snyk.configuration` payloads after clears. Invalid-credential smoke tests set OAuth auth and tokens via the token service; `WithAuthProvider` supports injecting auth in server tests. Related shard/timeouts/waits and scan-context init (no auto CLI download on Windows) adjustments.
> 
> **Remaining:** Smoke failures that need real Snyk Code credentials (401) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa98b6da9a04f417ad8f86a2f5cbcf4274483a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->