### PR TITLE
fix: correct malformed snyk:// URI for Windows paths [IDE-2548]

### DIFF
--- a/domain/ide/command/code_fix_diffs.go
+++ b/domain/ide/command/code_fix_diffs.go
@@ -83,7 +83,7 @@ func (cmd *codeFixDiffs) handleResponse(ctx context.Context, engine workflow.Eng
 	aiFixHandler := htmlRenderer.AiFixHandler
 
 	setStateCallback := func() {
-		SendShowDocumentRequest(ctx, logger, issue, cmd.srv)
+		SendShowDocumentRequest(ctx, &logger, issue, cmd.srv)
 		cmd.sendAiFixNotification(aiFixHandler, issue)
 	}
 

--- a/domain/ide/command/ignores_request.go
+++ b/domain/ide/command/ignores_request.go
@@ -132,7 +132,7 @@ func (cmd *submitIgnoreRequest) Execute(ctx context.Context) (any, error) {
 		cmd.treeEmitter.Emit(cmd.scanStateFunc())
 	}
 
-	SendShowDocumentRequest(ctx, logger, issue, cmd.srv)
+	SendShowDocumentRequest(ctx, &logger, issue, cmd.srv)
 
 	return nil, nil
 }

--- a/domain/ide/command/show_document.go
+++ b/domain/ide/command/show_document.go
@@ -27,18 +27,27 @@ import (
 	"github.com/snyk/snyk-ls/internal/types"
 )
 
-func SendShowDocumentRequest(ctx context.Context, logger zerolog.Logger, issue types.Issue, srv types.Server) {
-	snykUri, _ := code.SnykMagnetUri(issue, code.ShowInDetailPanelIdeCommand)
-	logger.Debug().
-		Str("method", "code.sendShowDocumentRequest").
+func SendShowDocumentRequest(ctx context.Context, logger *zerolog.Logger, issue types.Issue, srv types.Server) {
+	l := logger.With().
+		Str("method", "command.SendShowDocumentRequest").
+		Str("issueId", code.IssueId(issue)).
+		Logger()
+
+	snykUri, err := code.SnykMagnetUri(logger, issue, code.ShowInDetailPanelIdeCommand)
+	if err != nil {
+		l.Err(err).Msg("failed to build show-document URI")
+		return
+	}
+	l.Debug().
+		Str("uri", snykUri).
 		Msg("showing Document")
 
 	params := types.ShowDocumentParams{
 		Uri:       lsp.DocumentURI(snykUri),
 		Selection: converter.ToRange(issue.GetRange()),
 	}
-	_, err := srv.Callback(ctx, "window/showDocument", params)
+	_, err = srv.Callback(ctx, "window/showDocument", params)
 	if err != nil {
-		logger.Err(err).Msgf("failed to send snyk window/showDocument callback for file %s", issue.GetAffectedFilePath())
+		l.Err(err).Msgf("failed to send snyk window/showDocument callback for file %s", issue.GetAffectedFilePath())
 	}
 }

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -68,7 +68,7 @@ func setupTestData() (issue *snyk.Issue, expectedURI string, expectedTitle strin
 		Range:            fakeRange,
 	}
 
-	expectedURI = "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=123&action=showInDetailPanel"
+	expectedURI = "snyk:///Users/user/workspace/blah/app.js?action=showInDetailPanel&issueId=123&product=Snyk+Code"
 	expectedTitle = "⚡ Fix this issue: Test Issue (Snyk)"
 
 	return

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -18,6 +18,7 @@ package code
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -57,21 +58,40 @@ import (
 	"github.com/snyk/snyk-ls/internal/testutil/workspaceutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/types/mock_types"
+	"github.com/snyk/snyk-ls/internal/uri"
 	"github.com/snyk/snyk-ls/internal/vcs"
 )
 
-func setupTestData() (issue *snyk.Issue, expectedURI string, expectedTitle string) {
+func setupTestData(t *testing.T) (issue *snyk.Issue, expectedURI string, expectedTitle string) {
+	t.Helper()
+	affectedFilePath := filepath.Join(t.TempDir(), "app.js")
 	issue = &snyk.Issue{
-		AffectedFilePath: "/Users/user/workspace/blah/app.js",
+		AffectedFilePath: types.FilePath(affectedFilePath),
 		Product:          product.ProductCode,
 		AdditionalData:   snyk.CodeIssueData{Key: "123", Title: "Test Issue"},
 		Range:            fakeRange,
 	}
 
-	expectedURI = "snyk:///Users/user/workspace/blah/app.js?action=showInDetailPanel&issueId=123&product=Snyk+Code"
+	expectedURI = expectedSnykMagnetUri(t, affectedFilePath, url.Values{
+		"action":  {"showInDetailPanel"},
+		"issueId": {"123"},
+		"product": {"Snyk Code"},
+	})
 	expectedTitle = "⚡ Fix this issue: Test Issue (Snyk)"
 
 	return
+}
+
+// expectedSnykMagnetUri builds the expected snyk:// URI the same way SnykMagnetUri does,
+// so the assertion doesn't hardcode a path shape that's only valid on one OS.
+func expectedSnykMagnetUri(t *testing.T, affectedFilePath string, query url.Values) string {
+	t.Helper()
+	fileUri := uri.PathToUri(types.FilePath(affectedFilePath))
+	u, err := url.Parse(string(fileUri))
+	require.NoError(t, err)
+	u.Scheme = "snyk"
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 func sliceToChannel(slice []string) <-chan string {
@@ -713,7 +733,7 @@ func TestIssueEnhancer_createShowDocumentCodeAction(t *testing.T) {
 	}
 
 	t.Run("creates show document code action successfully", func(t *testing.T) {
-		issue, expectedURI, expectedTitle := setupTestData()
+		issue, expectedURI, expectedTitle := setupTestData(t)
 		codeAction := issueEnhancer.createShowDocumentCodeAction(issue)
 
 		assert.NotNil(t, codeAction)

--- a/infrastructure/code/code_test.go
+++ b/infrastructure/code/code_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -58,40 +59,56 @@ import (
 	"github.com/snyk/snyk-ls/internal/testutil/workspaceutil"
 	"github.com/snyk/snyk-ls/internal/types"
 	"github.com/snyk/snyk-ls/internal/types/mock_types"
-	"github.com/snyk/snyk-ls/internal/uri"
 	"github.com/snyk/snyk-ls/internal/vcs"
 )
 
-func setupTestData(t *testing.T) (issue *snyk.Issue, expectedURI string, expectedTitle string) {
+// Fixture pieces shared by SnykMagnetUri-related tests across this package.
+const (
+	testFixtureSubDir  = "some_dir"
+	testFixtureFile    = "app.js"
+	testFixtureIssueId = "123"
+)
+
+var testFixturePathSuffix = testFixtureSubDir + "/" + testFixtureFile // URI path always uses '/', regardless of OS
+
+func setupTestData(t *testing.T) (issue *snyk.Issue, expectedTitle string) {
 	t.Helper()
-	affectedFilePath := filepath.Join(t.TempDir(), "app.js")
+	affectedFilePath := filepath.Join(t.TempDir(), testFixtureSubDir, testFixtureFile)
 	issue = &snyk.Issue{
 		AffectedFilePath: types.FilePath(affectedFilePath),
 		Product:          product.ProductCode,
-		AdditionalData:   snyk.CodeIssueData{Key: "123", Title: "Test Issue"},
+		AdditionalData:   snyk.CodeIssueData{Key: testFixtureIssueId, Title: "Test Issue"},
 		Range:            fakeRange,
 	}
-
-	expectedURI = expectedSnykMagnetUri(t, affectedFilePath, url.Values{
-		"action":  {"showInDetailPanel"},
-		"issueId": {"123"},
-		"product": {"Snyk Code"},
-	})
 	expectedTitle = "⚡ Fix this issue: Test Issue (Snyk)"
 
 	return
 }
 
-// expectedSnykMagnetUri builds the expected snyk:// URI the same way SnykMagnetUri does,
-// so the assertion doesn't hardcode a path shape that's only valid on one OS.
-func expectedSnykMagnetUri(t *testing.T, affectedFilePath string, query url.Values) string {
+// assertTestDataSnykURI asserts actualURI matches what SnykMagnetUri should produce for the
+// issue setupTestData returned.
+func assertTestDataSnykURI(t *testing.T, actualURI string) {
 	t.Helper()
-	fileUri := uri.PathToUri(types.FilePath(affectedFilePath))
-	u, err := url.Parse(string(fileUri))
-	require.NoError(t, err)
-	u.Scheme = "snyk"
-	u.RawQuery = query.Encode()
-	return u.String()
+	assertSnykURIMatches(t, actualURI, testFixturePathSuffix, url.Values{
+		"action":  {ShowInDetailPanelIdeCommand},
+		"issueId": {testFixtureIssueId},
+		"product": {"Snyk Code"},
+	})
+}
+
+// assertSnykURIMatches asserts actualURI is a well-formed snyk:// URI: scheme "snyk", no
+// host (a Windows drive letter must never be swallowed as an authority — the exact bug this
+// package's URI building exists to avoid), a path ending in expectedPathSuffix, and a query
+// exactly matching expectedQuery.
+func assertSnykURIMatches(t *testing.T, actualURI string, expectedPathSuffix string, expectedQuery url.Values, msgAndArgs ...any) {
+	t.Helper()
+	parsed, err := url.Parse(actualURI)
+	require.NoError(t, err, msgAndArgs...)
+	assert.Equal(t, "snyk", parsed.Scheme, msgAndArgs...)
+	assert.Empty(t, parsed.Host, msgAndArgs...)
+	assert.True(t, strings.HasSuffix(parsed.Path, expectedPathSuffix),
+		"path %q should end with %q", parsed.Path, expectedPathSuffix)
+	assert.Equal(t, expectedQuery, parsed.Query(), msgAndArgs...)
 }
 
 func sliceToChannel(slice []string) <-chan string {
@@ -733,7 +750,7 @@ func TestIssueEnhancer_createShowDocumentCodeAction(t *testing.T) {
 	}
 
 	t.Run("creates show document code action successfully", func(t *testing.T) {
-		issue, expectedURI, expectedTitle := setupTestData(t)
+		issue, expectedTitle := setupTestData(t)
 		codeAction := issueEnhancer.createShowDocumentCodeAction(issue)
 
 		assert.NotNil(t, codeAction)
@@ -741,7 +758,9 @@ func TestIssueEnhancer_createShowDocumentCodeAction(t *testing.T) {
 		assert.NotNil(t, codeAction.GetCommand())
 		assert.Equal(t, expectedTitle, codeAction.GetCommand().Title)
 		assert.Equal(t, types.NavigateToRangeCommand, codeAction.GetCommand().CommandId)
-		assert.Equal(t, expectedURI, codeAction.GetCommand().Arguments[0])
+		actualURI, ok := codeAction.GetCommand().Arguments[0].(string)
+		require.True(t, ok)
+		assertTestDataSnykURI(t, actualURI)
 		assert.Equal(t, issue.Range, codeAction.GetCommand().Arguments[1])
 	})
 }

--- a/infrastructure/code/issue_enhancer.go
+++ b/infrastructure/code/issue_enhancer.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/rs/zerolog"
 	codeClientObservability "github.com/snyk/code-client-go/observability"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/snyk/snyk-ls/internal/notification"
 	"github.com/snyk/snyk-ls/internal/observability/performance"
 	"github.com/snyk/snyk-ls/internal/types"
+	"github.com/snyk/snyk-ls/internal/uri"
 	"github.com/snyk/snyk-ls/internal/util"
 )
 
@@ -96,7 +98,7 @@ func (b *IssueEnhancer) addIssueActions(_ context.Context, issues []types.Issue)
 			codeActionShowDocument := b.createShowDocumentCodeAction(issues[i])
 			issues[i].SetCodeActions(append(issues[i].GetCodeActions(), codeActionShowDocument))
 
-			uri, err := SnykMagnetUri(issues[i], ShowInDetailPanelIdeCommand)
+			snykUri, err := SnykMagnetUri(b.engine.GetLogger(), issues[i], ShowInDetailPanelIdeCommand)
 			if err != nil {
 				b.engine.GetLogger().Error().Str("method", method).Msg("Failed to create URI for showInDetailPanel action")
 				return
@@ -104,7 +106,7 @@ func (b *IssueEnhancer) addIssueActions(_ context.Context, issues []types.Issue)
 			issues[i].SetCodelensCommands(append(issues[i].GetCodelensCommands(), types.CommandData{
 				Title:     FixIssuePrefix + issueTitle(issues[i]),
 				CommandId: types.NavigateToRangeCommand,
-				Arguments: []any{uri, issues[i].GetRange()},
+				Arguments: []any{snykUri, issues[i].GetRange()},
 			}))
 		}
 		issues[i].SetAdditionalData(issueData)
@@ -121,7 +123,7 @@ func (b *IssueEnhancer) addIssueActions(_ context.Context, issues []types.Issue)
 // returns the deferred code action CodeAction which calls autofix.
 func (b *IssueEnhancer) createShowDocumentCodeAction(issue types.Issue) (codeAction types.CodeAction) {
 	method := "code.createShowDocumentCodeAction"
-	uri, err := SnykMagnetUri(issue, ShowInDetailPanelIdeCommand)
+	snykUri, err := SnykMagnetUri(b.engine.GetLogger(), issue, ShowInDetailPanelIdeCommand)
 	if err != nil {
 		b.engine.GetLogger().Error().Str("method", method).Msg("Failed to create URI for showInDetailPanel action")
 		return nil
@@ -135,7 +137,7 @@ func (b *IssueEnhancer) createShowDocumentCodeAction(issue types.Issue) (codeAct
 		Command: &types.CommandData{
 			Title:     title,
 			CommandId: types.NavigateToRangeCommand,
-			Arguments: []any{uri, issue.GetRange()},
+			Arguments: []any{snykUri, issue.GetRange()},
 		},
 	}
 	return codeAction
@@ -147,18 +149,23 @@ func (b *IssueEnhancer) autofixShowDetailsFunc(ctx context.Context, issue types.
 		s := b.instrumentor.StartSpan(ctx, method)
 		defer b.instrumentor.Finish(s)
 
-		return getSnykShowDocumentCommand(issue, ShowInDetailPanelIdeCommand)
+		return b.getSnykShowDocumentCommand(issue, ShowInDetailPanelIdeCommand)
 	}
 	return f
 }
 
-func getSnykShowDocumentCommand(issue types.Issue, action string) *types.CommandData {
-	uri, _ := SnykMagnetUri(issue, action)
+func (b *IssueEnhancer) getSnykShowDocumentCommand(issue types.Issue, action string) *types.CommandData {
+	logger := b.engine.GetLogger()
+	snykUri, err := SnykMagnetUri(logger, issue, action)
+	if err != nil {
+		logger.Err(err).Str("method", "code.getSnykShowDocumentCommand").Msg("failed to build show-document URI")
+		return nil
+	}
 
 	commandData := &types.CommandData{
 		Title:     types.NavigateToRangeCommand,
 		CommandId: types.NavigateToRangeCommand,
-		Arguments: []any{uri, issue.GetRange()},
+		Arguments: []any{snykUri, issue.GetRange()},
 	}
 	return commandData
 }
@@ -226,12 +233,28 @@ func IssueId(issue types.Issue) string {
 	return issue.GetID()
 }
 
-func SnykMagnetUri(issue types.Issue, ideAction string) (string, error) {
-	u := &url.URL{
-		Scheme:   "snyk",
-		Path:     string(issue.GetAffectedFilePath()),
-		RawQuery: fmt.Sprintf("product=%s&issueId=%s&action=%s", url.QueryEscape(string(issue.GetProduct())), url.QueryEscape(IssueId(issue)), ideAction),
-	}
+func SnykMagnetUri(logger *zerolog.Logger, issue types.Issue, ideAction string) (string, error) {
+	l := logger.With().Str("method", "code.SnykMagnetUri").Logger()
 
-	return u.String(), nil
+	affectedFilePath := string(issue.GetAffectedFilePath())
+	// Convert to file URI then swaps the scheme to "snyk",
+	// since building url.URL{Path: <raw OS path>} directly causes a malformed "snyk://C:%5Cpath%5Chere" URI
+	// on Windows, where "C:" gets interpreted as host:port.
+	fileUri := uri.PathToUri(types.FilePath(affectedFilePath))
+	u, err := url.Parse(string(fileUri))
+	if err != nil {
+		l.Err(err).Str("affectedFilePath", affectedFilePath).Msg("failed to parse file URI for affected path")
+		return "", err
+	}
+	u.Scheme = "snyk"
+	u.RawQuery = url.Values{
+		"product": {string(issue.GetProduct())},
+		"issueId": {IssueId(issue)},
+		"action":  {ideAction},
+	}.Encode()
+
+	snykUri := u.String()
+	l.Debug().Str("snykUri", snykUri).Msg("built show-document URI")
+
+	return snykUri, nil
 }

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -17,9 +17,12 @@
 package code
 
 import (
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -76,7 +79,7 @@ func TestIssueEnhancer_autofixShowDetailsFunc(t *testing.T) {
 		AdditionalData:   snyk.CodeIssueData{Key: "123"},
 		Range:            fakeRange,
 	}
-	expectedURI := "snyk:///Users/user/workspace/blah/app.js?product=Snyk+Code&issueId=123&action=showInDetailPanel"
+	expectedURI := "snyk:///Users/user/workspace/blah/app.js?action=showInDetailPanel&issueId=123&product=Snyk+Code"
 
 	t.Run("returns CommandData with correct URI and range", func(t *testing.T) {
 		commandDataFunc := issueEnhancer.autofixShowDetailsFunc(t.Context(), issue)
@@ -181,16 +184,36 @@ func Test_ideSnykURI(t *testing.T) {
 	testutil.UnitTest(t)
 	t.Run("generates correct URI", func(t *testing.T) {
 		issue, ideAction, expectedURI := setupAiFixTestData()
-		actualURI, err := SnykMagnetUri(issue, ideAction)
+		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ideAction)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURI, actualURI)
 	})
 
 	t.Run("handles missing Key in additional data", func(t *testing.T) {
 		issue, ideAction, expectedURI := setupAiFixTestData()
-		actualURI, err := SnykMagnetUri(issue, ideAction)
+		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ideAction)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURI, actualURI)
+	})
+
+	// lspUri.File's file:// shape puts a leading '/' before the drive letter (RFC 8089),
+	// keeping the authority empty; a raw path in url.URL instead renders "C:%5Cpath" and
+	// "C:" parses as host:port (RFC 3986).
+	t.Run("Windows paths follow RFCs for encoding", func(t *testing.T) {
+		filePath := `C:\Mac\Home\Documents\Code\JavaScript\snyk-goof\db.js`
+		issue := &snyk.Issue{
+			AffectedFilePath: types.FilePath(filePath),
+			Product:          "Code",
+			AdditionalData:   snyk.CodeIssueData{Key: "123"},
+		}
+
+		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ShowInDetailPanelIdeCommand)
+		require.NoError(t, err)
+
+		parsed, parseErr := url.Parse(actualURI)
+		require.NoError(t, parseErr, "generated URI should be re-parseable, but got: %s", actualURI)
+		assert.Empty(t, parsed.Host, "authority should be empty, not swallow the Windows drive letter as a host")
+		assert.True(t, strings.HasPrefix(parsed.Path, "/C:"), "path should start with a leading slash before the drive letter, got: %s", parsed.Path)
 	})
 }
 
@@ -248,7 +271,7 @@ func setupAiFixTestData() (issue *snyk.Issue, ideAction string, expectedURI stri
 		AdditionalData:   snyk.CodeIssueData{Key: "123"}, // Provide additional data
 	}
 	ideAction = "showInDetailPanel"
-	expectedURI = "snyk:///Users/user/workspace/blah/app.js?product=Code&issueId=123&action=showInDetailPanel"
+	expectedURI = "snyk:///Users/user/workspace/blah/app.js?action=showInDetailPanel&issueId=123&product=Code"
 
 	return
 }

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -18,6 +18,7 @@ package code
 
 import (
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -73,13 +74,18 @@ func TestIssueEnhancer_autofixShowDetailsFunc(t *testing.T) {
 		rootPath:     "/Users/user/workspace/blah",
 		engine:       engine,
 	}
+	affectedFilePath := filepath.Join(t.TempDir(), "app.js")
 	issue := &snyk.Issue{
-		AffectedFilePath: "/Users/user/workspace/blah/app.js",
+		AffectedFilePath: types.FilePath(affectedFilePath),
 		Product:          product.ProductCode,
 		AdditionalData:   snyk.CodeIssueData{Key: "123"},
 		Range:            fakeRange,
 	}
-	expectedURI := "snyk:///Users/user/workspace/blah/app.js?action=showInDetailPanel&issueId=123&product=Snyk+Code"
+	expectedURI := expectedSnykMagnetUri(t, affectedFilePath, url.Values{
+		"action":  {"showInDetailPanel"},
+		"issueId": {"123"},
+		"product": {"Snyk Code"},
+	})
 
 	t.Run("returns CommandData with correct URI and range", func(t *testing.T) {
 		commandDataFunc := issueEnhancer.autofixShowDetailsFunc(t.Context(), issue)
@@ -183,14 +189,14 @@ func Test_addIssueActions(t *testing.T) {
 func Test_ideSnykURI(t *testing.T) {
 	testutil.UnitTest(t)
 	t.Run("generates correct URI", func(t *testing.T) {
-		issue, ideAction, expectedURI := setupAiFixTestData()
+		issue, ideAction, expectedURI := setupAiFixTestData(t)
 		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ideAction)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURI, actualURI)
 	})
 
 	t.Run("handles missing Key in additional data", func(t *testing.T) {
-		issue, ideAction, expectedURI := setupAiFixTestData()
+		issue, ideAction, expectedURI := setupAiFixTestData(t)
 		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ideAction)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURI, actualURI)
@@ -264,14 +270,20 @@ func TestIssueId(t *testing.T) {
 	}
 }
 
-func setupAiFixTestData() (issue *snyk.Issue, ideAction string, expectedURI string) {
+func setupAiFixTestData(t *testing.T) (issue *snyk.Issue, ideAction string, expectedURI string) {
+	t.Helper()
+	affectedFilePath := filepath.Join(t.TempDir(), "app.js")
 	issue = &snyk.Issue{
-		AffectedFilePath: "/Users/user/workspace/blah/app.js",
+		AffectedFilePath: types.FilePath(affectedFilePath),
 		Product:          "Code",
 		AdditionalData:   snyk.CodeIssueData{Key: "123"}, // Provide additional data
 	}
 	ideAction = "showInDetailPanel"
-	expectedURI = "snyk:///Users/user/workspace/blah/app.js?action=showInDetailPanel&issueId=123&product=Code"
+	expectedURI = expectedSnykMagnetUri(t, affectedFilePath, url.Values{
+		"action":  {"showInDetailPanel"},
+		"issueId": {"123"},
+		"product": {"Code"},
+	})
 
 	return
 }

--- a/infrastructure/code/issue_enhancer_test.go
+++ b/infrastructure/code/issue_enhancer_test.go
@@ -74,18 +74,7 @@ func TestIssueEnhancer_autofixShowDetailsFunc(t *testing.T) {
 		rootPath:     "/Users/user/workspace/blah",
 		engine:       engine,
 	}
-	affectedFilePath := filepath.Join(t.TempDir(), "app.js")
-	issue := &snyk.Issue{
-		AffectedFilePath: types.FilePath(affectedFilePath),
-		Product:          product.ProductCode,
-		AdditionalData:   snyk.CodeIssueData{Key: "123"},
-		Range:            fakeRange,
-	}
-	expectedURI := expectedSnykMagnetUri(t, affectedFilePath, url.Values{
-		"action":  {"showInDetailPanel"},
-		"issueId": {"123"},
-		"product": {"Snyk Code"},
-	})
+	issue, _ := setupTestData(t)
 
 	t.Run("returns CommandData with correct URI and range", func(t *testing.T) {
 		commandDataFunc := issueEnhancer.autofixShowDetailsFunc(t.Context(), issue)
@@ -93,7 +82,9 @@ func TestIssueEnhancer_autofixShowDetailsFunc(t *testing.T) {
 
 		assert.Equal(t, types.NavigateToRangeCommand, commandData.Title)
 		assert.Equal(t, types.NavigateToRangeCommand, commandData.CommandId)
-		assert.Equal(t, expectedURI, commandData.Arguments[0])
+		actualURI, ok := commandData.Arguments[0].(string)
+		require.True(t, ok)
+		assertTestDataSnykURI(t, actualURI)
 		assert.Equal(t, issue.Range, commandData.Arguments[1])
 	})
 }
@@ -189,17 +180,28 @@ func Test_addIssueActions(t *testing.T) {
 func Test_ideSnykURI(t *testing.T) {
 	testutil.UnitTest(t)
 	t.Run("generates correct URI", func(t *testing.T) {
-		issue, ideAction, expectedURI := setupAiFixTestData(t)
-		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ideAction)
+		issue, _ := setupTestData(t)
+		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ShowInDetailPanelIdeCommand)
 		assert.NoError(t, err)
-		assert.Equal(t, expectedURI, actualURI)
+		assertTestDataSnykURI(t, actualURI)
 	})
 
 	t.Run("handles missing Key in additional data", func(t *testing.T) {
-		issue, ideAction, expectedURI := setupAiFixTestData(t)
-		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ideAction)
+		affectedFilePath := filepath.Join(t.TempDir(), testFixtureSubDir, testFixtureFile)
+		issue := &snyk.Issue{
+			ID:               "vuln-id",
+			AffectedFilePath: types.FilePath(affectedFilePath),
+			Product:          product.ProductCode,
+			AdditionalData:   snyk.CodeIssueData{Key: ""}, // falls back to issue.ID via IssueId()
+		}
+
+		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ShowInDetailPanelIdeCommand)
 		assert.NoError(t, err)
-		assert.Equal(t, expectedURI, actualURI)
+		assertSnykURIMatches(t, actualURI, testFixturePathSuffix, url.Values{
+			"action":  {ShowInDetailPanelIdeCommand},
+			"issueId": {"vuln-id"},
+			"product": {"Snyk Code"},
+		})
 	})
 
 	// lspUri.File's file:// shape puts a leading '/' before the drive letter (RFC 8089),
@@ -209,8 +211,8 @@ func Test_ideSnykURI(t *testing.T) {
 		filePath := `C:\Mac\Home\Documents\Code\JavaScript\snyk-goof\db.js`
 		issue := &snyk.Issue{
 			AffectedFilePath: types.FilePath(filePath),
-			Product:          "Code",
-			AdditionalData:   snyk.CodeIssueData{Key: "123"},
+			Product:          product.ProductCode,
+			AdditionalData:   snyk.CodeIssueData{Key: testFixtureIssueId},
 		}
 
 		actualURI, err := SnykMagnetUri(util.Ptr(zerolog.Nop()), issue, ShowInDetailPanelIdeCommand)
@@ -268,22 +270,4 @@ func TestIssueId(t *testing.T) {
 			}
 		})
 	}
-}
-
-func setupAiFixTestData(t *testing.T) (issue *snyk.Issue, ideAction string, expectedURI string) {
-	t.Helper()
-	affectedFilePath := filepath.Join(t.TempDir(), "app.js")
-	issue = &snyk.Issue{
-		AffectedFilePath: types.FilePath(affectedFilePath),
-		Product:          "Code",
-		AdditionalData:   snyk.CodeIssueData{Key: "123"}, // Provide additional data
-	}
-	ideAction = "showInDetailPanel"
-	expectedURI = expectedSnykMagnetUri(t, affectedFilePath, url.Values{
-		"action":  {"showInDetailPanel"},
-		"issueId": {"123"},
-		"product": {"Code"},
-	})
-
-	return
 }


### PR DESCRIPTION
### Description

`SnykMagnetUri` built the show-document URI from a raw `net/url.URL` with the OS path in `Path`, which on Windows lets `C:` get parsed as a `host:port` authority instead of a drive letter. The LS then sends the IDE a URI it can't parse — e.g. Visual Studio hangs on "Explaining..." because `new Uri()` throws.

Most of this diff is logger-signature cleanup (`*zerolog.Logger` to match the repo's dominant convention, `getSnykShowDocumentCommand` becoming a method, an `uri`/`snykUri` rename to stop shadowing the `internal/uri` import) — sorry, noisier than it needs to be. The actual fix is small: reviewers can focus on [`SnykMagnetUri`](https://github.com/snyk/snyk-ls/blob/ecc0c437964db80bbcfdc59ea61fc975068a5e31/infrastructure/code/issue_enhancer.go#L236) and its new [`"Windows paths follow RFCs for encoding"`](https://github.com/snyk/snyk-ls/blob/ecc0c437964db80bbcfdc59ea61fc975068a5e31/infrastructure/code/issue_enhancer_test.go#L202) test case.

Manually tested on Windows across all 4 IDE plugins (VS Code, IntelliJ, Eclipse, Visual Studio).

Also fixed a genuinely broken test along the way: `Test_ideSnykURI`'s `"handles missing Key in additional data"` subtest was byte-identical to its sibling on `main` — the key was hardcoded to `"123"`, never actually missing, so `IssueId()`'s fallback to `issue.GetID()` had zero coverage. It now builds an issue with an empty key and asserts that fallback. Also replaced a test helper that duplicated `SnykMagnetUri`'s own URI-building logic to construct its expected value with one that asserts structurally on the real output (scheme, host, path suffix, query), and fixed two spots using an invalid `Product: "Code"` literal instead of the real `product.ProductCode` constant.

### Checklist

- [x] Tests added and all succeed
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint-fix`)
- [ ] README.md updated, if user-facing
- [ ] License file updated, if new 3rd-party dependency is introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deep-link URI construction for all platforms on a critical IDE navigation path; the fix is targeted but any regression would break show-document and AI-fix flows.
> 
> **Overview**
> Fixes **malformed `snyk://` URIs on Windows** by changing how `SnykMagnetUri` is built: the affected file path is converted with `uri.PathToUri`, parsed, then the scheme is set to `snyk` with query params, instead of stuffing a raw OS path into `url.URL.Path` (which let `C:` be treated as a host and broke IDE parsing).
> 
> **`SendShowDocumentRequest`** now takes a `*zerolog.Logger`, propagates `SnykMagnetUri` errors (no callback if the URI fails), and adds structured debug fields. Call sites in autofix and ignore flows pass `&logger`. **`getSnykShowDocumentCommand`** is an `IssueEnhancer` method and logs/returns nil on URI build failure instead of ignoring errors.
> 
> Tests were reworked to assert URI structure (scheme, empty host, path suffix, query) rather than hard-coded strings, including a **Windows RFC encoding** case and a real **`IssueId` fallback** when the code issue key is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c4da6395685dfb0e3ae2520009f1fd5e5c9d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

